### PR TITLE
Fixed system stored procedures, sp_columns and sp_columns_100 to handle input @fusepattern = 0 correctly

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -299,89 +299,101 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
--- BABEL-1784: support for sp_columns/sp_columns_100
 CREATE OR REPLACE VIEW sys.sp_columns_100_view AS
-  SELECT 
-  CAST(t4."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
-  CAST(t4."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
-  CAST(t4."TABLE_NAME" AS sys.sysname) AS TABLE_NAME,
-  CAST(t4."COLUMN_NAME" AS sys.sysname) AS COLUMN_NAME,
-  CAST(t5.data_type AS smallint) AS DATA_TYPE,
-  CAST(coalesce(tsql_type_name, t.typname) AS sys.sysname) AS TYPE_NAME,
-
-  CASE WHEN t4."CHARACTER_MAXIMUM_LENGTH" = -1 THEN 0::INT
-    WHEN a.atttypmod != -1
-    THEN
-    CAST(coalesce(t4."NUMERIC_PRECISION", t4."CHARACTER_MAXIMUM_LENGTH", sys.tsql_type_precision_helper(t4."DATA_TYPE", a.atttypmod)) AS INT)
-    WHEN tsql_type_name = 'timestamp'
-    THEN 8
-    ELSE
-    CAST(coalesce(t4."NUMERIC_PRECISION", t4."CHARACTER_MAXIMUM_LENGTH", sys.tsql_type_precision_helper(t4."DATA_TYPE", t.typtypmod)) AS INT)
-  END AS PRECISION,
-
-  CASE WHEN a.atttypmod != -1
-    THEN
-    CAST(sys.tsql_type_length_for_sp_columns_helper(t4."DATA_TYPE", a.attlen, a.atttypmod) AS int)
-    ELSE
-    CAST(sys.tsql_type_length_for_sp_columns_helper(t4."DATA_TYPE", a.attlen, t.typtypmod) AS int)
-  END AS LENGTH,
-
-
-  CASE WHEN a.atttypmod != -1
-    THEN
-    CAST(coalesce(t4."NUMERIC_SCALE", sys.tsql_type_scale_helper(t4."DATA_TYPE", a.atttypmod, true)) AS smallint)
-    ELSE
-    CAST(coalesce(t4."NUMERIC_SCALE", sys.tsql_type_scale_helper(t4."DATA_TYPE", t.typtypmod, true)) AS smallint)
-  END AS SCALE,
-
-
-  CAST(coalesce(t4."NUMERIC_PRECISION_RADIX", sys.tsql_type_radix_for_sp_columns_helper(t4."DATA_TYPE")) AS smallint) AS RADIX,
-  case
-    when t4."IS_NULLABLE" = 'YES' then CAST(1 AS smallint)
-    else CAST(0 AS smallint)
-  end AS NULLABLE,
-
-  CAST(NULL AS varchar(254)) AS remarks,
-  CAST(t4."COLUMN_DEFAULT" AS sys.nvarchar(4000)) AS COLUMN_DEF,
-  CAST(t5.sql_data_type AS smallint) AS SQL_DATA_TYPE,
-  CAST(t5.SQL_DATETIME_SUB AS smallint) AS SQL_DATETIME_SUB,
-
-  CASE WHEN t4."DATA_TYPE" = 'xml' THEN 0::INT
-    WHEN t4."DATA_TYPE" = 'sql_variant' THEN 8000::INT
-    WHEN t4."CHARACTER_MAXIMUM_LENGTH" = -1 THEN 0::INT
-    ELSE CAST(t4."CHARACTER_OCTET_LENGTH" AS int)
-  END AS CHAR_OCTET_LENGTH,
-
-  CAST(t4."ORDINAL_POSITION" AS int) AS ORDINAL_POSITION,
-  CAST(t4."IS_NULLABLE" AS varchar(254)) AS IS_NULLABLE,
-  CAST(t5.ss_data_type AS sys.tinyint) AS SS_DATA_TYPE,
-  CAST(0 AS smallint) AS SS_IS_SPARSE,
-  CAST(0 AS smallint) AS SS_IS_COLUMN_SET,
-  CAST(t6.is_computed as smallint) AS SS_IS_COMPUTED,
-  CAST(t6.is_identity as smallint) AS SS_IS_IDENTITY,
-  CAST(NULL AS varchar(254)) SS_UDT_CATALOG_NAME,
-  CAST(NULL AS varchar(254)) SS_UDT_SCHEMA_NAME,
-  CAST(NULL AS varchar(254)) SS_UDT_ASSEMBLY_TYPE_NAME,
-  CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
-  CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
-  CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_NAME
-
-  FROM pg_catalog.pg_class t1
-     JOIN sys.pg_namespace_ext t2 ON t1.relnamespace = t2.oid
-     JOIN pg_catalog.pg_roles t3 ON t1.relowner = t3.oid
-     LEFT OUTER JOIN sys.babelfish_namespace_ext ext on t2.nspname = ext.nspname
-     JOIN information_schema_tsql.columns_internal t4 ON (t1.oid = t4."TABLE_OID")
-     LEFT JOIN pg_attribute a on a.attrelid = t1.oid AND a.attname::sys.nvarchar(128) = t4."COLUMN_NAME"
-     LEFT JOIN pg_type t ON t.oid = a.atttypid
-     LEFT JOIN sys.columns t6 ON
-     (
-      t1.oid = t6.object_id AND
-      t4."ORDINAL_POSITION" = t6.column_id
-     )
-     , sys.translate_pg_type_to_tsql(a.atttypid) AS tsql_type_name
-     , sys.spt_datatype_info_table AS t5
-  WHERE (t4."DATA_TYPE" = CAST(t5.TYPE_NAME AS sys.nvarchar(128)) OR (t4."DATA_TYPE" = 'bytea' AND t5.TYPE_NAME = 'image'))
-    AND ext.dbid = sys.db_id();
+SELECT 
+	CAST(t4."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
+	CAST(t4."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
+	CAST(
+		COALESCE(
+			(SELECT pg_catalog.string_agg(
+				CASE
+					WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23 /* prefix length */)
+					ELSE NULL
+				END, ',')
+			FROM unnest(t1.reloptions) AS option),
+			t4."TABLE_NAME")
+		AS sys.sysname) AS TABLE_NAME,
+	CAST(
+		COALESCE(
+			(SELECT pg_catalog.string_agg(
+				CASE
+					WHEN option LIKE 'bbf_original_name=%' THEN substring(option, 19 /* prefix length */)
+					ELSE NULL
+				END, ',')
+			FROM unnest(a.attoptions) AS option),
+			t4."COLUMN_NAME")
+		AS sys.sysname) AS COLUMN_NAME,
+	CAST(t5.data_type AS smallint) AS DATA_TYPE,
+	CAST(coalesce(tsql_type_name, t.typname) AS sys.sysname) AS TYPE_NAME,
+	CASE 
+		WHEN t4."CHARACTER_MAXIMUM_LENGTH" = -1 THEN 0::INT
+		WHEN a.atttypmod != -1
+			THEN CAST(coalesce(t4."NUMERIC_PRECISION", t4."CHARACTER_MAXIMUM_LENGTH", sys.tsql_type_precision_helper(t4."DATA_TYPE", a.atttypmod)) AS INT)
+		WHEN tsql_type_name = 'timestamp'
+			THEN 8
+		ELSE
+			CAST(coalesce(t4."NUMERIC_PRECISION", t4."CHARACTER_MAXIMUM_LENGTH", sys.tsql_type_precision_helper(t4."DATA_TYPE", t.typtypmod)) AS INT)
+	END AS PRECISION,
+	CASE 
+		WHEN a.atttypmod != -1
+			THEN CAST(sys.tsql_type_length_for_sp_columns_helper(t4."DATA_TYPE", a.attlen, a.atttypmod) AS int)
+		ELSE
+			CAST(sys.tsql_type_length_for_sp_columns_helper(t4."DATA_TYPE", a.attlen, t.typtypmod) AS int)
+	END AS LENGTH,
+	CASE 
+		WHEN a.atttypmod != -1
+			THEN CAST(coalesce(t4."NUMERIC_SCALE", sys.tsql_type_scale_helper(t4."DATA_TYPE", a.atttypmod, true)) AS smallint)
+		ELSE
+			CAST(coalesce(t4."NUMERIC_SCALE", sys.tsql_type_scale_helper(t4."DATA_TYPE", t.typtypmod, true)) AS smallint)
+	END AS SCALE,
+	CAST(coalesce(t4."NUMERIC_PRECISION_RADIX", sys.tsql_type_radix_for_sp_columns_helper(t4."DATA_TYPE")) AS smallint) AS RADIX,
+	CASE 
+		WHEN t4."IS_NULLABLE" = 'YES'
+			THEN CAST(1 AS smallint)
+		ELSE
+			CAST(0 AS smallint)
+	END AS NULLABLE,
+	CAST(NULL AS varchar(254)) AS remarks,
+	CAST(t4."COLUMN_DEFAULT" AS sys.nvarchar(4000)) AS COLUMN_DEF,
+	CAST(t5.sql_data_type AS smallint) AS SQL_DATA_TYPE,
+	CAST(t5.SQL_DATETIME_SUB AS smallint) AS SQL_DATETIME_SUB,
+	CASE 
+		WHEN t4."DATA_TYPE" = 'xml' THEN 0::INT
+		WHEN t4."DATA_TYPE" = 'sql_variant' THEN 8000::INT
+		WHEN t4."CHARACTER_MAXIMUM_LENGTH" = -1 THEN 0::INT
+		ELSE CAST(t4."CHARACTER_OCTET_LENGTH" AS int)
+	END AS CHAR_OCTET_LENGTH,
+	CAST(t4."ORDINAL_POSITION" AS int) AS ORDINAL_POSITION,
+	CAST(t4."IS_NULLABLE" AS varchar(254)) AS IS_NULLABLE,
+	CAST(t5.ss_data_type AS sys.tinyint) AS SS_DATA_TYPE,
+	CAST(0 AS smallint) AS SS_IS_SPARSE,
+	CAST(0 AS smallint) AS SS_IS_COLUMN_SET,
+	CAST(t6.is_computed as smallint) AS SS_IS_COMPUTED,
+	CAST(t6.is_identity as smallint) AS SS_IS_IDENTITY,
+	CAST(NULL AS varchar(254)) SS_UDT_CATALOG_NAME,
+	CAST(NULL AS varchar(254)) SS_UDT_SCHEMA_NAME,
+	CAST(NULL AS varchar(254)) SS_UDT_ASSEMBLY_TYPE_NAME,
+	CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
+	CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
+	CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_NAME
+FROM 
+	pg_catalog.pg_class t1
+	JOIN sys.pg_namespace_ext t2 ON t1.relnamespace = t2.oid
+	JOIN pg_catalog.pg_roles t3 ON t1.relowner = t3.oid
+	LEFT OUTER JOIN sys.babelfish_namespace_ext ext on t2.nspname = ext.nspname
+	JOIN information_schema_tsql.columns_internal t4 ON (t1.oid = t4."TABLE_OID")
+	LEFT JOIN pg_attribute a on a.attrelid = t1.oid AND a.attname::sys.nvarchar(128) = t4."COLUMN_NAME"
+	LEFT JOIN pg_type t ON t.oid = a.atttypid
+	LEFT JOIN sys.columns t6 ON
+	(
+		t1.oid = t6.object_id AND
+		t4."ORDINAL_POSITION" = t6.column_id
+	)
+	, sys.translate_pg_type_to_tsql(a.atttypid) AS tsql_type_name
+	, sys.spt_datatype_info_table AS t5
+WHERE 
+	(t4."DATA_TYPE" = CAST(t5.TYPE_NAME AS sys.nvarchar(128)) OR (t4."DATA_TYPE" = 'bytea' AND t5.TYPE_NAME = 'image'))
+	AND ext.dbid = sys.db_id();
 
 GRANT SELECT on sys.sp_columns_100_view TO PUBLIC;
 
@@ -395,6 +407,9 @@ CREATE OR REPLACE PROCEDURE sys.sp_columns (
     "@fusepattern" smallint = 1)
 AS $$
 BEGIN
+	-- TODO: we should be able to get rid of babelfish_truncate_identifier when we fix BABEL-5416
+	declare @truncated_ident sys.nvarchar(384);
+	select @truncated_ident = sys.babelfish_truncate_identifier(pg_catalog.lower(@table_name));
 	IF @fusepattern = 1 
 		select table_qualifier as TABLE_QUALIFIER, 
 			table_owner as TABLE_OWNER,
@@ -426,20 +441,49 @@ BEGIN
 				END
 			) as SS_DATA_TYPE
 		from sys.sp_columns_100_view
-		where pg_catalog.lower(table_name) like pg_catalog.lower(sys.babelfish_truncate_identifier(@table_name)) COLLATE database_default
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_owner),'')) = '' or table_owner like sys.babelfish_truncate_identifier(@table_owner) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_qualifier),'')) = '' or table_qualifier like sys.babelfish_truncate_identifier(@table_qualifier) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@column_name),'')) = '' or column_name like sys.babelfish_truncate_identifier(@column_name) collate database_default)
+		where table_name like @truncated_ident COLLATE database_default
+			and (coalesce(@table_owner,'') = '' or table_owner like @table_owner collate database_default)
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier like @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name like @column_name collate database_default)
 		order by table_qualifier,
 				 table_owner,
 				 table_name,
 				 ordinal_position;
 	ELSE 
-		select table_qualifier, precision from sys.sp_columns_100_view
-			where sys.babelfish_truncate_identifier(@table_name) = table_name collate database_default
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_owner), '')) = '' or table_owner = sys.babelfish_truncate_identifier(@table_owner) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_qualifier),'')) = '' or table_qualifier = sys.babelfish_truncate_identifier(@table_qualifier) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@column_name),'')) = '' or column_name = sys.babelfish_truncate_identifier(@column_name) collate database_default)
+		select table_qualifier as TABLE_QUALIFIER, 
+			table_owner as TABLE_OWNER,
+			table_name as TABLE_NAME,
+			column_name as COLUMN_NAME,
+			data_type as DATA_TYPE,
+			type_name as TYPE_NAME,
+			precision as PRECISION,
+			length as LENGTH,
+			scale as SCALE,
+			radix as RADIX,
+			nullable as NULLABLE,
+			remarks as REMARKS,
+			column_def as COLUMN_DEF,
+			sql_data_type as SQL_DATA_TYPE,
+			sql_datetime_sub as SQL_DATETIME_SUB,
+			char_octet_length as CHAR_OCTET_LENGTH,
+			ordinal_position as ORDINAL_POSITION,
+			is_nullable as IS_NULLABLE,
+			(
+				CASE
+					WHEN ss_is_identity = 1 AND sql_data_type = -6 THEN 48 -- Tinyint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 5 THEN 52 -- Smallint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 4 THEN 56 -- Int Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = -5 THEN 63 -- Bigint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 3 THEN 55 -- Decimal Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 2 THEN 63 -- Numeric Identity
+					ELSE ss_data_type
+				END
+			) as SS_DATA_TYPE
+		from sys.sp_columns_100_view
+			where table_name = @truncated_ident collate database_default
+			and (coalesce(@table_owner, '') = '' or table_owner = @table_owner collate database_default)
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier = @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name = @column_name collate database_default)
 		order by table_qualifier,
 				 table_owner,
 				 table_name,
@@ -459,6 +503,9 @@ CREATE OR REPLACE PROCEDURE sys.sp_columns_100 (
     "@fusepattern" smallint = 1)
 AS $$
 BEGIN
+	-- TODO: we should be able to get rid of babelfish_truncate_identifier when we fix BABEL-5416
+	declare @truncated_ident sys.nvarchar(384);
+	select @truncated_ident = sys.babelfish_truncate_identifier(pg_catalog.lower(@table_name));
 	IF @fusepattern = 1 
 		select table_qualifier as TABLE_QUALIFIER, 
 			table_owner as TABLE_OWNER,
@@ -501,20 +548,59 @@ BEGIN
 			) as SS_DATA_TYPE
 		from sys.sp_columns_100_view
 		-- TODO: Temporary fix to use \ as escape character for now, need to remove ESCAPE clause from LIKE once we have fixed the dependencies on this procedure
-		where pg_catalog.lower(table_name) like pg_catalog.lower(sys.babelfish_truncate_identifier(@table_name)) COLLATE database_default ESCAPE '\' -- '  adding quote in comment to suppress build warning
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_owner),'')) = '' or table_owner like sys.babelfish_truncate_identifier(@table_owner) collate database_default ESCAPE '\') -- '  adding quote in comment to suppress build warning
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_qualifier),'')) = '' or table_qualifier like sys.babelfish_truncate_identifier(@table_qualifier) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@column_name),'')) = '' or column_name like sys.babelfish_truncate_identifier(@column_name) collate database_default)
+		where table_name like @truncated_ident COLLATE database_default ESCAPE '\' -- '  adding quote in comment to suppress build warning
+			and (coalesce(@table_owner,'') = '' or table_owner like @table_owner collate database_default ESCAPE '\') -- '  adding quote in comment to suppress build warning
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier like @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name like @column_name collate database_default)
 		order by table_qualifier,
 				 table_owner,
 				 table_name,
 				 ordinal_position;
 	ELSE 
-		select table_qualifier, precision from sys.sp_columns_100_view
-			where sys.babelfish_truncate_identifier(@table_name) = table_name collate database_default
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_owner), '')) = '' or table_owner = sys.babelfish_truncate_identifier(@table_owner) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@table_qualifier),'')) = '' or table_qualifier = sys.babelfish_truncate_identifier(@table_qualifier) collate database_default)
-			and ((SELECT coalesce(sys.babelfish_truncate_identifier(@column_name),'')) = '' or column_name = sys.babelfish_truncate_identifier(@column_name) collate database_default)
+		select table_qualifier as TABLE_QUALIFIER, 
+			table_owner as TABLE_OWNER,
+			table_name as TABLE_NAME,
+			column_name as COLUMN_NAME,
+			data_type as DATA_TYPE,
+			type_name as TYPE_NAME,
+			precision as PRECISION,
+			length as LENGTH,
+			scale as SCALE,
+			radix as RADIX,
+			nullable as NULLABLE,
+			remarks as REMARKS,
+			column_def as COLUMN_DEF,
+			sql_data_type as SQL_DATA_TYPE,
+			sql_datetime_sub as SQL_DATETIME_SUB,
+			char_octet_length as CHAR_OCTET_LENGTH,
+			ordinal_position as ORDINAL_POSITION,
+			is_nullable as IS_NULLABLE,
+			ss_is_sparse as SS_IS_SPARSE,
+			ss_is_column_set as SS_IS_COLUMN_SET,
+			ss_is_computed as SS_IS_COMPUTED,
+			ss_is_identity as SS_IS_IDENTITY,
+			ss_udt_catalog_name as SS_UDT_CATALOG_NAME,
+			ss_udt_schema_name as SS_UDT_SCHEMA_NAME,
+			ss_udt_assembly_type_name as SS_UDT_ASSEMBLY_TYPE_NAME,
+			ss_xml_schemacollection_catalog_name as SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
+			ss_xml_schemacollection_schema_name as SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
+			ss_xml_schemacollection_name as SS_XML_SCHEMACOLLECTION_NAME,
+			(
+				CASE
+					WHEN ss_is_identity = 1 AND sql_data_type = -6 THEN 48 -- Tinyint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 5 THEN 52 -- Smallint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 4 THEN 56 -- Int Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = -5 THEN 63 -- Bigint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 3 THEN 55 -- Decimal Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 2 THEN 63 -- Numeric Identity
+					ELSE ss_data_type
+				END
+			) as SS_DATA_TYPE
+		from sys.sp_columns_100_view
+			where table_name = @truncated_ident collate database_default
+			and (coalesce(@table_owner, '') = '' or table_owner = @table_owner collate database_default)
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier = @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name = @column_name collate database_default)
 		order by table_qualifier,
 				 table_owner,
 				 table_name,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -992,6 +992,317 @@ END;
 $$;
 GRANT EXECUTE on PROCEDURE sys.sp_rename(IN sys.nvarchar(776), IN sys.SYSNAME, IN sys.varchar(13)) TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.sp_columns_100_view AS
+SELECT 
+	CAST(t4."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
+	CAST(t4."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
+	CAST(
+		COALESCE(
+			(SELECT pg_catalog.string_agg(
+				CASE
+					WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23 /* prefix length */)
+					ELSE NULL
+				END, ',')
+			FROM unnest(t1.reloptions) AS option),
+			t4."TABLE_NAME")
+		AS sys.sysname) AS TABLE_NAME,
+	CAST(
+		COALESCE(
+			(SELECT pg_catalog.string_agg(
+				CASE
+					WHEN option LIKE 'bbf_original_name=%' THEN substring(option, 19 /* prefix length */)
+					ELSE NULL
+				END, ',')
+			FROM unnest(a.attoptions) AS option),
+			t4."COLUMN_NAME")
+		AS sys.sysname) AS COLUMN_NAME,
+	CAST(t5.data_type AS smallint) AS DATA_TYPE,
+	CAST(coalesce(tsql_type_name, t.typname) AS sys.sysname) AS TYPE_NAME,
+	CASE 
+		WHEN t4."CHARACTER_MAXIMUM_LENGTH" = -1 THEN 0::INT
+		WHEN a.atttypmod != -1
+			THEN CAST(coalesce(t4."NUMERIC_PRECISION", t4."CHARACTER_MAXIMUM_LENGTH", sys.tsql_type_precision_helper(t4."DATA_TYPE", a.atttypmod)) AS INT)
+		WHEN tsql_type_name = 'timestamp'
+			THEN 8
+		ELSE
+			CAST(coalesce(t4."NUMERIC_PRECISION", t4."CHARACTER_MAXIMUM_LENGTH", sys.tsql_type_precision_helper(t4."DATA_TYPE", t.typtypmod)) AS INT)
+	END AS PRECISION,
+	CASE 
+		WHEN a.atttypmod != -1
+			THEN CAST(sys.tsql_type_length_for_sp_columns_helper(t4."DATA_TYPE", a.attlen, a.atttypmod) AS int)
+		ELSE
+			CAST(sys.tsql_type_length_for_sp_columns_helper(t4."DATA_TYPE", a.attlen, t.typtypmod) AS int)
+	END AS LENGTH,
+	CASE 
+		WHEN a.atttypmod != -1
+			THEN CAST(coalesce(t4."NUMERIC_SCALE", sys.tsql_type_scale_helper(t4."DATA_TYPE", a.atttypmod, true)) AS smallint)
+		ELSE
+			CAST(coalesce(t4."NUMERIC_SCALE", sys.tsql_type_scale_helper(t4."DATA_TYPE", t.typtypmod, true)) AS smallint)
+	END AS SCALE,
+	CAST(coalesce(t4."NUMERIC_PRECISION_RADIX", sys.tsql_type_radix_for_sp_columns_helper(t4."DATA_TYPE")) AS smallint) AS RADIX,
+	CASE 
+		WHEN t4."IS_NULLABLE" = 'YES'
+			THEN CAST(1 AS smallint)
+		ELSE
+			CAST(0 AS smallint)
+	END AS NULLABLE,
+	CAST(NULL AS varchar(254)) AS remarks,
+	CAST(t4."COLUMN_DEFAULT" AS sys.nvarchar(4000)) AS COLUMN_DEF,
+	CAST(t5.sql_data_type AS smallint) AS SQL_DATA_TYPE,
+	CAST(t5.SQL_DATETIME_SUB AS smallint) AS SQL_DATETIME_SUB,
+	CASE 
+		WHEN t4."DATA_TYPE" = 'xml' THEN 0::INT
+		WHEN t4."DATA_TYPE" = 'sql_variant' THEN 8000::INT
+		WHEN t4."CHARACTER_MAXIMUM_LENGTH" = -1 THEN 0::INT
+		ELSE CAST(t4."CHARACTER_OCTET_LENGTH" AS int)
+	END AS CHAR_OCTET_LENGTH,
+	CAST(t4."ORDINAL_POSITION" AS int) AS ORDINAL_POSITION,
+	CAST(t4."IS_NULLABLE" AS varchar(254)) AS IS_NULLABLE,
+	CAST(t5.ss_data_type AS sys.tinyint) AS SS_DATA_TYPE,
+	CAST(0 AS smallint) AS SS_IS_SPARSE,
+	CAST(0 AS smallint) AS SS_IS_COLUMN_SET,
+	CAST(t6.is_computed as smallint) AS SS_IS_COMPUTED,
+	CAST(t6.is_identity as smallint) AS SS_IS_IDENTITY,
+	CAST(NULL AS varchar(254)) SS_UDT_CATALOG_NAME,
+	CAST(NULL AS varchar(254)) SS_UDT_SCHEMA_NAME,
+	CAST(NULL AS varchar(254)) SS_UDT_ASSEMBLY_TYPE_NAME,
+	CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
+	CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
+	CAST(NULL AS varchar(254)) SS_XML_SCHEMACOLLECTION_NAME
+FROM 
+	pg_catalog.pg_class t1
+	JOIN sys.pg_namespace_ext t2 ON t1.relnamespace = t2.oid
+	JOIN pg_catalog.pg_roles t3 ON t1.relowner = t3.oid
+	LEFT OUTER JOIN sys.babelfish_namespace_ext ext on t2.nspname = ext.nspname
+	JOIN information_schema_tsql.columns_internal t4 ON (t1.oid = t4."TABLE_OID")
+	LEFT JOIN pg_attribute a on a.attrelid = t1.oid AND a.attname::sys.nvarchar(128) = t4."COLUMN_NAME"
+	LEFT JOIN pg_type t ON t.oid = a.atttypid
+	LEFT JOIN sys.columns t6 ON
+	(
+		t1.oid = t6.object_id AND
+		t4."ORDINAL_POSITION" = t6.column_id
+	)
+	, sys.translate_pg_type_to_tsql(a.atttypid) AS tsql_type_name
+	, sys.spt_datatype_info_table AS t5
+WHERE 
+	(t4."DATA_TYPE" = CAST(t5.TYPE_NAME AS sys.nvarchar(128)) OR (t4."DATA_TYPE" = 'bytea' AND t5.TYPE_NAME = 'image'))
+	AND ext.dbid = sys.db_id();
+
+GRANT SELECT on sys.sp_columns_100_view TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_columns (
+	"@table_name" sys.nvarchar(384),
+    "@table_owner" sys.nvarchar(384) = '', 
+    "@table_qualifier" sys.nvarchar(384) = '',
+    "@column_name" sys.nvarchar(384) = '',
+	"@namescope" int = 0,
+    "@odbcver" int = 2,
+    "@fusepattern" smallint = 1)
+AS $$
+BEGIN
+	-- TODO: we should be able to get rid of babelfish_truncate_identifier when we fix BABEL-5416
+	declare @truncated_ident sys.nvarchar(384);
+	select @truncated_ident = sys.babelfish_truncate_identifier(pg_catalog.lower(@table_name));
+	IF @fusepattern = 1 
+		select table_qualifier as TABLE_QUALIFIER, 
+			table_owner as TABLE_OWNER,
+			table_name as TABLE_NAME,
+			column_name as COLUMN_NAME,
+			data_type as DATA_TYPE,
+			type_name as TYPE_NAME,
+			precision as PRECISION,
+			length as LENGTH,
+			scale as SCALE,
+			radix as RADIX,
+			nullable as NULLABLE,
+			remarks as REMARKS,
+			column_def as COLUMN_DEF,
+			sql_data_type as SQL_DATA_TYPE,
+			sql_datetime_sub as SQL_DATETIME_SUB,
+			char_octet_length as CHAR_OCTET_LENGTH,
+			ordinal_position as ORDINAL_POSITION,
+			is_nullable as IS_NULLABLE,
+			(
+				CASE
+					WHEN ss_is_identity = 1 AND sql_data_type = -6 THEN 48 -- Tinyint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 5 THEN 52 -- Smallint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 4 THEN 56 -- Int Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = -5 THEN 63 -- Bigint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 3 THEN 55 -- Decimal Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 2 THEN 63 -- Numeric Identity
+					ELSE ss_data_type
+				END
+			) as SS_DATA_TYPE
+		from sys.sp_columns_100_view
+		where table_name like @truncated_ident COLLATE database_default
+			and (coalesce(@table_owner,'') = '' or table_owner like @table_owner collate database_default)
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier like @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name like @column_name collate database_default)
+		order by table_qualifier,
+				 table_owner,
+				 table_name,
+				 ordinal_position;
+	ELSE 
+		select table_qualifier as TABLE_QUALIFIER, 
+			table_owner as TABLE_OWNER,
+			table_name as TABLE_NAME,
+			column_name as COLUMN_NAME,
+			data_type as DATA_TYPE,
+			type_name as TYPE_NAME,
+			precision as PRECISION,
+			length as LENGTH,
+			scale as SCALE,
+			radix as RADIX,
+			nullable as NULLABLE,
+			remarks as REMARKS,
+			column_def as COLUMN_DEF,
+			sql_data_type as SQL_DATA_TYPE,
+			sql_datetime_sub as SQL_DATETIME_SUB,
+			char_octet_length as CHAR_OCTET_LENGTH,
+			ordinal_position as ORDINAL_POSITION,
+			is_nullable as IS_NULLABLE,
+			(
+				CASE
+					WHEN ss_is_identity = 1 AND sql_data_type = -6 THEN 48 -- Tinyint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 5 THEN 52 -- Smallint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 4 THEN 56 -- Int Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = -5 THEN 63 -- Bigint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 3 THEN 55 -- Decimal Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 2 THEN 63 -- Numeric Identity
+					ELSE ss_data_type
+				END
+			) as SS_DATA_TYPE
+		from sys.sp_columns_100_view
+			where table_name = @truncated_ident collate database_default
+			and (coalesce(@table_owner, '') = '' or table_owner = @table_owner collate database_default)
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier = @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name = @column_name collate database_default)
+		order by table_qualifier,
+				 table_owner,
+				 table_name,
+				 ordinal_position;
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT ALL on PROCEDURE sys.sp_columns TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_columns_100 (
+	"@table_name" sys.nvarchar(384),
+    "@table_owner" sys.nvarchar(384) = '', 
+    "@table_qualifier" sys.nvarchar(384) = '',
+    "@column_name" sys.nvarchar(384) = '',
+	"@namescope" int = 0,
+    "@odbcver" int = 2,
+    "@fusepattern" smallint = 1)
+AS $$
+BEGIN
+	-- TODO: we should be able to get rid of babelfish_truncate_identifier when we fix BABEL-5416
+	declare @truncated_ident sys.nvarchar(384);
+	select @truncated_ident = sys.babelfish_truncate_identifier(pg_catalog.lower(@table_name));
+	IF @fusepattern = 1 
+		select table_qualifier as TABLE_QUALIFIER, 
+			table_owner as TABLE_OWNER,
+			table_name as TABLE_NAME,
+			column_name as COLUMN_NAME,
+			data_type as DATA_TYPE,
+			type_name as TYPE_NAME,
+			precision as PRECISION,
+			length as LENGTH,
+			scale as SCALE,
+			radix as RADIX,
+			nullable as NULLABLE,
+			remarks as REMARKS,
+			column_def as COLUMN_DEF,
+			sql_data_type as SQL_DATA_TYPE,
+			sql_datetime_sub as SQL_DATETIME_SUB,
+			char_octet_length as CHAR_OCTET_LENGTH,
+			ordinal_position as ORDINAL_POSITION,
+			is_nullable as IS_NULLABLE,
+			ss_is_sparse as SS_IS_SPARSE,
+			ss_is_column_set as SS_IS_COLUMN_SET,
+			ss_is_computed as SS_IS_COMPUTED,
+			ss_is_identity as SS_IS_IDENTITY,
+			ss_udt_catalog_name as SS_UDT_CATALOG_NAME,
+			ss_udt_schema_name as SS_UDT_SCHEMA_NAME,
+			ss_udt_assembly_type_name as SS_UDT_ASSEMBLY_TYPE_NAME,
+			ss_xml_schemacollection_catalog_name as SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
+			ss_xml_schemacollection_schema_name as SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
+			ss_xml_schemacollection_name as SS_XML_SCHEMACOLLECTION_NAME,
+			(
+				CASE
+					WHEN ss_is_identity = 1 AND sql_data_type = -6 THEN 48 -- Tinyint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 5 THEN 52 -- Smallint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 4 THEN 56 -- Int Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = -5 THEN 63 -- Bigint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 3 THEN 55 -- Decimal Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 2 THEN 63 -- Numeric Identity
+					ELSE ss_data_type
+				END
+			) as SS_DATA_TYPE
+		from sys.sp_columns_100_view
+		-- TODO: Temporary fix to use \ as escape character for now, need to remove ESCAPE clause from LIKE once we have fixed the dependencies on this procedure
+		where table_name like @truncated_ident COLLATE database_default ESCAPE '\' -- '  adding quote in comment to suppress build warning
+			and (coalesce(@table_owner,'') = '' or table_owner like @table_owner collate database_default ESCAPE '\') -- '  adding quote in comment to suppress build warning
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier like @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name like @column_name collate database_default)
+		order by table_qualifier,
+				 table_owner,
+				 table_name,
+				 ordinal_position;
+	ELSE 
+		select table_qualifier as TABLE_QUALIFIER, 
+			table_owner as TABLE_OWNER,
+			table_name as TABLE_NAME,
+			column_name as COLUMN_NAME,
+			data_type as DATA_TYPE,
+			type_name as TYPE_NAME,
+			precision as PRECISION,
+			length as LENGTH,
+			scale as SCALE,
+			radix as RADIX,
+			nullable as NULLABLE,
+			remarks as REMARKS,
+			column_def as COLUMN_DEF,
+			sql_data_type as SQL_DATA_TYPE,
+			sql_datetime_sub as SQL_DATETIME_SUB,
+			char_octet_length as CHAR_OCTET_LENGTH,
+			ordinal_position as ORDINAL_POSITION,
+			is_nullable as IS_NULLABLE,
+			ss_is_sparse as SS_IS_SPARSE,
+			ss_is_column_set as SS_IS_COLUMN_SET,
+			ss_is_computed as SS_IS_COMPUTED,
+			ss_is_identity as SS_IS_IDENTITY,
+			ss_udt_catalog_name as SS_UDT_CATALOG_NAME,
+			ss_udt_schema_name as SS_UDT_SCHEMA_NAME,
+			ss_udt_assembly_type_name as SS_UDT_ASSEMBLY_TYPE_NAME,
+			ss_xml_schemacollection_catalog_name as SS_XML_SCHEMACOLLECTION_CATALOG_NAME,
+			ss_xml_schemacollection_schema_name as SS_XML_SCHEMACOLLECTION_SCHEMA_NAME,
+			ss_xml_schemacollection_name as SS_XML_SCHEMACOLLECTION_NAME,
+			(
+				CASE
+					WHEN ss_is_identity = 1 AND sql_data_type = -6 THEN 48 -- Tinyint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 5 THEN 52 -- Smallint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 4 THEN 56 -- Int Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = -5 THEN 63 -- Bigint Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 3 THEN 55 -- Decimal Identity
+					WHEN ss_is_identity = 1 AND sql_data_type = 2 THEN 63 -- Numeric Identity
+					ELSE ss_data_type
+				END
+			) as SS_DATA_TYPE
+		from sys.sp_columns_100_view
+			where table_name = @truncated_ident collate database_default
+			and (coalesce(@table_owner, '') = '' or table_owner = @table_owner collate database_default)
+			and (coalesce(@table_qualifier,'') = '' or table_qualifier = @table_qualifier collate database_default)
+			and (coalesce(@column_name,'') = '' or column_name = @column_name collate database_default)
+		order by table_qualifier,
+				 table_owner,
+				 table_name,
+				 ordinal_position;
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT ALL on PROCEDURE sys.sp_columns_100 TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/BABEL-SPCOLUMNS-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SPCOLUMNS-vu-verify.out
@@ -71,7 +71,7 @@ babel_sp_columns_vu_prepare_mydb1#!#dbo#!#babel_sp_columns_vu_prepare_t_money#!#
 EXEC sp_columns_100 '%_money', 'dbo', NULL, NULL, 0, 2, 0
 GO
 ~~START~~
-varchar#!#int
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-SPCOLUMNS.out
+++ b/test/JDBC/expected/BABEL-SPCOLUMNS.out
@@ -83,7 +83,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 '%_money', 'dbo', NULL, NULL, 0, 2, 0
 GO
 ~~START~~
-varchar#!#int
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 
@@ -229,7 +229,7 @@ mydb1#!#dbo#!#t_money#!#a#!#3#!#money#!#19#!#21#!#4#!#10#!#1#!#<NULL>#!#<NULL>#!
 EXEC sp_columns_100 '%_money', 'dbo', NULL, NULL, 0, 2, 0
 GO
 ~~START~~
-varchar#!#int
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/BABEL-SPCOLUMNS-vu-verify.out
+++ b/test/JDBC/expected/db_collation/BABEL-SPCOLUMNS-vu-verify.out
@@ -71,7 +71,7 @@ babel_sp_columns_vu_prepare_mydb1#!#dbo#!#babel_sp_columns_vu_prepare_t_money#!#
 EXEC sp_columns_100 '%_money', 'dbo', NULL, NULL, 0, 2, 0
 GO
 ~~START~~
-varchar#!#int
+varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/sp_columns_100.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/sp_columns_100.out
@@ -744,9 +744,9 @@ EXEC sys.sp_columns_100 N'テーブル'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
-master#!#dbo#!#????#!#??#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#名前#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -754,9 +754,9 @@ EXEC sys.sp_columns_100 N'テーブル%'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
-master#!#dbo#!#????#!#??#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#名前#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -764,9 +764,9 @@ EXEC sys.sp_columns_100 N'テーブル', @fUsePattern = 0
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
-master#!#dbo#!#????#!#??#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#名前#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -774,9 +774,9 @@ EXEC sys.sp_columns_100 N'テーブル', 'dbo'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
-master#!#dbo#!#????#!#??#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#ID#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#名前#!#-9#!#nvarchar#!#50#!#100#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#100#!#2#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#39
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -784,7 +784,7 @@ EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -792,7 +792,7 @@ EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢%'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -807,7 +807,7 @@ EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢', @fUsePattern 
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#????#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル#!#年齢#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#3#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -823,7 +823,7 @@ EXEC sys.sp_columns_100 N'テーブル 名前'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#???? ??#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル 名前#!#名前#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -831,7 +831,7 @@ EXEC sys.sp_columns_100  N'テーブル 名前', @column_name = N'名前'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#???? ??#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル 名前#!#名前#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -839,7 +839,7 @@ EXEC sys.sp_columns_100  N'%テーブル 名前', @column_name = N'名前%'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#???? ??#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル 名前#!#名前#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -847,7 +847,7 @@ EXEC sys.sp_columns_100  N'%テーブル[ ]名前', @column_name = N'名前%'
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#???? ??#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル 名前#!#名前#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 
@@ -855,7 +855,7 @@ EXEC sys.sp_columns_100  N'テーブル 名前', @column_name = N'名前', @fUse
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#smallint#!#varchar#!#int#!#int#!#smallint#!#smallint#!#smallint#!#varchar#!#nvarchar#!#smallint#!#smallint#!#int#!#int#!#varchar#!#smallint#!#smallint#!#smallint#!#smallint#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#int
-master#!#dbo#!#???? ??#!#??#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
+master#!#dbo#!#テーブル 名前#!#名前#!#4#!#int#!#10#!#4#!#0#!#10#!#1#!#<NULL>#!#<NULL>#!#4#!#<NULL>#!#<NULL>#!#1#!#YES#!#0#!#0#!#0#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#38
 ~~END~~
 
 

--- a/test/JDBC/input/BABEL-SPCOLUMNS.sql
+++ b/test/JDBC/input/BABEL-SPCOLUMNS.sql
@@ -1,3 +1,4 @@
+-- sla_for_parallel_query_enforced 60000
 USE master
 GO
 CREATE DATABASE mydb1

--- a/test/JDBC/input/sp_columns_100.sql
+++ b/test/JDBC/input/sp_columns_100.sql
@@ -1,4 +1,4 @@
--- sla_for_parallel_query_enforced 150000
+-- sla_for_parallel_query_enforced 1500000
 -- create tables with most of the datatypes
 create table var(a char(10), b nchar(9), c nvarchar(8), d varchar(7), e text, f ntext, g varbinary(10), h binary(9), i image, j xml)
 go

--- a/test/JDBC/input/sp_columns_100.sql
+++ b/test/JDBC/input/sp_columns_100.sql
@@ -316,3 +316,214 @@ go
 drop database sp_cols
 go
 
+-- regular identifier
+CREATE TABLE RegularTable (RegularColumn int, Name varchar(50))
+GO
+
+EXEC sys.sp_columns_100 'RegularTable%'
+GO
+
+EXEC sys.sp_columns_100 '%regulartable'
+GO
+
+EXEC sys.sp_columns_100 'regulartable', @column_name = 'RegularColumn'
+GO
+
+EXEC sys.sp_columns_100 'regulartable', @column_name = 'regularColumn'
+GO
+
+EXEC sys.sp_columns_100 'RegularTable', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 'regulartable', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 'regulartable', @column_name = 'RegularColumn', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 'regulartable', @column_name = 'regularColumn', @fUsePattern = 0
+GO
+
+
+EXEC sys.sp_columns_100 'regulartable%', @column_name = 'regularColumn', @fUsePattern = 0
+GO
+
+DROP TABLE RegularTable
+GO
+
+-- quoted identifiers 
+CREATE TABLE [Quoted Table] (ID int, Name varchar(50))
+GO
+
+EXEC sys.sp_columns_100 'Quoted Table'
+GO
+
+EXEC sys.sp_columns_100 'Quoted[ ]Table%'
+GO
+
+EXEC sys.sp_columns_100 'Quoted table'
+GO
+
+EXEC sys.sp_columns_100 'Quoted table', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 'Quoted table', @column_name = 'id'
+GO
+
+EXEC sys.sp_columns_100 'Quoted table', @column_name = 'i[d]'
+GO
+
+EXEC sys.sp_columns_100 'Quoted table', @column_name = 'id', @fUsePattern = 0
+GO
+
+DROP TABLE [Quoted Table]
+GO
+
+-- regular identifier with chinese chars
+CREATE TABLE [テーブル] (ID int, [名前] nvarchar(50), [年齢] int)
+GO
+
+EXEC sys.sp_columns_100 N'テーブル'
+GO
+
+EXEC sys.sp_columns_100 N'テーブル%'
+GO
+
+EXEC sys.sp_columns_100 N'テーブル', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 N'テーブル', 'dbo'
+GO
+
+EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢'
+GO
+
+EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢%'
+GO
+
+EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢%', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 N'テーブル', @column_name = N'年齢', @fUsePattern = 0
+GO
+
+DROP TABLE [テーブル]
+GO
+
+-- quoted identifiers with chinese chars
+
+CREATE TABLE [テーブル 名前] ([名前] int)
+GO
+
+EXEC sys.sp_columns_100 N'テーブル 名前'
+GO
+
+EXEC sys.sp_columns_100  N'テーブル 名前', @column_name = N'名前'
+GO
+
+EXEC sys.sp_columns_100  N'%テーブル 名前', @column_name = N'名前%'
+GO
+
+EXEC sys.sp_columns_100  N'%テーブル[ ]名前', @column_name = N'名前%'
+GO
+
+EXEC sys.sp_columns_100  N'テーブル 名前', @column_name = N'名前', @fUsePattern = 0
+GO
+
+DROP TABLE [テーブル 名前] 
+GO
+
+-- regular identifiers with length > 63
+CREATE TABLE dbo.tidentityintbiddgwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63(a int)
+GO
+
+EXEC sys.sp_columns_100 'tidentityintbiddgwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63'
+GO
+
+EXEC sys.sp_columns_100 'tidentityintbiddgwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63', @fUsePattern = 0
+GO
+
+-- should be fixed with BABEL-5416
+EXEC sys.sp_columns_100 '%tidentityintbiddgwithareallylongtablenamewhickcausesbabelfish%'
+GO
+
+drop table tidentityintbiddgwithareallylongtablenamewhickcausesbabelfishtoaddahashcodetothenamebecauseofdefault63
+GO
+
+create table long_colname(xnffrfrfrfrfjvndjknvjkdfnvjnxfjnvjkxnvjnxfjknvjfnvjkxnfjkvbxjkvjkxfbnvjkbxfkjvbxfkjbvkxfjbvkjxfbvjkfxb int)
+GO
+
+EXEC sys.sp_columns_100 'long_colname'
+GO
+
+EXEC sys.sp_columns_100 'long_colname', @column_name = 'xnffrfrfrfrfjvndjknvjkdfnvjnxfjnvjkxnvjnxfjknvjfnvjkxnfjkvbxjkvjkxfbnvjkbxfkjvbxfkjbvkxfjbvkjxfbvjkfxb'
+GO
+
+EXEC sys.sp_columns_100 'long_colname', @column_name = 'xnffrfrfrfrfjvndjknvjkdfnvjnxfjnvjkxnvjnxfjknvjfnvjkxnfjkvbxjkvjkxfbnvjkbxfkjvbxfkjbvkxfjbvkjxfbvjkfxb', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 'long_colname', @column_name = 'xnffrfrfrfrfjvndjknvjkdfnvjnxfjnvjkxnvjnxfjknvjfnvjkxnfjkvbxjkvjkxfbnvjkbxfkjvbxfkjbvkxfjbvkjxfbvjkfxb'
+GO
+
+drop table long_colname
+GO
+
+-- quoted identifiers with length > 63
+
+CREATE TABLE [tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63](a int)
+GO
+
+EXEC sys.sp_columns_100 N'tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63'
+GO
+
+EXEC sys.sp_columns_100 N'tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63', @fUsePattern = 0
+GO
+
+-- should be fixed with BABEL-5416
+EXEC sys.sp_columns_100 N'tide[ ]Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63'
+GO
+
+DROP TABLE [tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63]
+GO
+
+create table long_col_name ([tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63] int)
+GO
+
+EXEC sys.sp_columns_100 N'long_col_name', @column_name = 'tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63'
+GO
+
+EXEC sys.sp_columns_100 N'long_col_name', @column_name = 'tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63', @fUsePattern = 0
+GO
+
+EXEC sys.sp_columns_100 N'long_col_name', @column_name = 'tide[ ]Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63'
+GO
+
+EXEC sys.sp_columns_100 N'long_col_name', @column_name = 'Tide Ntityintbiddgwithareallyl ongtablenamewhickcausesbabelfishtoaddahadddededjnfjsnjfbsd bbfjdhft63'
+GO
+
+DROP table long_col_name
+GO
+
+CREATE SCHEMA [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema]
+GO
+
+CREATE TABLE [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema].[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongTable] (ID int)
+GO
+
+EXEC sys.sp_columns_100 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongTable', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema'
+GO
+
+EXEC sys.sp_columns_100 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongTable', 'ABCdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema'
+GO
+
+EXEC sys.sp_columns_100 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongTable', 'ABCdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789[_]LongSchema'
+GO
+
+EXEC sys.sp_columns_100 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongTable', 'ABCdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema', @fUsePattern = 0
+GO
+
+DROP TABLE [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema].[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongTable]
+GO
+
+DROP SCHEMA [abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_LongSchema]
+GO


### PR DESCRIPTION


Previously, the parameter value @fUsePattern=0 is broken for sp_columns_100, returning only a partial data set. Also, overall handling of identifier was incorrect when it comes to truncation of identifiers. This commit aims to fix these issue by appropriately using truncate function as well as fixes issue of @fUsePattern=0 which now should return proper data.

Task: BABEL-5314

Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).