### PR TITLE
Fix namespace for string functions in system views/functions

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -866,10 +866,10 @@ BEGIN
             CAST(is_filestream AS int)
         FROM sys.spt_columns_view_managed s_cv
         WHERE
-        (in_catalog IS NULL OR s_cv.TABLE_CATALOG LIKE LOWER(in_catalog)) AND
-        (in_owner IS NULL OR s_cv.TABLE_SCHEMA LIKE LOWER(in_owner)) AND
-        (in_table IS NULL OR s_cv.TABLE_NAME LIKE LOWER(in_table)) AND
-        (in_column IS NULL OR s_cv.COLUMN_NAME LIKE LOWER(in_column)) AND
+        (in_catalog IS NULL OR s_cv.TABLE_CATALOG LIKE pg_catalog.lower(in_catalog)) AND
+        (in_owner IS NULL OR s_cv.TABLE_SCHEMA LIKE pg_catalog.lower(in_owner)) AND
+        (in_table IS NULL OR s_cv.TABLE_NAME LIKE pg_catalog.lower(in_table)) AND
+        (in_column IS NULL OR s_cv.COLUMN_NAME LIKE pg_catalog.lower(in_column)) AND
         (in_schematype = 0 AND (s_cv.IS_SPARSE = 0) OR in_schematype = 1 OR in_schematype = 2 AND (s_cv.IS_SPARSE = 1));
 END;
 $$
@@ -1011,7 +1011,7 @@ BEGIN
 
 	SELECT @current_db_name = sys.db_name();
 
-	IF (@table_qualifier != '' AND LOWER(@table_qualifier) != LOWER(@current_db_name))
+	IF (@table_qualifier != '' AND pg_catalog.lower(@table_qualifier) != pg_catalog.lower(@current_db_name))
 	BEGIN
 		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
 	END
@@ -1203,7 +1203,7 @@ CAST(t1.relname AS sys.sysname) AS INDEX_QUALIFIER,
 -- the ones not in pg_constraint) and restoring it back before display
 CASE 
 WHEN t8.oid > 0 THEN CAST(t6.relname AS sys.sysname)
-ELSE CAST(SUBSTRING(t6.relname,1,LENGTH(t6.relname)-32-LENGTH(t1.relname)) AS sys.sysname) 
+ELSE CAST(pg_catalog.SUBSTRING(t6.relname,1,LENGTH(t6.relname)-32-LENGTH(t1.relname)) AS sys.sysname) 
 END AS INDEX_NAME,
 CASE
 WHEN t5.indisclustered = 't' THEN CAST(1 AS smallint)
@@ -1416,7 +1416,7 @@ CREATE OR REPLACE PROCEDURE sys.sp_column_privileges(
 )
 AS $$
 BEGIN
-    IF (@table_qualifier != '') AND (LOWER(@table_qualifier) != LOWER(sys.db_name()))
+    IF (@table_qualifier != '') AND (pg_catalog.lower(@table_qualifier) != pg_catalog.lower(sys.db_name()))
 	BEGIN
 		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
 	END
@@ -1426,7 +1426,7 @@ BEGIN
 		
 		IF EXISTS ( 
 			SELECT * FROM sys.sp_column_privileges_view 
-			WHERE LOWER(@table_name) = LOWER(table_name) and LOWER(SCHEMA_NAME()) = LOWER(table_qualifier)
+			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name) and pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_qualifier)
 			)
 		BEGIN 
 			SELECT 
@@ -1439,10 +1439,10 @@ BEGIN
 			PRIVILEGE,
 			IS_GRANTABLE
 			FROM sys.sp_column_privileges_view
-			WHERE LOWER(@table_name) = LOWER(table_name)
-				AND (LOWER(SCHEMA_NAME()) = LOWER(table_owner))
-				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@table_qualifier))
-				AND ((SELECT COALESCE(@column_name,'')) = '' OR LOWER(column_name) LIKE LOWER(@column_name))
+			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND (pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_owner))
+				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
 			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
 		END
 		ELSE
@@ -1457,10 +1457,10 @@ BEGIN
 			PRIVILEGE,
 			IS_GRANTABLE
 			FROM sys.sp_column_privileges_view
-			WHERE LOWER(@table_name) = LOWER(table_name)
-				AND (LOWER('dbo')= LOWER(table_owner))
-				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@table_qualifier))
-				AND ((SELECT COALESCE(@column_name,'')) = '' OR LOWER(column_name) LIKE LOWER(@column_name))
+			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND (pg_catalog.lower('dbo')= pg_catalog.lower(table_owner))
+				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
 			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
 		END
 	END
@@ -1476,10 +1476,10 @@ BEGIN
 		PRIVILEGE,
 		IS_GRANTABLE
 		FROM sys.sp_column_privileges_view
-		WHERE LOWER(@table_name) = LOWER(table_name)
-			AND ((SELECT COALESCE(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-			AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@table_qualifier))
-			AND ((SELECT COALESCE(@column_name,'')) = '' OR LOWER(column_name) LIKE LOWER(@column_name))
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND ((SELECT COALESCE(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+			AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+			AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
 		ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
 	END
 END; 
@@ -1525,7 +1525,7 @@ CREATE OR REPLACE PROCEDURE sys.sp_table_privileges(
 AS $$
 BEGIN
 	
-	IF (@table_qualifier != '') AND (LOWER(@table_qualifier) != LOWER(sys.db_name()))
+	IF (@table_qualifier != '') AND (pg_catalog.lower(@table_qualifier) != pg_catalog.lower(sys.db_name()))
 	BEGIN
 		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
 	END
@@ -1540,8 +1540,8 @@ BEGIN
 		GRANTEE,
 		PRIVILEGE,
 		IS_GRANTABLE FROM sys.sp_table_privileges_view
-		WHERE LOWER(TABLE_NAME) LIKE LOWER(@table_name)
-			AND ((SELECT COALESCE(@table_owner,'')) = '' OR LOWER(TABLE_OWNER) LIKE LOWER(@table_owner))
+		WHERE pg_catalog.lower(TABLE_NAME) LIKE pg_catalog.lower(@table_name)
+			AND ((SELECT COALESCE(@table_owner,'')) = '' OR pg_catalog.lower(TABLE_OWNER) LIKE pg_catalog.lower(@table_owner))
 		ORDER BY table_qualifier, table_owner, table_name, privilege, grantee;
 	END
 	ELSE 
@@ -1554,8 +1554,8 @@ BEGIN
 		GRANTEE,
 		PRIVILEGE,
 		IS_GRANTABLE FROM sys.sp_table_privileges_view
-		WHERE LOWER(TABLE_NAME) = LOWER(@table_name)
-			AND ((SELECT COALESCE(@table_owner,'')) = '' OR LOWER(TABLE_OWNER) = LOWER(@table_owner))
+		WHERE pg_catalog.lower(TABLE_NAME) = pg_catalog.lower(@table_name)
+			AND ((SELECT COALESCE(@table_owner,'')) = '' OR pg_catalog.lower(TABLE_OWNER) = pg_catalog.lower(@table_owner))
 		ORDER BY table_qualifier, table_owner, table_name, privilege, grantee;
 	END
 	
@@ -1667,23 +1667,23 @@ AS $$
 DECLARE @special_col_type sys.sysname;
 DECLARE @constraint_name sys.sysname;
 BEGIN
-	IF (@qualifier != '') AND (LOWER(@qualifier) != LOWER(sys.db_name()))
+	IF (@qualifier != '') AND (pg_catalog.lower(@qualifier) != pg_catalog.lower(sys.db_name()))
 	BEGIN
 		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
 		
 	END
 	
-	IF (LOWER(@col_type) = LOWER('V'))
+	IF (pg_catalog.lower(@col_type) = pg_catalog.lower('V'))
 	BEGIN
 		THROW 33557097, N'TIMESTAMP datatype is not currently supported in Babelfish', 1;
 	END
 	
-	IF (LOWER(@nullable) = LOWER('O'))
+	IF (pg_catalog.lower(@nullable) = pg_catalog.lower('O'))
 	BEGIN
 		SELECT TOP 1 @special_col_type = constraint_type, @constraint_name = constraint_name FROM sys.sp_special_columns_view
-		WHERE LOWER(@table_name) = LOWER(table_name)
-			AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-			AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND (is_nullable = 0)
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+			AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0)
 		ORDER BY constraint_type, index_id;
 	
 		IF @special_col_type='u'
@@ -1699,9 +1699,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND (is_nullable = 0) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND @constraint_name = constraint_name
 				ORDER BY scope, column_name;
 				
@@ -1717,9 +1717,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND (is_nullable = 0) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND @constraint_name = constraint_name
 				ORDER BY scope, column_name;
 			END
@@ -1739,9 +1739,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND (is_nullable = 0) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND CONSTRAINT_TYPE = 'p'
 				ORDER BY scope, column_name;
 			END
@@ -1755,9 +1755,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN  FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND (is_nullable = 0) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND CONSTRAINT_TYPE = 'p'
 				ORDER BY scope, column_name;
 			END
@@ -1767,9 +1767,9 @@ BEGIN
 	ELSE 
 	BEGIN
 		SELECT TOP 1 @special_col_type = constraint_type, @constraint_name = constraint_name FROM sys.sp_special_columns_view
-		WHERE LOWER(@table_name) = LOWER(table_name)
-			AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-			AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier))
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+			AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier))
 		ORDER BY constraint_type, index_id;
 
 		IF @special_col_type='u'
@@ -1785,9 +1785,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND @constraint_name = constraint_name
 				ORDER BY scope, column_name;
 			END
@@ -1802,9 +1802,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND @constraint_name = constraint_name
 				ORDER BY scope, column_name;
 			END
@@ -1823,9 +1823,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND CONSTRAINT_TYPE = 'p'
 				ORDER BY scope, column_name; 
 			END
@@ -1840,9 +1840,9 @@ BEGIN
 				LENGTH,
 				SCALE,
 				PSEUDO_COLUMN FROM sys.sp_special_columns_view
-				WHERE LOWER(@table_name) = LOWER(table_name)
-				AND ((SELECT coalesce(@table_owner,'')) = '' OR LOWER(table_owner) = LOWER(@table_owner))
-				AND ((SELECT coalesce(@qualifier,'')) = '' OR LOWER(table_qualifier) = LOWER(@qualifier)) AND LOWER(constraint_type) = LOWER(@special_col_type)
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
 				AND CONSTRAINT_TYPE = 'p'
 				ORDER BY scope, column_name;
 			END
@@ -1974,12 +1974,12 @@ BEGIN
 	PK_NAME,
 	DEFERRABILITY
 	FROM sys.sp_fkeys_view
-	WHERE ((SELECT coalesce(@pktable_name,'')) = '' OR LOWER(pktable_name) = LOWER(@pktable_name))
-		AND ((SELECT coalesce(@fktable_name,'')) = '' OR LOWER(fktable_name) = LOWER(@fktable_name))
-		AND ((SELECT coalesce(@pktable_owner,'')) = '' OR LOWER(pktable_owner) = LOWER(@pktable_owner))
-		AND ((SELECT coalesce(@pktable_qualifier,'')) = '' OR LOWER(pktable_qualifier) = LOWER(@pktable_qualifier))
-		AND ((SELECT coalesce(@fktable_owner,'')) = '' OR LOWER(fktable_owner) = LOWER(@fktable_owner))
-		AND ((SELECT coalesce(@fktable_qualifier,'')) = '' OR LOWER(fktable_qualifier) = LOWER(@fktable_qualifier))
+	WHERE ((SELECT coalesce(@pktable_name,'')) = '' OR pg_catalog.lower(pktable_name) = pg_catalog.lower(@pktable_name))
+		AND ((SELECT coalesce(@fktable_name,'')) = '' OR pg_catalog.lower(fktable_name) = pg_catalog.lower(@fktable_name))
+		AND ((SELECT coalesce(@pktable_owner,'')) = '' OR pg_catalog.lower(pktable_owner) = pg_catalog.lower(@pktable_owner))
+		AND ((SELECT coalesce(@pktable_qualifier,'')) = '' OR pg_catalog.lower(pktable_qualifier) = pg_catalog.lower(@pktable_qualifier))
+		AND ((SELECT coalesce(@fktable_owner,'')) = '' OR pg_catalog.lower(fktable_owner) = pg_catalog.lower(@fktable_owner))
+		AND ((SELECT coalesce(@fktable_qualifier,'')) = '' OR pg_catalog.lower(fktable_qualifier) = pg_catalog.lower(@fktable_qualifier))
 	ORDER BY fktable_qualifier, fktable_owner, fktable_name, key_seq;
 
 END; 
@@ -2039,7 +2039,7 @@ CREATE OR REPLACE PROCEDURE sys.sp_stored_procedures(
 )
 AS $$
 BEGIN
-	IF (@sp_qualifier != '') AND LOWER(sys.db_name()) != LOWER(@sp_qualifier)
+	IF (@sp_qualifier != '') AND pg_catalog.lower(sys.db_name()) != pg_catalog.lower(@sp_qualifier)
 	BEGIN
 		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
 	END
@@ -2078,7 +2078,7 @@ BEGIN
 			NUM_RESULT_SETS,
 			REMARKS,
 			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-			WHERE ((SELECT COALESCE(@sp_owner,'')) = '' OR LOWER(procedure_owner) LIKE LOWER(@sp_owner))
+			WHERE ((SELECT COALESCE(@sp_owner,'')) = '' OR pg_catalog.lower(procedure_owner) LIKE pg_catalog.lower(@sp_owner))
 			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 		END
 		ELSE
@@ -2092,7 +2092,7 @@ BEGIN
 			NUM_RESULT_SETS,
 			REMARKS,
 			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-			WHERE ((SELECT COALESCE(@sp_owner,'')) = '' OR LOWER(procedure_owner) LIKE LOWER(@sp_owner))
+			WHERE ((SELECT COALESCE(@sp_owner,'')) = '' OR pg_catalog.lower(procedure_owner) LIKE pg_catalog.lower(@sp_owner))
 			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 		END
 	END
@@ -2104,8 +2104,8 @@ BEGIN
 		BEGIN
 			IF EXISTS ( -- Search in the sys schema 
 					SELECT * FROM sys.sp_stored_procedures_view
-					WHERE (LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) = LOWER(@sp_name))
-						AND (LOWER(procedure_owner) = 'sys'))
+					WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+						AND (pg_catalog.lower(procedure_owner) = 'sys'))
 			BEGIN
 				SELECT PROCEDURE_QUALIFIER,
 				PROCEDURE_OWNER,
@@ -2115,14 +2115,14 @@ BEGIN
 				NUM_RESULT_SETS,
 				REMARKS,
 				PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-				WHERE (LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) = LOWER(@sp_name))
-					AND (LOWER(procedure_owner) = 'sys')
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = 'sys')
 				ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 			END
 			ELSE IF EXISTS ( 
 				SELECT * FROM sys.sp_stored_procedures_view
-				WHERE (LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) = LOWER(@sp_name))
-					AND (LOWER(procedure_owner) = LOWER(SCHEMA_NAME()))
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = pg_catalog.lower(SCHEMA_NAME()))
 					)
 			BEGIN
 				SELECT PROCEDURE_QUALIFIER,
@@ -2133,8 +2133,8 @@ BEGIN
 				NUM_RESULT_SETS,
 				REMARKS,
 				PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-				WHERE (LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) = LOWER(@sp_name))
-					AND (LOWER(procedure_owner) = LOWER(SCHEMA_NAME()))
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = pg_catalog.lower(SCHEMA_NAME()))
 				ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 			END
 			ELSE -- Search in the dbo schema (if nothing exists it should just return nothing). 
@@ -2147,8 +2147,8 @@ BEGIN
 				NUM_RESULT_SETS,
 				REMARKS,
 				PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-				WHERE (LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) = LOWER(@sp_name))
-					AND (LOWER(procedure_owner) = 'dbo')
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = 'dbo')
 				ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 			END
 			
@@ -2164,8 +2164,8 @@ BEGIN
 			NUM_RESULT_SETS,
 			REMARKS,
 			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-			WHERE (LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) = LOWER(@sp_name))
-				AND (LOWER(procedure_owner) = LOWER(@sp_owner))
+			WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+				AND (pg_catalog.lower(procedure_owner) = pg_catalog.lower(@sp_owner))
 			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 		END
 		ELSE -- fusepattern = 1
@@ -2179,8 +2179,8 @@ BEGIN
 			NUM_RESULT_SETS,
 			REMARKS,
 			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
-			WHERE ((SELECT COALESCE(@sp_name,'')) = '' OR LOWER(LEFT(procedure_name, LEN(procedure_name)-2)) LIKE LOWER(@sp_name))
-				AND ((SELECT COALESCE(@sp_owner,'')) = '' OR LOWER(procedure_owner) LIKE LOWER(@sp_owner))
+			WHERE ((SELECT COALESCE(@sp_name,'')) = '' OR pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) LIKE pg_catalog.lower(@sp_name))
+				AND ((SELECT COALESCE(@sp_owner,'')) = '' OR pg_catalog.lower(procedure_owner) LIKE pg_catalog.lower(@sp_owner))
 			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
 		END
 	END	
@@ -2195,14 +2195,14 @@ $$
 DECLARE has_role BOOLEAN;
 DECLARE login_valid BOOLEAN;
 BEGIN
-	role  := TRIM(trailing from LOWER(role));
-	login := TRIM(trailing from LOWER(login));
+	role  := TRIM(trailing from pg_catalog.LOWER(role));
+	login := TRIM(trailing from pg_catalog.LOWER(login));
 	
 	login_valid = (login = suser_name()) OR 
 		(EXISTS (SELECT name
 	 			FROM sys.server_principals
 		 	 	WHERE 
-				LOWER(name) = login 
+				pg_catalog.LOWER(name) = login 
 				AND type = 'S'));
  	
  	IF NOT login_valid THEN
@@ -2373,7 +2373,7 @@ BEGIN
 	ELSE IF EXISTS (SELECT 1 
 					FROM sys.babelfish_authid_user_ext
 					WHERE (orig_username = @rolename
-					OR lower(orig_username) = lower(@rolename))
+					OR pg_catalog.lower(orig_username) = pg_catalog.lower(@rolename))
 					AND database_name = DB_NAME()
 					AND type = 'R')
 	BEGIN
@@ -2385,7 +2385,7 @@ BEGIN
 		ON Base.rolname = Ext.rolname
 		WHERE Ext.database_name = DB_NAME()
 		AND Ext.type = 'R'
-		AND (Ext.orig_username = @rolename OR lower(Ext.orig_username) = lower(@rolename))
+		AND (Ext.orig_username = @rolename OR pg_catalog.lower(Ext.orig_username) = pg_catalog.lower(@rolename))
 		ORDER BY RoleName;
 	END
 	-- If the specified role is not valid
@@ -2421,7 +2421,7 @@ BEGIN
 	ELSE IF EXISTS (SELECT 1
 					FROM sys.babelfish_authid_user_ext
 					WHERE (orig_username = @rolename
-					OR lower(orig_username) = lower(@rolename))
+					OR pg_catalog.lower(orig_username) = pg_catalog.lower(@rolename))
 					AND database_name = DB_NAME()
 					AND type = 'R')
 	BEGIN
@@ -2437,7 +2437,7 @@ BEGIN
 		AND Ext2.database_name = DB_NAME()
 		AND Ext1.type = 'R'
 		AND Ext2.orig_username != 'db_owner'
-		AND (Ext1.orig_username = @rolename OR lower(Ext1.orig_username) = lower(@rolename))
+		AND (Ext1.orig_username = @rolename OR pg_catalog.lower(Ext1.orig_username) = pg_catalog.lower(@rolename))
 		ORDER BY RoleName, MemberName;
 	END
 	-- If the specified role is not valid
@@ -2470,10 +2470,10 @@ BEGIN
 	-- do not raise an error even if it does not exist
 	ELSE IF EXISTS (SELECT 1
 					FROM sys.babelfish_authid_login_ext
-					WHERE (rolname = RTRIM(@srvrolename)
-					OR lower(rolname) = lower(RTRIM(@srvrolename)))
+					WHERE (rolname = PG_CATALOG.RTRIM(@srvrolename)
+					OR pg_catalog.lower(rolname) = pg_catalog.lower(PG_CATALOG.RTRIM(@srvrolename)))
 					AND type = 'R')
-					OR lower(RTRIM(@srvrolename)) IN (
+					OR pg_catalog.lower(pg_catalog.RTRIM(@srvrolename)) IN (
 					'serveradmin', 'setupadmin', 'securityadmin', 'processadmin',
 					'dbcreator', 'diskadmin', 'bulkadmin')
 	BEGIN
@@ -2486,7 +2486,7 @@ BEGIN
 		INNER JOIN sys.babelfish_authid_login_ext AS Ext1 ON Base1.rolname = Ext1.rolname
 		INNER JOIN sys.babelfish_authid_login_ext AS Ext2 ON Base2.rolname = Ext2.rolname
 		WHERE Ext1.type = 'R'
-		AND (Ext1.rolname = RTRIM(@srvrolename) OR lower(Ext1.rolname) = lower(RTRIM(@srvrolename)))
+		AND (Ext1.rolname = pg_catalog.RTRIM(@srvrolename) OR pg_catalog.lower(Ext1.rolname) = pg_catalog.lower(pg_catalog.RTRIM(@srvrolename)))
 		ORDER BY ServerRole, MemberName;
 	END
 	-- If the specified server role is not valid
@@ -2502,11 +2502,11 @@ $$
 BEGIN
 	-- Returns a list of the fixed database roles. 
 	-- Only fixed role present in babelfish is db_owner.
-	IF LOWER(RTRIM(@rolename)) IS NULL OR LOWER(RTRIM(@rolename)) = 'db_owner'
+	IF pg_catalog.LOWER(pg_catalog.RTRIM(@rolename)) IS NULL OR pg_catalog.LOWER(pg_catalog.RTRIM(@rolename)) = 'db_owner'
 	BEGIN
 		SELECT CAST('db_owner' AS sys.SYSNAME) AS DbFixedRole, CAST('DB Owners' AS sys.nvarchar(70)) AS Description;
 	END
-	ELSE IF LOWER(RTRIM(@rolename)) IN (
+	ELSE IF pg_catalog.LOWER(pg_catalog.RTRIM(@rolename)) IN (
 			'db_accessadmin','db_securityadmin','db_ddladmin', 'db_backupoperator', 
 			'db_datareader', 'db_datawriter', 'db_denydatareader', 'db_denydatawriter')
 	BEGIN
@@ -2855,12 +2855,12 @@ CREATE OR REPLACE PROCEDURE sys.sp_sproc_columns(
 	"@fusepattern" sys.bit = '1'
 )	
 AS $$
-	SELECT @procedure_name = LOWER(COALESCE(@procedure_name, ''))
-	SELECT @procedure_owner = LOWER(COALESCE(@procedure_owner, ''))
-	SELECT @procedure_qualifier = LOWER(COALESCE(@procedure_qualifier, ''))
-	SELECT @column_name = LOWER(COALESCE(@column_name, ''))
+	SELECT @procedure_name = pg_catalog.lower(COALESCE(@procedure_name, ''))
+	SELECT @procedure_owner = pg_catalog.lower(COALESCE(@procedure_owner, ''))
+	SELECT @procedure_qualifier = pg_catalog.lower(COALESCE(@procedure_qualifier, ''))
+	SELECT @column_name = pg_catalog.lower(COALESCE(@column_name, ''))
 BEGIN 
-	IF (@procedure_qualifier != '' AND (SELECT LOWER(sys.db_name())) != @procedure_qualifier)
+	IF (@procedure_qualifier != '' AND (SELECT pg_catalog.lower(sys.db_name())) != @procedure_qualifier)
 		BEGIN
 			THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
  	   	END
@@ -3241,7 +3241,7 @@ BEGIN
 		RETURN		
 	END
 	
-	IF TRIM(@tab) = ''
+	IF sys.TRIM(@tab) = ''
 	BEGIN
 		RAISERROR('Must specify table name', 16, 1)
 		RETURN		
@@ -3258,7 +3258,7 @@ BEGIN
 		SET @id = sys.OBJECT_ID(@tab)
 		IF @id IS NULL
 		BEGIN
-			IF sys.SUBSTRING(UPPER(@tab),1,4) = 'DBO.'
+			IF sys.SUBSTRING(pg_catalog.UPPER(@tab),1,4) = 'DBO.'
 			BEGIN
 				SET @id = sys.OBJECT_ID('SYS.' + sys.SUBSTRING(@tab,5))
 			END
@@ -3280,10 +3280,10 @@ BEGIN
 	END
 	
 	-- check for 'ORDER BY', if specified
-	SET @orderby = TRIM(@orderby)
+	SET @orderby = sys.TRIM(@orderby)
 	IF @orderby <> ''
 	BEGIN
-		IF UPPER(@orderby) NOT LIKE 'ORDER BY%'
+		IF pg_catalog.UPPER(@orderby) NOT LIKE 'ORDER BY%'
 		BEGIN
 			RAISERROR('@orderby parameter must start with ''ORDER BY''', 16, 1)
 			RETURN
@@ -3299,7 +3299,7 @@ BEGIN
 		SET @hiddencols = sys.REPLACE(@hiddencols, ', ', ',')
 	END
 	IF sys.LEN(@hiddencols) IS NOT NULL SET @hiddencols = ',' + @hiddencols + ','
-	SET @hiddencols = UPPER(@hiddencols)	
+	SET @hiddencols = pg_catalog.UPPER(@hiddencols)	
 
 	-- Need to use a guaranteed-uniquely named table as intermediate step since we cannot 
 	-- access the metadata in case a #tmp table is passed as argument
@@ -3348,7 +3348,7 @@ BEGIN
 			IF sys.LEN(@colname) > @maxlen SET @maxlen = sys.LEN(@colname)
 			IF @maxlen <= 0 SET @maxlen = 1
 			
-			IF (sys.CHARINDEX(',' + UPPER(@colname) + ',', @hiddencols) > 0) OR (sys.CHARINDEX(',[' + UPPER(@colname) + '],', @hiddencols) > 0) 
+			IF (sys.CHARINDEX(',' + pg_catalog.UPPER(@colname) + ',', @hiddencols) > 0) OR (sys.CHARINDEX(',[' + pg_catalog.UPPER(@colname) + '],', @hiddencols) > 0) 
 			BEGIN
 				SET @selectlist += ' [' + @colname + '],'			
 			END
@@ -3421,7 +3421,7 @@ BEGIN
 	
 	IF @option IS NOT NULL
 	BEGIN
-		IF LOWER(TRIM(@option)) <> 'postgres' 
+		IF pg_catalog.lower(sys.TRIM(@option)) <> 'postgres' 
 		BEGIN
 			RAISERROR('Parameter @option can only be ''postgres''', 16, 1)
 			RETURN			
@@ -3435,7 +3435,7 @@ BEGIN
 	-- This is for informational purposes only
 	SELECT pid, CAST(query AS sys.VARCHAR(MAX)) INTO #sp_who_tmp FROM pg_stat_activity pgsa
 	
-	UPDATE #sp_who_tmp SET query = ' ' + TRIM(CAST(UPPER(query) AS sys.VARCHAR(MAX)))
+	UPDATE #sp_who_tmp SET query = ' ' + sys.TRIM(CAST(pg_catalog.UPPER(query) AS sys.VARCHAR(MAX)))
 	UPDATE #sp_who_tmp SET query = sys.REPLACE(query,  chr(9), ' ')
 	UPDATE #sp_who_tmp SET query = sys.REPLACE(query,  chr(10), ' ')
 	UPDATE #sp_who_tmp SET query = sys.REPLACE(query,  chr(13), ' ')
@@ -3466,7 +3466,7 @@ BEGIN
 
 	-- The executing spid is always shown as doing a SELECT
 	UPDATE #sp_who_tmp SET query = 'SELECT' WHERE pid = @@spid
-	UPDATE #sp_who_tmp SET query = TRIM(query)
+	UPDATE #sp_who_tmp SET query = sys.TRIM(query)
 
 	-- Get all current connections
 	SELECT 
@@ -3503,7 +3503,7 @@ BEGIN
 	WHERE hostprocess IS NULL 
 
 	-- Keep or delete PG connections
-	IF (LOWER(@loginame) = 'postgres' OR LOWER(@option) = 'postgres')
+	IF (pg_catalog.lower(@loginame) = 'postgres' OR pg_catalog.lower(@option) = 'postgres')
 	begin    
 		-- Show PG connections; these have dbid = 0
 		-- This is a Babelfish-specific enhancement, since PG connections may also be active in the Babelfish DB
@@ -3511,7 +3511,7 @@ BEGIN
 		SET @show_pg = 1
 		
 		-- blank out the loginame parameter for the tests below
-		IF LOWER(@loginame) = 'postgres' SET @loginame = NULL
+		IF pg_catalog.lower(@loginame) = 'postgres' SET @loginame = NULL
 	END
 	
 	-- By default, do not show the column indicating the connection type since SQL Server does not have this column
@@ -3531,7 +3531,7 @@ BEGIN
 	-- Apply filter if specified
 	IF (@loginame IS NOT NULL)
 	BEGIN
-		IF (TRIM(@loginame) = '')
+		IF (sys.TRIM(@loginame) = '')
 		BEGIN
 			-- Raise error
 			SET @msg = ''''+@loginame+''' is not a valid login or you do not have permission.'
@@ -3547,7 +3547,7 @@ BEGIN
 		END
 		ELSE 
 		BEGIN	
-			IF (LOWER(@loginame) = 'active')
+			IF (pg_catalog.lower(@loginame) = 'active')
 			BEGIN
 				-- Remove all 'idle' connections 
 				DELETE #sp_who_proc
@@ -3576,12 +3576,12 @@ BEGIN
 	SELECT distinct 
 		p.spid AS spid, 
 		p.ecid AS ecid, 
-		CAST(LEFT(p.status,20) AS sys.VARCHAR(20)) AS status,
-		CAST(LEFT(p.loginname,40) AS sys.VARCHAR(40)) AS loginame,
-		CAST(LEFT(p.hostname,60) AS sys.VARCHAR(60)) AS hostname,
+		CAST(pg_catalog.LEFT(p.status,20) AS sys.VARCHAR(20)) AS status,
+		CAST(pg_catalog.LEFT(p.loginname,40) AS sys.VARCHAR(40)) AS loginame,
+		CAST(pg_catalog.LEFT(p.hostname,60) AS sys.VARCHAR(60)) AS hostname,
 		p.blocked AS blk, 
-		CAST(LEFT(db_name(p.dbid),40) AS sys.VARCHAR(40)) AS dbname,
-		CAST(LEFT(#sp_who_tmp.query,30)as sys.VARCHAR(30)) AS cmd,
+		CAST(pg_catalog.LEFT(db_name(p.dbid),40) AS sys.VARCHAR(40)) AS dbname,
+		CAST(pg_catalog.LEFT(#sp_who_tmp.query,30)as sys.VARCHAR(30)) AS cmd,
 		p.request_id AS request_id,
 		connection
 	INTO #sp_who_tmp2
@@ -3592,11 +3592,11 @@ BEGIN
 	-- Patch up remaining cases
 	UPDATE #sp_who_tmp2
 	SET cmd = 'AWAITING COMMAND'
-	WHERE TRIM(ISNULL(cmd,'')) = '' AND status = 'idle'
+	WHERE sys.TRIM(ISNULL(cmd,'')) = '' AND status = 'idle'
 	
 	UPDATE #sp_who_tmp2
 	SET cmd = 'UNKNOWN'
-	WHERE TRIM(cmd) = ''	
+	WHERE sys.TRIM(cmd) = ''	
 	
 	-- Format the result set as narrow as possible for readability
 	SET @hide_col += ',hostprocess'

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -243,7 +243,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.columns_internal AS
 			CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 			CAST(
 				COALESCE(
-					(SELECT string_agg(
+					(SELECT PG_CATALOG.string_agg(
 						CASE
 						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23 /* prefix length */)
 						ELSE NULL
@@ -254,7 +254,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.columns_internal AS
 
 			CAST(
 				COALESCE(
-					(SELECT string_agg(
+					(SELECT PG_CATALOG.string_agg(
 						CASE
 						WHEN option LIKE 'bbf_original_name=%' THEN substring(option, 19 /* prefix length */)
 						ELSE NULL
@@ -461,7 +461,7 @@ CREATE VIEW information_schema_tsql.tables AS
 		   CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 		   CAST(
 				COALESCE(
-					(SELECT string_agg(
+					(SELECT PG_CATALOG.string_agg(
 						CASE
 						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23)
 						ELSE NULL

--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -115,7 +115,7 @@ DECLARE
     DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*$';
     DATATYPE_MASK_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(?:CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*\(\s*(\d+|MAX)\s*\)\s*$';
 BEGIN
-    v_datatype := pg_catalog.upper(trim(p_datatype));
+    v_datatype := pg_catalog.upper(pg_catalog.btrim(p_datatype));
     v_style := floor(p_style)::SMALLINT;
 
     IF (scale(p_style) > 0) THEN
@@ -227,7 +227,7 @@ EXCEPTION
                     HINT := 'Change "style" parameter to the proper value and try again.';
 
     WHEN invalid_datetime_format THEN
-        RAISE USING MESSAGE := pg_catalog.format('Error converting data type DATE to %s.', trim(p_datatype)),
+        RAISE USING MESSAGE := pg_catalog.format('Error converting data type DATE to %s.', pg_catalog.btrim(p_datatype)),
                     DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
                     HINT := 'Check the input parameters values, correct them if needed, and try again.';
 
@@ -299,8 +299,8 @@ DECLARE
     DATATYPE_MASK_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(?:CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*\(\s*(\d+|MAX)\s*\)\s*$';
     v_datetimeval TIMESTAMP(6) WITHOUT TIME ZONE;
 BEGIN
-    v_datatype := pg_catalog.upper(trim(p_datatype));
-    v_src_datatype := pg_catalog.upper(trim(p_src_datatype));
+    v_datatype := pg_catalog.upper(pg_catalog.btrim(p_datatype));
+    v_src_datatype := pg_catalog.upper(pg_catalog.btrim(p_src_datatype));
     v_style := floor(p_style)::SMALLINT;
 
     IF (v_src_datatype ~* SRCDATATYPE_MASK_REGEXP)
@@ -754,7 +754,7 @@ EXCEPTION
 
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'integer\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.', v_err_message),
                     DETAIL := 'Supplied value contains illegal characters.',
@@ -868,7 +868,7 @@ DECLARE
     DIGITMASK2_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\d{8}$';
 BEGIN
     v_style := floor(p_style)::SMALLINT;
-    v_datestring := trim(p_datestring);
+    v_datestring := pg_catalog.btrim(p_datestring);
 
     IF (scale(p_style) > 0) THEN
         RAISE most_specific_type_mismatch;
@@ -882,7 +882,7 @@ BEGIN
 
     IF (v_datestring ~* HHMMSSFS_PART_REGEXP AND v_datestring !~* HHMMSSFS_REGEXP)
     THEN
-        v_datestring := trim(regexp_pg_catalog.replace(v_datestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
+        v_datestring := pg_catalog.btrim(regexp_pg_catalog.replace(v_datestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
     END IF;
 
     BEGIN
@@ -1178,7 +1178,7 @@ EXCEPTION
 
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'integer\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
                                       v_err_message),
@@ -1310,8 +1310,8 @@ DECLARE
     SHORT_DIGITMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*\d{6}\s*(', HHMMSSFS_PART_REGEXP, ')?$');
     FULL_DIGITMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*\d{8}\s*(', HHMMSSFS_PART_REGEXP, ')?$');
 BEGIN
-    v_datatype := trim(p_datatype);
-    v_datetimestring := pg_catalog.upper(trim(p_datetimestring));
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_datetimestring := pg_catalog.upper(pg_catalog.btrim(p_datetimestring));
     v_style := floor(p_style)::SMALLINT;
 
     v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
@@ -1342,8 +1342,8 @@ BEGIN
         RAISE invalid_parameter_value;
     END IF;
 
-    v_timepart := trim(substring(v_datetimestring, HHMMSSFS_PART_REGEXP));
-    v_datestring := trim(regexp_replace(v_datetimestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
+    v_timepart := pg_catalog.btrim(substring(v_datetimestring, HHMMSSFS_PART_REGEXP));
+    v_datestring := pg_catalog.btrim(regexp_replace(v_datetimestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
 
     BEGIN
         v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(CONVERSION_LANG);
@@ -1819,8 +1819,8 @@ DECLARE
     HH_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '$');
     DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^(TIME)\s*(?:\()?\s*((?:-)?\d+)?\s*(?:\))?$';
 BEGIN
-    v_datatype := trim(regexp_replace(p_datatype, 'DATETIME', 'TIME', 'gi'));
-    v_timestring := pg_catalog.upper(trim(p_timestring));
+    v_datatype := pg_catalog.btrim(regexp_replace(p_datatype, 'DATETIME', 'TIME', 'gi'));
+    v_timestring := pg_catalog.upper(pg_catalog.btrim(p_timestring));
     v_style := floor(p_style)::SMALLINT;
 
     v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
@@ -1848,7 +1848,7 @@ BEGIN
     END IF;
 
     v_daypart := substring(v_timestring, 'AM|PM');
-    v_timestring := trim(regexp_replace(v_timestring, coalesce(v_daypart, ''), ''));
+    v_timestring := pg_catalog.btrim(regexp_replace(v_timestring, coalesce(v_daypart, ''), ''));
 
     v_timeunit_mask :=
         CASE
@@ -1965,8 +1965,8 @@ DECLARE
     DATATYPE_MASK_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(?:CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*\(\s*(\d+|MAX)\s*\)\s*$';
     SRCDATATYPE_MASK_REGEXP VARCHAR COLLATE "C" := '^\s*(?:TIME)\s*(?:\s*\(\s*(\d+)\s*\)\s*)?\s*$';
 BEGIN
-    v_datatype := pg_catalog.upper(trim(p_datatype));
-    v_src_datatype := pg_catalog.upper(trim(p_src_datatype));
+    v_datatype := pg_catalog.upper(pg_catalog.btrim(p_datatype));
+    v_src_datatype := pg_catalog.upper(pg_catalog.btrim(p_src_datatype));
     v_style := floor(p_style)::SMALLINT;
 
     IF (v_src_datatype ~* SRCDATATYPE_MASK_REGEXP)
@@ -2105,7 +2105,7 @@ EXCEPTION
 
     WHEN invalid_datetime_format THEN
         RAISE USING MESSAGE := pg_catalog.format('Error converting data type TIME to %s.',
-                                      PG_CATALOG.rtrim(split_part(trim(p_datatype), '(', 1))),
+                                      PG_CATALOG.rtrim(split_part(pg_catalog.btrim(p_datatype), '(', 1))),
                     DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
                     HINT := 'Check the input parameters values, correct them if needed, and try again.';
 END;
@@ -2164,7 +2164,7 @@ BEGIN
         IF (v_short_year <= 99)
         THEN
             v_base_century := CASE
-                                 WHEN (p_base_century ~ '^\s*([1-9]{1,2})\s*$') THEN pg_catalog.concat(trim(p_base_century), '00')::SMALLINT
+                                 WHEN (p_base_century ~ '^\s*([1-9]{1,2})\s*$') THEN pg_catalog.concat(pg_catalog.btrim(p_base_century), '00')::SMALLINT
                                  ELSE trunc(extract(year from current_date)::NUMERIC, -2)
                               END;
 
@@ -2194,7 +2194,7 @@ BEGIN
 EXCEPTION
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'integer\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
                                       v_err_message),
@@ -2261,7 +2261,7 @@ DECLARE
     v_lang_spec_culture VARCHAR COLLATE "C";
     v_is_cached BOOLEAN := FALSE;
 BEGIN
-    v_lang_spec_culture := pg_catalog.upper(trim(p_lang_spec_culture));
+    v_lang_spec_culture := pg_catalog.upper(pg_catalog.btrim(p_lang_spec_culture));
 
     IF (char_length(v_lang_spec_culture) > 0)
     THEN
@@ -2382,7 +2382,7 @@ DECLARE
     v_pureplaces_len INTEGER;
     v_err_message VARCHAR COLLATE "C";
 BEGIN
-    v_fractsecs := trim(p_fractsecs);
+    v_fractsecs := pg_catalog.btrim(p_fractsecs);
     v_fractsecs_len := char_length(v_fractsecs);
     v_scale := floor(p_scale)::SMALLINT;
 
@@ -2407,7 +2407,7 @@ BEGIN
 EXCEPTION
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'integer\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.', v_err_message),
                     DETAIL := 'Supplied value contains illegal characters.',
@@ -2427,7 +2427,7 @@ DECLARE
     v_monthname TEXT;
     v_monthnum SMALLINT;
 BEGIN
-    v_monthname := pg_catalog.lower(trim(p_monthname));
+    v_monthname := pg_catalog.lower(pg_catalog.btrim(p_monthname));
 
     v_monthnum := array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'months_shortnames'))), v_monthname);
 
@@ -2448,7 +2448,7 @@ BEGIN
 EXCEPTION
     WHEN datetime_field_overflow THEN
         RAISE USING MESSAGE := pg_catalog.format('Can not convert value "%s" to a correct month number.',
-                                      trim(p_monthname)),
+                                      pg_catalog.btrim(p_monthname)),
                     DETAIL := 'Supplied month name is not valid.',
                     HINT := 'Correct supplied month name value and try again.';
 END;
@@ -2507,11 +2507,11 @@ DECLARE
     HHMM_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '$');
     HH_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '$');
 BEGIN
-    v_timepart := pg_catalog.upper(trim(p_timepart));
-    v_timeunit := pg_catalog.upper(trim(p_timeunit));
+    v_timepart := pg_catalog.upper(pg_catalog.btrim(p_timepart));
+    v_timeunit := pg_catalog.upper(pg_catalog.btrim(p_timeunit));
 
     v_daypart := substring(v_timepart, 'AM|PM');
-    v_timepart := trim(regexp_replace(v_timepart, coalesce(v_daypart, ''), ''));
+    v_timepart := pg_catalog.btrim(regexp_replace(v_timepart, coalesce(v_daypart, ''), ''));
 
     v_timeunit_mask :=
         CASE
@@ -2598,7 +2598,7 @@ DECLARE
     v_weekdayname TEXT;
     v_weekdaynum SMALLINT;
 BEGIN
-    v_weekdayname := pg_catalog.lower(trim(p_weekdayname));
+    v_weekdayname := pg_catalog.lower(pg_catalog.btrim(p_weekdayname));
 
     v_weekdaynum := array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'days_names'))), v_weekdayname);
 
@@ -2616,7 +2616,7 @@ BEGIN
 EXCEPTION
     WHEN datetime_field_overflow THEN
         RAISE USING MESSAGE := pg_catalog.format('Can not convert value "%s" to a correct weekday number.',
-                                      trim(p_weekdayname)),
+                                      pg_catalog.btrim(p_weekdayname)),
                     DETAIL := 'Supplied weekday name is not valid.',
                     HINT := 'Correct supplied weekday name value and try again.';
 END;
@@ -3111,8 +3111,8 @@ DECLARE
     CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
     DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
 BEGIN
-    v_datestring := pg_catalog.upper(trim(p_datestring));
-    v_culture := coalesce(nullif(pg_catalog.upper(trim(p_culture)), ''), 'EN-US');
+    v_datestring := pg_catalog.upper(pg_catalog.btrim(p_datestring));
+    v_culture := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(p_culture)), ''), 'EN-US');
 
     v_dayparts := ARRAY(SELECT pg_catalog.upper(array_to_string(regexp_matches(v_datestring, '[AP]M|ص|م', 'gi'), '')));
 
@@ -3156,7 +3156,7 @@ BEGIN
                                        'gi');
     END IF;
 
-    v_date_format := coalesce(nullif(pg_catalog.upper(trim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
+    v_date_format := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
 
     v_compmonth_regexp :=
         array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
@@ -3509,7 +3509,7 @@ BEGIN
                 END IF;
 
                 v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
-                v_raw_year := sys.babelfish_get_full_year(substring(v_year::TEXT, 3, 2), '14');
+                v_raw_year := sys.babelfish_get_full_year(pg_catalog.substring(v_year::TEXT, 3, 2), '14');
 
             ELSIF (v_resmask_cnt = 12)
             THEN
@@ -4099,9 +4099,9 @@ DECLARE
     CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
     DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
 BEGIN
-    v_datatype := trim(p_datatype);
-    v_datetimestring := pg_catalog.upper(trim(p_datetimestring));
-    v_culture := coalesce(nullif(pg_catalog.upper(trim(p_culture)), ''), 'EN-US');
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_datetimestring := pg_catalog.upper(pg_catalog.btrim(p_datetimestring));
+    v_culture := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(p_culture)), ''), 'EN-US');
 
     v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
 
@@ -4162,7 +4162,7 @@ BEGIN
                                            'gi');
     END IF;
 
-    v_date_format := coalesce(nullif(pg_catalog.upper(trim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
+    v_date_format := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
 
     v_compmonth_regexp :=
         array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
@@ -4515,7 +4515,7 @@ BEGIN
                 END IF;
 
                 v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
-                v_raw_year := sys.babelfish_get_full_year(substring(v_year::TEXT, 3, 2), '14');
+                v_raw_year := sys.babelfish_get_full_year(pg_catalog.substring(v_year::TEXT, 3, 2), '14');
 
             ELSIF (v_resmask_cnt = 12)
             THEN
@@ -5157,9 +5157,9 @@ DECLARE
     CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
     DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
 BEGIN
-    v_datatype := trim(p_datatype);
-    v_srctimestring := pg_catalog.upper(trim(p_srctimestring));
-    v_culture := coalesce(nullif(pg_catalog.upper(trim(p_culture)), ''), 'EN-US');
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_srctimestring := pg_catalog.upper(pg_catalog.btrim(p_srctimestring));
+    v_culture := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(p_culture)), ''), 'EN-US');
 
     v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
 
@@ -5217,7 +5217,7 @@ BEGIN
                                           'gi');
     END IF;
 
-    v_date_format := coalesce(nullif(pg_catalog.upper(trim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
+    v_date_format := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
 
     v_compmonth_regexp :=
         array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
@@ -5570,7 +5570,7 @@ BEGIN
                 END IF;
 
                 v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
-                v_raw_year := sys.babelfish_get_full_year(substring(v_year::TEXT, 3, 2), '14');
+                v_raw_year := sys.babelfish_get_full_year(pg_catalog.substring(v_year::TEXT, 3, 2), '14');
 
             ELSIF (v_resmask_cnt = 12)
             THEN
@@ -5862,7 +5862,7 @@ BEGIN
     RETURN sys.babelfish_round_fractseconds(p_fractseconds::NUMERIC);
 EXCEPTION
     WHEN invalid_text_representation THEN
-        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', trim(p_fractseconds)),
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', pg_catalog.btrim(p_fractseconds)),
                     DETAIL := 'Passed argument value contains illegal characters.',
                     HINT := 'Correct passed argument value, remove all illegal characters.';
 
@@ -6937,7 +6937,7 @@ BEGIN
     RETURN;
   END IF;
 
-  IF (LOWER(UPPER(par_name)) = LOWER('ALL'))
+  IF (LOWER(pg_catalog.UPPER(par_name)) = LOWER('ALL'))
   THEN
     SELECT - 1 INTO var_schedule_id;
 
@@ -7771,7 +7771,7 @@ BEGIN
     END IF
     /* Turn [nullable] empty string parameters into NULLs */;
 
-    IF (LOWER(par_description) = LOWER('')) THEN
+    IF (pg_catalog.LOWER(par_description) = pg_catalog.LOWER('')) THEN
         SELECT
             NULL
             INTO par_description;
@@ -7819,11 +7819,11 @@ BEGIN
         IF (EXISTS (SELECT
             1
             FROM sys.sysjobsteps
-            WHERE (job_id = par_job_id) AND (LOWER(subsystem) = LOWER('TSQL')))) THEN
+            WHERE (job_id = par_job_id) AND (pg_catalog.LOWER(subsystem) = pg_catalog.LOWER('TSQL')))) THEN
             /* The job is being re-assigned to an non-SA */
             UPDATE sys.sysjobsteps
             SET database_user_name = NULL
-                WHERE (job_id = par_job_id) AND (LOWER(subsystem) = LOWER('TSQL'));
+                WHERE (job_id = par_job_id) AND (pg_catalog.LOWER(subsystem) = pg_catalog.LOWER('TSQL'));
         END IF;
     END IF;
     UPDATE sys.sysjobs
@@ -8235,7 +8235,7 @@ BEGIN
     END IF;
     /* Turn [nullable] empty string parameters into NULLs */
 
-    IF (LOWER(par_command) = LOWER('')) THEN
+    IF (pg_catalog.LOWER(par_command) = pg_catalog.LOWER('')) THEN
         SELECT NULL INTO par_command;
     END IF;
 
@@ -8251,7 +8251,7 @@ BEGIN
         SELECT NULL INTO par_database_user_name;
     END IF;
 
-    IF (LOWER(par_output_file_name) = LOWER('')) THEN
+    IF (pg_catalog.LOWER(par_output_file_name) = pg_catalog.LOWER('')) THEN
         SELECT NULL INTO par_output_file_name;
     END IF
     /* Check new values */;
@@ -8899,7 +8899,7 @@ BEGIN
     RETURN;
   END IF;
 
-  IF (LOWER(UPPER(par_subsystem)) <> LOWER('TSQL')) THEN /* Failure */
+  IF (LOWER(pg_catalog.UPPER(par_subsystem)) <> LOWER('TSQL')) THEN /* Failure */
     RAISE 'The specified "%" is invalid (valid values are: %).', '@subsystem', 'TSQL' USING ERRCODE := '50000';
     returncode := (1);
     RETURN;
@@ -8966,7 +8966,7 @@ BEGIN
       RETURN;
   END IF;
 
-  IF (UPPER(par_name) = 'ALL')
+  IF (pg_catalog.UPPER(par_name) = 'ALL')
   THEN /* Failure */
     RAISE 'The specified "%" is invalid.', 'name' USING ERRCODE := '50000';
     returncode := 1;
@@ -9399,8 +9399,8 @@ AS
 $BODY$
 BEGIN
   CASE
-    WHEN LOWER(in_str) = 'true' OR in_str = '1' THEN RETURN 1;
-    WHEN LOWER(in_str) = 'false' OR in_str = '0' THEN RETURN 0;
+    WHEN pg_catalog.LOWER(in_str) = 'true' OR in_str = '1' THEN RETURN 1;
+    WHEN pg_catalog.LOWER(in_str) = 'false' OR in_str = '0' THEN RETURN 0;
     ELSE RETURN 0;
   END CASE;
 END;
@@ -10266,7 +10266,7 @@ DECLARE
     counter int;
     cur_pos int;
 BEGIN
-    lower_object_name = lower(PG_CATALOG.rtrim(name));
+    lower_object_name = pg_catalog.lower(PG_CATALOG.rtrim(name));
 
     counter = 1;
     cur_pos = babelfish_get_name_delimiter_pos(lower_object_name);

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -431,7 +431,7 @@ EXCEPTION
 
    WHEN numeric_value_out_of_range THEN
       GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-      v_err_message := upper(split_part(v_err_message, ' ', 1));
+      v_err_message := pg_catalog.upper(split_part(v_err_message, ' ', 1));
 
       RAISE USING MESSAGE := pg_catalog.format('Error while trying to cast to %s data type.', v_err_message),
                   DETAIL := pg_catalog.format('Source value is out of %s data type range.', v_err_message),
@@ -614,7 +614,7 @@ BEGIN
 EXCEPTION
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'numeric\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'numeric\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', v_err_message),
                     DETAIL := 'Supplied string value contains illegal characters.',
@@ -680,7 +680,7 @@ EXCEPTION
 
     WHEN numeric_value_out_of_range THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := upper(split_part(v_err_message, ' ', 1));
+        v_err_message := pg_catalog.upper(split_part(v_err_message, ' ', 1));
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to cast to %s data type.', v_err_message),
                     DETAIL := pg_catalog.format('Source value is out of %s data type range.', v_err_message),
@@ -711,7 +711,7 @@ BEGIN
 EXCEPTION
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'numeric\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'numeric\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', v_err_message),
                     DETAIL := 'Supplied string value contains illegal characters.',
@@ -852,7 +852,7 @@ EXCEPTION
 
     WHEN numeric_value_out_of_range THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := upper(split_part(v_err_message, ' ', 1));
+        v_err_message := pg_catalog.upper(split_part(v_err_message, ' ', 1));
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to cast to %s data type.', v_err_message),
                     DETAIL := pg_catalog.format('Source value is out of %s data type range.', v_err_message),
@@ -881,7 +881,7 @@ BEGIN
 EXCEPTION
     WHEN invalid_text_representation THEN
         GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
-        v_err_message := substring(lower(v_err_message), 'numeric\:\s\"(.*)\"');
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'numeric\:\s\"(.*)\"');
 
         RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', v_err_message),
                     DETAIL := 'Supplied string value contains illegal characters.',
@@ -1127,7 +1127,7 @@ BEGIN
     	RETURN NULL;
     END IF;
 
-    lower_tzn := lower(tzzone);
+    lower_tzn := pg_catalog.lower(tzzone);
     IF lower_tzn <> 'utc' THEN
         tz_name := sys.babelfish_timezone_mapping(lower_tzn);
     ELSE
@@ -2843,11 +2843,11 @@ BEGIN
 
     -- Lower-case to avoid case issues, remove trailing whitespace to match SQL SERVER behavior
     -- Objects created in Babelfish are stored in lower-case in pg_class/pg_proc
-    cs_as_securable = lower(PG_CATALOG.rtrim(cs_as_securable));
-    cs_as_securable_class = lower(PG_CATALOG.rtrim(cs_as_securable_class));
-    cs_as_permission = lower(PG_CATALOG.rtrim(cs_as_permission));
-    cs_as_sub_securable = lower(PG_CATALOG.rtrim(cs_as_sub_securable));
-    cs_as_sub_securable_class = lower(PG_CATALOG.rtrim(cs_as_sub_securable_class));
+    cs_as_securable = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_securable));
+    cs_as_securable_class = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_securable_class));
+    cs_as_permission = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_permission));
+    cs_as_sub_securable = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_sub_securable));
+    cs_as_sub_securable_class = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_sub_securable_class));
 
     -- Assert that sub_securable and sub_securable_class are either both NULL or both defined
     IF cs_as_sub_securable IS NOT NULL AND cs_as_sub_securable_class IS NULL THEN
@@ -3122,7 +3122,7 @@ DECLARE
     return_value INTEGER;
 BEGIN
 	return_value:=
-        CASE LOWER(property_name)
+        CASE pg_catalog.LOWER(property_name)
             WHEN 'charmaxlen' COLLATE sys.database_default THEN (SELECT
                 CASE
                     WHEN a.atttypmod > 0 THEN a.atttypmod - extra_bytes
@@ -4179,7 +4179,7 @@ DECLARE
     json_new_value JSONB;
     result_json sys.NVARCHAR;
 BEGIN
-    path_split_array = regexp_split_to_array(TRIM(path_json) COLLATE "C",'\s+');
+    path_split_array = regexp_split_to_array(PG_CATALOG.btrim(path_json) COLLATE "C",'\s+');
     word_count = array_length(path_split_array,1);
     /* 
      * This if else block is added to set the create_if_missing and append_modifier flags.
@@ -4627,8 +4627,8 @@ $BODY$
 DECLARE
 ret_val INT;
 BEGIN
-	index_or_statistics_name = LOWER(TRIM(index_or_statistics_name));
-	property = LOWER(TRIM(property));
+	index_or_statistics_name = LOWER(PG_CATALOG.btrim(index_or_statistics_name));
+	property = LOWER(PG_CATALOG.btrim(property));
     SELECT INTO ret_val
     CASE
        
@@ -4776,13 +4776,13 @@ BEGIN
     END IF;
 
     -- Truncate and normalize the column name
-    col_name := sys.babelfish_truncate_identifier(sys.babelfish_remove_delimiter_pair(lower(column_name)));
+    col_name := sys.babelfish_truncate_identifier(sys.babelfish_remove_delimiter_pair(pg_catalog.lower(column_name)));
 
     -- Get the column ID, typeid, length, and typmod for the provided column_name
     SELECT attnum, a.atttypid, a.attlen, a.atttypmod
     INTO column_id, typeid, typelen, typemod
     FROM pg_attribute a
-    WHERE attrelid = object_id AND lower(attname) = col_name COLLATE sys.database_default;
+    WHERE attrelid = object_id AND pg_catalog.lower(attname) = col_name COLLATE sys.database_default;
 
     IF column_id IS NULL THEN
         RETURN NULL;

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -60,11 +60,11 @@ DECLARE
   cur refcursor;
   cursor_source int;
 BEGIN
-  IF lower("@cursor_source") = 'local' THEN
+  IF pg_catalog.lower("@cursor_source") = 'local' THEN
     cursor_source := 1;
-  ELSIF lower("@cursor_source") = 'global' THEN
+  ELSIF pg_catalog.lower("@cursor_source") = 'global' THEN
     cursor_source := 2;
-  ELSIF lower("@cursor_source") = 'variable' THEN
+  ELSIF pg_catalog.lower("@cursor_source") = 'variable' THEN
     cursor_source := 3;
   ELSE
     RAISE 'invalid @cursor_source: %', "@cursor_source";
@@ -123,7 +123,7 @@ DECLARE
   server boolean := false;
   prev_user text;
 BEGIN
-  IF lower("@option_name") like 'babelfishpg_tsql.%' collate "C" THEN
+  IF pg_catalog.lower("@option_name") like 'babelfishpg_tsql.%' collate "C" THEN
     SELECT "@option_name" INTO normalized_name;
   ELSE
     SELECT pg_catalog.concat('babelfishpg_tsql.',"@option_name") INTO normalized_name;
@@ -137,7 +137,7 @@ BEGIN
 
   SELECT COUNT(*) INTO cnt FROM sys.babelfish_configurations_view where name collate "C" like normalized_name;
   IF cnt = 0 THEN 
-    IF LOWER(normalized_name) = 'babelfishpg_tsql.escape_hatch_unique_constraint' COLLATE C THEN
+    IF pg_catalog.LOWER(normalized_name) = 'babelfishpg_tsql.escape_hatch_unique_constraint' COLLATE C THEN
       CALl sys.printarg('Config option babelfishpg_tsql.escape_hatch_unique_constraint has been deprecated, babelfish now supports unique constraints on nullable columns');
     ELSE
       RAISE EXCEPTION 'unknown configuration: %', normalized_name;

--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -25,14 +25,14 @@ select
   , 0 as parent_object_id
   , CAST('U' as sys.bpchar(2)) as type
   , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
-  , CAST((select string_agg(
+  , CAST((select PG_CATALOG.string_agg(
                   case
                   when option like 'bbf_rel_create_date=%%' then substring(option, 21)
                   else NULL
                   end, ',')
           from unnest(t.reloptions) as option)
         as sys.datetime) as create_date
-  , CAST((select string_agg(
+  , CAST((select PG_CATALOG.string_agg(
                   case
                   when option like 'bbf_rel_create_date=%%' then substring(option, 21)
                   else NULL
@@ -1881,14 +1881,14 @@ select
   , CAST(0 as int) as parent_object_id
   , CAST('TT' as char(2)) as type
   , CAST('TABLE_TYPE' as sys.nvarchar(60)) as type_desc
-  , CAST((select string_agg(
+  , CAST((select PG_CATALOG.string_agg(
                     case
                     when option like 'bbf_rel_create_date=%%' then substring(option, 21)
                     else NULL
                     end, ',')
           from unnest(c.reloptions) as option)
      as sys.datetime) as create_date
-  , CAST((select string_agg(
+  , CAST((select PG_CATALOG.string_agg(
                     case
                     when option like 'bbf_rel_create_date=%%' then substring(option, 21)
                     else NULL
@@ -2388,7 +2388,7 @@ CREATE OR REPLACE VIEW sys.syslanguages
 AS
 SELECT
     lang_id AS langid,
-    CAST(lower(lang_data_jsonb ->> 'date_format'::TEXT) AS SYS.NCHAR(3)) AS dateformat,
+    CAST(pg_catalog.lower(lang_data_jsonb ->> 'date_format'::TEXT) AS SYS.NCHAR(3)) AS dateformat,
     CAST(lang_data_jsonb -> 'date_first'::TEXT AS SYS.TINYINT) AS datefirst,
     CAST(NULL AS INT) AS upgrade,
     CAST(coalesce(lang_name_mssql, lang_name_pg) AS SYS.SYSNAME) AS name,
@@ -3147,7 +3147,7 @@ SELECT
   CAST(f.srvname as sys.sysname) AS name,
   CAST('' as sys.sysname) AS product,
   CAST('tds_fdw' as sys.sysname) AS provider,
-  CAST((select string_agg(
+  CAST((select PG_CATALOG.string_agg(
                   case
                   when option like 'servername=%%' then substring(option, 12)
                   else NULL
@@ -3155,7 +3155,7 @@ SELECT
           from unnest(f.srvoptions) as option) as sys.nvarchar(4000)) AS data_source,
   CAST(NULL as sys.nvarchar(4000)) AS location,
   CAST(NULL as sys.nvarchar(4000)) AS provider_string,
-  CAST((select string_agg(
+  CAST((select PG_CATALOG.string_agg(
                   case
                   when option like 'database=%%' then substring(option, 10)
                   else NULL
@@ -3191,7 +3191,7 @@ SELECT
   CAST(u.srvid as int) AS server_id,
   CAST(0 as int) AS local_principal_id,
   CAST(0 as sys.bit) AS uses_self_credential,
-  CAST((select string_agg(
+  CAST((select PG_CATALOG.string_agg(
                   case
                   when option like 'username=%%' then substring(option, 10)
                   else NULL

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
@@ -11,6 +11,9479 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
  * final behaviour.
  */
 
+CREATE OR REPLACE FUNCTION sys.sp_columns_managed_internal(
+    in_catalog sys.nvarchar(128), 
+    in_owner sys.nvarchar(128),
+    in_table sys.nvarchar(128),
+    in_column sys.nvarchar(128),
+    in_schematype int)
+RETURNS TABLE (
+    out_table_catalog sys.nvarchar(128),
+    out_table_schema sys.nvarchar(128),
+    out_table_name sys.nvarchar(128),
+    out_column_name sys.nvarchar(128),
+    out_ordinal_position int,
+    out_column_default sys.nvarchar(4000),
+    out_is_nullable sys.nvarchar(3),
+    out_data_type sys.nvarchar,
+    out_character_maximum_length int,
+    out_character_octet_length int,
+    out_numeric_precision int,
+    out_numeric_precision_radix int,
+    out_numeric_scale int,
+    out_datetime_precision int,
+    out_character_set_catalog sys.nvarchar(128),
+    out_character_set_schema sys.nvarchar(128),
+    out_character_set_name sys.nvarchar(128),
+    out_collation_catalog sys.nvarchar(128),
+    out_is_sparse int,
+    out_is_column_set int,
+    out_is_filestream int
+    )
+AS
+$$
+BEGIN
+    RETURN QUERY 
+        SELECT CAST(table_catalog AS sys.nvarchar(128)),
+            CAST(table_schema AS sys.nvarchar(128)),
+            CAST(table_name AS sys.nvarchar(128)),
+            CAST(column_name AS sys.nvarchar(128)),
+            CAST(ordinal_position AS int),
+            CAST(column_default AS sys.nvarchar(4000)),
+            CAST(is_nullable AS sys.nvarchar(3)),
+            CAST(data_type AS sys.nvarchar),
+            CAST(character_maximum_length AS int),
+            CAST(character_octet_length AS int),
+            CAST(numeric_precision AS int),
+            CAST(numeric_precision_radix AS int),
+            CAST(numeric_scale AS int),
+            CAST(datetime_precision AS int),
+            CAST(character_set_catalog AS sys.nvarchar(128)),
+            CAST(character_set_schema AS sys.nvarchar(128)),
+            CAST(character_set_name AS sys.nvarchar(128)),
+            CAST(collation_catalog AS sys.nvarchar(128)),
+            CAST(is_sparse AS int),
+            CAST(is_column_set AS int),
+            CAST(is_filestream AS int)
+        FROM sys.spt_columns_view_managed s_cv
+        WHERE
+        (in_catalog IS NULL OR s_cv.TABLE_CATALOG LIKE pg_catalog.lower(in_catalog)) AND
+        (in_owner IS NULL OR s_cv.TABLE_SCHEMA LIKE pg_catalog.lower(in_owner)) AND
+        (in_table IS NULL OR s_cv.TABLE_NAME LIKE pg_catalog.lower(in_table)) AND
+        (in_column IS NULL OR s_cv.COLUMN_NAME LIKE pg_catalog.lower(in_column)) AND
+        (in_schematype = 0 AND (s_cv.IS_SPARSE = 0) OR in_schematype = 1 OR in_schematype = 2 AND (s_cv.IS_SPARSE = 1));
+END;
+$$
+language plpgsql STABLE;
+
+CREATE OR REPLACE PROCEDURE sys.sp_tables (
+    "@table_name" sys.nvarchar(384) = NULL,
+    "@table_owner" sys.nvarchar(384) = NULL, 
+    "@table_qualifier" sys.sysname = NULL,
+    "@table_type" sys.nvarchar(100) = NULL,
+    "@fusepattern" sys.bit = '1')
+AS $$
+BEGIN
+
+	-- Temporary variable to hold the current database name
+	DECLARE @current_db_name sys.sysname;
+
+	-- Handle special case: Enumerate all databases when name and owner are blank but qualifier is '%'
+	IF (@table_qualifier = '%' AND @table_owner = '' AND @table_name = '')
+	BEGIN
+		SELECT
+			d.name AS TABLE_QUALIFIER,
+			CAST(NULL AS sys.sysname) AS TABLE_OWNER,
+			CAST(NULL AS sys.sysname) AS TABLE_NAME,
+			CAST(NULL AS sys.varchar(32)) AS TABLE_TYPE,
+			CAST(NULL AS sys.varchar(254)) AS REMARKS
+		FROM sys.databases d ORDER BY TABLE_QUALIFIER;
+		
+		RETURN;
+	END;
+
+	SELECT @current_db_name = sys.db_name();
+
+	IF (@table_qualifier != '' AND pg_catalog.lower(@table_qualifier) != pg_catalog.lower(@current_db_name))
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+	END
+	
+	IF (@fusepattern = 1)
+		SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			remarks AS REMARKS
+		FROM sys.sp_tables_view 
+		WHERE (@table_name IS NULL OR table_name LIKE @table_name collate database_default)
+		AND (@table_owner IS NULL OR table_owner LIKE @table_owner collate database_default)
+		AND (@table_qualifier IS NULL OR table_qualifier LIKE @table_qualifier collate database_default)
+		AND (
+			@table_type IS NULL OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
+		)
+		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
+	ELSE
+		SELECT 
+			CAST(table_qualifier AS sys.sysname) AS TABLE_QUALIFIER,
+			CAST(table_owner AS sys.sysname) AS TABLE_OWNER,
+			CAST(table_name AS sys.sysname) AS TABLE_NAME,
+			CAST(table_type AS sys.varchar(32)) AS TABLE_TYPE,
+			remarks AS REMARKS
+		FROM sys.sp_tables_view
+		WHERE (@table_name IS NULL OR table_name = @table_name collate database_default)
+		AND (@table_owner IS NULL OR table_owner = @table_owner collate database_default)
+		AND (@table_qualifier IS NULL OR table_qualifier = @table_qualifier collate database_default)
+		AND (
+			@table_type IS NULL OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''TABLE''%' collate database_default AND table_type = 'TABLE' collate database_default) OR 
+			(CAST(@table_type AS varchar(100)) LIKE '%''VIEW''%' collate database_default AND table_type = 'VIEW' collate database_default)
+		)
+		ORDER BY TABLE_QUALIFIER, TABLE_OWNER, TABLE_NAME;
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_tables TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.sp_statistics_view AS
+SELECT
+CAST(t3."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
+CAST(t3."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
+CAST(t3."TABLE_NAME" AS sys.sysname) AS TABLE_NAME,
+CAST(NULL AS smallint) AS NON_UNIQUE,
+CAST(NULL AS sys.sysname) AS INDEX_QUALIFIER,
+CAST(NULL AS sys.sysname) AS INDEX_NAME,
+CAST(0 AS smallint) AS TYPE,
+CAST(NULL AS smallint) AS SEQ_IN_INDEX,
+CAST(NULL AS sys.sysname) AS COLUMN_NAME,
+CAST(NULL AS sys.varchar(1)) AS COLLATION,
+CAST(t1.reltuples AS int) AS CARDINALITY,
+CAST(t1.relpages AS int) AS PAGES,
+CAST(NULL AS sys.varchar(128)) AS FILTER_CONDITION
+FROM pg_catalog.pg_class t1
+    JOIN sys.schemas s1 ON s1.schema_id = t1.relnamespace
+    JOIN information_schema_tsql.columns_internal t3 ON (t1.oid = t3."TABLE_OID")
+    , generate_series(0,31) seq -- SQL server has max 32 columns per index
+UNION
+SELECT
+CAST(t4."TABLE_CATALOG" AS sys.sysname) AS TABLE_QUALIFIER,
+CAST(t4."TABLE_SCHEMA" AS sys.sysname) AS TABLE_OWNER,
+CAST(t4."TABLE_NAME" AS sys.sysname) AS TABLE_NAME,
+CASE
+WHEN t5.indisunique = 't' THEN CAST(0 AS smallint)
+ELSE CAST(1 AS smallint)
+END AS NON_UNIQUE,
+CAST(t1.relname AS sys.sysname) AS INDEX_QUALIFIER,
+-- the index name created by CREATE INDEX is re-mapped, find it (by checking
+-- the ones not in pg_constraint) and restoring it back before display
+CASE 
+WHEN t8.oid > 0 THEN CAST(t6.relname AS sys.sysname)
+ELSE CAST(pg_catalog.SUBSTRING(t6.relname,1,LENGTH(t6.relname)-32-LENGTH(t1.relname)) AS sys.sysname) 
+END AS INDEX_NAME,
+CASE
+WHEN t5.indisclustered = 't' THEN CAST(1 AS smallint)
+ELSE CAST(3 AS smallint)
+END AS TYPE,
+CAST(seq + 1 AS smallint) AS SEQ_IN_INDEX,
+CAST(t4."COLUMN_NAME" AS sys.sysname) AS COLUMN_NAME,
+CAST('A' AS sys.varchar(1)) AS COLLATION,
+CAST(t7.n_distinct AS int) AS CARDINALITY,
+CAST(0 AS int) AS PAGES, --not supported
+CAST(NULL AS sys.varchar(128)) AS FILTER_CONDITION
+FROM pg_catalog.pg_class t1
+    JOIN sys.schemas s1 ON s1.schema_id = t1.relnamespace
+    JOIN pg_catalog.pg_roles t3 ON t1.relowner = t3.oid
+    JOIN information_schema_tsql.columns_internal t4 ON (t1.oid = t4."TABLE_OID")
+	JOIN (pg_catalog.pg_index t5 JOIN
+		pg_catalog.pg_class t6 ON t5.indexrelid = t6.oid) ON t1.oid = t5.indrelid
+	JOIN pg_catalog.pg_namespace nsp ON (t1.relnamespace = nsp.oid)
+	LEFT JOIN pg_catalog.pg_stats t7 ON (t1.relname = t7.tablename AND t7.schemaname = nsp.nspname)
+	LEFT JOIN pg_catalog.pg_constraint t8 ON t5.indexrelid = t8.conindid
+    , generate_series(0,31) seq -- SQL server has max 32 columns per index
+WHERE CAST(t4."ORDINAL_POSITION" AS smallint) = ANY (t5.indkey)
+    AND CAST(t4."ORDINAL_POSITION" AS smallint) = t5.indkey[seq];
+GRANT SELECT on sys.sp_statistics_view TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_column_privileges(
+    "@table_name" sys.sysname,
+    "@table_owner" sys.sysname = '',
+    "@table_qualifier" sys.sysname = '',
+    "@column_name" sys.nvarchar(384) = ''
+)
+AS $$
+BEGIN
+    IF (@table_qualifier != '') AND (pg_catalog.lower(@table_qualifier) != pg_catalog.lower(sys.db_name()))
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+	END
+ 	
+	IF (COALESCE(@table_owner, '') = '')
+	BEGIN
+		
+		IF EXISTS ( 
+			SELECT * FROM sys.sp_column_privileges_view 
+			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name) and pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_qualifier)
+			)
+		BEGIN 
+			SELECT 
+			TABLE_QUALIFIER,
+			TABLE_OWNER,
+			TABLE_NAME,
+			COLUMN_NAME,
+			GRANTOR,
+			GRANTEE,
+			PRIVILEGE,
+			IS_GRANTABLE
+			FROM sys.sp_column_privileges_view
+			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND (pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_owner))
+				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
+			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
+		END
+		ELSE
+		BEGIN
+			SELECT 
+			TABLE_QUALIFIER,
+			TABLE_OWNER,
+			TABLE_NAME,
+			COLUMN_NAME,
+			GRANTOR,
+			GRANTEE,
+			PRIVILEGE,
+			IS_GRANTABLE
+			FROM sys.sp_column_privileges_view
+			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND (pg_catalog.lower('dbo')= pg_catalog.lower(table_owner))
+				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
+			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
+		END
+	END
+	ELSE
+	BEGIN
+		SELECT 
+		TABLE_QUALIFIER,
+		TABLE_OWNER,
+		TABLE_NAME,
+		COLUMN_NAME,
+		GRANTOR,
+		GRANTEE,
+		PRIVILEGE,
+		IS_GRANTABLE
+		FROM sys.sp_column_privileges_view
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND ((SELECT COALESCE(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+			AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+			AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
+		ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
+	END
+END; 
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_column_privileges TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_table_privileges(
+	"@table_name" sys.nvarchar(384),
+	"@table_owner" sys.nvarchar(384) = '',
+	"@table_qualifier" sys.sysname = '',
+	"@fusepattern" sys.bit = 1
+)
+AS $$
+BEGIN
+	
+	IF (@table_qualifier != '') AND (pg_catalog.lower(@table_qualifier) != pg_catalog.lower(sys.db_name()))
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+	END
+	
+	IF @fusepattern = 1
+	BEGIN
+		SELECT 
+		TABLE_QUALIFIER,
+		TABLE_OWNER,
+		TABLE_NAME,
+		GRANTOR,
+		GRANTEE,
+		PRIVILEGE,
+		IS_GRANTABLE FROM sys.sp_table_privileges_view
+		WHERE pg_catalog.lower(TABLE_NAME) LIKE pg_catalog.lower(@table_name)
+			AND ((SELECT COALESCE(@table_owner,'')) = '' OR pg_catalog.lower(TABLE_OWNER) LIKE pg_catalog.lower(@table_owner))
+		ORDER BY table_qualifier, table_owner, table_name, privilege, grantee;
+	END
+	ELSE 
+	BEGIN
+		SELECT
+		TABLE_QUALIFIER,
+		TABLE_OWNER,
+		TABLE_NAME,
+		GRANTOR,
+		GRANTEE,
+		PRIVILEGE,
+		IS_GRANTABLE FROM sys.sp_table_privileges_view
+		WHERE pg_catalog.lower(TABLE_NAME) = pg_catalog.lower(@table_name)
+			AND ((SELECT COALESCE(@table_owner,'')) = '' OR pg_catalog.lower(TABLE_OWNER) = pg_catalog.lower(@table_owner))
+		ORDER BY table_qualifier, table_owner, table_name, privilege, grantee;
+	END
+	
+END; 
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_table_privileges TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_special_columns(
+	"@table_name" sys.sysname,
+	"@table_owner" sys.sysname = '',
+	"@qualifier" sys.sysname = '',
+	"@col_type" char(1) = 'R',
+	"@scope" char(1) = 'T',
+	"@nullable" char(1) = 'U',
+	"@odbcver" int = 2
+)
+AS $$
+DECLARE @special_col_type sys.sysname;
+DECLARE @constraint_name sys.sysname;
+BEGIN
+	IF (@qualifier != '') AND (pg_catalog.lower(@qualifier) != pg_catalog.lower(sys.db_name()))
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+		
+	END
+	
+	IF (pg_catalog.lower(@col_type) = pg_catalog.lower('V'))
+	BEGIN
+		THROW 33557097, N'TIMESTAMP datatype is not currently supported in Babelfish', 1;
+	END
+	
+	IF (pg_catalog.lower(@nullable) = pg_catalog.lower('O'))
+	BEGIN
+		SELECT TOP 1 @special_col_type = constraint_type, @constraint_name = constraint_name FROM sys.sp_special_columns_view
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+			AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0)
+		ORDER BY constraint_type, index_id;
+	
+		IF @special_col_type='u'
+		BEGIN
+			IF @scope='C'
+			BEGIN
+				SELECT  
+				CAST(0 AS smallint) AS SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND @constraint_name = constraint_name
+				ORDER BY scope, column_name;
+				
+			END
+			ELSE
+			BEGIN
+				SELECT  
+				SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND @constraint_name = constraint_name
+				ORDER BY scope, column_name;
+			END
+		
+		END
+		
+		ELSE 
+		BEGIN
+			IF @scope='C'
+			BEGIN
+				SELECT 
+				CAST(0 AS smallint) AS SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND CONSTRAINT_TYPE = 'p'
+				ORDER BY scope, column_name;
+			END
+			ELSE
+			BEGIN
+				SELECT SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN  FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND (is_nullable = 0) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND CONSTRAINT_TYPE = 'p'
+				ORDER BY scope, column_name;
+			END
+		END
+	END
+	
+	ELSE 
+	BEGIN
+		SELECT TOP 1 @special_col_type = constraint_type, @constraint_name = constraint_name FROM sys.sp_special_columns_view
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+			AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier))
+		ORDER BY constraint_type, index_id;
+
+		IF @special_col_type='u'
+		BEGIN
+			IF @scope='C'
+			BEGIN
+				SELECT 
+				CAST(0 AS smallint) AS SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND @constraint_name = constraint_name
+				ORDER BY scope, column_name;
+			END
+			
+			ELSE
+			BEGIN
+				SELECT SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND @constraint_name = constraint_name
+				ORDER BY scope, column_name;
+			END
+		
+		END
+		ELSE
+		BEGIN
+			IF @scope='C'
+			BEGIN
+				SELECT 
+				CAST(0 AS smallint) AS SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND CONSTRAINT_TYPE = 'p'
+				ORDER BY scope, column_name; 
+			END
+			
+			ELSE
+			BEGIN
+				SELECT SCOPE,
+				COLUMN_NAME,
+				DATA_TYPE,
+				TYPE_NAME,
+				PRECISION,
+				LENGTH,
+				SCALE,
+				PSEUDO_COLUMN FROM sys.sp_special_columns_view
+				WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+				AND ((SELECT coalesce(@table_owner,'')) = '' OR pg_catalog.lower(table_owner) = pg_catalog.lower(@table_owner))
+				AND ((SELECT coalesce(@qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@qualifier)) AND pg_catalog.lower(constraint_type) = pg_catalog.lower(@special_col_type)
+				AND CONSTRAINT_TYPE = 'p'
+				ORDER BY scope, column_name;
+			END
+    
+		END
+	END
+
+END; 
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE on PROCEDURE sys.sp_special_columns TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_fkeys(
+	"@pktable_name" sys.sysname = '',
+	"@pktable_owner" sys.sysname = '',
+	"@pktable_qualifier" sys.sysname = '',
+	"@fktable_name" sys.sysname = '',
+	"@fktable_owner" sys.sysname = '',
+	"@fktable_qualifier" sys.sysname = ''
+)
+AS $$
+BEGIN
+	
+	IF coalesce(@pktable_name,'') = '' AND coalesce(@fktable_name,'') = '' 
+	BEGIN
+		THROW 33557097, N'Primary or foreign key table name must be given.', 1;
+	END
+	
+	IF (@pktable_qualifier != '' AND (SELECT sys.db_name()) != @pktable_qualifier) OR 
+		(@fktable_qualifier != '' AND (SELECT sys.db_name()) != @fktable_qualifier) 
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+  	END
+  	
+  	SELECT 
+	PKTABLE_QUALIFIER,
+	PKTABLE_OWNER,
+	PKTABLE_NAME,
+	PKCOLUMN_NAME,
+	FKTABLE_QUALIFIER,
+	FKTABLE_OWNER,
+	FKTABLE_NAME,
+	FKCOLUMN_NAME,
+	KEY_SEQ,
+	UPDATE_RULE,
+	DELETE_RULE,
+	FK_NAME,
+	PK_NAME,
+	DEFERRABILITY
+	FROM sys.sp_fkeys_view
+	WHERE ((SELECT coalesce(@pktable_name,'')) = '' OR pg_catalog.lower(pktable_name) = pg_catalog.lower(@pktable_name))
+		AND ((SELECT coalesce(@fktable_name,'')) = '' OR pg_catalog.lower(fktable_name) = pg_catalog.lower(@fktable_name))
+		AND ((SELECT coalesce(@pktable_owner,'')) = '' OR pg_catalog.lower(pktable_owner) = pg_catalog.lower(@pktable_owner))
+		AND ((SELECT coalesce(@pktable_qualifier,'')) = '' OR pg_catalog.lower(pktable_qualifier) = pg_catalog.lower(@pktable_qualifier))
+		AND ((SELECT coalesce(@fktable_owner,'')) = '' OR pg_catalog.lower(fktable_owner) = pg_catalog.lower(@fktable_owner))
+		AND ((SELECT coalesce(@fktable_qualifier,'')) = '' OR pg_catalog.lower(fktable_qualifier) = pg_catalog.lower(@fktable_qualifier))
+	ORDER BY fktable_qualifier, fktable_owner, fktable_name, key_seq;
+
+END; 
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_fkeys TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_stored_procedures(
+    "@sp_name" sys.nvarchar(390) = '',
+    "@sp_owner" sys.nvarchar(384) = '',
+    "@sp_qualifier" sys.sysname = '',
+    "@fusepattern" sys.bit = '1'
+)
+AS $$
+BEGIN
+	IF (@sp_qualifier != '') AND pg_catalog.lower(sys.db_name()) != pg_catalog.lower(@sp_qualifier)
+	BEGIN
+		THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+	END
+	
+	-- If @sp_name or @sp_owner = '%', it gets converted to NULL or '' regardless of @fusepattern 
+	IF @sp_name = '%'
+	BEGIN
+		SELECT @sp_name = ''
+	END
+	
+	IF @sp_owner = '%'
+	BEGIN
+		SELECT @sp_owner = ''
+	END
+	
+	-- Changes fusepattern to 0 if no wildcards are used. NOTE: Need to add [] wildcard pattern when it is implemented. Wait for BABEL-2452
+	IF @fusepattern = 1
+	BEGIN
+		IF (CHARINDEX('%', @sp_name) != 0 AND CHARINDEX('_', @sp_name) != 0 AND CHARINDEX('%', @sp_owner) != 0 AND CHARINDEX('_', @sp_owner) != 0 )
+		BEGIN
+			SELECT @fusepattern = 0;
+		END
+	END
+	
+	-- Condition for when sp_name argument is not given or is null, or is just a wildcard (same order)
+	IF COALESCE(@sp_name, '') = ''
+	BEGIN
+		IF @fusepattern=1 
+		BEGIN
+			SELECT 
+			PROCEDURE_QUALIFIER,
+			PROCEDURE_OWNER,
+			PROCEDURE_NAME,
+			NUM_INPUT_PARAMS,
+			NUM_OUTPUT_PARAMS,
+			NUM_RESULT_SETS,
+			REMARKS,
+			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+			WHERE ((SELECT COALESCE(@sp_owner,'')) = '' OR pg_catalog.lower(procedure_owner) LIKE pg_catalog.lower(@sp_owner))
+			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+		END
+		ELSE
+		BEGIN
+			SELECT 
+			PROCEDURE_QUALIFIER,
+			PROCEDURE_OWNER,
+			PROCEDURE_NAME,
+			NUM_INPUT_PARAMS,
+			NUM_OUTPUT_PARAMS,
+			NUM_RESULT_SETS,
+			REMARKS,
+			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+			WHERE ((SELECT COALESCE(@sp_owner,'')) = '' OR pg_catalog.lower(procedure_owner) LIKE pg_catalog.lower(@sp_owner))
+			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+		END
+	END
+	-- When @sp_name is not null
+	ELSE
+	BEGIN
+		-- When sp_owner is null and fusepattern = 0
+		IF (@fusepattern = 0 AND  COALESCE(@sp_owner,'') = '') 
+		BEGIN
+			IF EXISTS ( -- Search in the sys schema 
+					SELECT * FROM sys.sp_stored_procedures_view
+					WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+						AND (pg_catalog.lower(procedure_owner) = 'sys'))
+			BEGIN
+				SELECT PROCEDURE_QUALIFIER,
+				PROCEDURE_OWNER,
+				PROCEDURE_NAME,
+				NUM_INPUT_PARAMS,
+				NUM_OUTPUT_PARAMS,
+				NUM_RESULT_SETS,
+				REMARKS,
+				PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = 'sys')
+				ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+			END
+			ELSE IF EXISTS ( 
+				SELECT * FROM sys.sp_stored_procedures_view
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = pg_catalog.lower(SCHEMA_NAME()))
+					)
+			BEGIN
+				SELECT PROCEDURE_QUALIFIER,
+				PROCEDURE_OWNER,
+				PROCEDURE_NAME,
+				NUM_INPUT_PARAMS,
+				NUM_OUTPUT_PARAMS,
+				NUM_RESULT_SETS,
+				REMARKS,
+				PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = pg_catalog.lower(SCHEMA_NAME()))
+				ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+			END
+			ELSE -- Search in the dbo schema (if nothing exists it should just return nothing). 
+			BEGIN
+				SELECT PROCEDURE_QUALIFIER,
+				PROCEDURE_OWNER,
+				PROCEDURE_NAME,
+				NUM_INPUT_PARAMS,
+				NUM_OUTPUT_PARAMS,
+				NUM_RESULT_SETS,
+				REMARKS,
+				PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+				WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+					AND (pg_catalog.lower(procedure_owner) = 'dbo')
+				ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+			END
+			
+		END
+		ELSE IF (@fusepattern = 0 AND  COALESCE(@sp_owner,'') != '')
+		BEGIN
+			SELECT 
+			PROCEDURE_QUALIFIER,
+			PROCEDURE_OWNER,
+			PROCEDURE_NAME,
+			NUM_INPUT_PARAMS,
+			NUM_OUTPUT_PARAMS,
+			NUM_RESULT_SETS,
+			REMARKS,
+			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+			WHERE (pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) = pg_catalog.lower(@sp_name))
+				AND (pg_catalog.lower(procedure_owner) = pg_catalog.lower(@sp_owner))
+			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+		END
+		ELSE -- fusepattern = 1
+		BEGIN
+			SELECT 
+			PROCEDURE_QUALIFIER,
+			PROCEDURE_OWNER,
+			PROCEDURE_NAME,
+			NUM_INPUT_PARAMS,
+			NUM_OUTPUT_PARAMS,
+			NUM_RESULT_SETS,
+			REMARKS,
+			PROCEDURE_TYPE FROM sys.sp_stored_procedures_view
+			WHERE ((SELECT COALESCE(@sp_name,'')) = '' OR pg_catalog.lower(pg_catalog.LEFT(procedure_name, LEN(procedure_name)-2)) LIKE pg_catalog.lower(@sp_name))
+				AND ((SELECT COALESCE(@sp_owner,'')) = '' OR pg_catalog.lower(procedure_owner) LIKE pg_catalog.lower(@sp_owner))
+			ORDER BY procedure_qualifier, procedure_owner, procedure_name;
+		END
+	END	
+END; 
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE on PROCEDURE sys.sp_stored_procedures TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION is_srvrolemember(role sys.SYSNAME, login sys.SYSNAME DEFAULT suser_name())
+RETURNS INTEGER AS
+$$
+DECLARE has_role BOOLEAN;
+DECLARE login_valid BOOLEAN;
+BEGIN
+	role  := TRIM(trailing from pg_catalog.LOWER(role));
+	login := TRIM(trailing from pg_catalog.LOWER(login));
+	
+	login_valid = (login = suser_name()) OR 
+		(EXISTS (SELECT name
+	 			FROM sys.server_principals
+		 	 	WHERE 
+				pg_catalog.LOWER(name) = login 
+				AND type = 'S'));
+ 	
+ 	IF NOT login_valid THEN
+ 		RETURN NULL;
+    
+    ELSIF role = 'public' THEN
+    	RETURN 1;
+	
+ 	ELSIF role = 'sysadmin' THEN
+	  	has_role = pg_has_role(login::TEXT, role::TEXT, 'MEMBER');
+	    IF has_role THEN
+			RETURN 1;
+		ELSE
+			RETURN 0;
+		END IF;
+	
+    ELSIF role IN (
+            'serveradmin',
+            'securityadmin',
+            'setupadmin',
+            'securityadmin',
+            'processadmin',
+            'dbcreator',
+            'diskadmin',
+            'bulkadmin') THEN 
+    	RETURN 0;
+ 	
+    ELSE
+ 		  RETURN NULL;
+ 	END IF;
+	
+ 	EXCEPTION WHEN OTHERS THEN
+	 	  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE PROCEDURE sys.sp_helprole("@rolename" sys.SYSNAME = NULL) AS
+$$
+BEGIN
+	-- If role is not specified, return info for all roles in the current db
+	IF @rolename IS NULL
+	BEGIN
+		SELECT CAST(Ext.orig_username AS sys.SYSNAME) AS 'RoleName',
+			   CAST(Base.oid AS INT) AS 'RoleId',
+			   0 AS 'IsAppRole'
+		FROM pg_catalog.pg_roles AS Base 
+		INNER JOIN sys.babelfish_authid_user_ext AS Ext
+		ON Base.rolname = Ext.rolname
+		WHERE Ext.database_name = DB_NAME()
+		AND Ext.type = 'R'
+		ORDER BY RoleName;
+	END
+	-- If a valid role is specified, return its info
+	ELSE IF EXISTS (SELECT 1 
+					FROM sys.babelfish_authid_user_ext
+					WHERE (orig_username = @rolename
+					OR pg_catalog.lower(orig_username) = pg_catalog.lower(@rolename))
+					AND database_name = DB_NAME()
+					AND type = 'R')
+	BEGIN
+		SELECT CAST(Ext.orig_username AS sys.SYSNAME) AS 'RoleName',
+			   CAST(Base.oid AS INT) AS 'RoleId',
+			   0 AS 'IsAppRole'
+		FROM pg_catalog.pg_roles AS Base 
+		INNER JOIN sys.babelfish_authid_user_ext AS Ext
+		ON Base.rolname = Ext.rolname
+		WHERE Ext.database_name = DB_NAME()
+		AND Ext.type = 'R'
+		AND (Ext.orig_username = @rolename OR pg_catalog.lower(Ext.orig_username) = pg_catalog.lower(@rolename))
+		ORDER BY RoleName;
+	END
+	-- If the specified role is not valid
+	ELSE
+		RAISERROR('%s is not a role.', 16, 1, @rolename);
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_helprole TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_helprolemember("@rolename" sys.SYSNAME = NULL) AS
+$$
+BEGIN
+	-- If role is not specified, return info for all roles that have at least
+	-- one member in the current db
+	IF @rolename IS NULL
+	BEGIN
+		SELECT CAST(Ext1.orig_username AS sys.SYSNAME) AS 'RoleName',
+			   CAST(Ext2.orig_username AS sys.SYSNAME) AS 'MemberName',
+			   CAST(CAST(Base2.oid AS INT) AS sys.VARBINARY(85)) AS 'MemberSID'
+		FROM pg_catalog.pg_auth_members AS Authmbr
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.oid = Authmbr.roleid
+		INNER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.member
+		INNER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Base1.rolname = Ext1.rolname
+		INNER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext2.database_name = DB_NAME()
+		AND Ext1.type = 'R'
+		AND Ext2.orig_username != 'db_owner'
+		ORDER BY RoleName, MemberName;
+	END
+	-- If a valid role is specified, return its member info
+	ELSE IF EXISTS (SELECT 1
+					FROM sys.babelfish_authid_user_ext
+					WHERE (orig_username = @rolename
+					OR pg_catalog.lower(orig_username) = pg_catalog.lower(@rolename))
+					AND database_name = DB_NAME()
+					AND type = 'R')
+	BEGIN
+		SELECT CAST(Ext1.orig_username AS sys.SYSNAME) AS 'RoleName',
+			   CAST(Ext2.orig_username AS sys.SYSNAME) AS 'MemberName',
+			   CAST(CAST(Base2.oid AS INT) AS sys.VARBINARY(85)) AS 'MemberSID'
+		FROM pg_catalog.pg_auth_members AS Authmbr
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.oid = Authmbr.roleid
+		INNER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.member
+		INNER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Base1.rolname = Ext1.rolname
+		INNER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		WHERE Ext1.database_name = DB_NAME()
+		AND Ext2.database_name = DB_NAME()
+		AND Ext1.type = 'R'
+		AND Ext2.orig_username != 'db_owner'
+		AND (Ext1.orig_username = @rolename OR pg_catalog.lower(Ext1.orig_username) = pg_catalog.lower(@rolename))
+		ORDER BY RoleName, MemberName;
+	END
+	-- If the specified role is not valid
+	ELSE
+		RAISERROR('%s is not a role.', 16, 1, @rolename);
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_helprolemember TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_helpsrvrolemember("@srvrolename" sys.SYSNAME = NULL) AS
+$$
+BEGIN
+	-- If server role is not specified, return info for all server roles
+	IF @srvrolename IS NULL
+	BEGIN
+		SELECT CAST(Ext1.rolname AS sys.SYSNAME) AS 'ServerRole',
+			   CAST(Ext2.rolname AS sys.SYSNAME) AS 'MemberName',
+			   CAST(CAST(Base2.oid AS INT) AS sys.VARBINARY(85)) AS 'MemberSID'
+		FROM pg_catalog.pg_auth_members AS Authmbr
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.oid = Authmbr.roleid
+		INNER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.member
+		INNER JOIN sys.babelfish_authid_login_ext AS Ext1 ON Base1.rolname = Ext1.rolname
+		INNER JOIN sys.babelfish_authid_login_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		WHERE Ext1.type = 'R'
+		ORDER BY ServerRole, MemberName;
+	END
+	-- If a valid server role is specified, return its member info
+	-- If the role is a SQL server predefined role (i.e. serveradmin), 
+	-- do not raise an error even if it does not exist
+	ELSE IF EXISTS (SELECT 1
+					FROM sys.babelfish_authid_login_ext
+					WHERE (rolname = PG_CATALOG.RTRIM(@srvrolename)
+					OR pg_catalog.lower(rolname) = pg_catalog.lower(PG_CATALOG.RTRIM(@srvrolename)))
+					AND type = 'R')
+					OR pg_catalog.lower(pg_catalog.RTRIM(@srvrolename)) IN (
+					'serveradmin', 'setupadmin', 'securityadmin', 'processadmin',
+					'dbcreator', 'diskadmin', 'bulkadmin')
+	BEGIN
+		SELECT CAST(Ext1.rolname AS sys.SYSNAME) AS 'ServerRole',
+			   CAST(Ext2.rolname AS sys.SYSNAME) AS 'MemberName',
+			   CAST(CAST(Base2.oid AS INT) AS sys.VARBINARY(85)) AS 'MemberSID'
+		FROM pg_catalog.pg_auth_members AS Authmbr
+		INNER JOIN pg_catalog.pg_roles AS Base1 ON Base1.oid = Authmbr.roleid
+		INNER JOIN pg_catalog.pg_roles AS Base2 ON Base2.oid = Authmbr.member
+		INNER JOIN sys.babelfish_authid_login_ext AS Ext1 ON Base1.rolname = Ext1.rolname
+		INNER JOIN sys.babelfish_authid_login_ext AS Ext2 ON Base2.rolname = Ext2.rolname
+		WHERE Ext1.type = 'R'
+		AND (Ext1.rolname = pg_catalog.RTRIM(@srvrolename) OR pg_catalog.lower(Ext1.rolname) = pg_catalog.lower(pg_catalog.RTRIM(@srvrolename)))
+		ORDER BY ServerRole, MemberName;
+	END
+	-- If the specified server role is not valid
+	ELSE
+		RAISERROR('%s is not a known fixed role.', 16, 1, @srvrolename);
+END;
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_helpsrvrolemember TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_helpdbfixedrole("@rolename" sys.SYSNAME = NULL) AS
+$$
+BEGIN
+	-- Returns a list of the fixed database roles. 
+	-- Only fixed role present in babelfish is db_owner.
+	IF pg_catalog.LOWER(pg_catalog.RTRIM(@rolename)) IS NULL OR pg_catalog.LOWER(pg_catalog.RTRIM(@rolename)) = 'db_owner'
+	BEGIN
+		SELECT CAST('db_owner' AS sys.SYSNAME) AS DbFixedRole, CAST('DB Owners' AS sys.nvarchar(70)) AS Description;
+	END
+	ELSE IF pg_catalog.LOWER(pg_catalog.RTRIM(@rolename)) IN (
+			'db_accessadmin','db_securityadmin','db_ddladmin', 'db_backupoperator', 
+			'db_datareader', 'db_datawriter', 'db_denydatareader', 'db_denydatawriter')
+	BEGIN
+		-- Return an empty result set instead of raising an error
+		SELECT CAST(NULL AS sys.SYSNAME) AS DbFixedRole, CAST(NULL AS sys.nvarchar(70)) AS Description
+		WHERE 1=0;	
+	END
+	ELSE
+		RAISERROR('''%s'' is not a known fixed role.', 16, 1, @rolename);
+END
+$$
+LANGUAGE 'pltsql';
+GRANT EXECUTE ON PROCEDURE sys.sp_helpdbfixedrole TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_sproc_columns(
+	"@procedure_name" sys.nvarchar(390) = '%',
+	"@procedure_owner" sys.nvarchar(384) = NULL,
+	"@procedure_qualifier" sys.sysname = NULL,
+	"@column_name" sys.nvarchar(384) = NULL,
+	"@odbcver" int = 2,
+	"@fusepattern" sys.bit = '1'
+)	
+AS $$
+	SELECT @procedure_name = pg_catalog.lower(COALESCE(@procedure_name, ''))
+	SELECT @procedure_owner = pg_catalog.lower(COALESCE(@procedure_owner, ''))
+	SELECT @procedure_qualifier = pg_catalog.lower(COALESCE(@procedure_qualifier, ''))
+	SELECT @column_name = pg_catalog.lower(COALESCE(@column_name, ''))
+BEGIN 
+	IF (@procedure_qualifier != '' AND (SELECT pg_catalog.lower(sys.db_name())) != @procedure_qualifier)
+		BEGIN
+			THROW 33557097, N'The database name component of the object qualifier must be the name of the current database.', 1;
+ 	   	END
+	IF @fusepattern = '1'
+		BEGIN
+			SELECT PROCEDURE_QUALIFIER,
+					PROCEDURE_OWNER,
+					PROCEDURE_NAME,
+					COLUMN_NAME,
+					COLUMN_TYPE,
+					DATA_TYPE,
+					TYPE_NAME,
+					PRECISION,
+					LENGTH,
+					SCALE,
+					RADIX,
+					NULLABLE,
+					REMARKS,
+					COLUMN_DEF,
+					SQL_DATA_TYPE,
+					SQL_DATETIME_SUB,
+					CHAR_OCTET_LENGTH,
+					ORDINAL_POSITION,
+					IS_NULLABLE,
+					SS_DATA_TYPE
+			FROM sys.sp_sproc_columns_view
+			WHERE (@procedure_name = '' OR original_procedure_name LIKE @procedure_name)
+				AND (@procedure_owner = '' OR procedure_owner LIKE @procedure_owner)
+				AND (@column_name = '' OR column_name LIKE @column_name)
+				AND (@procedure_qualifier = '' OR procedure_qualifier = @procedure_qualifier)
+			ORDER BY procedure_qualifier, procedure_owner, procedure_name, ordinal_position;
+		END
+	ELSE
+		BEGIN
+			SELECT PROCEDURE_QUALIFIER,
+					PROCEDURE_OWNER,
+					PROCEDURE_NAME,
+					COLUMN_NAME,
+					COLUMN_TYPE,
+					DATA_TYPE,
+					TYPE_NAME,
+					PRECISION,
+					LENGTH,
+					SCALE,
+					RADIX,
+					NULLABLE,
+					REMARKS,
+					COLUMN_DEF,
+					SQL_DATA_TYPE,
+					SQL_DATETIME_SUB,
+					CHAR_OCTET_LENGTH,
+					ORDINAL_POSITION,
+					IS_NULLABLE,
+					SS_DATA_TYPE
+			FROM sys.sp_sproc_columns_view
+			WHERE (@procedure_name = '' OR original_procedure_name = @procedure_name)
+				AND (@procedure_owner = '' OR procedure_owner = @procedure_owner)
+				AND (@column_name = '' OR column_name = @column_name)
+				AND (@procedure_qualifier = '' OR procedure_qualifier = @procedure_qualifier)
+			ORDER BY procedure_qualifier, procedure_owner, procedure_name, ordinal_position;
+		END
+END; 
+$$
+LANGUAGE 'pltsql';
+GRANT ALL ON PROCEDURE sys.sp_sproc_columns TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_babelfish_autoformat(
+	IN "@tab"        sys.VARCHAR(257) DEFAULT NULL,
+	IN "@orderby"    sys.VARCHAR(1000) DEFAULT '',
+	IN "@printrc"    sys.bit DEFAULT 1,
+	IN "@hiddencols" sys.VARCHAR(1000) DEFAULT NULL)
+LANGUAGE 'pltsql'
+AS $$
+BEGIN
+	SET NOCOUNT ON
+	DECLARE @rc INT
+	DECLARE @id INT
+	DECLARE @objtype sys.VARCHAR(2)	
+	DECLARE @msg sys.VARCHAR(200)	
+	
+	IF @tab IS NULL
+	BEGIN
+		RAISERROR('Must specify table name', 16, 1)
+		RETURN		
+	END
+	
+	IF sys.TRIM(@tab) = ''
+	BEGIN
+		RAISERROR('Must specify table name', 16, 1)
+		RETURN		
+	END	
+	
+	-- Since we cannot find #tmp tables in the Babelfish catalogs, we cannot check 
+	-- their existence other than by trying to select from them
+	-- Function sys.babelfish_get_enr_list() could be used to determine if a #tmp table
+	-- exists but the columns and datatypes can still not be retrieved, it would be of 
+	-- little use here. 
+	-- NB: not handling uncommon but valid T-SQL syntax '<schemaname>.#tmp' for #tmp tables
+	IF sys.SUBSTRING(@tab,1,1) <> '#'
+	BEGIN
+		SET @id = sys.OBJECT_ID(@tab)
+		IF @id IS NULL
+		BEGIN
+			IF sys.SUBSTRING(pg_catalog.UPPER(@tab),1,4) = 'DBO.'
+			BEGIN
+				SET @id = sys.OBJECT_ID('SYS.' + sys.SUBSTRING(@tab,5))
+			END
+			IF @id IS NULL
+			BEGIN		
+				SET @msg = 'Table or view '''+@tab+''' not found'
+				RAISERROR(@msg, 16, 1)
+				RETURN		
+			END
+		END
+	END
+	
+	SELECT @objtype = type COLLATE DATABASE_DEFAULT FROM sys.sysobjects WHERE id = @id 
+	IF @objtype NOT IN ('U', 'S', 'V') 
+	BEGIN
+		SET @msg = ''''+@tab+''' is not a table or view'
+		RAISERROR(@msg, 16, 1)
+		RETURN		
+	END
+	
+	-- check for 'ORDER BY', if specified
+	SET @orderby = sys.TRIM(@orderby)
+	IF @orderby <> ''
+	BEGIN
+		IF pg_catalog.UPPER(@orderby) NOT LIKE 'ORDER BY%'
+		BEGIN
+			RAISERROR('@orderby parameter must start with ''ORDER BY''', 16, 1)
+			RETURN
+		END
+	END
+	
+	-- columns to hide in final client output
+	-- assuming delimited column names do not contain spaces or commas inside the name
+	-- remove any spaces around the commas:
+	WHILE (sys.CHARINDEX(' ,', @hiddencols) > 0) or (sys.CHARINDEX(', ', @hiddencols) > 0)
+	BEGIN
+		SET @hiddencols = sys.REPLACE(@hiddencols, ' ,', ',')
+		SET @hiddencols = sys.REPLACE(@hiddencols, ', ', ',')
+	END
+	IF sys.LEN(@hiddencols) IS NOT NULL SET @hiddencols = ',' + @hiddencols + ','
+	SET @hiddencols = pg_catalog.UPPER(@hiddencols)	
+
+	-- Need to use a guaranteed-uniquely named table as intermediate step since we cannot 
+	-- access the metadata in case a #tmp table is passed as argument
+	-- But when we copy the #tmp table into another table, we get all the attributes and metadata
+	DECLARE @tmptab sys.VARCHAR(63) = 'sp_babelfish_autoformat' + sys.REPLACE(CAST(NEWID() AS sys.NVARCHAR(36)), '-', '')
+	DECLARE @tmptab2 sys.VARCHAR(63) = 'sp_babelfish_autoformat' + sys.REPLACE(CAST(NEWID() AS sys.NVARCHAR(36)), '-', '')
+	DECLARE @cmd sys.VARCHAR(1000) = 'SELECT * INTO ' + @tmptab + ' FROM ' + @tab
+	
+	BEGIN TRY
+		-- create the first work table
+		EXECUTE(@cmd)
+
+		-- Get the columns
+		SELECT 
+		   c.name AS colname, c.colid AS colid, t.name AS basetype, 0 AS maxlen
+		INTO #sp_bbf_autoformat
+		FROM sys.syscolumns c left join sys.systypes t 
+		ON c.xusertype = t.xusertype		
+		WHERE c.id = sys.OBJECT_ID(@tmptab)
+		ORDER BY c.colid
+
+		-- Get max length for each column based on the data
+		DECLARE @colname sys.VARCHAR(63), @basetype sys.VARCHAR(63), @maxlen int
+		DECLARE c CURSOR FOR SELECT colname, basetype, maxlen FROM #sp_bbf_autoformat ORDER BY colid
+		OPEN c
+		WHILE 1=1
+		BEGIN
+			FETCH c INTO @colname, @basetype, @maxlen
+			IF @@fetch_status <> 0 BREAK
+			SET @cmd = 'DECLARE @i INT SELECT @i=ISNULL(MAX(sys.LEN(CAST([' + @colname + '] AS sys.VARCHAR(500)))),4) FROM ' + @tmptab + ' UPDATE #sp_bbf_autoformat SET maxlen = @i WHERE colname = ''' + @colname + ''''
+			EXECUTE(@cmd)
+		END
+		CLOSE c
+		DEALLOCATE c
+
+		-- Generate the final SELECT
+		DECLARE @selectlist sys.VARCHAR(8000) = ''
+		DECLARE @collist sys.VARCHAR(8000) = ''
+		DECLARE @fmtstart sys.VARCHAR(30) = ''
+		DECLARE @fmtend sys.VARCHAR(30) = ''
+		OPEN c
+		WHILE 1=1
+		BEGIN
+			FETCH c INTO @colname, @basetype, @maxlen
+			IF @@fetch_status <> 0 BREAK
+			IF sys.LEN(@colname) > @maxlen SET @maxlen = sys.LEN(@colname)
+			IF @maxlen <= 0 SET @maxlen = 1
+			
+			IF (sys.CHARINDEX(',' + pg_catalog.UPPER(@colname) + ',', @hiddencols) > 0) OR (sys.CHARINDEX(',[' + pg_catalog.UPPER(@colname) + '],', @hiddencols) > 0) 
+			BEGIN
+				SET @selectlist += ' [' + @colname + '],'			
+			END
+			ELSE 
+			BEGIN
+				SET @fmtstart = ''
+				SET @fmtend = ''
+				IF @basetype IN ('tinyint', 'smallint', 'int', 'bigint', 'decimal', 'numeric', 'real', 'float') 
+				BEGIN
+					SET @fmtstart = 'CAST(right(space('+CAST(@maxlen AS sys.VARCHAR)+')+'
+					SET @fmtend = ','+CAST(@maxlen AS sys.VARCHAR)+') AS sys.VARCHAR(' + CAST(@maxlen AS sys.VARCHAR) + '))'
+				END
+
+				SET @selectlist += ' '+@fmtstart+'CAST([' + @colname + '] AS sys.VARCHAR(' + CAST(@maxlen AS sys.VARCHAR) + '))'+@fmtend+' AS [' + @colname + '],'
+				SET @collist += '['+@colname + '],'
+			END
+		END
+		CLOSE c
+		DEALLOCATE c
+
+		-- Remove redundant commas
+		SET @collist = sys.SUBSTRING(@collist, 1, sys.LEN(@collist)-1)
+		SET @selectlist = sys.SUBSTRING(@selectlist, 1, sys.LEN(@selectlist)-1)	
+		SET @selectlist = 'SELECT ' + @selectlist + ' INTO ' + @tmptab2 + ' FROM ' + @tmptab + ' ' + @orderby
+		
+		-- create the second work table
+		EXECUTE(@selectlist)
+		
+		-- perform the final SELECT to generate the result set for the client
+		EXECUTE('SELECT ' + @collist + ' FROM ' + @tmptab2)
+			
+		-- PRINT rowcount if desired
+		SET @rc = @@rowcount
+		IF @printrc = 1
+		BEGIN
+			PRINT '   '
+			SET @cmd = '(' + CAST(@rc AS sys.VARCHAR) + ' rows affected)'
+			PRINT @cmd
+		END
+		
+		-- Cleanup: these work tables are permanent tables after all
+		EXECUTE('DROP TABLE IF EXISTS ' + @tmptab)
+		EXECUTE('DROP TABLE IF EXISTS ' + @tmptab2)	
+	END TRY	
+	BEGIN CATCH
+		-- Cleanup in case of an unexpected error
+		EXECUTE('DROP TABLE IF EXISTS ' + @tmptab)
+		EXECUTE('DROP TABLE IF EXISTS ' + @tmptab2)		
+	END CATCH
+
+	RETURN
+END
+$$;
+GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_autoformat(IN sys.VARCHAR(257), IN sys.VARCHAR(1000), sys.bit, sys.VARCHAR(1000)) TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_who(
+	IN "@loginame" sys.sysname DEFAULT NULL,
+	IN "@option"   sys.VARCHAR(30) DEFAULT NULL)
+LANGUAGE 'pltsql'
+AS $$
+BEGIN
+	SET NOCOUNT ON
+	DECLARE @msg sys.VARCHAR(200)
+	DECLARE @show_pg BIT = 0
+	DECLARE @hide_col sys.VARCHAR(50) 
+	
+	IF @option IS NOT NULL
+	BEGIN
+		IF pg_catalog.lower(sys.TRIM(@option)) <> 'postgres' 
+		BEGIN
+			RAISERROR('Parameter @option can only be ''postgres''', 16, 1)
+			RETURN			
+		END
+	END
+	
+	-- Take a copy of sysprocesses so that we reference it only once
+	SELECT DISTINCT * INTO #sp_who_sysprocesses FROM sys.sysprocesses
+
+	-- Get the executing statement for each spid and extract the main stmt type
+	-- This is for informational purposes only
+	SELECT pid, CAST(query AS sys.VARCHAR(MAX)) INTO #sp_who_tmp FROM pg_stat_activity pgsa
+	
+	UPDATE #sp_who_tmp SET query = ' ' + sys.TRIM(CAST(pg_catalog.UPPER(query) AS sys.VARCHAR(MAX)))
+	UPDATE #sp_who_tmp SET query = sys.REPLACE(query,  chr(9), ' ')
+	UPDATE #sp_who_tmp SET query = sys.REPLACE(query,  chr(10), ' ')
+	UPDATE #sp_who_tmp SET query = sys.REPLACE(query,  chr(13), ' ')
+	WHILE (SELECT count(*) FROM #sp_who_tmp WHERE sys.CHARINDEX('  ',query)>0) > 0 
+	BEGIN
+		UPDATE #sp_who_tmp SET query = sys.REPLACE(query, '  ', ' ')
+	END
+
+	-- Determine type of stmt to report by sp_who: very basic only
+	-- NB: not handling presence of comments in the query string
+	UPDATE #sp_who_tmp 
+	SET query = 
+	    CASE 
+			WHEN PATINDEX('%[^a-zA-Z0-9_]UPDATE[^a-zA-Z0-9_]%', query) > 0 THEN 'UPDATE'
+			WHEN PATINDEX('%[^a-zA-Z0-9_]DELETE[^a-zA-Z0-9_]%', query) > 0 THEN 'DELETE'
+			WHEN PATINDEX('%[^a-zA-Z0-9_]INSERT[^a-zA-Z0-9_]%', query) > 0 THEN 'INSERT'
+			WHEN PATINDEX('%[^a-zA-Z0-9_]SELECT[^a-zA-Z0-9_]%', query) > 0 THEN 'SELECT'
+			WHEN PATINDEX('%[^a-zA-Z0-9_]WAITFOR[^a-zA-Z0-9_]%', query) > 0 THEN 'WAITFOR'
+			WHEN PATINDEX('%[^a-zA-Z0-9_]CREATE ]%', query) > 0 THEN sys.SUBSTRING(query,1,sys.CHARINDEX('CREATE ', query))
+			WHEN PATINDEX('%[^a-zA-Z0-9_]ALTER ]%', query) > 0 THEN sys.SUBSTRING(query,1,sys.CHARINDEX('ALTER ', query))
+			WHEN PATINDEX('%[^a-zA-Z0-9_]DROP ]%', query) > 0 THEN sys.SUBSTRING(query,1,sys.CHARINDEX('DROP ', query))
+			ELSE sys.SUBSTRING(query, 1, sys.CHARINDEX(' ', query))
+		END
+
+	UPDATE #sp_who_tmp 
+	SET query = sys.SUBSTRING(query,1, 8-1 + sys.CHARINDEX(' ', sys.SUBSTRING(query,8,99)))
+	WHERE query LIKE 'CREATE %' OR query LIKE 'ALTER %' OR query LIKE 'DROP %'	
+
+	-- The executing spid is always shown as doing a SELECT
+	UPDATE #sp_who_tmp SET query = 'SELECT' WHERE pid = @@spid
+	UPDATE #sp_who_tmp SET query = sys.TRIM(query)
+
+	-- Get all current connections
+	SELECT 
+		spid, 
+		MAX(blocked) AS blocked, 
+		0 AS ecid, 
+		CAST('' AS sys.VARCHAR(100)) AS status,
+		CAST('' AS sys.VARCHAR(100)) AS loginname,
+		CAST('' AS sys.VARCHAR(100)) AS hostname,
+		0 AS dbid,
+		CAST('' AS sys.VARCHAR(100)) AS cmd,
+		0 AS request_id,
+		CAST('TDS' AS sys.VARCHAR(20)) AS connection,
+		hostprocess
+	INTO #sp_who_proc
+	FROM #sp_who_sysprocesses
+		GROUP BY spid, status, hostprocess
+		
+	-- Add attributes to each connection
+	UPDATE #sp_who_proc
+	SET ecid = sp.ecid,
+		status = sp.status,
+		loginname = sp.loginname,
+		hostname = sp.hostname,
+		dbid = sp.dbid,
+		request_id = sp.request_id
+	FROM #sp_who_sysprocesses sp
+		WHERE #sp_who_proc.spid = sp.spid				
+
+	-- Identify PG connections: the hostprocess PID comes from the TDS login packet 
+	-- and therefore PG connections do not have a value here
+	UPDATE #sp_who_proc
+	SET connection = 'PostgreSQL'
+	WHERE hostprocess IS NULL 
+
+	-- Keep or delete PG connections
+	IF (pg_catalog.lower(@loginame) = 'postgres' OR pg_catalog.lower(@option) = 'postgres')
+	begin    
+		-- Show PG connections; these have dbid = 0
+		-- This is a Babelfish-specific enhancement, since PG connections may also be active in the Babelfish DB
+		-- and it may be useful to see these displayed
+		SET @show_pg = 1
+		
+		-- blank out the loginame parameter for the tests below
+		IF pg_catalog.lower(@loginame) = 'postgres' SET @loginame = NULL
+	END
+	
+	-- By default, do not show the column indicating the connection type since SQL Server does not have this column
+	SET @hide_col = 'connection' 
+	
+	IF (@show_pg = 1) 
+	BEGIN
+		SET @hide_col = ''
+	END
+	ELSE 
+	BEGIN
+		-- Delete PG connections
+		DELETE #sp_who_proc
+		WHERE dbid = 0
+	END
+			
+	-- Apply filter if specified
+	IF (@loginame IS NOT NULL)
+	BEGIN
+		IF (sys.TRIM(@loginame) = '')
+		BEGIN
+			-- Raise error
+			SET @msg = ''''+@loginame+''' is not a valid login or you do not have permission.'
+			RAISERROR(@msg, 16, 1)
+			RETURN
+		END
+		
+		IF (sys.ISNUMERIC(@loginame) = 1)
+		BEGIN
+			-- Remove all connections except the specified one
+			DELETE #sp_who_proc
+			WHERE spid <> CAST(@loginame AS INT)
+		END
+		ELSE 
+		BEGIN	
+			IF (pg_catalog.lower(@loginame) = 'active')
+			BEGIN
+				-- Remove all 'idle' connections 
+				DELETE #sp_who_proc
+				WHERE status = 'idle'
+			END
+			ELSE 
+			BEGIN
+				-- Verify the specified login name exists
+				IF (sys.SUSER_ID(@loginame) IS NULL)
+				BEGIN
+					SET @msg = ''''+@loginame+''' is not a valid login or you do not have permission.'
+					RAISERROR(@msg, 16, 1)
+					RETURN					
+				END
+				ELSE 
+				BEGIN
+					-- Keep only connections for the specified login
+					DELETE #sp_who_proc
+					WHERE sys.SUSER_ID(loginname) <> sys.SUSER_ID(@loginame)
+				END
+			END
+		END
+	END			
+			
+	-- Create final result set; use DISTINCT since there are usually duplicate rows from the PG catalogs
+	SELECT distinct 
+		p.spid AS spid, 
+		p.ecid AS ecid, 
+		CAST(pg_catalog.LEFT(p.status,20) AS sys.VARCHAR(20)) AS status,
+		CAST(pg_catalog.LEFT(p.loginname,40) AS sys.VARCHAR(40)) AS loginame,
+		CAST(pg_catalog.LEFT(p.hostname,60) AS sys.VARCHAR(60)) AS hostname,
+		p.blocked AS blk, 
+		CAST(pg_catalog.LEFT(db_name(p.dbid),40) AS sys.VARCHAR(40)) AS dbname,
+		CAST(pg_catalog.LEFT(#sp_who_tmp.query,30)as sys.VARCHAR(30)) AS cmd,
+		p.request_id AS request_id,
+		connection
+	INTO #sp_who_tmp2
+	FROM #sp_who_proc p, #sp_who_tmp
+		WHERE p.spid = #sp_who_tmp.pid
+		ORDER BY spid		
+	
+	-- Patch up remaining cases
+	UPDATE #sp_who_tmp2
+	SET cmd = 'AWAITING COMMAND'
+	WHERE sys.TRIM(ISNULL(cmd,'')) = '' AND status = 'idle'
+	
+	UPDATE #sp_who_tmp2
+	SET cmd = 'UNKNOWN'
+	WHERE sys.TRIM(cmd) = ''	
+	
+	-- Format the result set as narrow as possible for readability
+	SET @hide_col += ',hostprocess'
+	EXECUTE sys.sp_babelfish_autoformat @tab='#sp_who_tmp2', @orderby='ORDER BY spid', @hiddencols=@hide_col, @printrc=0
+	RETURN
+END	
+$$;
+GRANT EXECUTE ON PROCEDURE sys.sp_who(IN sys.sysname, IN sys.VARCHAR(30)) TO PUBLIC;
+
+CREATE OR REPLACE VIEW information_schema_tsql.columns_internal AS
+	SELECT c.oid AS "TABLE_OID",
+			CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+			CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+			CAST(
+				COALESCE(
+					(SELECT PG_CATALOG.string_agg(
+						CASE
+						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23 /* prefix length */)
+						ELSE NULL
+						END, ',')
+					FROM unnest(c.reloptions) AS option),
+					c.relname)
+				AS sys.nvarchar(128)) AS "TABLE_NAME",
+
+			CAST(
+				COALESCE(
+					(SELECT PG_CATALOG.string_agg(
+						CASE
+						WHEN option LIKE 'bbf_original_name=%' THEN substring(option, 19 /* prefix length */)
+						ELSE NULL
+						END, ',')
+					FROM unnest(a.attoptions) AS option),
+					a.attname)
+				AS sys.nvarchar(128)) AS "COLUMN_NAME",
+
+			CAST(a.attnum AS int) AS "ORDINAL_POSITION",
+			CAST(CASE WHEN a.attgenerated = '' THEN pg_get_expr(ad.adbin, ad.adrelid) END AS sys.nvarchar(4000)) AS "COLUMN_DEFAULT",
+			CAST(CASE WHEN a.attnotnull OR (t.typtype = 'd' AND t.typnotnull) THEN 'NO' ELSE 'YES' END
+				AS varchar(3))
+				AS "IS_NULLABLE",
+
+			CAST(
+				CASE WHEN tsql_type_name = 'sysname' THEN sys.translate_pg_type_to_tsql(t.typbasetype)
+				WHEN tsql_type_name.tsql_type_name IS NULL THEN format_type(t.oid, NULL::integer)
+				ELSE tsql_type_name END
+				AS sys.nvarchar(128))
+				AS "DATA_TYPE",
+
+			CAST(
+				information_schema_tsql._pgtsql_char_max_length(tsql_type_name, true_typmod)
+				AS int)
+				AS "CHARACTER_MAXIMUM_LENGTH",
+
+			CAST(
+				information_schema_tsql._pgtsql_char_octet_length(tsql_type_name, true_typmod)
+				AS int)
+				AS "CHARACTER_OCTET_LENGTH",
+
+			CAST(
+				/* Handle Tinyint separately */
+				information_schema_tsql._pgtsql_numeric_precision(tsql_type_name, true_typid, true_typmod)
+				AS sys.tinyint)
+				AS "NUMERIC_PRECISION",
+
+			CAST(
+				information_schema_tsql._pgtsql_numeric_precision_radix(tsql_type_name, true_typid, true_typmod)
+				AS smallint)
+				AS "NUMERIC_PRECISION_RADIX",
+
+			CAST(
+				information_schema_tsql._pgtsql_numeric_scale(tsql_type_name, true_typid, true_typmod)
+				AS int)
+				AS "NUMERIC_SCALE",
+
+			CAST(
+				information_schema_tsql._pgtsql_datetime_precision(tsql_type_name, true_typmod)
+				AS smallint)
+				AS "DATETIME_PRECISION",
+
+			CAST(null AS sys.nvarchar(128)) AS "CHARACTER_SET_CATALOG",
+			CAST(null AS sys.nvarchar(128)) AS "CHARACTER_SET_SCHEMA",
+			/*
+			 * TODO: We need to first create mapping of collation name to char-set name;
+			 * Until then return null.
+			 */
+			CAST(null AS sys.nvarchar(128)) AS "CHARACTER_SET_NAME",
+
+			CAST(NULL as sys.nvarchar(128)) AS "COLLATION_CATALOG",
+			CAST(NULL as sys.nvarchar(128)) AS "COLLATION_SCHEMA",
+
+			/* Returns Babelfish specific collation name. */
+			CAST(co.collname AS sys.nvarchar(128)) AS "COLLATION_NAME",
+
+			CAST(CASE WHEN t.typtype = 'd' AND nt.nspname <> 'pg_catalog' AND nt.nspname <> 'sys'
+				THEN nc.dbname ELSE null END
+				AS sys.nvarchar(128)) AS "DOMAIN_CATALOG",
+			CAST(CASE WHEN t.typtype = 'd' AND nt.nspname <> 'pg_catalog' AND nt.nspname <> 'sys'
+				THEN ext.orig_name ELSE null END
+				AS sys.nvarchar(128)) AS "DOMAIN_SCHEMA",
+			CAST(CASE WHEN t.typtype = 'd' AND nt.nspname <> 'pg_catalog' AND nt.nspname <> 'sys'
+				THEN t.typname ELSE null END
+				AS sys.nvarchar(128)) AS "DOMAIN_NAME"
+
+	FROM (pg_attribute a LEFT JOIN pg_attrdef ad ON attrelid = adrelid AND attnum = adnum)
+		JOIN (pg_class c JOIN sys.pg_namespace_ext nc ON (c.relnamespace = nc.oid)) ON a.attrelid = c.oid
+		JOIN (pg_type t JOIN pg_namespace nt ON (t.typnamespace = nt.oid)) ON a.atttypid = t.oid
+		LEFT JOIN (pg_type bt JOIN pg_namespace nbt ON (bt.typnamespace = nbt.oid))
+			ON (t.typtype = 'd' AND t.typbasetype = bt.oid)
+		LEFT JOIN pg_collation co on co.oid = a.attcollation
+		LEFT OUTER JOIN sys.babelfish_namespace_ext ext on nc.nspname = ext.nspname,
+		information_schema_tsql._pgtsql_truetypid(nt, a, t) AS true_typid,
+		information_schema_tsql._pgtsql_truetypmod(nt, a, t) AS true_typmod,
+		sys.translate_pg_type_to_tsql(true_typid) AS tsql_type_name
+
+	WHERE (NOT pg_is_other_temp_schema(nc.oid))
+		AND a.attnum > 0 AND NOT a.attisdropped
+		AND c.relkind IN ('r', 'v', 'p')
+		AND (pg_has_role(c.relowner, 'USAGE')
+			OR has_column_privilege(c.oid, a.attnum,
+									'SELECT, INSERT, UPDATE, REFERENCES'))
+		AND ext.dbid =sys.db_id();
+
+CREATE OR REPLACE VIEW information_schema_tsql.tables AS
+	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		   CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+		   CAST(
+				COALESCE(
+					(SELECT PG_CATALOG.string_agg(
+						CASE
+						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23)
+						ELSE NULL
+						END, ',')
+					FROM unnest(c.reloptions) AS option),
+				c.relname)
+			AS sys._ci_sysname) AS "TABLE_NAME",
+
+		   CAST(
+			 CASE WHEN c.relkind IN ('r', 'p') THEN 'BASE TABLE'
+				  WHEN c.relkind = 'v' THEN 'VIEW'
+				  ELSE null END
+			 AS sys.varchar(10)) COLLATE sys.database_default AS "TABLE_TYPE"
+
+	FROM sys.pg_namespace_ext nc JOIN pg_class c ON (nc.oid = c.relnamespace)
+		   LEFT OUTER JOIN sys.babelfish_namespace_ext ext on nc.nspname = ext.nspname
+		   LEFT JOIN sys.table_types_internal tt on c.oid = tt.typrelid
+
+	WHERE c.relkind IN ('r', 'v', 'p')
+		AND (NOT pg_is_other_temp_schema(nc.oid))
+		AND tt.typrelid IS NULL
+		AND (pg_has_role(c.relowner, 'USAGE')
+			OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+			OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )
+		AND ext.dbid = sys.db_id()
+		AND (NOT c.relname = 'sysdatabases');
+
+GRANT SELECT ON information_schema_tsql.tables TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_date_to_string(IN p_datatype TEXT,
+                                                                 IN p_dateval DATE,
+                                                                 IN p_style NUMERIC DEFAULT 20)
+RETURNS TEXT
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_dateval DATE;
+    v_style SMALLINT;
+    v_month SMALLINT;
+    v_resmask VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_language VARCHAR COLLATE "C";
+    v_monthname VARCHAR COLLATE "C";
+    v_resstring VARCHAR COLLATE "C";
+    v_lengthexpr VARCHAR COLLATE "C";
+    v_maxlength SMALLINT;
+    v_res_length SMALLINT;
+    v_err_message VARCHAR COLLATE "C";
+    v_res_datatype VARCHAR COLLATE "C";
+    v_lang_metadata_json JSONB;
+    VARCHAR_MAX CONSTANT SMALLINT := 8000;
+    NVARCHAR_MAX CONSTANT SMALLINT := 4000;
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*$';
+    DATATYPE_MASK_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(?:CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*\(\s*(\d+|MAX)\s*\)\s*$';
+BEGIN
+    v_datatype := pg_catalog.upper(pg_catalog.btrim(p_datatype));
+    v_style := floor(p_style)::SMALLINT;
+
+    IF (scale(p_style) > 0) THEN
+        RAISE most_specific_type_mismatch;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 13) OR
+                (v_style BETWEEN 20 AND 25) OR
+                (v_style BETWEEN 100 AND 113) OR
+                v_style IN (120, 121, 126, 127, 130, 131)))
+    THEN
+        RAISE invalid_parameter_value;
+    ELSIF (v_style IN (8, 24, 108)) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (v_datatype ~* DATATYPE_MASK_REGEXP) THEN
+        v_res_datatype := PG_CATALOG.rtrim(split_part(v_datatype, '(', 1));
+
+        v_maxlength := CASE
+                          WHEN (v_res_datatype IN ('CHAR', 'VARCHAR')) THEN VARCHAR_MAX
+                          ELSE NVARCHAR_MAX
+                       END;
+
+        v_lengthexpr := substring(v_datatype, DATATYPE_MASK_REGEXP);
+
+        IF (v_lengthexpr <> 'MAX' AND char_length(v_lengthexpr) > 4) THEN
+            RAISE interval_field_overflow;
+        END IF;
+
+        v_res_length := CASE v_lengthexpr
+                           WHEN 'MAX' THEN v_maxlength
+                           ELSE v_lengthexpr::SMALLINT
+                        END;
+    ELSIF (v_datatype ~* DATATYPE_REGEXP) THEN
+        v_res_datatype := v_datatype;
+    ELSE
+        RAISE datatype_mismatch;
+    END IF;
+
+    v_dateval := CASE
+                    WHEN (v_style NOT IN (130, 131)) THEN p_dateval
+                    ELSE sys.babelfish_conv_greg_to_hijri(p_dateval) + 1
+                 END;
+
+    v_day := PG_CATALOG.ltrim(to_char(v_dateval, 'DD'), '0');
+    v_month := to_char(v_dateval, 'MM')::SMALLINT;
+
+    v_language := CASE
+                     WHEN (v_style IN (130, 131)) THEN 'HIJRI'
+                     ELSE CONVERSION_LANG
+                  END;
+ RAISE NOTICE 'v_language=[%]', v_language;		  
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(v_language);
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_character_value_for_cast;
+    END;
+
+    v_monthname := (v_lang_metadata_json -> 'months_shortnames') ->> v_month - 1;
+
+    v_resmask := CASE
+                    WHEN (v_style IN (1, 22)) THEN 'MM/DD/YY'
+                    WHEN (v_style = 101) THEN 'MM/DD/YYYY'
+                    WHEN (v_style = 2) THEN 'YY.MM.DD'
+                    WHEN (v_style = 102) THEN 'YYYY.MM.DD'
+                    WHEN (v_style = 3) THEN 'DD/MM/YY'
+                    WHEN (v_style = 103) THEN 'DD/MM/YYYY'
+                    WHEN (v_style = 4) THEN 'DD.MM.YY'
+                    WHEN (v_style = 104) THEN 'DD.MM.YYYY'
+                    WHEN (v_style = 5) THEN 'DD-MM-YY'
+                    WHEN (v_style = 105) THEN 'DD-MM-YYYY'
+                    WHEN (v_style = 6) THEN 'DD $mnme$ YY'
+                    WHEN (v_style IN (13, 106, 113)) THEN 'DD $mnme$ YYYY'
+                    WHEN (v_style = 7) THEN '$mnme$ DD, YY'
+                    WHEN (v_style = 107) THEN '$mnme$ DD, YYYY'
+                    WHEN (v_style = 10) THEN 'MM-DD-YY'
+                    WHEN (v_style = 110) THEN 'MM-DD-YYYY'
+                    WHEN (v_style = 11) THEN 'YY/MM/DD'
+                    WHEN (v_style = 111) THEN 'YYYY/MM/DD'
+                    WHEN (v_style = 12) THEN 'YYMMDD'
+                    WHEN (v_style = 112) THEN 'YYYYMMDD'
+                    WHEN (v_style IN (20, 21, 23, 25, 120, 121, 126, 127)) THEN 'YYYY-MM-DD'
+                    WHEN (v_style = 130) THEN 'DD $mnme$ YYYY'
+                    WHEN (v_style = 131) THEN pg_catalog.format('%s/MM/YYYY', lpad(v_day, 2, ' '))
+                    WHEN (v_style IN (0, 9, 100, 109)) THEN pg_catalog.format('$mnme$ %s YYYY', lpad(v_day, 2, ' '))
+                 END;
+
+    v_resstring := to_char(v_dateval, v_resmask);
+    v_resstring := pg_catalog.replace(v_resstring, '$mnme$', v_monthname);
+    v_resstring := substring(v_resstring, 1, coalesce(v_res_length, char_length(v_resstring)));
+    v_res_length := coalesce(v_res_length,
+                             CASE v_res_datatype
+                                WHEN 'CHAR' THEN 30
+                                ELSE 60
+                             END);
+    RETURN CASE
+              WHEN (v_res_datatype NOT IN ('CHAR', 'NCHAR')) THEN v_resstring
+              ELSE rpad(v_resstring, v_res_length, ' ')
+           END;
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 3 of convert function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('%s is not a valid style number when converting from DATE to a character string.', v_style),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := pg_catalog.format('Error converting data type DATE to %s.', pg_catalog.btrim(p_datatype)),
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+   WHEN interval_field_overflow THEN
+       RAISE USING MESSAGE := pg_catalog.format('The size (%s) given to the convert specification ''%s'' exceeds the maximum allowed for any data type (%s).',
+                                     v_lengthexpr,
+                                     pg_catalog.lower(v_res_datatype),
+                                     v_maxlength),
+                   DETAIL := 'Use of incorrect size value of data type parameter during conversion process.',
+                   HINT := 'Change size component of data type parameter to the allowable value and try again.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Data type should be one of these values: ''CHAR(n|MAX)'', ''NCHAR(n|MAX)'', ''VARCHAR(n|MAX)'', ''NVARCHAR(n|MAX)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_character_value_for_cast THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                      CONVERSION_LANG),
+                    DETAIL := 'Compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Correct CONVERSION_LANG constant value in function''s body, recompile it and try again.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT (or INTEGER) data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_datetime_to_string(IN p_datatype TEXT,
+                                                                     IN p_src_datatype TEXT,
+                                                                     IN p_datetimeval TIMESTAMP(6) WITHOUT TIME ZONE,
+                                                                     IN p_style NUMERIC DEFAULT -1)
+RETURNS TEXT
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_hour VARCHAR COLLATE "C";
+    v_month SMALLINT;
+    v_style SMALLINT;
+    v_scale SMALLINT;
+    v_resmask VARCHAR COLLATE "C";
+    v_language VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_fseconds VARCHAR COLLATE "C";
+    v_fractsep VARCHAR COLLATE "C";
+    v_monthname VARCHAR COLLATE "C";
+    v_resstring VARCHAR COLLATE "C";
+    v_lengthexpr VARCHAR COLLATE "C";
+    v_maxlength SMALLINT;
+    v_res_length SMALLINT;
+    v_err_message VARCHAR COLLATE "C";
+    v_src_datatype VARCHAR COLLATE "C";
+    v_res_datatype VARCHAR COLLATE "C";
+    v_lang_metadata_json JSONB;
+    VARCHAR_MAX CONSTANT SMALLINT := 8000;
+    NVARCHAR_MAX CONSTANT SMALLINT := 4000;
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*$';
+    SRCDATATYPE_MASK_REGEXP VARCHAR COLLATE "C" := '^(?:DATETIME|SMALLDATETIME|DATETIME2)\s*(?:\s*\(\s*(\d+)\s*\)\s*)?$';
+    DATATYPE_MASK_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(?:CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*\(\s*(\d+|MAX)\s*\)\s*$';
+    v_datetimeval TIMESTAMP(6) WITHOUT TIME ZONE;
+BEGIN
+    v_datatype := pg_catalog.upper(pg_catalog.btrim(p_datatype));
+    v_src_datatype := pg_catalog.upper(pg_catalog.btrim(p_src_datatype));
+    v_style := floor(p_style)::SMALLINT;
+
+    IF (v_src_datatype ~* SRCDATATYPE_MASK_REGEXP)
+    THEN
+        v_scale := substring(v_src_datatype, SRCDATATYPE_MASK_REGEXP)::SMALLINT;
+
+        v_src_datatype := PG_CATALOG.rtrim(split_part(v_src_datatype, '(', 1));
+
+        IF (v_src_datatype <> 'DATETIME2' AND v_scale IS NOT NULL) THEN
+            RAISE invalid_indicator_parameter_value;
+        ELSIF (v_scale NOT BETWEEN 0 AND 7) THEN
+            RAISE invalid_regular_expression;
+        END IF;
+
+        v_scale := coalesce(v_scale, 7);
+    ELSE
+        RAISE most_specific_type_mismatch;
+    END IF;
+
+    IF (scale(p_style) > 0) THEN
+        RAISE escape_character_conflict;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 14) OR
+                (v_style BETWEEN 20 AND 25) OR
+                (v_style BETWEEN 100 AND 114) OR
+                v_style IN (-1, 120, 121, 126, 127, 130, 131)))
+    THEN
+        RAISE invalid_parameter_value;
+    END IF;
+
+    IF (v_datatype ~* DATATYPE_MASK_REGEXP) THEN
+        v_res_datatype := PG_CATALOG.rtrim(split_part(v_datatype, '(', 1));
+
+        v_maxlength := CASE
+                          WHEN (v_res_datatype IN ('CHAR', 'VARCHAR')) THEN VARCHAR_MAX
+                          ELSE NVARCHAR_MAX
+                       END;
+
+        v_lengthexpr := substring(v_datatype, DATATYPE_MASK_REGEXP);
+
+        IF (v_lengthexpr <> 'MAX' AND char_length(v_lengthexpr) > 4)
+        THEN
+            RAISE interval_field_overflow;
+        END IF;
+
+        v_res_length := CASE v_lengthexpr
+                           WHEN 'MAX' THEN v_maxlength
+                           ELSE v_lengthexpr::SMALLINT
+                        END;
+    ELSIF (v_datatype ~* DATATYPE_REGEXP) THEN
+        v_res_datatype := v_datatype;
+    ELSE
+        RAISE datatype_mismatch;
+    END IF;
+
+    v_datetimeval := CASE
+                        WHEN (v_style NOT IN (130, 131)) THEN p_datetimeval
+                        ELSE sys.babelfish_conv_greg_to_hijri(p_datetimeval) + INTERVAL '1 day'
+                     END;
+
+    v_day := PG_CATALOG.ltrim(to_char(v_datetimeval, 'DD'), '0');
+    v_hour := PG_CATALOG.ltrim(to_char(v_datetimeval, 'HH12'), '0');
+    v_month := to_char(v_datetimeval, 'MM')::SMALLINT;
+
+    v_language := CASE
+                     WHEN (v_style IN (130, 131)) THEN 'HIJRI'
+                     ELSE CONVERSION_LANG
+                  END;
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(v_language);
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_character_value_for_cast;
+    END;
+
+    v_monthname := (v_lang_metadata_json -> 'months_shortnames') ->> v_month - 1;
+
+    IF (v_src_datatype IN ('DATETIME', 'SMALLDATETIME')) THEN
+        v_fseconds := sys.babelfish_round_fractseconds(to_char(v_datetimeval, 'MS'));
+
+        IF (v_fseconds::INTEGER = 1000) THEN
+            v_fseconds := '000';
+            v_datetimeval := v_datetimeval + INTERVAL '1 second';
+        ELSE
+            v_fseconds := lpad(v_fseconds, 3, '0');
+        END IF;
+    ELSE
+        v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(to_char(v_datetimeval, 'US'), v_scale);
+
+        IF (v_scale = 7) THEN
+            v_fseconds := pg_catalog.concat(v_fseconds, '0');
+        END IF;
+    END IF;
+
+    v_fractsep := CASE v_src_datatype
+                     WHEN 'DATETIME2' THEN '.'
+                     ELSE ':'
+                  END;
+
+    IF ((v_style = -1 AND v_src_datatype <> 'DATETIME2') OR
+        v_style IN (0, 9, 100, 109))
+    THEN
+        v_resmask := pg_catalog.format('$mnme$ %s YYYY %s:MI%s',
+                            lpad(v_day, 2, ' '),
+                            lpad(v_hour, 2, ' '),
+                            CASE
+                               WHEN (v_style IN (-1, 0, 100)) THEN 'AM'
+                               ELSE pg_catalog.format(':SS:%sAM', v_fseconds)
+                            END);
+    ELSIF (v_style = 1) THEN
+        v_resmask := 'MM/DD/YY';
+    ELSIF (v_style = 101) THEN
+        v_resmask := 'MM/DD/YYYY';
+    ELSIF (v_style = 2) THEN
+        v_resmask := 'YY.MM.DD';
+    ELSIF (v_style = 102) THEN
+        v_resmask := 'YYYY.MM.DD';
+    ELSIF (v_style = 3) THEN
+        v_resmask := 'DD/MM/YY';
+    ELSIF (v_style = 103) THEN
+        v_resmask := 'DD/MM/YYYY';
+    ELSIF (v_style = 4) THEN
+        v_resmask := 'DD.MM.YY';
+    ELSIF (v_style = 104) THEN
+        v_resmask := 'DD.MM.YYYY';
+    ELSIF (v_style = 5) THEN
+        v_resmask := 'DD-MM-YY';
+    ELSIF (v_style = 105) THEN
+        v_resmask := 'DD-MM-YYYY';
+    ELSIF (v_style = 6) THEN
+        v_resmask := 'DD $mnme$ YY';
+    ELSIF (v_style = 106) THEN
+        v_resmask := 'DD $mnme$ YYYY';
+    ELSIF (v_style = 7) THEN
+        v_resmask := '$mnme$ DD, YY';
+    ELSIF (v_style = 107) THEN
+        v_resmask := '$mnme$ DD, YYYY';
+    ELSIF (v_style IN (8, 24, 108)) THEN
+        v_resmask := 'HH24:MI:SS';
+    ELSIF (v_style = 10) THEN
+        v_resmask := 'MM-DD-YY';
+    ELSIF (v_style = 110) THEN
+        v_resmask := 'MM-DD-YYYY';
+    ELSIF (v_style = 11) THEN
+        v_resmask := 'YY/MM/DD';
+    ELSIF (v_style = 111) THEN
+        v_resmask := 'YYYY/MM/DD';
+    ELSIF (v_style = 12) THEN
+        v_resmask := 'YYMMDD';
+    ELSIF (v_style = 112) THEN
+        v_resmask := 'YYYYMMDD';
+    ELSIF (v_style IN (13, 113)) THEN
+        v_resmask := pg_catalog.format('DD $mnme$ YYYY HH24:MI:SS%s%s', v_fractsep, v_fseconds);
+    ELSIF (v_style IN (14, 114)) THEN
+        v_resmask := pg_catalog.format('HH24:MI:SS%s%s', v_fractsep, v_fseconds);
+    ELSIF (v_style IN (20, 120)) THEN
+        v_resmask := 'YYYY-MM-DD HH24:MI:SS';
+    ELSIF ((v_style = -1 AND v_src_datatype = 'DATETIME2') OR
+           v_style IN (21, 25, 121))
+    THEN
+        v_resmask := pg_catalog.format('YYYY-MM-DD HH24:MI:SS.%s', v_fseconds);
+    ELSIF (v_style = 22) THEN
+        v_resmask := pg_catalog.format('MM/DD/YY %s:MI:SS AM', lpad(v_hour, 2, ' '));
+    ELSIF (v_style = 23) THEN
+        v_resmask := 'YYYY-MM-DD';
+    ELSIF (v_style IN (126, 127)) THEN
+        v_resmask := CASE v_src_datatype
+                        WHEN 'SMALLDATETIME' THEN 'YYYY-MM-DDT$rem$HH24:MI:SS'
+                        ELSE pg_catalog.format('YYYY-MM-DDT$rem$HH24:MI:SS.%s', v_fseconds)
+                     END;
+    ELSIF (v_style IN (130, 131)) THEN
+        v_resmask := pg_catalog.concat(CASE p_style
+                               WHEN 131 THEN pg_catalog.format('%s/MM/YYYY ', lpad(v_day, 2, ' '))
+                               ELSE pg_catalog.format('%s $mnme$ YYYY ', lpad(v_day, 2, ' '))
+                            END,
+                            pg_catalog.format('%s:MI:SS%s%sAM', lpad(v_hour, 2, ' '), v_fractsep, v_fseconds));
+    END IF;
+
+    v_resstring := to_char(v_datetimeval, v_resmask);
+    v_resstring := pg_catalog.replace(v_resstring, '$mnme$', v_monthname);
+    v_resstring := pg_catalog.replace(v_resstring, '$rem$', '');
+
+    v_resstring := substring(v_resstring, 1, coalesce(v_res_length, char_length(v_resstring)));
+    v_res_length := coalesce(v_res_length,
+                             CASE v_res_datatype
+                                WHEN 'CHAR' THEN 30
+                                ELSE 60
+                             END);
+    RETURN CASE
+              WHEN (v_res_datatype NOT IN ('CHAR', 'NCHAR')) THEN v_resstring
+              ELSE rpad(v_resstring, v_res_length, ' ')
+           END;
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Source data type should be one of these values: ''DATETIME'', ''SMALLDATETIME'', ''DATETIME2'' or ''DATETIME2(n)''.',
+                    DETAIL := 'Use of incorrect "src_datatype" parameter value during conversion process.',
+                    HINT := 'Change "srcdatatype" parameter to the proper value and try again.';
+
+   WHEN invalid_regular_expression THEN
+       RAISE USING MESSAGE := pg_catalog.format('The source data type scale (%s) given to the convert specification exceeds the maximum allowable value (7).',
+                                     v_scale),
+                   DETAIL := 'Use of incorrect scale value of source data type parameter during conversion process.',
+                   HINT := 'Change scale component of source data type parameter to the allowable value and try again.';
+
+    WHEN invalid_indicator_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid attributes specified for data type %s.', v_src_datatype),
+                    DETAIL := 'Use of incorrect scale value, which is not corresponding to specified data type.',
+                    HINT := 'Change data type scale component or select different data type and try again.';
+
+    WHEN escape_character_conflict THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 4 of convert function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('%s is not a valid style number when converting from %s to a character string.',
+                                      v_style, v_src_datatype),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN interval_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('The size (%s) given to the convert specification ''%s'' exceeds the maximum allowed for any data type (%s).',
+                                      v_lengthexpr, pg_catalog.lower(v_res_datatype), v_maxlength),
+                    DETAIL := 'Use of incorrect size value of data type parameter during conversion process.',
+                    HINT := 'Change size component of data type parameter to the allowable value and try again.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Data type should be one of these values: ''CHAR(n|MAX)'', ''NCHAR(n|MAX)'', ''VARCHAR(n|MAX)'', ''NVARCHAR(n|MAX)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_character_value_for_cast THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                      CONVERSION_LANG),
+                    DETAIL := 'Compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Correct CONVERSION_LANG constant value in function''s body, recompile it and try again.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_hijri_to_greg(IN p_day NUMERIC,
+                                                                IN p_month NUMERIC,
+                                                                IN p_year NUMERIC)
+RETURNS DATE
+AS
+$BODY$
+DECLARE
+    v_day SMALLINT;
+    v_month SMALLINT;
+    v_year INTEGER;
+    v_err_message VARCHAR COLLATE "C";
+    v_jdnum DOUBLE PRECISION;
+    v_lnum DOUBLE PRECISION;
+    v_inum DOUBLE PRECISION;
+    v_nnum DOUBLE PRECISION;
+    v_jnum DOUBLE PRECISION;
+    v_knum DOUBLE PRECISION;
+BEGIN
+    v_day := floor(p_day)::SMALLINT;
+    v_month := floor(p_month)::SMALLINT;
+    v_year := floor(p_year)::INTEGER;
+
+    IF ((sign(v_day) = -1) OR (sign(v_month) = -1) OR (sign(v_year) = -1))
+    THEN
+        RAISE invalid_character_value_for_cast;
+    ELSIF (v_year = 0) THEN
+        RAISE null_value_not_allowed;
+    END IF;
+
+    v_jdnum = sys.babelfish_get_int_part((11 * v_year + 3) / 30) + 354 * v_year + 30 * v_month -
+              sys.babelfish_get_int_part((v_month - 1) / 2) + v_day + 1948440 - 385;
+
+    IF (v_jdnum > 2299160)
+    THEN
+        v_lnum := v_jdnum + 68569;
+        v_nnum := sys.babelfish_get_int_part((4 * v_lnum) / 146097);
+        v_lnum := v_lnum - sys.babelfish_get_int_part((146097 * v_nnum + 3) / 4);
+        v_inum := sys.babelfish_get_int_part((4000 * (v_lnum + 1)) / 1461001);
+        v_lnum := v_lnum - sys.babelfish_get_int_part((1461 * v_inum) / 4) + 31;
+        v_jnum := sys.babelfish_get_int_part((80 * v_lnum) / 2447);
+        v_day := v_lnum - sys.babelfish_get_int_part((2447 * v_jnum) / 80);
+        v_lnum := sys.babelfish_get_int_part(v_jnum / 11);
+        v_month := v_jnum + 2 - 12 * v_lnum;
+        v_year := 100 * (v_nnum - 49) + v_inum + v_lnum;
+    ELSE
+        v_jnum := v_jdnum + 1402;
+        v_knum := sys.babelfish_get_int_part((v_jnum - 1) / 1461);
+        v_lnum := v_jnum - 1461 * v_knum;
+        v_nnum := sys.babelfish_get_int_part((v_lnum - 1) / 365) - sys.babelfish_get_int_part(v_lnum / 1461);
+        v_inum := v_lnum - 365 * v_nnum + 30;
+        v_jnum := sys.babelfish_get_int_part((80 * v_inum) / 2447);
+        v_day := v_inum-sys.babelfish_get_int_part((2447 * v_jnum) / 80);
+        v_inum := sys.babelfish_get_int_part(v_jnum / 11);
+        v_month := v_jnum + 2 - 12 * v_inum;
+        v_year := 4 * v_knum + v_nnum + v_inum - 4716;
+    END IF;
+
+    RETURN to_date(pg_catalog.concat_ws('.', v_day, v_month, v_year), 'DD.MM.YYYY');
+EXCEPTION
+    WHEN invalid_character_value_for_cast THEN
+        RAISE USING MESSAGE := 'Could not convert Hijri to Gregorian date if any part of the date is negative.',
+                    DETAIL := 'Some of the supplied date parts (day, month, year) is negative.',
+                    HINT := 'Change the value of the date part (day, month, year) wich was found to be negative.';
+
+    WHEN null_value_not_allowed THEN
+        RAISE USING MESSAGE := 'Could not convert Hijri to Gregorian date if year value is equal to zero.',
+                    DETAIL := 'Supplied year value is equal to zero.',
+                    HINT := 'Change the value of the year so that it is greater than zero.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.', v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_string_to_date(IN p_datestring TEXT,
+                                                                 IN p_style NUMERIC DEFAULT 0)
+RETURNS DATE
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_year VARCHAR COLLATE "C";
+    v_month VARCHAR COLLATE "C";
+    v_hijridate DATE;
+    v_style SMALLINT;
+    v_leftpart VARCHAR COLLATE "C";
+    v_middlepart VARCHAR COLLATE "C";
+    v_rightpart VARCHAR COLLATE "C";
+    v_fractsecs VARCHAR COLLATE "C";
+    v_datestring VARCHAR COLLATE "C";
+    v_err_message VARCHAR COLLATE "C";
+    v_date_format VARCHAR COLLATE "C";
+    v_regmatch_groups TEXT[];
+    v_lang_metadata_json JSONB;
+    v_compmonth_regexp VARCHAR COLLATE "C";
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
+    DAYMM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{4})';
+    SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    COMPYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2}|\d{4})';
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:[AP]M)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,2}\s*';
+    FRACTSECS_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,9}';
+    HHMMSSFS_PART_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('(', TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '(?:\.|\:)', FRACTSECS_REGEXP,
+                                                    ')\s*', AMPM_REGEXP, '?');
+    HHMMSSFS_DOTPART_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('(', TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+                                                       TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '|',
+                                                       TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '|',
+                                                       TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP,
+                                                       ')\s*', AMPM_REGEXP, '?');
+    HHMMSSFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', HHMMSSFS_PART_REGEXP, '$');
+    HHMMSSFS_DOT_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', HHMMSSFS_DOTPART_REGEXP, '$');
+    v_defmask1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '$');
+    v_defmask2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*($comp_month$)\s*', COMPYEAR_REGEXP, '$');
+    v_defmask3_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '$');
+    v_defmask4_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*($comp_month$)$');
+    v_defmask5_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*($comp_month$)$');
+    v_defmask6_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '$');
+    v_defmask7_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^($comp_month$)\s*', DAYMM_REGEXP, '\s*\,\s*', COMPYEAR_REGEXP, '$');
+    v_defmask8_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*($comp_month$)$');
+    v_defmask9_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^($comp_month$)\s*', FULLYEAR_REGEXP, '$');
+    v_defmask10_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*($comp_month$)\s*(?:\.|/|-)\s*', COMPYEAR_REGEXP, '$');
+    DOT_SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*\.\s*', DAYMM_REGEXP, '\s*\.\s*', SHORTYEAR_REGEXP, '$');
+    DOT_FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*\.\s*', DAYMM_REGEXP, '\s*\.\s*', FULLYEAR_REGEXP, '$');
+    SLASH_SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*/\s*', DAYMM_REGEXP, '\s*/\s*', SHORTYEAR_REGEXP, '$');
+    SLASH_FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*/\s*', DAYMM_REGEXP, '\s*/\s*', FULLYEAR_REGEXP, '$');
+    DASH_SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*-\s*', DAYMM_REGEXP, '\s*-\s*', SHORTYEAR_REGEXP, '$');
+    DASH_FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*-\s*', DAYMM_REGEXP, '\s*-\s*', FULLYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_YEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', COMPYEAR_REGEXP, '$');
+    YEAR_DOTMASK_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*\.\s*', DAYMM_REGEXP, '\s*\.\s*', DAYMM_REGEXP, '$');
+    YEAR_SLASHMASK_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*/\s*', DAYMM_REGEXP, '\s*/\s*', DAYMM_REGEXP, '$');
+    YEAR_DASHMASK_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*-\s*', DAYMM_REGEXP, '\s*-\s*', DAYMM_REGEXP, '$');
+    YEAR_DOT_SLASH_DASH_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '$');
+    DIGITMASK1_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\d{6}$';
+    DIGITMASK2_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\d{8}$';
+BEGIN
+    v_style := floor(p_style)::SMALLINT;
+    v_datestring := pg_catalog.btrim(p_datestring);
+
+    IF (scale(p_style) > 0) THEN
+        RAISE most_specific_type_mismatch;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 14) OR
+                (v_style BETWEEN 20 AND 25) OR
+                (v_style BETWEEN 100 AND 114) OR
+                v_style IN (120, 121, 126, 127, 130, 131)))
+    THEN
+        RAISE invalid_parameter_value;
+    END IF;
+
+    IF (v_datestring ~* HHMMSSFS_PART_REGEXP AND v_datestring !~* HHMMSSFS_REGEXP)
+    THEN
+        v_datestring := pg_catalog.btrim(regexp_pg_catalog.replace(v_datestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
+    END IF;
+
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(CONVERSION_LANG);
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_character_value_for_cast;
+    END;
+
+    v_date_format := coalesce(nullif(DATE_FORMAT, ''), v_lang_metadata_json ->> 'date_format');
+
+    v_compmonth_regexp := array_to_string(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
+                                                    ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_names'))), '|');
+
+    v_defmask1_regexp := pg_catalog.replace(v_defmask1_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask2_regexp := pg_catalog.replace(v_defmask2_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask3_regexp := pg_catalog.replace(v_defmask3_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask4_regexp := pg_catalog.replace(v_defmask4_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask5_regexp := pg_catalog.replace(v_defmask5_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask6_regexp := pg_catalog.replace(v_defmask6_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask7_regexp := pg_catalog.replace(v_defmask7_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask8_regexp := pg_catalog.replace(v_defmask8_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask9_regexp := pg_catalog.replace(v_defmask9_regexp, '$comp_month$', v_compmonth_regexp);
+    v_defmask10_regexp := pg_catalog.replace(v_defmask10_regexp, '$comp_month$', v_compmonth_regexp);
+
+    IF (v_datestring ~* v_defmask1_regexp OR
+        v_datestring ~* v_defmask2_regexp OR
+        v_datestring ~* v_defmask3_regexp OR
+        v_datestring ~* v_defmask4_regexp OR
+        v_datestring ~* v_defmask5_regexp OR
+        v_datestring ~* v_defmask6_regexp OR
+        v_datestring ~* v_defmask7_regexp OR
+        v_datestring ~* v_defmask8_regexp OR
+        v_datestring ~* v_defmask9_regexp OR
+        v_datestring ~* v_defmask10_regexp)
+    THEN
+        IF (v_style IN (130, 131)) THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF (v_datestring ~* v_defmask1_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask1_regexp, 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* v_defmask2_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask2_regexp, 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* v_defmask3_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask3_regexp, 'gi');
+            v_day := v_regmatch_groups[3];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* v_defmask4_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask4_regexp, 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* v_defmask5_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask5_regexp, 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[2]);
+
+        ELSIF (v_datestring ~* v_defmask6_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask6_regexp, 'gi');
+            v_day := v_regmatch_groups[3];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := v_regmatch_groups[2];
+
+        ELSIF (v_datestring ~* v_defmask7_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask7_regexp, 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* v_defmask8_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask8_regexp, 'gi');
+            v_day := '01';
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* v_defmask9_regexp)
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask9_regexp, 'gi');
+            v_day := '01';
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := v_regmatch_groups[2];
+        ELSE
+            v_regmatch_groups := regexp_matches(v_datestring, v_defmask10_regexp, 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+        END IF;
+    ELSEIF (v_datestring ~* DOT_SHORTYEAR_REGEXP OR
+            v_datestring ~* DOT_FULLYEAR_REGEXP OR
+            v_datestring ~* SLASH_SHORTYEAR_REGEXP OR
+            v_datestring ~* SLASH_FULLYEAR_REGEXP OR
+            v_datestring ~* DASH_SHORTYEAR_REGEXP OR
+            v_datestring ~* DASH_FULLYEAR_REGEXP)
+    THEN
+        IF (v_style IN (6, 7, 8, 9, 12, 13, 14, 24, 100, 106, 107, 108, 109, 112, 113, 114, 130)) THEN
+            RAISE invalid_regular_expression;
+        ELSIF (v_style IN (20, 21, 23, 25, 102, 111, 120, 121, 126, 127)) THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, DOT_SLASH_DASH_YEAR_REGEXP, 'gi');
+        v_leftpart := v_regmatch_groups[1];
+        v_middlepart := v_regmatch_groups[2];
+        v_rightpart := v_regmatch_groups[3];
+
+        IF (v_datestring ~* DOT_SHORTYEAR_REGEXP OR
+            v_datestring ~* SLASH_SHORTYEAR_REGEXP OR
+            v_datestring ~* DASH_SHORTYEAR_REGEXP)
+        THEN
+            IF ((v_style IN (1, 10, 22) AND v_date_format <> 'MDY') OR
+                ((v_style IS NULL OR v_style IN (0, 1, 10, 22)) AND v_date_format NOT IN ('YDM', 'YMD', 'DMY', 'DYM', 'MYD')))
+            THEN
+                v_day := v_middlepart;
+                v_month := v_leftpart;
+                v_year := sys.babelfish_get_full_year(v_rightpart);
+
+            ELSIF ((v_style IN (2, 11) AND v_date_format <> 'YMD') OR
+                   ((v_style IS NULL OR v_style IN (0, 2, 11)) AND v_date_format = 'YMD'))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+                v_year := sys.babelfish_get_full_year(v_leftpart);
+
+            ELSIF ((v_style IN (3, 4, 5) AND v_date_format <> 'DMY') OR
+                   ((v_style IS NULL OR v_style IN (0, 3, 4, 5)) AND v_date_format = 'DMY'))
+            THEN
+                v_day := v_leftpart;
+                v_month := v_middlepart;
+                v_year := sys.babelfish_get_full_year(v_rightpart);
+
+            ELSIF ((v_style IS NULL OR v_style = 0) AND v_date_format = 'DYM')
+            THEN
+                v_day := v_leftpart;
+                v_month := v_rightpart;
+                v_year := sys.babelfish_get_full_year(v_middlepart);
+
+            ELSIF ((v_style IS NULL OR v_style = 0) AND v_date_format = 'MYD')
+            THEN
+                v_day := v_rightpart;
+                v_month := v_leftpart;
+                v_year := sys.babelfish_get_full_year(v_middlepart);
+
+            ELSIF ((v_style IS NULL OR v_style = 0) AND v_date_format = 'YDM') THEN
+                RAISE character_not_in_repertoire;
+            ELSIF (v_style IN (101, 103, 104, 105, 110, 131)) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+        ELSE
+            v_year := v_rightpart;
+
+            IF (v_leftpart::SMALLINT <= 12)
+            THEN
+                IF ((v_style IN (103, 104, 105, 131) AND v_date_format <> 'DMY') OR
+                    ((v_style IS NULL OR v_style IN (0, 103, 104, 105, 131)) AND v_date_format = 'DMY'))
+                THEN
+                    v_day := v_leftpart;
+                    v_month := v_middlepart;
+                ELSIF ((v_style IN (101, 110) AND v_date_format IN ('YDM', 'DMY', 'DYM')) OR
+                       ((v_style IS NULL OR v_style IN (0, 101, 110)) AND v_date_format NOT IN ('YDM', 'DMY', 'DYM')))
+                THEN
+                    v_day := v_middlepart;
+                    v_month := v_leftpart;
+                ELSIF ((v_style IN (1, 2, 3, 4, 5, 10, 11, 22) AND v_date_format <> 'YDM') OR
+                       ((v_style IS NULL OR v_style IN (0, 1, 2, 3, 4, 5, 10, 11, 22)) AND v_date_format = 'YDM'))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+            ELSE
+                IF ((v_style IN (103, 104, 105, 131) AND v_date_format <> 'DMY') OR
+                    ((v_style IS NULL OR v_style IN (0, 103, 104, 105, 131)) AND v_date_format = 'DMY'))
+                THEN
+                    v_day := v_leftpart;
+                    v_month := v_middlepart;
+                ELSIF ((v_style IN (1, 2, 3, 4, 5, 10, 11, 22, 101, 110) AND v_date_format = 'DMY') OR
+                       ((v_style IS NULL OR v_style IN (0, 1, 2, 3, 4, 5, 10, 11, 22, 101, 110)) AND v_date_format <> 'DMY'))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+            END IF;
+        END IF;
+    ELSIF (v_datestring ~* YEAR_DOTMASK_REGEXP OR
+           v_datestring ~* YEAR_SLASHMASK_REGEXP OR
+           v_datestring ~* YEAR_DASHMASK_REGEXP)
+    THEN
+        IF (v_style IN (6, 7, 8, 9, 12, 13, 14, 24, 100, 106, 107, 108, 109, 112, 113, 114, 130)) THEN
+            RAISE invalid_regular_expression;
+        ELSIF (v_style IN (1, 2, 3, 4, 5, 10, 11, 22, 101, 103, 104, 105, 110, 131)) THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, YEAR_DOT_SLASH_DASH_REGEXP, 'gi');
+        v_day := v_regmatch_groups[3];
+        v_month := v_regmatch_groups[2];
+        v_year := v_regmatch_groups[1];
+
+    ELSIF (v_datestring ~* DIGITMASK1_REGEXP OR
+           v_datestring ~* DIGITMASK2_REGEXP)
+    THEN
+        IF (v_datestring ~* DIGITMASK1_REGEXP)
+        THEN
+            v_day := substring(v_datestring, 5, 2);
+            v_month := substring(v_datestring, 3, 2);
+            v_year := sys.babelfish_get_full_year(substring(v_datestring, 1, 2));
+        ELSE
+            v_day := substring(v_datestring, 7, 2);
+            v_month := substring(v_datestring, 5, 2);
+            v_year := substring(v_datestring, 1, 4);
+        END IF;
+    ELSIF (v_datestring ~* HHMMSSFS_REGEXP)
+    THEN
+        v_fractsecs := coalesce(sys.babelfish_get_timeunit_from_string(v_datestring, 'FRACTSECONDS'), '');
+        IF (v_datestring !~* HHMMSSFS_DOT_REGEXP AND char_length(v_fractsecs) > 3) THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_day := '01';
+        v_month := '01';
+        v_year := '1900';
+    ELSE
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (((v_datestring ~* HHMMSSFS_REGEXP OR v_datestring ~* DIGITMASK1_REGEXP OR v_datestring ~* DIGITMASK2_REGEXP) AND v_style IN (130, 131)) OR
+        ((v_datestring ~* DOT_FULLYEAR_REGEXP OR v_datestring ~* SLASH_FULLYEAR_REGEXP OR v_datestring ~* DASH_FULLYEAR_REGEXP) AND v_style = 131))
+    THEN
+        IF ((v_day::SMALLINT NOT BETWEEN 1 AND 29) OR
+            (v_month::SMALLINT NOT BETWEEN 1 AND 12))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_year) - 1;
+        v_datestring := to_char(v_hijridate, 'DD.MM.YYYY');
+
+        v_day := split_part(v_datestring, '.', 1);
+        v_month := split_part(v_datestring, '.', 2);
+        v_year := split_part(v_datestring, '.', 3);
+    END IF;
+
+    RETURN to_date(pg_catalog.concat_ws('.', v_day, v_month, v_year), 'DD.MM.YYYY');
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 2 of conv_string_to_date function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('The style %s is not supported for conversions from VARCHAR to DATE.', v_style),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_regular_expression THEN
+        RAISE USING MESSAGE := pg_catalog.format('The input character string doesn''t follow style %s.', v_style),
+                    DETAIL := 'Selected "style" param value isn''t valid for conversion of passed character string.',
+                    HINT := 'Either change the input character string or use a different style.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := 'Conversion failed when converting date from character string.',
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN character_not_in_repertoire THEN
+        RAISE USING MESSAGE := 'The YDM date format isn''t supported when converting from this string format to date.',
+                    DETAIL := 'Use of incorrect DATE_FORMAT constant value regarding string format parameter during conversion process.',
+                    HINT := 'Change DATE_FORMAT constant to one of these values: MDY|DMY|DYM, recompile function and try again.';
+
+    WHEN invalid_character_value_for_cast THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                      CONVERSION_LANG),
+                    DETAIL := 'Compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Correct CONVERSION_LANG constant value in function''s body, recompile it and try again.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Passed argument value contains illegal characters.',
+                    HINT := 'Correct passed argument value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_string_to_datetime(IN p_datatype TEXT,
+                                                                     IN p_datetimestring TEXT,
+                                                                     IN p_style NUMERIC DEFAULT 0)
+RETURNS TIMESTAMP WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_year VARCHAR COLLATE "C";
+    v_month VARCHAR COLLATE "C";
+    v_style SMALLINT;
+    v_scale SMALLINT;
+    v_hours VARCHAR COLLATE "C";
+    v_hijridate DATE;
+    v_minutes VARCHAR COLLATE "C";
+    v_seconds VARCHAR COLLATE "C";
+    v_fseconds VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_timepart VARCHAR COLLATE "C";
+    v_leftpart VARCHAR COLLATE "C";
+    v_middlepart VARCHAR COLLATE "C";
+    v_rightpart VARCHAR COLLATE "C";
+    v_datestring VARCHAR COLLATE "C";
+    v_err_message VARCHAR COLLATE "C";
+    v_date_format VARCHAR COLLATE "C";
+    v_res_datatype VARCHAR COLLATE "C";
+    v_datetimestring VARCHAR COLLATE "C";
+    v_datatype_groups TEXT[];
+    v_regmatch_groups TEXT[];
+    v_lang_metadata_json JSONB;
+    v_compmonth_regexp VARCHAR COLLATE "C";
+    v_resdatetime TIMESTAMP(6) WITHOUT TIME ZONE;
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
+    DAYMM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{4})';
+    SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    COMPYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2}|\d{4})';
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:[AP]M)';
+    MASKSEP_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\.|-|/)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,2}\s*';
+    FRACTSECS_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,9}\s*';
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^(DATETIME|SMALLDATETIME|DATETIME2)\s*(?:\()?\s*((?:-)?\d+)?\s*(?:\))?$';
+    DIGITREPRESENT_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\-?\d+\.?(?:\d+)?$';
+    HHMMSSFS_PART_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP, AMPM_REGEXP, '?|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '(?:\.|\:)', FRACTSECS_REGEXP, AMPM_REGEXP, '?');
+    HHMMSSFS_DOT_PART_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP, AMPM_REGEXP, '?|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '(?:\.)', FRACTSECS_REGEXP, AMPM_REGEXP, '?');
+    HHMMSSFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')$');
+    DEFMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '$');
+    DEFMASK1_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '$');
+    DEFMASK2_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)\s*', COMPYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK2_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK2_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK3_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)\s*', DAYMM_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK3_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', DAYMM_REGEXP, '$');
+    DEFMASK3_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '$');
+    DEFMASK4_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)',
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK4_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)$');
+    DEFMASK4_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)$');
+    DEFMASK5_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)',
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK5_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)$');
+    DEFMASK5_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)$');
+    DEFMASK6_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK6_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '$');
+    DEFMASK6_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '$');
+    DEFMASK7_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', DAYMM_REGEXP, '\s*,\s*', COMPYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK7_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', DAYMM_REGEXP, '\s*,\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK7_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '\s*,\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK8_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)',
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK8_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)$');
+    DEFMASK8_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)$');
+    DEFMASK9_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', FULLYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK9_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', FULLYEAR_REGEXP, '$');
+    DEFMASK9_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', FULLYEAR_REGEXP, '$');
+    DEFMASK10_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                  DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', MASKSEP_REGEXP, '\s*', COMPYEAR_REGEXP,
+                                                  '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK10_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', MASKSEP_REGEXP, '\s*', COMPYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_COMPYEAR1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                                 DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', COMPYEAR_REGEXP,
+                                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DOT_SLASH_DASH_COMPYEAR1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', COMPYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', SHORTYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_FULLYEAR1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                                 DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', FULLYEAR_REGEXP,
+                                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DOT_SLASH_DASH_FULLYEAR1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', FULLYEAR_REGEXP, '$');
+    FULLYEAR_DOT_SLASH_DASH1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                                 FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP,
+                                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    FULLYEAR_DOT_SLASH_DASH1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '$');
+    SHORT_DIGITMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*\d{6}\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    FULL_DIGITMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*\d{8}\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+BEGIN
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_datetimestring := pg_catalog.upper(pg_catalog.btrim(p_datetimestring));
+    v_style := floor(p_style)::SMALLINT;
+
+    v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
+
+    v_res_datatype := pg_catalog.upper(v_datatype_groups[1]);
+    v_scale := v_datatype_groups[2]::SMALLINT;
+
+    IF (v_res_datatype IS NULL) THEN
+        RAISE datatype_mismatch;
+    ELSIF (v_res_datatype <> 'DATETIME2' AND v_scale IS NOT NULL)
+    THEN
+        RAISE invalid_indicator_parameter_value;
+    ELSIF (coalesce(v_scale, 0) NOT BETWEEN 0 AND 7)
+    THEN
+        RAISE interval_field_overflow;
+    ELSIF (v_scale IS NULL) THEN
+        v_scale := 7;
+    END IF;
+
+    IF (scale(p_style) > 0) THEN
+        RAISE most_specific_type_mismatch;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 14) OR
+             (v_style BETWEEN 20 AND 25) OR
+             (v_style BETWEEN 100 AND 114) OR
+             (v_style IN (120, 121, 126, 127, 130, 131))) AND
+             v_res_datatype = 'DATETIME2')
+    THEN
+        RAISE invalid_parameter_value;
+    END IF;
+
+    v_timepart := pg_catalog.btrim(substring(v_datetimestring, HHMMSSFS_PART_REGEXP));
+    v_datestring := pg_catalog.btrim(regexp_replace(v_datetimestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
+
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(CONVERSION_LANG);
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_escape_sequence;
+    END;
+
+    v_date_format := coalesce(nullif(DATE_FORMAT, ''), v_lang_metadata_json ->> 'date_format');
+
+    v_compmonth_regexp := array_to_string(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
+                                                    ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_names'))), '|');
+
+    IF (v_datetimestring ~* pg_catalog.replace(DEFMASK1_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK2_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK3_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK4_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK5_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK6_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK7_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK8_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK9_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK10_0_REGEXP, '$comp_month$', v_compmonth_regexp))
+    THEN
+        IF ((v_style IN (127, 130, 131) AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+            (v_style IN (130, 131) AND v_res_datatype = 'DATETIME2'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF ((v_datestring ~* pg_catalog.replace(DEFMASK1_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK2_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK3_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK4_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK5_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK6_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK7_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK8_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK9_2_REGEXP, '$comp_month$', v_compmonth_regexp)) AND
+            v_res_datatype = 'DATETIME2')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF (v_datestring ~* pg_catalog.replace(DEFMASK1_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK1_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK2_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK2_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK3_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK3_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[3];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK4_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK4_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK5_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK5_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[2]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK6_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK6_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[3];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := v_regmatch_groups[2];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK7_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK7_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK8_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK8_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := '01';
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK9_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK9_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := '01';
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := v_regmatch_groups[2];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK10_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK10_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+        ELSE
+            RAISE invalid_character_value_for_cast;
+        END IF;
+    ELSIF (v_datetimestring ~* DOT_SLASH_DASH_COMPYEAR1_0_REGEXP)
+    THEN
+        IF (v_style IN (6, 7, 8, 9, 12, 13, 14, 24, 100, 106, 107, 108, 109, 112, 113, 114, 130) AND
+            v_res_datatype = 'DATETIME2')
+        THEN
+            RAISE invalid_regular_expression;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, DOT_SLASH_DASH_COMPYEAR1_1_REGEXP, 'gi');
+        v_leftpart := v_regmatch_groups[1];
+        v_middlepart := v_regmatch_groups[2];
+        v_rightpart := v_regmatch_groups[3];
+
+        IF (v_datestring ~* DOT_SLASH_DASH_SHORTYEAR_REGEXP)
+        THEN
+            IF ((v_style NOT IN (0, 1, 2, 3, 4, 5, 10, 11) AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                (v_style NOT IN (0, 1, 2, 3, 4, 5, 10, 11, 12) AND v_res_datatype = 'DATETIME2'))
+            THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            IF ((v_style IN (1, 10) AND v_date_format <> 'MDY' AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                (v_style IN (0, 1, 10) AND v_date_format NOT IN ('DMY', 'DYM', 'MYD', 'YMD', 'YDM') AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                (v_style IN (0, 1, 10, 22) AND v_date_format NOT IN ('DMY', 'DYM', 'MYD', 'YMD', 'YDM') AND v_res_datatype = 'DATETIME2') OR
+                (v_style IN (1, 10, 22) AND v_date_format IN ('DMY', 'DYM', 'MYD', 'YMD', 'YDM') AND v_res_datatype = 'DATETIME2'))
+            THEN
+                v_day := v_middlepart;
+                v_month := v_leftpart;
+                v_year := sys.babelfish_get_full_year(v_rightpart);
+
+            ELSIF ((v_style IN (2, 11) AND v_date_format <> 'YMD') OR
+                   (v_style IN (0, 2, 11) AND v_date_format = 'YMD'))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+                v_year := sys.babelfish_get_full_year(v_leftpart);
+
+            ELSIF ((v_style IN (3, 4, 5) AND v_date_format <> 'DMY') OR
+                   (v_style IN (0, 3, 4, 5) AND v_date_format = 'DMY'))
+            THEN
+                v_day := v_leftpart;
+                v_month := v_middlepart;
+                v_year := sys.babelfish_get_full_year(v_rightpart);
+
+            ELSIF (v_style = 0 AND v_date_format = 'DYM')
+            THEN
+                v_day = v_leftpart;
+                v_month = v_rightpart;
+                v_year = sys.babelfish_get_full_year(v_middlepart);
+
+            ELSIF (v_style = 0 AND v_date_format = 'MYD')
+            THEN
+                v_day := v_rightpart;
+                v_month := v_leftpart;
+                v_year = sys.babelfish_get_full_year(v_middlepart);
+
+            ELSIF (v_style = 0 AND v_date_format = 'YDM')
+            THEN
+                IF (v_res_datatype = 'DATETIME2') THEN
+                    RAISE character_not_in_repertoire;
+                END IF;
+
+                v_day := v_middlepart;
+                v_month := v_rightpart;
+                v_year := sys.babelfish_get_full_year(v_leftpart);
+            ELSE
+                RAISE invalid_character_value_for_cast;
+            END IF;
+        ELSIF (v_datestring ~* DOT_SLASH_DASH_FULLYEAR1_1_REGEXP)
+        THEN
+            IF (v_style NOT IN (0, 20, 21, 101, 102, 103, 104, 105, 110, 111, 120, 121, 130, 131) AND
+                v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+            THEN
+                RAISE invalid_datetime_format;
+            ELSIF (v_style IN (130, 131) AND v_res_datatype = 'SMALLDATETIME') THEN
+                RAISE invalid_character_value_for_cast;
+            END IF;
+
+            v_year := v_rightpart;
+            IF (v_leftpart::SMALLINT <= 12)
+            THEN
+                IF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                    (v_style IN (0, 103, 104, 105, 130, 131) AND ((v_date_format = 'DMY' AND v_res_datatype = 'DATETIME2') OR
+                    (v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2'))) OR
+                    (v_style IN (103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype = 'DATETIME2'))
+                THEN
+                    v_day := v_leftpart;
+                    v_month := v_middlepart;
+
+                ELSIF ((v_style IN (20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                       (v_style IN (0, 20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM') AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                       (v_style IN (101, 110) AND v_date_format IN ('DMY', 'DYM', 'MYD', 'YDM') AND v_res_datatype = 'DATETIME2') OR
+                       (v_style IN (0, 101, 110) AND v_date_format NOT IN ('DMY', 'DYM', 'MYD', 'YDM') AND v_res_datatype = 'DATETIME2'))
+                THEN
+                    v_day := v_middlepart;
+                    v_month := v_leftpart;
+                END IF;
+            ELSE
+                IF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                    (v_style IN (0, 103, 104, 105, 130, 131) AND ((v_date_format = 'DMY' AND v_res_datatype = 'DATETIME2') OR
+                    (v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2'))) OR
+                    (v_style IN (103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype = 'DATETIME2'))
+                THEN
+                    v_day := v_leftpart;
+                    v_month := v_middlepart;
+                ELSE
+                    IF (v_res_datatype = 'DATETIME2') THEN
+                        RAISE invalid_datetime_format;
+                    END IF;
+
+                    RAISE invalid_character_value_for_cast;
+                END IF;
+            END IF;
+        END IF;
+    ELSIF (v_datetimestring ~* FULLYEAR_DOT_SLASH_DASH1_0_REGEXP)
+    THEN
+        IF (v_style NOT IN (0, 20, 21, 101, 102, 103, 104, 105, 110, 111, 120, 121, 130, 131) AND
+            v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+        THEN
+            RAISE invalid_datetime_format;
+        ELSIF (v_style IN (6, 7, 8, 9, 12, 13, 14, 24, 100, 106, 107, 108, 109, 112, 113, 114, 130) AND
+            v_res_datatype = 'DATETIME2')
+        THEN
+            RAISE invalid_regular_expression;
+        ELSIF (v_style IN (130, 131) AND v_res_datatype = 'SMALLDATETIME')
+        THEN
+            RAISE invalid_character_value_for_cast;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, FULLYEAR_DOT_SLASH_DASH1_1_REGEXP, 'gi');
+        v_year := v_regmatch_groups[1];
+        v_middlepart := v_regmatch_groups[2];
+        v_rightpart := v_regmatch_groups[3];
+
+        IF ((v_res_datatype IN ('DATETIME', 'SMALLDATETIME') AND v_rightpart::SMALLINT <= 12) OR v_res_datatype = 'DATETIME2')
+        THEN
+            IF ((v_style IN (20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2') OR
+                (v_style IN (0, 20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2') OR
+                (v_style IN (0, 20, 21, 23, 25, 101, 102, 110, 111, 120, 121, 126, 127) AND v_res_datatype = 'DATETIME2'))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+
+            ELSIF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                    v_style IN (0, 103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM'))
+            THEN
+                v_day := v_middlepart;
+                v_month := v_rightpart;
+            END IF;
+        ELSIF (v_res_datatype IN ('DATETIME', 'SMALLDATETIME') AND v_rightpart::SMALLINT > 12)
+        THEN
+            IF ((v_style IN (20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format IN ('DMY', 'DYM', 'YDM')) OR
+                (v_style IN (0, 20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+
+            ELSIF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                   (v_style IN (0, 103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM')))
+            THEN
+                RAISE invalid_character_value_for_cast;
+            END IF;
+        END IF;
+    ELSIF (v_datetimestring ~* SHORT_DIGITMASK1_0_REGEXP OR
+           v_datetimestring ~* FULL_DIGITMASK1_0_REGEXP)
+    THEN
+        IF (v_style = 127 AND v_res_datatype <> 'DATETIME2')
+        THEN
+            RAISE invalid_datetime_format;
+        ELSIF (v_style IN (130, 131) AND v_res_datatype = 'SMALLDATETIME')
+        THEN
+            RAISE invalid_character_value_for_cast;
+        END IF;
+
+        IF (v_datestring ~* '^\d{6}$')
+        THEN
+            v_day := substr(v_datestring, 5, 2);
+            v_month := substr(v_datestring, 3, 2);
+            v_year := sys.babelfish_get_full_year(substr(v_datestring, 1, 2));
+
+        ELSIF (v_datestring ~* '^\d{8}$')
+        THEN
+            v_day := substr(v_datestring, 7, 2);
+            v_month := substr(v_datestring, 5, 2);
+            v_year := substr(v_datestring, 1, 4);
+        END IF;
+    ELSIF (v_datetimestring ~* HHMMSSFS_REGEXP)
+    THEN
+        v_day := '01';
+        v_month := '01';
+        v_year := '1900';
+    ELSIF (v_datetimestring ~* DIGITREPRESENT_REGEXP)
+    THEN
+        v_resdatetime = CAST('1900-01-01 00:00:00.0' AS sys.DATETIME) + v_datetimestring::NUMERIC;
+        RETURN v_resdatetime;
+    ELSE
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (((v_datetimestring ~* HHMMSSFS_PART_REGEXP AND v_res_datatype = 'DATETIME2') OR
+        (v_datetimestring ~* SHORT_DIGITMASK1_0_REGEXP OR v_datetimestring ~* FULL_DIGITMASK1_0_REGEXP OR
+          v_datetimestring ~* FULLYEAR_DOT_SLASH_DASH1_0_REGEXP OR v_datetimestring ~* DOT_SLASH_DASH_FULLYEAR1_0_REGEXP)) AND
+        v_style IN (130, 131))
+    THEN
+        v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_year) - 1;
+        v_day = to_char(v_hijridate, 'DD');
+        v_month = to_char(v_hijridate, 'MM');
+        v_year = to_char(v_hijridate, 'YYYY');
+    END IF;
+
+    v_hours := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'HOURS'), '0');
+    v_minutes := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'MINUTES'), '0');
+    v_seconds := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'SECONDS'), '0');
+    v_fseconds := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'FRACTSECONDS'), '0');
+
+    IF ((v_res_datatype IN ('DATETIME', 'SMALLDATETIME') OR
+         (v_res_datatype = 'DATETIME2' AND v_timepart !~* HHMMSSFS_DOT_PART_REGEXP)) AND
+        char_length(v_fseconds) > 3)
+    THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    BEGIN
+        IF (v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+        THEN
+            v_resdatetime := sys.datetimefromparts(v_year, v_month, v_day,
+                                                                 v_hours, v_minutes, v_seconds,
+                                                                 rpad(v_fseconds, 3, '0'));
+            IF (v_res_datatype = 'SMALLDATETIME' AND
+                to_char(v_resdatetime, 'SS') <> '00')
+            THEN
+                IF (to_char(v_resdatetime, 'SS')::SMALLINT >= 30) THEN
+                    v_resdatetime := v_resdatetime + INTERVAL '1 minute';
+                END IF;
+
+                v_resdatetime := to_timestamp(to_char(v_resdatetime, 'DD.MM.YYYY.HH24.MI'), 'DD.MM.YYYY.HH24.MI');
+            END IF;
+        ELSIF (v_res_datatype = 'DATETIME2')
+        THEN
+            v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(v_fseconds, v_scale);
+            v_seconds := pg_catalog.concat_ws('.', v_seconds, v_fseconds);
+            v_resdatetime := make_timestamp(v_year::SMALLINT, v_month::SMALLINT, v_day::SMALLINT,
+                                            v_hours::SMALLINT, v_minutes::SMALLINT, v_seconds::NUMERIC);
+        END IF;
+    EXCEPTION
+        WHEN datetime_field_overflow THEN
+            RAISE invalid_datetime_format;
+        WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+
+        IF (v_err_message ~* 'Cannot construct data type') THEN
+            RAISE invalid_character_value_for_cast;
+        END IF;
+    END;
+
+    RETURN v_resdatetime;
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 3 of conv_string_to_datetime function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('The style %s is not supported for conversions from VARCHAR to %s.', v_style, v_res_datatype),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_regular_expression THEN
+        RAISE USING MESSAGE := pg_catalog.format('The input character string doesn''t follow style %s.', v_style),
+                    DETAIL := 'Selected "style" param value isn''t valid for conversion of passed character string.',
+                    HINT := 'Either change the input character string or use a different style.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Data type should be one of these values: ''DATETIME'', ''SMALLDATETIME'', ''DATETIME2''/''DATETIME2(n)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_indicator_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid attributes specified for data type %s.', v_res_datatype),
+                    DETAIL := 'Use of incorrect scale value, which is not corresponding to specified data type.',
+                    HINT := 'Change data type scale component or select different data type and try again.';
+
+    WHEN interval_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_scale),
+                    DETAIL := 'Use of incorrect data type scale value during conversion process.',
+                    HINT := 'Change scale component of data type parameter to be in range [0..7] and try again.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := CASE v_res_datatype
+                                  WHEN 'SMALLDATETIME' THEN 'Conversion failed when converting character string to SMALLDATETIME data type.'
+                                  ELSE 'Conversion failed when converting date and time from character string.'
+                               END,
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN invalid_character_value_for_cast THEN
+        RAISE USING MESSAGE := 'The conversion of a VARCHAR data type to a DATETIME data type resulted in an out-of-range value.',
+                    DETAIL := 'Use of incorrect pair of input parameter values during conversion process.',
+                    HINT := 'Check input parameter values, correct them if needed, and try again.';
+
+    WHEN character_not_in_repertoire THEN
+        RAISE USING MESSAGE := 'The YDM date format isn''t supported when converting from this string format to date and time.',
+                    DETAIL := 'Use of incorrect DATE_FORMAT constant value regarding string format parameter during conversion process.',
+                    HINT := 'Change DATE_FORMAT constant to one of these values: MDY|DMY|DYM, recompile function and try again.';
+
+    WHEN invalid_escape_sequence THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                      CONVERSION_LANG),
+                    DETAIL := 'Compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Correct CONVERSION_LANG constant value in function''s body, recompile it and try again.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Passed argument value contains illegal characters.',
+                    HINT := 'Correct passed argument value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_string_to_time(IN p_datatype TEXT,
+                                                                 IN p_timestring TEXT,
+                                                                 IN p_style NUMERIC DEFAULT 0)
+RETURNS TIME WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_hours SMALLINT;
+    v_style SMALLINT;
+    v_scale SMALLINT;
+    v_daypart VARCHAR COLLATE "C";
+    v_seconds VARCHAR COLLATE "C";
+    v_minutes SMALLINT;
+    v_fseconds VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_timestring VARCHAR COLLATE "C";
+    v_err_message VARCHAR COLLATE "C";
+    v_src_datatype VARCHAR COLLATE "C";
+    v_timeunit_mask VARCHAR COLLATE "C";
+    v_datatype_groups TEXT[];
+    v_regmatch_groups TEXT[];
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*([AP]M)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(\d{1,2})\s*';
+    FRACTSECS_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(\d{1,9})';
+    HHMMSSFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP,
+                                               '\:', TIMEUNIT_REGEXP,
+                                               '\:', TIMEUNIT_REGEXP,
+                                               '(?:\.|\:)', FRACTSECS_REGEXP, '$');
+    HHMMSS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '$');
+    HHMMFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP, '$');
+    HHMM_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '$');
+    HH_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '$');
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^(TIME)\s*(?:\()?\s*((?:-)?\d+)?\s*(?:\))?$';
+BEGIN
+    v_datatype := pg_catalog.btrim(regexp_replace(p_datatype, 'DATETIME', 'TIME', 'gi'));
+    v_timestring := pg_catalog.upper(pg_catalog.btrim(p_timestring));
+    v_style := floor(p_style)::SMALLINT;
+
+    v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
+
+    v_src_datatype := pg_catalog.upper(v_datatype_groups[1]);
+    v_scale := v_datatype_groups[2]::SMALLINT;
+
+    IF (v_src_datatype IS NULL) THEN
+        RAISE datatype_mismatch;
+    ELSIF (coalesce(v_scale, 0) NOT BETWEEN 0 AND 7)
+    THEN
+        RAISE interval_field_overflow;
+    ELSIF (v_scale IS NULL) THEN
+        v_scale := 7;
+    END IF;
+
+    IF (scale(p_style) > 0) THEN
+        RAISE most_specific_type_mismatch;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 14) OR
+             (v_style BETWEEN 20 AND 25) OR
+             (v_style BETWEEN 100 AND 114) OR
+             v_style IN (120, 121, 126, 127, 130, 131)))
+    THEN
+        RAISE invalid_parameter_value;
+    END IF;
+
+    v_daypart := substring(v_timestring, 'AM|PM');
+    v_timestring := pg_catalog.btrim(regexp_replace(v_timestring, coalesce(v_daypart, ''), ''));
+
+    v_timeunit_mask :=
+        CASE
+           WHEN (v_timestring ~* HHMMSSFS_REGEXP) THEN HHMMSSFS_REGEXP
+           WHEN (v_timestring ~* HHMMSS_REGEXP) THEN HHMMSS_REGEXP
+           WHEN (v_timestring ~* HHMMFS_REGEXP) THEN HHMMFS_REGEXP
+           WHEN (v_timestring ~* HHMM_REGEXP) THEN HHMM_REGEXP
+           WHEN (v_timestring ~* HH_REGEXP) THEN HH_REGEXP
+        END;
+
+    IF (v_timeunit_mask IS NULL) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    v_regmatch_groups := regexp_matches(v_timestring, v_timeunit_mask, 'gi');
+
+    v_hours := v_regmatch_groups[1]::SMALLINT;
+    v_minutes := v_regmatch_groups[2]::SMALLINT;
+
+    IF (v_timestring ~* HHMMFS_REGEXP) THEN
+        v_fseconds := v_regmatch_groups[3];
+    ELSE
+        v_seconds := v_regmatch_groups[3];
+        v_fseconds := v_regmatch_groups[4];
+    END IF;
+
+   IF (v_daypart IS NOT NULL) THEN
+      IF ((v_daypart = 'AM' AND v_hours NOT BETWEEN 0 AND 12) OR
+          (v_daypart = 'PM' AND v_hours NOT BETWEEN 1 AND 23))
+      THEN
+          RAISE numeric_value_out_of_range;
+      ELSIF (v_daypart = 'PM' AND v_hours < 12) THEN
+          v_hours := v_hours + 12;
+      ELSIF (v_daypart = 'AM' AND v_hours = 12) THEN
+          v_hours := v_hours - 12;
+      END IF;
+   END IF;
+
+    v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(v_fseconds, v_scale);
+    v_seconds := pg_catalog.concat_ws('.', v_seconds, v_fseconds);
+
+    RETURN make_time(v_hours, v_minutes, v_seconds::NUMERIC);
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 3 of conv_string_to_time function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('The style %s is not supported for conversions from VARCHAR to TIME.', v_style),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Source data type should be ''TIME'' or ''TIME(n)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN interval_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_scale),
+                    DETAIL := 'Use of incorrect data type scale value during conversion process.',
+                    HINT := 'Change scale component of data type parameter to be in range [0..7] and try again.';
+
+    WHEN numeric_value_out_of_range THEN
+        RAISE USING MESSAGE := 'Could not extract correct hour value due to it''s inconsistency with AM|PM day part mark.',
+                    DETAIL := 'Extracted hour value doesn''t fall in correct day part mark range: 0..12 for "AM" or 1..23 for "PM".',
+                    HINT := 'Correct a hour value in the source string or remove AM|PM day part mark out of it.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := 'Conversion failed when converting time from character string.',
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_time_to_string(IN p_datatype TEXT,
+                                                                 IN p_src_datatype TEXT,
+                                                                 IN p_timeval TIME(6) WITHOUT TIME ZONE,
+                                                                 IN p_style NUMERIC DEFAULT 25)
+RETURNS TEXT
+AS
+$BODY$
+DECLARE
+    v_hours VARCHAR COLLATE "C";
+    v_style SMALLINT;
+    v_scale SMALLINT;
+    v_resmask VARCHAR COLLATE "C";
+    v_fseconds VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_resstring VARCHAR COLLATE "C";
+    v_lengthexpr VARCHAR COLLATE "C";
+    v_res_length SMALLINT;
+    v_res_datatype VARCHAR COLLATE "C";
+    v_src_datatype VARCHAR COLLATE "C";
+    v_res_maxlength SMALLINT;
+    VARCHAR_MAX CONSTANT SMALLINT := 8000;
+    NVARCHAR_MAX CONSTANT SMALLINT := 4000;
+    -- We use the regex below to make sure input p_datatype is one of them
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*$';
+    -- We use the regex below to get the length of the datatype, if specified
+    -- For example, to get the '10' out of 'varchar(10)'
+    DATATYPE_MASK_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\s*(?:CHAR|NCHAR|VARCHAR|NVARCHAR|CHARACTER VARYING)\s*\(\s*(\d+|MAX)\s*\)\s*$';
+    SRCDATATYPE_MASK_REGEXP VARCHAR COLLATE "C" := '^\s*(?:TIME)\s*(?:\s*\(\s*(\d+)\s*\)\s*)?\s*$';
+BEGIN
+    v_datatype := pg_catalog.upper(pg_catalog.btrim(p_datatype));
+    v_src_datatype := pg_catalog.upper(pg_catalog.btrim(p_src_datatype));
+    v_style := floor(p_style)::SMALLINT;
+
+    IF (v_src_datatype ~* SRCDATATYPE_MASK_REGEXP)
+    THEN
+        v_scale := coalesce(substring(v_src_datatype, SRCDATATYPE_MASK_REGEXP)::SMALLINT, 7);
+
+        IF (v_scale NOT BETWEEN 0 AND 7) THEN
+            RAISE invalid_regular_expression;
+        END IF;
+    ELSE
+        RAISE most_specific_type_mismatch;
+    END IF;
+
+    IF (v_datatype ~* DATATYPE_MASK_REGEXP)
+    THEN
+        v_res_datatype := PG_CATALOG.rtrim(split_part(v_datatype, '(', 1));
+
+        v_res_maxlength := CASE
+                              WHEN (v_res_datatype IN ('CHAR', 'VARCHAR')) THEN VARCHAR_MAX
+                              ELSE NVARCHAR_MAX
+                           END;
+
+        v_lengthexpr := substring(v_datatype, DATATYPE_MASK_REGEXP);
+
+        IF (v_lengthexpr <> 'MAX' AND char_length(v_lengthexpr) > 4) THEN
+            RAISE interval_field_overflow;
+        END IF;
+
+        v_res_length := CASE v_lengthexpr
+                           WHEN 'MAX' THEN v_res_maxlength
+                           ELSE v_lengthexpr::SMALLINT
+                        END;
+    ELSIF (v_datatype ~* DATATYPE_REGEXP) THEN
+        v_res_datatype := v_datatype;
+    ELSE
+        RAISE datatype_mismatch;
+    END IF;
+
+    IF (scale(p_style) > 0) THEN
+        RAISE escape_character_conflict;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 14) OR
+                (v_style BETWEEN 20 AND 25) OR
+                (v_style BETWEEN 100 AND 114) OR
+                v_style IN (120, 121, 126, 127, 130, 131)))
+    THEN
+        RAISE invalid_parameter_value;
+    ELSIF ((v_style BETWEEN 1 AND 7) OR
+           (v_style BETWEEN 10 AND 12) OR
+           (v_style BETWEEN 101 AND 107) OR
+           (v_style BETWEEN 110 AND 112) OR
+           v_style = 23)
+    THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    v_hours := PG_CATALOG.ltrim(to_char(p_timeval, 'HH12'), '0');
+    v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(to_char(p_timeval, 'US'), v_scale);
+
+    IF (v_scale = 7) THEN
+        v_fseconds := pg_catalog.concat(v_fseconds, '0');
+    END IF;
+
+    IF (v_style IN (0, 100))
+    THEN
+        v_resmask := pg_catalog.concat(v_hours, ':MIAM');
+    ELSIF (v_style IN (8, 20, 24, 108, 120))
+    THEN
+        v_resmask := 'HH24:MI:SS';
+    ELSIF (v_style IN (9, 109))
+    THEN
+        v_resmask := CASE
+                        WHEN (char_length(v_fseconds) = 0) THEN pg_catalog.concat(v_hours, ':MI:SSAM')
+                        ELSE pg_catalog.format('%s:MI:SS.%sAM', v_hours, v_fseconds)
+                     END;
+    ELSIF (v_style IN (13, 14, 21, 25, 113, 114, 121, 126, 127))
+    THEN
+        v_resmask := CASE
+                        WHEN (char_length(v_fseconds) = 0) THEN 'HH24:MI:SS'
+                        ELSE pg_catalog.concat('HH24:MI:SS.', v_fseconds)
+                     END;
+    ELSIF (v_style = 22)
+    THEN
+        v_resmask := pg_catalog.format('%s:MI:SS AM', lpad(v_hours, 2, ' '));
+    ELSIF (v_style IN (130, 131))
+    THEN
+        v_resmask := CASE
+                        WHEN (char_length(v_fseconds) = 0) THEN pg_catalog.concat(lpad(v_hours, 2, ' '), ':MI:SSAM')
+                        ELSE pg_catalog.format('%s:MI:SS.%sAM', lpad(v_hours, 2, ' '), v_fseconds)
+                     END;
+    END IF;
+
+    v_resstring := to_char(p_timeval, v_resmask);
+
+    v_resstring := substring(v_resstring, 1, coalesce(v_res_length, char_length(v_resstring)));
+    v_res_length := coalesce(v_res_length,
+                             CASE v_res_datatype
+                                WHEN 'CHAR' THEN 30
+                                ELSE 60
+                             END);
+    RETURN CASE
+              WHEN (v_res_datatype NOT IN ('CHAR', 'NCHAR')) THEN v_resstring
+              ELSE rpad(v_resstring, v_res_length, ' ')
+           END;
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Source data type should be ''TIME'' or ''TIME(n)''.',
+                    DETAIL := 'Use of incorrect "src_datatype" parameter value during conversion process.',
+                    HINT := 'Change "src_datatype" parameter to the proper value and try again.';
+
+   WHEN invalid_regular_expression THEN
+       RAISE USING MESSAGE := pg_catalog.format('The source data type scale (%s) given to the convert specification exceeds the maximum allowable value (7).',
+                                     v_scale),
+                   DETAIL := 'Use of incorrect scale value of source data type parameter during conversion process.',
+                   HINT := 'Change scale component of source data type parameter to the allowable value and try again.';
+
+   WHEN interval_field_overflow THEN
+       RAISE USING MESSAGE := pg_catalog.format('The size (%s) given to the convert specification ''%s'' exceeds the maximum allowed for any data type (%s).',
+                                     v_lengthexpr, pg_catalog.lower(v_res_datatype), v_res_maxlength),
+                   DETAIL := 'Use of incorrect size value of target data type parameter during conversion process.',
+                   HINT := 'Change size component of data type parameter to the allowable value and try again.';
+
+    WHEN escape_character_conflict THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 4 of convert function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('%s is not a valid style number when converting from TIME to a character string.', v_style),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Data type should be one of these values: ''CHAR(n|MAX)'', ''NCHAR(n|MAX)'', ''VARCHAR(n|MAX)'', ''NVARCHAR(n|MAX)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := pg_catalog.format('Error converting data type TIME to %s.',
+                                      PG_CATALOG.rtrim(split_part(pg_catalog.btrim(p_datatype), '(', 1))),
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_full_year(IN p_short_year TEXT,
+                                                           IN p_base_century TEXT DEFAULT '',
+                                                           IN p_year_cutoff NUMERIC DEFAULT 49)
+RETURNS VARCHAR
+AS
+$BODY$
+DECLARE
+    v_err_message VARCHAR;
+    v_full_year SMALLINT;
+    v_short_year SMALLINT;
+    v_base_century SMALLINT;
+    v_result_param_set JSONB;
+    v_full_year_res_jsonb JSONB;
+BEGIN
+    v_short_year := p_short_year::SMALLINT;
+
+    BEGIN
+        v_full_year_res_jsonb := nullif(current_setting('sys.full_year_res_json'), '')::JSONB;
+    EXCEPTION
+        WHEN undefined_object THEN
+        v_full_year_res_jsonb := NULL;
+    END;
+
+    SELECT result
+      INTO v_full_year
+      FROM jsonb_to_recordset(v_full_year_res_jsonb) AS result_set (param1 SMALLINT,
+                                                                    param2 TEXT,
+                                                                    param3 NUMERIC,
+                                                                    result VARCHAR)
+     WHERE param1 = v_short_year
+       AND param2 = p_base_century
+       AND param3 = p_year_cutoff;
+
+    IF (v_full_year IS NULL)
+    THEN
+        IF (v_short_year <= 99)
+        THEN
+            v_base_century := CASE
+                                 WHEN (p_base_century ~ '^\s*([1-9]{1,2})\s*$') THEN pg_catalog.concat(pg_catalog.btrim(p_base_century), '00')::SMALLINT
+                                 ELSE trunc(extract(year from current_date)::NUMERIC, -2)
+                              END;
+
+            v_full_year = v_base_century + v_short_year;
+            v_full_year = CASE
+                             WHEN (v_short_year::NUMERIC > p_year_cutoff) THEN v_full_year - 100
+                             ELSE v_full_year
+                          END;
+        ELSE v_full_year := v_short_year;
+        END IF;
+
+        v_result_param_set := jsonb_build_object('param1', v_short_year,
+                                                 'param2', p_base_century,
+                                                 'param3', p_year_cutoff,
+                                                 'result', v_full_year);
+        v_full_year_res_jsonb := CASE
+                                    WHEN (v_full_year_res_jsonb IS NULL) THEN jsonb_build_array(v_result_param_set)
+                                    ELSE v_full_year_res_jsonb || v_result_param_set
+                                 END;
+
+        PERFORM set_config('sys.full_year_res_json',
+                           v_full_year_res_jsonb::TEXT,
+                           FALSE);
+    END IF;
+
+    RETURN v_full_year;
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_lang_metadata_json(IN p_lang_spec_culture TEXT)
+RETURNS JSONB
+AS
+$BODY$
+DECLARE
+    v_locale_parts TEXT[] COLLATE "C";
+    v_lang_data_jsonb JSONB;
+    v_lang_spec_culture VARCHAR COLLATE "C";
+    v_is_cached BOOLEAN := FALSE;
+BEGIN
+    v_lang_spec_culture := pg_catalog.upper(pg_catalog.btrim(p_lang_spec_culture));
+
+    IF (char_length(v_lang_spec_culture) > 0)
+    THEN
+        BEGIN
+            v_lang_data_jsonb := nullif(current_setting(format('sys.lang_metadata_json.%s',
+                                                               v_lang_spec_culture)), '')::JSONB;
+        EXCEPTION
+            WHEN undefined_object THEN
+            v_lang_data_jsonb := NULL;
+        END;
+
+        IF (v_lang_data_jsonb IS NULL)
+        THEN
+            v_lang_spec_culture := pg_catalog.upper(regexp_replace(v_lang_spec_culture, '-\s*', '_', 'gi'));
+            IF (v_lang_spec_culture IN ('AR', 'FI') OR
+                v_lang_spec_culture ~ '_')
+            THEN
+                SELECT lang_data_jsonb
+                  INTO STRICT v_lang_data_jsonb
+                  FROM sys.babelfish_syslanguages
+                 WHERE spec_culture = v_lang_spec_culture;
+            ELSE
+                SELECT lang_data_jsonb
+                  INTO STRICT v_lang_data_jsonb
+                  FROM sys.babelfish_syslanguages
+                 WHERE lang_name_mssql = v_lang_spec_culture
+                    OR lang_alias_mssql = v_lang_spec_culture;
+            END IF;
+        ELSE
+            v_is_cached := TRUE;
+        END IF;
+    ELSE
+        v_lang_spec_culture := current_setting('LC_TIME');
+
+        v_lang_spec_culture := CASE
+                                  WHEN (v_lang_spec_culture !~ '\.') THEN v_lang_spec_culture
+                                  ELSE substring(v_lang_spec_culture, '(.*)(?:\.)')
+                               END;
+
+        v_lang_spec_culture := pg_catalog.upper(regexp_replace(v_lang_spec_culture, ',\s*', '_', 'gi'));
+
+        BEGIN
+            v_lang_data_jsonb := nullif(current_setting(format('sys.lang_metadata_json.%s',
+                                                               v_lang_spec_culture)), '')::JSONB;
+        EXCEPTION
+            WHEN undefined_object THEN
+            v_lang_data_jsonb := NULL;
+        END;
+
+        IF (v_lang_data_jsonb IS NULL)
+        THEN
+            BEGIN
+                IF (char_length(v_lang_spec_culture) = 5)
+                THEN
+                    SELECT lang_data_jsonb
+                      INTO STRICT v_lang_data_jsonb
+                      FROM sys.babelfish_syslanguages
+                     WHERE spec_culture = v_lang_spec_culture;
+                ELSE
+                    v_locale_parts := string_to_array(v_lang_spec_culture, '-');
+
+                    SELECT lang_data_jsonb
+                      INTO STRICT v_lang_data_jsonb
+                      FROM sys.babelfish_syslanguages
+                     WHERE lang_name_pg = v_locale_parts[1]
+                       AND territory = v_locale_parts[2];
+                END IF;
+            EXCEPTION
+                WHEN OTHERS THEN
+                    v_lang_spec_culture := 'EN_US';
+
+                    SELECT lang_data_jsonb
+                      INTO v_lang_data_jsonb
+                      FROM sys.babelfish_syslanguages
+                     WHERE spec_culture = v_lang_spec_culture;
+            END;
+        ELSE
+            v_is_cached := TRUE;
+        END IF;
+    END IF;
+
+    IF (NOT v_is_cached) THEN
+        PERFORM set_config(format('sys.lang_metadata_json.%s',
+                                  v_lang_spec_culture),
+                           v_lang_data_jsonb::TEXT,
+                           FALSE);
+    END IF;
+
+    RETURN v_lang_data_jsonb;
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        RAISE USING MESSAGE := pg_catalog.format('The language metadata JSON value extracted from chache is not a valid JSON object.',
+                                      p_lang_spec_culture),
+                    HINT := 'Drop the current session, fix the appropriate record in "sys.babelfish_syslanguages" table, and try again after reconnection.';
+
+    WHEN OTHERS THEN
+        RAISE USING MESSAGE := pg_catalog.format('"%s" is not a valid special culture or language name parameter.',
+                                      p_lang_spec_culture),
+                    DETAIL := 'Use of incorrect "lang_spec_culture" parameter value during conversion process.',
+                    HINT := 'Change "lang_spec_culture" parameter to the proper value and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_microsecs_from_fractsecs(IN p_fractsecs TEXT,
+                                                                          IN p_scale NUMERIC DEFAULT 7)
+RETURNS VARCHAR
+AS
+$BODY$
+DECLARE
+    v_scale SMALLINT;
+    v_decplaces INTEGER;
+    v_fractsecs VARCHAR COLLATE "C";
+    v_pureplaces VARCHAR COLLATE "C";
+    v_rnd_fractsecs INTEGER;
+    v_fractsecs_len INTEGER;
+    v_pureplaces_len INTEGER;
+    v_err_message VARCHAR COLLATE "C";
+BEGIN
+    v_fractsecs := pg_catalog.btrim(p_fractsecs);
+    v_fractsecs_len := char_length(v_fractsecs);
+    v_scale := floor(p_scale)::SMALLINT;
+
+    IF (v_fractsecs_len < 7) THEN
+        v_fractsecs := rpad(v_fractsecs, 7, '0');
+        v_fractsecs_len := char_length(v_fractsecs);
+    END IF;
+
+    v_pureplaces := trim(leading '0' from v_fractsecs);
+    v_pureplaces_len := char_length(v_pureplaces);
+
+    v_decplaces := v_fractsecs_len - v_pureplaces_len;
+
+    v_rnd_fractsecs := round(v_fractsecs::INTEGER, (v_pureplaces_len - (v_scale - (v_fractsecs_len - v_pureplaces_len))) * (-1));
+
+    v_fractsecs := pg_catalog.concat(pg_catalog.replace(rpad('', v_decplaces), ' ', '0'), v_rnd_fractsecs);
+
+    RETURN substring(v_fractsecs, 1, CASE
+                                        WHEN (v_scale >= 7) THEN 6
+                                        ELSE v_scale
+                                     END);
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.', v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_monthnum_by_name(IN p_monthname TEXT,
+                                                                  IN p_lang_metadata_json JSONB)
+RETURNS VARCHAR
+AS
+$BODY$
+DECLARE
+    v_monthname TEXT;
+    v_monthnum SMALLINT;
+BEGIN
+    v_monthname := pg_catalog.lower(pg_catalog.btrim(p_monthname));
+
+    v_monthnum := array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'months_shortnames'))), v_monthname);
+
+    v_monthnum := coalesce(v_monthnum,
+                           array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'months_names'))), v_monthname));
+
+    v_monthnum := coalesce(v_monthnum,
+                           array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'months_extrashortnames'))), v_monthname));
+
+    v_monthnum := coalesce(v_monthnum,
+                           array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'months_extranames'))), v_monthname));
+
+    IF (v_monthnum IS NULL) THEN
+        RAISE datetime_field_overflow;
+    END IF;
+
+    RETURN v_monthnum;
+EXCEPTION
+    WHEN datetime_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Can not convert value "%s" to a correct month number.',
+                                      pg_catalog.btrim(p_monthname)),
+                    DETAIL := 'Supplied month name is not valid.',
+                    HINT := 'Correct supplied month name value and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_timeunit_from_string(IN p_timepart TEXT,
+                                                                      IN p_timeunit TEXT)
+RETURNS VARCHAR
+AS
+$BODY$
+DECLARE
+    v_hours VARCHAR COLLATE "C";
+    v_minutes VARCHAR COLLATE "C";
+    v_seconds VARCHAR COLLATE "C";
+    v_fractsecs VARCHAR COLLATE "C";
+    v_daypart VARCHAR COLLATE "C";
+    v_timepart VARCHAR COLLATE "C";
+    v_timeunit VARCHAR COLLATE "C";
+    v_err_message VARCHAR COLLATE "C";
+    v_timeunit_mask VARCHAR COLLATE "C";
+    v_regmatch_groups TEXT[];
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*([AP]M)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(\d{1,2})\s*';
+    FRACTSECS_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(\d{1,9})';
+    HHMMSSFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP,
+                                               '\:', TIMEUNIT_REGEXP,
+                                               '\:', TIMEUNIT_REGEXP,
+                                               '(?:\.|\:)', FRACTSECS_REGEXP, '$');
+    HHMMSS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '$');
+    HHMMFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP, '$');
+    HHMM_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '$');
+    HH_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', TIMEUNIT_REGEXP, '$');
+BEGIN
+    v_timepart := pg_catalog.upper(pg_catalog.btrim(p_timepart));
+    v_timeunit := pg_catalog.upper(pg_catalog.btrim(p_timeunit));
+
+    v_daypart := substring(v_timepart, 'AM|PM');
+    v_timepart := pg_catalog.btrim(regexp_replace(v_timepart, coalesce(v_daypart, ''), ''));
+
+    v_timeunit_mask :=
+        CASE
+           WHEN (v_timepart ~* HHMMSSFS_REGEXP) THEN HHMMSSFS_REGEXP
+           WHEN (v_timepart ~* HHMMSS_REGEXP) THEN HHMMSS_REGEXP
+           WHEN (v_timepart ~* HHMMFS_REGEXP) THEN HHMMFS_REGEXP
+           WHEN (v_timepart ~* HHMM_REGEXP) THEN HHMM_REGEXP
+           WHEN (v_timepart ~* HH_REGEXP) THEN HH_REGEXP
+        END;
+
+    v_regmatch_groups := regexp_matches(v_timepart, v_timeunit_mask, 'gi');
+
+    v_hours := v_regmatch_groups[1];
+    v_minutes := v_regmatch_groups[2];
+
+    IF (v_timepart ~* HHMMFS_REGEXP) THEN
+        v_fractsecs := v_regmatch_groups[3];
+    ELSE
+        v_seconds := v_regmatch_groups[3];
+        v_fractsecs := v_regmatch_groups[4];
+    END IF;
+
+    IF (v_timeunit = 'HOURS' AND v_daypart IS NOT NULL)
+    THEN
+        IF ((v_daypart = 'AM' AND v_hours::SMALLINT NOT BETWEEN 0 AND 12) OR
+            (v_daypart = 'PM' AND v_hours::SMALLINT NOT BETWEEN 1 AND 23))
+        THEN
+            RAISE numeric_value_out_of_range;
+        ELSIF (v_daypart = 'PM' AND v_hours::SMALLINT < 12) THEN
+            v_hours := (v_hours::SMALLINT + 12)::VARCHAR;
+        ELSIF (v_daypart = 'AM' AND v_hours::SMALLINT = 12) THEN
+            v_hours := (v_hours::SMALLINT - 12)::VARCHAR;
+        END IF;
+    END IF;
+
+    RETURN CASE v_timeunit
+              WHEN 'HOURS' THEN v_hours
+              WHEN 'MINUTES' THEN v_minutes
+              WHEN 'SECONDS' THEN v_seconds
+              WHEN 'FRACTSECONDS' THEN v_fractsecs
+           END;
+EXCEPTION
+    WHEN numeric_value_out_of_range THEN
+        RAISE USING MESSAGE := 'Could not extract correct hour value due to it''s inconsistency with AM|PM day part mark.',
+                    DETAIL := 'Extracted hour value doesn''t fall in correct day part mark range: 0..12 for "AM" or 1..23 for "PM".',
+                    HINT := 'Correct a hour value in the source string or remove AM|PM day part mark out of it.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.', v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_get_weekdaynum_by_name(IN p_weekdayname TEXT,
+                                                                    IN p_lang_metadata_json JSONB)
+RETURNS SMALLINT
+AS
+$BODY$
+DECLARE
+    v_weekdayname TEXT;
+    v_weekdaynum SMALLINT;
+BEGIN
+    v_weekdayname := pg_catalog.lower(pg_catalog.btrim(p_weekdayname));
+
+    v_weekdaynum := array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'days_names'))), v_weekdayname);
+
+    v_weekdaynum := coalesce(v_weekdaynum,
+                             array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'days_shortnames'))), v_weekdayname));
+
+    v_weekdaynum := coalesce(v_weekdaynum,
+                             array_position(ARRAY(SELECT pg_catalog.lower(jsonb_array_elements_text(p_lang_metadata_json -> 'days_extrashortnames'))), v_weekdayname));
+
+    IF (v_weekdaynum IS NULL) THEN
+        RAISE datetime_field_overflow;
+    END IF;
+
+    RETURN v_weekdaynum;
+EXCEPTION
+    WHEN datetime_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Can not convert value "%s" to a correct weekday number.',
+                                      pg_catalog.btrim(p_weekdayname)),
+                    DETAIL := 'Supplied weekday name is not valid.',
+                    HINT := 'Correct supplied weekday name value and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_parse_to_date(IN p_datestring TEXT,
+                                                           IN p_culture TEXT DEFAULT '')
+RETURNS DATE
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_year SMALLINT;
+    v_month VARCHAR COLLATE "C";
+    v_res_date DATE;
+    v_hijridate DATE;
+    v_culture VARCHAR COLLATE "C";
+    v_dayparts TEXT[];
+    v_resmask VARCHAR COLLATE "C";
+    v_raw_year VARCHAR COLLATE "C";
+    v_left_part VARCHAR COLLATE "C";
+    v_right_part VARCHAR COLLATE "C";
+    v_resmask_fi VARCHAR COLLATE "C";
+    v_datestring VARCHAR COLLATE "C";
+    v_timestring VARCHAR COLLATE "C";
+    v_correctnum VARCHAR COLLATE "C";
+    v_weekdaynum SMALLINT;
+    v_err_message VARCHAR COLLATE "C";
+    v_date_format VARCHAR COLLATE "C";
+    v_weekdaynames TEXT[];
+    v_hours SMALLINT := 0;
+    v_minutes SMALLINT := 0;
+    v_seconds NUMERIC := 0;
+    v_found BOOLEAN := TRUE;
+    v_compday_regexp VARCHAR COLLATE "C";
+    v_regmatch_groups TEXT[];
+    v_compmonth_regexp VARCHAR COLLATE "C";
+    v_lang_metadata_json JSONB;
+    v_resmask_cnt SMALLINT := 10;
+    DAYMM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{3,4})';
+    SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    COMPYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,4})';
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:[AP]M|ص|م)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,2}\s*';
+    MASKSEPONE_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:/|-)?';
+    MASKSEPTWO_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:\s|/|-|\.|,)';
+    MASKSEPTWO_FI_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:\s|/|-|,)';
+    MASKSEPTHREE_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:/|-|\.|,)';
+    TIME_MASKSEP_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\s|\.|,)*';
+    TIME_MASKSEP_FI_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\s|,)*';
+    WEEKDAYAMPM_START_REGEXP CONSTANT VARCHAR COLLATE "C" := '(^|[[:digit:][:space:]\.,])';
+    WEEKDAYAMPM_END_REGEXP CONSTANT VARCHAR COLLATE "C" := '([[:digit:][:space:]\.,]|$)(?=[^/-]|$)';
+    CORRECTNUM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:([+-]\d{1,4})(?:[[:space:]\.,]|[AP]M|ص|م|$))';
+    ANNO_DOMINI_REGEXP VARCHAR COLLATE "C" := '(AD|A\.D\.)';
+    ANNO_DOMINI_COMPREGEXP VARCHAR COLLATE "C" := pg_catalog.concat(WEEKDAYAMPM_START_REGEXP, ANNO_DOMINI_REGEXP, WEEKDAYAMPM_END_REGEXP);
+    HHMMSSFS_PART_REGEXP CONSTANT VARCHAR COLLATE "C" :=
+        pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\s*\d{1,2}\.\d+(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?');
+    HHMMSSFS_PART_FI_REGEXP CONSTANT VARCHAR COLLATE "C" :=
+        pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?\.?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '\s*\d{1,2}\.\d+(?!\d)\.?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?');
+    v_defmask1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(?:[\.|,]+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP, '$');
+    v_defmask1_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(?:[\.|,]+', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(?:(?:[\.|,]+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?)|',
+                                        CORRECTNUM_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask2_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           AMPM_REGEXP, TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(?:(?:[\.|,]+', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?)|',
+                                           CORRECTNUM_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask3_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, ')|',
+                                        '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(', TIME_MASKSEP_REGEXP, AMPM_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask3_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '[\./]?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)',
+                                           FULLYEAR_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask4_0_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask4_1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          '(?:\s|,)+',
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask4_2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          '\s*[\.]+', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask5_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask5_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask6_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask6_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:\s*[\.])?',
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask7_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask7_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask8_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:[\.|,]+', AMPM_REGEXP, ')?',
+                                        TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask8_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:[\,]+|\s*/\s*)', AMPM_REGEXP, ')?',
+                                           TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask9_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(',
+                                        HHMMSSFS_PART_REGEXP,
+                                        ')', TIME_MASKSEP_REGEXP, '$');
+    v_defmask9_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '(',
+                                           HHMMSSFS_PART_FI_REGEXP,
+                                           ')', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask10_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask10_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)?', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask11_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask11_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           '($comp_month$)',
+                                           '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask12_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask12_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask13_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask13_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask14_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)'
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask14_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)'
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_FI_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask15_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask15_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask16_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask16_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask17_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask17_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask18_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                         '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask18_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                            '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask19_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                         '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask19_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                            '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
+BEGIN
+    v_datestring := pg_catalog.upper(pg_catalog.btrim(p_datestring));
+    v_culture := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(p_culture)), ''), 'EN-US');
+
+    v_dayparts := ARRAY(SELECT pg_catalog.upper(array_to_string(regexp_matches(v_datestring, '[AP]M|ص|م', 'gi'), '')));
+
+    IF (array_length(v_dayparts, 1) > 1) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(coalesce(nullif(CONVERSION_LANG, ''), p_culture));
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_parameter_value;
+    END;
+
+    v_compday_regexp := array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_names')),
+                                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_shortnames'))),
+                                                  ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_extrashortnames'))), '|');
+
+    v_weekdaynames := ARRAY(SELECT array_to_string(regexp_matches(v_datestring, v_compday_regexp, 'gi'), ''));
+
+    IF (array_length(v_weekdaynames, 1) > 1) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (v_weekdaynames[1] IS NOT NULL AND
+        v_datestring ~* pg_catalog.concat(WEEKDAYAMPM_START_REGEXP, '(', v_compday_regexp, ')', WEEKDAYAMPM_END_REGEXP))
+    THEN
+        v_datestring := pg_catalog.replace(v_datestring, v_weekdaynames[1], ' ');
+    END IF;
+
+    IF (v_datestring ~* ANNO_DOMINI_COMPREGEXP)
+    THEN
+        IF (v_culture !~ 'EN[-_]US|DA[-_]DK|SV[-_]SE|EN[-_]GB|HI[-_]IS') THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_datestring := regexp_replace(v_datestring,
+                                       ANNO_DOMINI_COMPREGEXP,
+                                       regexp_replace(array_to_string(regexp_matches(v_datestring, ANNO_DOMINI_COMPREGEXP, 'gi'), ''),
+                                                      ANNO_DOMINI_REGEXP, ' ', 'gi'),
+                                       'gi');
+    END IF;
+
+    v_date_format := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
+
+    v_compmonth_regexp :=
+        array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
+                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_names'))),
+                                  array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_extrashortnames')),
+                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_extranames')))
+                                 ), '|');
+
+    IF ((v_datestring ~* v_defmask1_regexp AND v_culture <> 'FI') OR
+        (v_datestring ~* v_defmask1_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_datestring ~ pg_catalog.concat(CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                  CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                  AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                  '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                  CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+            v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                             WHEN 'FI' THEN v_defmask1_fi_regexp
+                                                             ELSE v_defmask1_regexp
+                                                          END, 'gi');
+        v_timestring := v_regmatch_groups[2];
+        v_correctnum := coalesce(v_regmatch_groups[1], v_regmatch_groups[3],
+                                 v_regmatch_groups[5], v_regmatch_groups[6]);
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('SV-SE', 'SV_SE', 'LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[4];
+            v_month := v_regmatch_groups[7];
+        ELSE
+            v_day := v_regmatch_groups[7];
+            v_month := v_regmatch_groups[4];
+        END IF;
+
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+        THEN
+            IF (v_day::SMALLINT > 30 OR
+                v_month::SMALLINT > 12) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_raw_year := to_char(sys.babelfish_conv_greg_to_hijri(current_date + 1), 'YYYY');
+            v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+            v_day := to_char(v_hijridate, 'DD');
+            v_month := to_char(v_hijridate, 'MM');
+            v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+        ELSE
+            v_year := to_char(current_date, 'YYYY')::SMALLINT;
+        END IF;
+
+    ELSIF ((v_datestring ~* v_defmask6_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask6_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}',
+                                   '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                   '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                   '\d{3,4}', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                   TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                   '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                             WHEN 'FI' THEN v_defmask6_fi_regexp
+                                                             ELSE v_defmask6_regexp
+                                                          END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_day := v_regmatch_groups[4];
+        v_month := v_regmatch_groups[3];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[2]::SMALLINT - 543
+                     ELSE v_regmatch_groups[2]::SMALLINT
+                  END;
+
+    ELSIF ((v_datestring ~* v_defmask2_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask2_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}',
+                                   '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                   '(?:', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                   AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                   '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                             WHEN 'FI' THEN v_defmask2_fi_regexp
+                                                             ELSE v_defmask2_regexp
+                                                          END, 'gi');
+        v_timestring := v_regmatch_groups[2];
+        v_correctnum := coalesce(v_regmatch_groups[1], v_regmatch_groups[3], v_regmatch_groups[5],
+                                 v_regmatch_groups[6], v_regmatch_groups[8], v_regmatch_groups[9]);
+        v_day := '01';
+        v_month := v_regmatch_groups[7];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[4]::SMALLINT - 543
+                     ELSE v_regmatch_groups[4]::SMALLINT
+                  END;
+
+    ELSIF (v_datestring ~* v_defmask4_1_regexp OR
+           (v_datestring ~* v_defmask4_2_regexp AND v_culture !~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV') OR
+           (v_datestring ~* v_defmask9_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask9_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_datestring ~ pg_catalog.concat('\d+\s*\.?(?:,+|,*', AMPM_REGEXP, ')', TIME_MASKSEP_FI_REGEXP, '\.+', TIME_MASKSEP_REGEXP, '$|',
+                                  '\d+\s*\.', TIME_MASKSEP_FI_REGEXP, '\.', TIME_MASKSEP_FI_REGEXP, '$') AND
+            v_culture = 'FI')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF (v_datestring ~* v_defmask4_0_regexp) THEN
+            v_timestring := (regexp_matches(v_datestring, v_defmask4_0_regexp, 'gi'))[1];
+        ELSE
+            v_timestring := v_datestring;
+        END IF;
+
+        v_res_date := current_date;
+        v_day := to_char(v_res_date, 'DD');
+        v_month := to_char(v_res_date, 'MM');
+        v_year := to_char(v_res_date, 'YYYY')::SMALLINT;
+
+    ELSIF ((v_datestring ~* v_defmask3_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask3_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?',
+                                   TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP, '|',
+                                   '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                             WHEN 'FI' THEN v_defmask3_fi_regexp
+                                                             ELSE v_defmask3_regexp
+                                                          END, 'gi');
+        v_timestring := v_regmatch_groups[1];
+        v_day := '01';
+        v_month := v_regmatch_groups[2];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[3]::SMALLINT - 543
+                     ELSE v_regmatch_groups[3]::SMALLINT
+                  END;
+
+    ELSIF ((v_datestring ~* v_defmask5_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask5_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                   TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                   TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$|',
+                                   '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}\s*(?:\.)+|',
+                                   '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, v_defmask5_regexp, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[4]::SMALLINT - 543
+                     ELSE v_regmatch_groups[4]::SMALLINT
+                  END;
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[2];
+            v_month := v_regmatch_groups[3];
+        ELSE
+            v_day := v_regmatch_groups[3];
+            v_month := v_regmatch_groups[2];
+        END IF;
+
+    ELSIF ((v_datestring ~* v_defmask7_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask7_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}',
+                                   MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}|',
+                                   '\d{3,4}', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                   '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                             WHEN 'FI' THEN v_defmask7_fi_regexp
+                                                             ELSE v_defmask7_regexp
+                                                          END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_day := v_regmatch_groups[4];
+        v_month := v_regmatch_groups[2];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[3]::SMALLINT - 543
+                     ELSE v_regmatch_groups[3]::SMALLINT
+                  END;
+
+    ELSIF ((v_datestring ~* v_defmask8_regexp AND v_culture <> 'FI') OR
+           (v_datestring ~* v_defmask8_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_datestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}',
+                                  MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                  TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                  '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                  TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                  '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+            v_culture ~ 'FI|DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                             WHEN 'FI' THEN v_defmask8_fi_regexp
+                                                             ELSE v_defmask8_regexp
+                                                          END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[2];
+            v_month := v_regmatch_groups[3];
+            v_raw_year := v_regmatch_groups[4];
+        ELSIF (v_date_format = 'YMD')
+        THEN
+            v_day := v_regmatch_groups[4];
+            v_month := v_regmatch_groups[3];
+            v_raw_year := v_regmatch_groups[2];
+        ELSE
+            v_day := v_regmatch_groups[3];
+            v_month := v_regmatch_groups[2];
+            v_raw_year := v_regmatch_groups[4];
+        END IF;
+
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+        THEN
+            IF (v_day::SMALLINT > 30 OR
+                v_month::SMALLINT > 12) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_raw_year := sys.babelfish_get_full_year(v_raw_year, '14');
+            v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+            v_day := to_char(v_hijridate, 'DD');
+            v_month := to_char(v_hijridate, 'MM');
+            v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+
+        ELSIF (v_culture IN ('TH-TH', 'TH_TH')) THEN
+            v_year := sys.babelfish_get_full_year(v_raw_year)::SMALLINT - 43;
+        ELSE
+            v_year := sys.babelfish_get_full_year(v_raw_year, '', 29)::SMALLINT;
+        END IF;
+    ELSE
+        v_found := FALSE;
+    END IF;
+
+    WHILE (NOT v_found AND v_resmask_cnt < 20)
+    LOOP
+        v_resmask := pg_catalog.replace(CASE v_resmask_cnt
+                                WHEN 10 THEN v_defmask10_regexp
+                                WHEN 11 THEN v_defmask11_regexp
+                                WHEN 12 THEN v_defmask12_regexp
+                                WHEN 13 THEN v_defmask13_regexp
+                                WHEN 14 THEN v_defmask14_regexp
+                                WHEN 15 THEN v_defmask15_regexp
+                                WHEN 16 THEN v_defmask16_regexp
+                                WHEN 17 THEN v_defmask17_regexp
+                                WHEN 18 THEN v_defmask18_regexp
+                                WHEN 19 THEN v_defmask19_regexp
+                             END,
+                             '$comp_month$', v_compmonth_regexp);
+
+        v_resmask_fi := pg_catalog.replace(CASE v_resmask_cnt
+                                   WHEN 10 THEN v_defmask10_fi_regexp
+                                   WHEN 11 THEN v_defmask11_fi_regexp
+                                   WHEN 12 THEN v_defmask12_fi_regexp
+                                   WHEN 13 THEN v_defmask13_fi_regexp
+                                   WHEN 14 THEN v_defmask14_fi_regexp
+                                   WHEN 15 THEN v_defmask15_fi_regexp
+                                   WHEN 16 THEN v_defmask16_fi_regexp
+                                   WHEN 17 THEN v_defmask17_fi_regexp
+                                   WHEN 18 THEN v_defmask18_fi_regexp
+                                   WHEN 19 THEN v_defmask19_fi_regexp
+                                END,
+                                '$comp_month$', v_compmonth_regexp);
+
+        IF ((v_datestring ~* v_resmask AND v_culture <> 'FI') OR
+            (v_datestring ~* v_resmask_fi AND v_culture = 'FI'))
+        THEN
+            v_found := TRUE;
+            v_regmatch_groups := regexp_matches(v_datestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_resmask_fi
+                                                                 ELSE v_resmask
+                                                              END, 'gi');
+            v_timestring := CASE
+                               WHEN v_resmask_cnt IN (10, 11, 12, 13) THEN pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[4])
+                               ELSE pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5])
+                            END;
+
+            IF (v_resmask_cnt = 10)
+            THEN
+                IF (v_regmatch_groups[3] = 'MAR' AND
+                    v_culture IN ('IT-IT', 'IT_IT'))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+
+                IF (v_date_format = 'YMD' AND v_culture NOT IN ('SV-SE', 'SV_SE', 'LV-LV', 'LV_LV'))
+                THEN
+                    v_day := '01';
+                    v_year := sys.babelfish_get_full_year(v_regmatch_groups[2], '', 29)::SMALLINT;
+                ELSE
+                    v_day := v_regmatch_groups[2];
+                    v_year := to_char(current_date, 'YYYY')::SMALLINT;
+                END IF;
+
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := to_char(sys.babelfish_conv_greg_to_hijri(current_date + 1), 'YYYY');
+
+            ELSIF (v_resmask_cnt = 11)
+            THEN
+                IF (v_date_format IN ('YMD', 'MDY') AND v_culture NOT IN ('SV-SE', 'SV_SE'))
+                THEN
+                    v_day := v_regmatch_groups[3];
+                    v_year := to_char(current_date, 'YYYY')::SMALLINT;
+                ELSE
+                    v_day := '01';
+                    v_year := CASE
+                                 WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_regmatch_groups[3])::SMALLINT - 43
+                                 ELSE sys.babelfish_get_full_year(v_regmatch_groups[3], '', 29)::SMALLINT
+                              END;
+                END IF;
+
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := sys.babelfish_get_full_year(pg_catalog.substring(v_year::TEXT, 3, 2), '14');
+
+            ELSIF (v_resmask_cnt = 12)
+            THEN
+                v_day := '01';
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 13)
+            THEN
+                v_day := '01';
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[3];
+
+            ELSIF (v_resmask_cnt IN (14, 15, 16))
+            THEN
+                IF (v_resmask_cnt = 14)
+                THEN
+                    v_left_part := v_regmatch_groups[4];
+                    v_right_part := v_regmatch_groups[3];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                ELSIF (v_resmask_cnt = 15)
+                THEN
+                    v_left_part := v_regmatch_groups[4];
+                    v_right_part := v_regmatch_groups[2];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                ELSE
+                    v_left_part := v_regmatch_groups[3];
+                    v_right_part := v_regmatch_groups[2];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[4], v_lang_metadata_json);
+                END IF;
+
+                IF (char_length(v_left_part) <= 2)
+                THEN
+                    IF (v_date_format = 'YMD' AND v_culture NOT IN ('LV-LV', 'LV_LV'))
+                    THEN
+                        v_day := v_left_part;
+                        v_raw_year := sys.babelfish_get_full_year(v_right_part, '14');
+                        v_year := CASE
+                                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_right_part)::SMALLINT - 43
+                                     ELSE sys.babelfish_get_full_year(v_right_part, '', 29)::SMALLINT
+                                  END;
+                        BEGIN
+                            v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+                        EXCEPTION
+                        WHEN OTHERS THEN
+                            v_day := v_right_part;
+                            v_raw_year := sys.babelfish_get_full_year(v_left_part, '14');
+                            v_year := CASE
+                                         WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_left_part)::SMALLINT - 43
+                                         ELSE sys.babelfish_get_full_year(v_left_part, '', 29)::SMALLINT
+                                      END;
+                        END;
+                    END IF;
+
+                    IF (v_date_format IN ('MDY', 'DMY') OR v_culture IN ('LV-LV', 'LV_LV'))
+                    THEN
+                        v_day := v_right_part;
+                        v_raw_year := sys.babelfish_get_full_year(v_left_part, '14');
+                        v_year := CASE
+                                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_left_part)::SMALLINT - 43
+                                     ELSE sys.babelfish_get_full_year(v_left_part, '', 29)::SMALLINT
+                                  END;
+                        BEGIN
+                            v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+                        EXCEPTION
+                        WHEN OTHERS THEN
+                            v_day := v_left_part;
+                            v_raw_year := sys.babelfish_get_full_year(v_right_part, '14');
+                            v_year := CASE
+                                         WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_right_part)::SMALLINT - 43
+                                         ELSE sys.babelfish_get_full_year(v_right_part, '', 29)::SMALLINT
+                                      END;
+                        END;
+                    END IF;
+                ELSE
+                    v_day := v_right_part;
+                    v_raw_year := v_left_part;
+	            v_year := CASE
+                                 WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_left_part::SMALLINT - 543
+                                 ELSE v_left_part::SMALLINT
+                              END;
+                END IF;
+
+            ELSIF (v_resmask_cnt = 17)
+            THEN
+                v_day := v_regmatch_groups[4];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 18)
+            THEN
+                v_day := v_regmatch_groups[3];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[4], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 19)
+            THEN
+                v_day := v_regmatch_groups[4];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[3];
+            END IF;
+
+            IF (v_resmask_cnt NOT IN (10, 11, 14, 15, 16))
+            THEN
+                v_year := CASE
+                             WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_raw_year::SMALLINT - 543
+                             ELSE v_raw_year::SMALLINT
+                          END;
+            END IF;
+
+            IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+            THEN
+                IF (v_day::SMALLINT > 30 OR
+                    (v_resmask_cnt NOT IN (10, 11, 14, 15, 16) AND v_year NOT BETWEEN 1318 AND 1501) OR
+                    (v_resmask_cnt IN (14, 15, 16) AND v_raw_year::SMALLINT NOT BETWEEN 1318 AND 1501))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+
+                v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+                v_day := to_char(v_hijridate, 'DD');
+                v_month := to_char(v_hijridate, 'MM');
+                v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+            END IF;
+        END IF;
+
+        v_resmask_cnt := v_resmask_cnt + 1;
+    END LOOP;
+
+    IF (NOT v_found) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (char_length(v_timestring) > 0 AND v_timestring NOT IN ('AM', 'ص', 'PM', 'م'))
+    THEN
+        IF (v_culture = 'FI') THEN
+            v_timestring := PG_CATALOG.translate(v_timestring, '.,', ': ');
+
+            IF (char_length(split_part(v_timestring, ':', 4)) > 0) THEN
+                v_timestring := regexp_replace(v_timestring, ':(?=\s*\d+\s*:?\s*(?:[AP]M|ص|م)?\s*$)', '.');
+            END IF;
+        END IF;
+
+        v_timestring := pg_catalog.replace(regexp_replace(v_timestring, '\.?[AP]M|ص|م|\s|\,|\.\D|[\.|:]$', '', 'gi'), ':.', ':');
+        BEGIN
+            v_hours := coalesce(split_part(v_timestring, ':', 1)::SMALLINT, 0);
+
+            IF ((v_dayparts[1] IN ('AM', 'ص') AND v_hours NOT BETWEEN 0 AND 12) OR
+                (v_dayparts[1] IN ('PM', 'م') AND v_hours NOT BETWEEN 1 AND 23))
+            THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_minutes := coalesce(nullif(split_part(v_timestring, ':', 2), '')::SMALLINT, 0);
+            v_seconds := coalesce(nullif(split_part(v_timestring, ':', 3), '')::NUMERIC, 0);
+        EXCEPTION
+            WHEN OTHERS THEN
+            RAISE invalid_datetime_format;
+        END;
+    ELSIF (v_dayparts[1] IN ('PM', 'م'))
+    THEN
+        v_hours := 12;
+    END IF;
+
+    v_res_date := make_timestamp(v_year, v_month::SMALLINT, v_day::SMALLINT,
+                                 v_hours, v_minutes, v_seconds);
+
+    IF (v_weekdaynames[1] IS NOT NULL) THEN
+        v_weekdaynum := sys.babelfish_get_weekdaynum_by_name(v_weekdaynames[1], v_lang_metadata_json);
+
+        IF (CASE date_part('dow', v_res_date)::SMALLINT
+               WHEN 0 THEN 7
+               ELSE date_part('dow', v_res_date)::SMALLINT
+            END <> v_weekdaynum)
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+    END IF;
+
+    RETURN v_res_date;
+EXCEPTION
+    WHEN invalid_datetime_format OR datetime_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Error converting string value ''%s'' into data type DATE using culture ''%s''.',
+                                      p_datestring, p_culture),
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := CASE char_length(coalesce(CONVERSION_LANG, ''))
+                                  WHEN 0 THEN pg_catalog.format('The culture parameter ''%s'' provided in the function call is not supported.',
+                                                     p_culture)
+                                  ELSE pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                              CONVERSION_LANG)
+                               END,
+                    DETAIL := 'Passed incorrect value for "p_culture" parameter or compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Check "p_culture" input parameter value, correct it if needed, and try again. Also check CONVERSION_LANG constant value.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_parse_to_datetime(IN p_datatype TEXT,
+                                                               IN p_datetimestring TEXT,
+                                                               IN p_culture TEXT DEFAULT '')
+RETURNS TIMESTAMP WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_year SMALLINT;
+    v_month VARCHAR COLLATE "C";
+    v_res_date DATE;
+    v_scale SMALLINT;
+    v_hijridate DATE;
+    v_culture VARCHAR COLLATE "C";
+    v_dayparts TEXT[];
+    v_resmask VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_raw_year VARCHAR COLLATE "C";
+    v_left_part VARCHAR COLLATE "C";
+    v_right_part VARCHAR COLLATE "C";
+    v_resmask_fi VARCHAR COLLATE "C";
+    v_timestring VARCHAR COLLATE "C";
+    v_correctnum VARCHAR COLLATE "C";
+    v_weekdaynum SMALLINT;
+    v_err_message VARCHAR COLLATE "C";
+    v_date_format VARCHAR COLLATE "C";
+    v_weekdaynames TEXT[];
+    v_hours SMALLINT := 0;
+    v_minutes SMALLINT := 0;
+    v_res_datatype VARCHAR COLLATE "C";
+    v_error_message VARCHAR COLLATE "C";
+    v_found BOOLEAN := TRUE;
+    v_compday_regexp VARCHAR COLLATE "C";
+    v_regmatch_groups TEXT[];
+    v_datatype_groups TEXT[];
+    v_datetimestring VARCHAR COLLATE "C";
+    v_seconds VARCHAR COLLATE "C" := '0';
+    v_fseconds VARCHAR COLLATE "C" := '0';
+    v_compmonth_regexp VARCHAR COLLATE "C";
+    v_lang_metadata_json JSONB;
+    v_resmask_cnt SMALLINT := 10;
+    v_res_datetime TIMESTAMP(6) WITHOUT TIME ZONE;
+    DAYMM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{3,4})';
+    SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    COMPYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,4})';
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:[AP]M|ص|م)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,2}\s*';
+    MASKSEPONE_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:/|-)?';
+    MASKSEPTWO_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:\s|/|-|\.|,)';
+    MASKSEPTWO_FI_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:\s|/|-|,)';
+    MASKSEPTHREE_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:/|-|\.|,)';
+    TIME_MASKSEP_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\s|\.|,)*';
+    TIME_MASKSEP_FI_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\s|,)*';
+    WEEKDAYAMPM_START_REGEXP CONSTANT VARCHAR COLLATE "C" := '(^|[[:digit:][:space:]\.,])';
+    WEEKDAYAMPM_END_REGEXP CONSTANT VARCHAR COLLATE "C" := '([[:digit:][:space:]\.,]|$)(?=[^/-]|$)';
+    CORRECTNUM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:([+-]\d{1,4})(?:[[:space:]\.,]|[AP]M|ص|م|$))';
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^(DATETIME|SMALLDATETIME|DATETIME2)\s*(?:\()?\s*((?:-)?\d+)?\s*(?:\))?$';
+    ANNO_DOMINI_REGEXP VARCHAR COLLATE "C" := '(AD|A\.D\.)';
+    ANNO_DOMINI_COMPREGEXP VARCHAR COLLATE "C" := pg_catalog.concat(WEEKDAYAMPM_START_REGEXP, ANNO_DOMINI_REGEXP, WEEKDAYAMPM_END_REGEXP);
+    HHMMSSFS_PART_REGEXP CONSTANT VARCHAR COLLATE "C" :=
+        pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\s*\d{1,2}\.\d+(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?');
+    HHMMSSFS_PART_FI_REGEXP CONSTANT VARCHAR COLLATE "C" :=
+        pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?\.?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '\s*\d{1,2}\.\d+(?!\d)\.?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?');
+    v_defmask1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(?:[\.|,]+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP, '$');
+    v_defmask1_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(?:[\.|,]+', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(?:(?:[\.|,]+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?)|',
+                                        CORRECTNUM_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask2_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           AMPM_REGEXP, TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(?:(?:[\.|,]+', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?)|',
+                                           CORRECTNUM_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask3_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, ')|',
+                                        '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(', TIME_MASKSEP_REGEXP, AMPM_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask3_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '[\./]?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)',
+                                           FULLYEAR_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask4_0_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask4_1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          '(?:\s|,)+',
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask4_2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          '\s*[\.]+', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask5_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask5_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask6_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask6_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:\s*[\.])?',
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask7_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask7_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask8_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:[\.|,]+', AMPM_REGEXP, ')?',
+                                        TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask8_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:[\,]+|\s*/\s*)', AMPM_REGEXP, ')?',
+                                           TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask9_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(',
+                                        HHMMSSFS_PART_REGEXP,
+                                        ')', TIME_MASKSEP_REGEXP, '$');
+    v_defmask9_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '(',
+                                           HHMMSSFS_PART_FI_REGEXP,
+                                           ')', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask10_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask10_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)?', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask11_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask11_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           '($comp_month$)',
+                                           '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask12_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask12_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask13_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask13_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask14_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)'
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask14_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)'
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_FI_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask15_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask15_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask16_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask16_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask17_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask17_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask18_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                         '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask18_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                            '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask19_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                         '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask19_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                            '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
+BEGIN
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_datetimestring := pg_catalog.upper(pg_catalog.btrim(p_datetimestring));
+    v_culture := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(p_culture)), ''), 'EN-US');
+
+    v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
+
+    v_res_datatype := pg_catalog.upper(v_datatype_groups[1]);
+    v_scale := v_datatype_groups[2]::SMALLINT;
+
+    IF (v_res_datatype IS NULL) THEN
+        RAISE datatype_mismatch;
+    ELSIF (v_res_datatype <> 'DATETIME2' AND v_scale IS NOT NULL)
+    THEN
+        RAISE invalid_indicator_parameter_value;
+    ELSIF (coalesce(v_scale, 0) NOT BETWEEN 0 AND 7)
+    THEN
+        RAISE interval_field_overflow;
+    ELSIF (v_scale IS NULL) THEN
+        v_scale := 7;
+    END IF;
+
+    v_dayparts := ARRAY(SELECT pg_catalog.upper(array_to_string(regexp_matches(v_datetimestring, '[AP]M|ص|م', 'gi'), '')));
+
+    IF (array_length(v_dayparts, 1) > 1) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(coalesce(nullif(CONVERSION_LANG, ''), p_culture));
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_parameter_value;
+    END;
+
+    v_compday_regexp := array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_names')),
+                                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_shortnames'))),
+                                                  ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_extrashortnames'))), '|');
+
+    v_weekdaynames := ARRAY(SELECT array_to_string(regexp_matches(v_datetimestring, v_compday_regexp, 'gi'), ''));
+
+    IF (array_length(v_weekdaynames, 1) > 1) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (v_weekdaynames[1] IS NOT NULL AND
+        v_datetimestring ~* pg_catalog.concat(WEEKDAYAMPM_START_REGEXP, '(', v_compday_regexp, ')', WEEKDAYAMPM_END_REGEXP))
+    THEN
+        v_datetimestring := pg_catalog.replace(v_datetimestring, v_weekdaynames[1], ' ');
+    END IF;
+
+    IF (v_datetimestring ~* ANNO_DOMINI_COMPREGEXP)
+    THEN
+        IF (v_culture !~ 'EN[-_]US|DA[-_]DK|SV[-_]SE|EN[-_]GB|HI[-_]IS') THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_datetimestring := regexp_replace(v_datetimestring,
+                                           ANNO_DOMINI_COMPREGEXP,
+                                           regexp_replace(array_to_string(regexp_matches(v_datetimestring, ANNO_DOMINI_COMPREGEXP, 'gi'), ''),
+                                                          ANNO_DOMINI_REGEXP, ' ', 'gi'),
+                                           'gi');
+    END IF;
+
+    v_date_format := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
+
+    v_compmonth_regexp :=
+        array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
+                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_names'))),
+                                  array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_extrashortnames')),
+                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_extranames')))
+                                 ), '|');
+
+    IF ((v_datetimestring ~* v_defmask1_regexp AND v_culture <> 'FI') OR
+        (v_datetimestring ~* v_defmask1_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_datetimestring ~ pg_catalog.concat(CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                      CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                      AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                      CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+            v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_defmask1_fi_regexp
+                                                                 ELSE v_defmask1_regexp
+                                                              END, 'gi');
+        v_timestring := v_regmatch_groups[2];
+        v_correctnum := coalesce(v_regmatch_groups[1], v_regmatch_groups[3],
+                                 v_regmatch_groups[5], v_regmatch_groups[6]);
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('SV-SE', 'SV_SE', 'LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[4];
+            v_month := v_regmatch_groups[7];
+        ELSE
+            v_day := v_regmatch_groups[7];
+            v_month := v_regmatch_groups[4];
+        END IF;
+
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+        THEN
+            IF (v_day::SMALLINT > 30 OR
+                v_month::SMALLINT > 12) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_raw_year := to_char(sys.babelfish_conv_greg_to_hijri(current_date + 1), 'YYYY');
+            v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+            v_day := to_char(v_hijridate, 'DD');
+            v_month := to_char(v_hijridate, 'MM');
+            v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+        ELSE
+            v_year := to_char(current_date, 'YYYY')::SMALLINT;
+        END IF;
+
+    ELSIF ((v_datetimestring ~* v_defmask6_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask6_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datetimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}',
+                                       '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                       '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                       '\d{3,4}', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                       TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                       '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_defmask6_fi_regexp
+                                                                 ELSE v_defmask6_regexp
+                                                              END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_day := v_regmatch_groups[4];
+        v_month := v_regmatch_groups[3];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[2]::SMALLINT - 543
+                     ELSE v_regmatch_groups[2]::SMALLINT
+                  END;
+
+    ELSIF ((v_datetimestring ~* v_defmask2_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask2_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datetimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}',
+                                       '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                       '(?:', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                       AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                       '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_defmask2_fi_regexp
+                                                                 ELSE v_defmask2_regexp
+                                                              END, 'gi');
+        v_timestring := v_regmatch_groups[2];
+        v_correctnum := coalesce(v_regmatch_groups[1], v_regmatch_groups[3], v_regmatch_groups[5],
+                                 v_regmatch_groups[6], v_regmatch_groups[8], v_regmatch_groups[9]);
+        v_day := '01';
+        v_month := v_regmatch_groups[7];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[4]::SMALLINT - 543
+                     ELSE v_regmatch_groups[4]::SMALLINT
+                  END;
+
+    ELSIF (v_datetimestring ~* v_defmask4_1_regexp OR
+           (v_datetimestring ~* v_defmask4_2_regexp AND v_culture !~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV') OR
+           (v_datetimestring ~* v_defmask9_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask9_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_datetimestring ~ pg_catalog.concat('\d+\s*\.?(?:,+|,*', AMPM_REGEXP, ')', TIME_MASKSEP_FI_REGEXP, '\.+', TIME_MASKSEP_REGEXP, '$|',
+                                      '\d+\s*\.', TIME_MASKSEP_FI_REGEXP, '\.', TIME_MASKSEP_FI_REGEXP, '$') AND
+            v_culture = 'FI')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF (v_datetimestring ~* v_defmask4_0_regexp) THEN
+            v_timestring := (regexp_matches(v_datetimestring, v_defmask4_0_regexp, 'gi'))[1];
+        ELSE
+            v_timestring := v_datetimestring;
+        END IF;
+
+        v_res_date := current_date;
+        v_day := to_char(v_res_date, 'DD');
+        v_month := to_char(v_res_date, 'MM');
+        v_year := to_char(v_res_date, 'YYYY')::SMALLINT;
+
+    ELSIF ((v_datetimestring ~* v_defmask3_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask3_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datetimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?',
+                                       TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP, '|',
+                                       '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_defmask3_fi_regexp
+                                                                 ELSE v_defmask3_regexp
+                                                              END, 'gi');
+        v_timestring := v_regmatch_groups[1];
+        v_day := '01';
+        v_month := v_regmatch_groups[2];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[3]::SMALLINT - 543
+                     ELSE v_regmatch_groups[3]::SMALLINT
+                  END;
+
+    ELSIF ((v_datetimestring ~* v_defmask5_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask5_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datetimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                       TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                       TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$|',
+                                       '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}\s*(?:\.)+|',
+                                       '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, v_defmask5_regexp, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[4]::SMALLINT - 543
+                     ELSE v_regmatch_groups[4]::SMALLINT
+                  END;
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[2];
+            v_month := v_regmatch_groups[3];
+        ELSE
+            v_day := v_regmatch_groups[3];
+            v_month := v_regmatch_groups[2];
+        END IF;
+
+    ELSIF ((v_datetimestring ~* v_defmask7_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask7_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_datetimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}',
+                                       MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}|',
+                                       '\d{3,4}', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                       '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_defmask7_fi_regexp
+                                                                 ELSE v_defmask7_regexp
+                                                              END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_day := v_regmatch_groups[4];
+        v_month := v_regmatch_groups[2];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[3]::SMALLINT - 543
+                     ELSE v_regmatch_groups[3]::SMALLINT
+                  END;
+
+    ELSIF ((v_datetimestring ~* v_defmask8_regexp AND v_culture <> 'FI') OR
+           (v_datetimestring ~* v_defmask8_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_datetimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}',
+                                      MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                      TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                      '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                      TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+            v_culture ~ 'FI|DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                 WHEN 'FI' THEN v_defmask8_fi_regexp
+                                                                 ELSE v_defmask8_regexp
+                                                              END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[2];
+            v_month := v_regmatch_groups[3];
+            v_raw_year := v_regmatch_groups[4];
+        ELSIF (v_date_format = 'YMD')
+        THEN
+            v_day := v_regmatch_groups[4];
+            v_month := v_regmatch_groups[3];
+            v_raw_year := v_regmatch_groups[2];
+        ELSE
+            v_day := v_regmatch_groups[3];
+            v_month := v_regmatch_groups[2];
+            v_raw_year := v_regmatch_groups[4];
+        END IF;
+
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+        THEN
+            IF (v_day::SMALLINT > 30 OR
+                v_month::SMALLINT > 12) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_raw_year := sys.babelfish_get_full_year(v_raw_year, '14');
+            v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+            v_day := to_char(v_hijridate, 'DD');
+            v_month := to_char(v_hijridate, 'MM');
+            v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+
+        ELSIF (v_culture IN ('TH-TH', 'TH_TH')) THEN
+            v_year := sys.babelfish_get_full_year(v_raw_year)::SMALLINT - 43;
+        ELSE
+            v_year := sys.babelfish_get_full_year(v_raw_year, '', 29)::SMALLINT;
+        END IF;
+    ELSE
+        v_found := FALSE;
+    END IF;
+
+    WHILE (NOT v_found AND v_resmask_cnt < 20)
+    LOOP
+        v_resmask := pg_catalog.replace(CASE v_resmask_cnt
+                                WHEN 10 THEN v_defmask10_regexp
+                                WHEN 11 THEN v_defmask11_regexp
+                                WHEN 12 THEN v_defmask12_regexp
+                                WHEN 13 THEN v_defmask13_regexp
+                                WHEN 14 THEN v_defmask14_regexp
+                                WHEN 15 THEN v_defmask15_regexp
+                                WHEN 16 THEN v_defmask16_regexp
+                                WHEN 17 THEN v_defmask17_regexp
+                                WHEN 18 THEN v_defmask18_regexp
+                                WHEN 19 THEN v_defmask19_regexp
+                             END,
+                             '$comp_month$', v_compmonth_regexp);
+
+        v_resmask_fi := pg_catalog.replace(CASE v_resmask_cnt
+                                   WHEN 10 THEN v_defmask10_fi_regexp
+                                   WHEN 11 THEN v_defmask11_fi_regexp
+                                   WHEN 12 THEN v_defmask12_fi_regexp
+                                   WHEN 13 THEN v_defmask13_fi_regexp
+                                   WHEN 14 THEN v_defmask14_fi_regexp
+                                   WHEN 15 THEN v_defmask15_fi_regexp
+                                   WHEN 16 THEN v_defmask16_fi_regexp
+                                   WHEN 17 THEN v_defmask17_fi_regexp
+                                   WHEN 18 THEN v_defmask18_fi_regexp
+                                   WHEN 19 THEN v_defmask19_fi_regexp
+                                END,
+                                '$comp_month$', v_compmonth_regexp);
+
+        IF ((v_datetimestring ~* v_resmask AND v_culture <> 'FI') OR
+            (v_datetimestring ~* v_resmask_fi AND v_culture = 'FI'))
+        THEN
+            v_found := TRUE;
+            v_regmatch_groups := regexp_matches(v_datetimestring, CASE v_culture
+                                                                     WHEN 'FI' THEN v_resmask_fi
+                                                                     ELSE v_resmask
+                                                                  END, 'gi');
+            v_timestring := CASE
+                               WHEN v_resmask_cnt IN (10, 11, 12, 13) THEN pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[4])
+                               ELSE pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5])
+                            END;
+
+            IF (v_resmask_cnt = 10)
+            THEN
+                IF (v_regmatch_groups[3] = 'MAR' AND
+                    v_culture IN ('IT-IT', 'IT_IT'))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+
+                IF (v_date_format = 'YMD' AND v_culture NOT IN ('SV-SE', 'SV_SE', 'LV-LV', 'LV_LV'))
+                THEN
+                    v_day := '01';
+                    v_year := sys.babelfish_get_full_year(v_regmatch_groups[2], '', 29)::SMALLINT;
+                ELSE
+                    v_day := v_regmatch_groups[2];
+                    v_year := to_char(current_date, 'YYYY')::SMALLINT;
+                END IF;
+
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := to_char(sys.babelfish_conv_greg_to_hijri(current_date + 1), 'YYYY');
+
+            ELSIF (v_resmask_cnt = 11)
+            THEN
+                IF (v_date_format IN ('YMD', 'MDY') AND v_culture NOT IN ('SV-SE', 'SV_SE'))
+                THEN
+                    v_day := v_regmatch_groups[3];
+                    v_year := to_char(current_date, 'YYYY')::SMALLINT;
+                ELSE
+                    v_day := '01';
+                    v_year := CASE
+                                 WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_regmatch_groups[3])::SMALLINT - 43
+                                 ELSE sys.babelfish_get_full_year(v_regmatch_groups[3], '', 29)::SMALLINT
+                              END;
+                END IF;
+
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := sys.babelfish_get_full_year(pg_catalog.substring(v_year::TEXT, 3, 2), '14');
+
+            ELSIF (v_resmask_cnt = 12)
+            THEN
+                v_day := '01';
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 13)
+            THEN
+                v_day := '01';
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[3];
+
+            ELSIF (v_resmask_cnt IN (14, 15, 16))
+            THEN
+                IF (v_resmask_cnt = 14)
+                THEN
+                    v_left_part := v_regmatch_groups[4];
+                    v_right_part := v_regmatch_groups[3];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                ELSIF (v_resmask_cnt = 15)
+                THEN
+                    v_left_part := v_regmatch_groups[4];
+                    v_right_part := v_regmatch_groups[2];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                ELSE
+                    v_left_part := v_regmatch_groups[3];
+                    v_right_part := v_regmatch_groups[2];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[4], v_lang_metadata_json);
+                END IF;
+
+                IF (char_length(v_left_part) <= 2)
+                THEN
+                    IF (v_date_format = 'YMD' AND v_culture NOT IN ('LV-LV', 'LV_LV'))
+                    THEN
+                        v_day := v_left_part;
+                        v_raw_year := sys.babelfish_get_full_year(v_right_part, '14');
+                        v_year := CASE
+                                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_right_part)::SMALLINT - 43
+                                     ELSE sys.babelfish_get_full_year(v_right_part, '', 29)::SMALLINT
+                                  END;
+                        BEGIN
+                            v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+                        EXCEPTION
+                        WHEN OTHERS THEN
+                            v_day := v_right_part;
+                            v_raw_year := sys.babelfish_get_full_year(v_left_part, '14');
+                            v_year := CASE
+                                         WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_left_part)::SMALLINT - 43
+                                         ELSE sys.babelfish_get_full_year(v_left_part, '', 29)::SMALLINT
+                                      END;
+                        END;
+                    END IF;
+
+                    IF (v_date_format IN ('MDY', 'DMY') OR v_culture IN ('LV-LV', 'LV_LV'))
+                    THEN
+                        v_day := v_right_part;
+                        v_raw_year := sys.babelfish_get_full_year(v_left_part, '14');
+                        v_year := CASE
+                                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_left_part)::SMALLINT - 43
+                                     ELSE sys.babelfish_get_full_year(v_left_part, '', 29)::SMALLINT
+                                  END;
+                        BEGIN
+                            v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+                        EXCEPTION
+                        WHEN OTHERS THEN
+                            v_day := v_left_part;
+                            v_raw_year := sys.babelfish_get_full_year(v_right_part, '14');
+                            v_year := CASE
+                                         WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_right_part)::SMALLINT - 43
+                                         ELSE sys.babelfish_get_full_year(v_right_part, '', 29)::SMALLINT
+                                      END;
+                        END;
+                    END IF;
+                ELSE
+                    v_day := v_right_part;
+                    v_raw_year := v_left_part;
+	            v_year := CASE
+                                 WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_left_part::SMALLINT - 543
+                                 ELSE v_left_part::SMALLINT
+                              END;
+                END IF;
+
+            ELSIF (v_resmask_cnt = 17)
+            THEN
+                v_day := v_regmatch_groups[4];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 18)
+            THEN
+                v_day := v_regmatch_groups[3];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[4], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 19)
+            THEN
+                v_day := v_regmatch_groups[4];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[3];
+            END IF;
+
+            IF (v_resmask_cnt NOT IN (10, 11, 14, 15, 16))
+            THEN
+                v_year := CASE
+                             WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_raw_year::SMALLINT - 543
+                             ELSE v_raw_year::SMALLINT
+                          END;
+            END IF;
+
+            IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+            THEN
+                IF (v_day::SMALLINT > 30 OR
+                    (v_resmask_cnt NOT IN (10, 11, 14, 15, 16) AND v_year NOT BETWEEN 1318 AND 1501) OR
+                    (v_resmask_cnt IN (14, 15, 16) AND v_raw_year::SMALLINT NOT BETWEEN 1318 AND 1501))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+
+                v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+                v_day := to_char(v_hijridate, 'DD');
+                v_month := to_char(v_hijridate, 'MM');
+                v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+            END IF;
+        END IF;
+
+        v_resmask_cnt := v_resmask_cnt + 1;
+    END LOOP;
+
+    IF (NOT v_found) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (char_length(v_timestring) > 0 AND v_timestring NOT IN ('AM', 'ص', 'PM', 'م'))
+    THEN
+        IF (v_culture = 'FI') THEN
+            v_timestring := PG_CATALOG.translate(v_timestring, '.,', ': ');
+
+            IF (char_length(split_part(v_timestring, ':', 4)) > 0) THEN
+                v_timestring := regexp_replace(v_timestring, ':(?=\s*\d+\s*:?\s*(?:[AP]M|ص|م)?\s*$)', '.');
+            END IF;
+        END IF;
+
+        v_timestring := pg_catalog.replace(regexp_replace(v_timestring, '\.?[AP]M|ص|م|\s|\,|\.\D|[\.|:]$', '', 'gi'), ':.', ':');
+        BEGIN
+            v_hours := coalesce(split_part(v_timestring, ':', 1)::SMALLINT, 0);
+
+            IF ((v_dayparts[1] IN ('AM', 'ص') AND v_hours NOT BETWEEN 0 AND 12) OR
+                (v_dayparts[1] IN ('PM', 'م') AND v_hours NOT BETWEEN 1 AND 23))
+            THEN
+                RAISE invalid_datetime_format;
+            ELSIF (v_dayparts[1] = 'PM' AND v_hours < 12) THEN
+                v_hours := v_hours + 12;
+            ELSIF (v_dayparts[1] = 'AM' AND v_hours = 12) THEN
+                v_hours := v_hours - 12;
+            END IF;
+
+            v_minutes := coalesce(nullif(split_part(v_timestring, ':', 2), '')::SMALLINT, 0);
+            v_seconds := coalesce(nullif(split_part(v_timestring, ':', 3), ''), '0');
+
+            IF (v_seconds ~ '\.') THEN
+                v_fseconds := split_part(v_seconds, '.', 2);
+                v_seconds := split_part(v_seconds, '.', 1);
+            END IF;
+        EXCEPTION
+            WHEN OTHERS THEN
+            RAISE invalid_datetime_format;
+        END;
+    ELSIF (v_dayparts[1] IN ('PM', 'م'))
+    THEN
+        v_hours := 12;
+    END IF;
+
+    BEGIN
+        IF (v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+        THEN
+            v_res_datetime := sys.datetimefromparts(v_year, v_month::SMALLINT, v_day::SMALLINT,
+                                                                  v_hours, v_minutes, v_seconds::SMALLINT,
+                                                                  rpad(v_fseconds, 3, '0')::NUMERIC);
+            IF (v_res_datatype = 'SMALLDATETIME' AND
+                to_char(v_res_datetime, 'SS') <> '00')
+            THEN
+                IF (to_char(v_res_datetime, 'SS')::SMALLINT >= 30) THEN
+                    v_res_datetime := v_res_datetime + INTERVAL '1 minute';
+                END IF;
+
+                v_res_datetime := to_timestamp(to_char(v_res_datetime, 'DD.MM.YYYY.HH24.MI'), 'DD.MM.YYYY.HH24.MI');
+            END IF;
+        ELSE
+            v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(rpad(v_fseconds, 9, '0'), v_scale);
+            v_seconds := pg_catalog.concat_ws('.', v_seconds, v_fseconds);
+
+            v_res_datetime := make_timestamp(v_year, v_month::SMALLINT, v_day::SMALLINT,
+                                             v_hours, v_minutes, v_seconds::NUMERIC);
+        END IF;
+    EXCEPTION
+        WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+
+        IF (v_err_message ~* 'Cannot construct data type') THEN
+            RAISE invalid_datetime_format;
+        END IF;
+    END;
+
+    IF (v_weekdaynames[1] IS NOT NULL) THEN
+        v_weekdaynum := sys.babelfish_get_weekdaynum_by_name(v_weekdaynames[1], v_lang_metadata_json);
+
+        IF (CASE date_part('dow', v_res_date)::SMALLINT
+               WHEN 0 THEN 7
+               ELSE date_part('dow', v_res_date)::SMALLINT
+            END <> v_weekdaynum)
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+    END IF;
+
+    RETURN v_res_datetime;
+EXCEPTION
+    WHEN invalid_datetime_format OR datetime_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Error converting string value ''%s'' into data type %s using culture ''%s''.',
+                                      p_datetimestring, v_res_datatype, p_culture),
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Data type should be one of these values: ''DATETIME'', ''SMALLDATETIME'', ''DATETIME2''/''DATETIME2(n)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_indicator_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid attributes specified for data type %s.', v_res_datatype),
+                    DETAIL := 'Use of incorrect scale value, which is not corresponding to specified data type.',
+                    HINT := 'Change data type scale component or select different data type and try again.';
+
+    WHEN interval_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_scale),
+                    DETAIL := 'Use of incorrect data type scale value during conversion process.',
+                    HINT := 'Change scale component of data type parameter to be in range [0..7] and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := CASE char_length(coalesce(CONVERSION_LANG, ''))
+                                  WHEN 0 THEN pg_catalog.format('The culture parameter ''%s'' provided in the function call is not supported.',
+                                                     p_culture)
+                                  ELSE pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                              CONVERSION_LANG)
+                               END,
+                    DETAIL := 'Passed incorrect value for "p_culture" parameter or compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Check "p_culture" input parameter value, correct it if needed, and try again. Also check CONVERSION_LANG constant value.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_parse_to_time(IN p_datatype TEXT,
+                                                           IN p_srctimestring TEXT,
+                                                           IN p_culture TEXT DEFAULT '')
+RETURNS TIME WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_year SMALLINT;
+    v_month VARCHAR COLLATE "C";
+    v_res_date DATE;
+    v_scale SMALLINT;
+    v_hijridate DATE;
+    v_culture VARCHAR COLLATE "C";
+    v_dayparts TEXT[];
+    v_resmask VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_raw_year VARCHAR COLLATE "C";
+    v_left_part VARCHAR COLLATE "C";
+    v_right_part VARCHAR COLLATE "C";
+    v_resmask_fi VARCHAR COLLATE "C";
+    v_timestring VARCHAR COLLATE "C";
+    v_correctnum VARCHAR COLLATE "C";
+    v_weekdaynum SMALLINT;
+    v_err_message VARCHAR COLLATE "C";
+    v_date_format VARCHAR COLLATE "C";
+    v_weekdaynames TEXT[];
+    v_hours SMALLINT := 0;
+    v_srctimestring VARCHAR COLLATE "C";
+    v_minutes SMALLINT := 0;
+    v_res_datatype VARCHAR COLLATE "C";
+    v_error_message VARCHAR COLLATE "C";
+    v_found BOOLEAN := TRUE;
+    v_compday_regexp VARCHAR COLLATE "C";
+    v_regmatch_groups TEXT[];
+    v_datatype_groups TEXT[];
+    v_seconds VARCHAR COLLATE "C" := '0';
+    v_fseconds VARCHAR COLLATE "C" := '0';
+    v_compmonth_regexp VARCHAR COLLATE "C";
+    v_lang_metadata_json JSONB;
+    v_resmask_cnt SMALLINT := 10;
+    v_res_time TIME WITHOUT TIME ZONE;
+    DAYMM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{3,4})';
+    SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    COMPYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,4})';
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:[AP]M|ص|م)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,2}\s*';
+    MASKSEPONE_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:/|-)?';
+    MASKSEPTWO_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:\s|/|-|\.|,)';
+    MASKSEPTWO_FI_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:\s|/|-|,)';
+    MASKSEPTHREE_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*(?:/|-|\.|,)';
+    TIME_MASKSEP_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\s|\.|,)*';
+    TIME_MASKSEP_FI_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\s|,)*';
+    WEEKDAYAMPM_START_REGEXP CONSTANT VARCHAR COLLATE "C" := '(^|[[:digit:][:space:]\.,])';
+    WEEKDAYAMPM_END_REGEXP CONSTANT VARCHAR COLLATE "C" := '([[:digit:][:space:]\.,]|$)(?=[^/-]|$)';
+    CORRECTNUM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:([+-]\d{1,4})(?:[[:space:]\.,]|[AP]M|ص|م|$))';
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^(TIME)\s*(?:\()?\s*((?:-)?\d+)?\s*(?:\))?$';
+    ANNO_DOMINI_REGEXP VARCHAR COLLATE "C" := '(AD|A\.D\.)';
+    ANNO_DOMINI_COMPREGEXP VARCHAR COLLATE "C" := pg_catalog.concat(WEEKDAYAMPM_START_REGEXP, ANNO_DOMINI_REGEXP, WEEKDAYAMPM_END_REGEXP);
+    HHMMSSFS_PART_REGEXP CONSTANT VARCHAR COLLATE "C" :=
+        pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, TIMEUNIT_REGEXP, '\:', TIME_MASKSEP_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\s*\d{1,2}\.\d+(?!\d)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?');
+    HHMMSSFS_PART_FI_REGEXP CONSTANT VARCHAR COLLATE "C" :=
+        pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?\.?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '(?!\d)', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, TIMEUNIT_REGEXP, '[\:\.]', TIME_MASKSEP_FI_REGEXP,
+               AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '\s*\d{1,2}\.\d+(?!\d)\.?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?|',
+               AMPM_REGEXP, '?');
+    v_defmask1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(?:[\.|,]+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP, '$');
+    v_defmask1_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(?:[\.|,]+', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                        AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(?:(?:[\.|,]+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?)|',
+                                        CORRECTNUM_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask2_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP,
+                                           AMPM_REGEXP, TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(?:(?:[\.|,]+', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, TIME_MASKSEP_FI_REGEXP, CORRECTNUM_REGEXP, '?)|',
+                                           CORRECTNUM_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask3_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, ')|',
+                                        '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(', TIME_MASKSEP_REGEXP, AMPM_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask3_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '[\./]?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)',
+                                           FULLYEAR_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask4_0_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask4_1_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          '(?:\s|,)+',
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask4_2_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP,
+                                          '\s*[\.]+', TIME_MASKSEP_REGEXP,
+                                          DAYMM_REGEXP, '\s*(', AMPM_REGEXP, ')',
+                                          TIME_MASKSEP_REGEXP, '$');
+    v_defmask5_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask5_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask6_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask6_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:\s*[\.])?',
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask7_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        FULLYEAR_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask7_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           FULLYEAR_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask8_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                        '(?:[\.|,]+', AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                        DAYMM_REGEXP,
+                                        '(?:[\.|,]+', AMPM_REGEXP, ')?',
+                                        TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask8_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_FI_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)|',
+                                           '(?:[,]+', AMPM_REGEXP, '))', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '(?:(?:[\,]+|\s*/\s*)', AMPM_REGEXP, ')?',
+                                           TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask9_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(',
+                                        HHMMSSFS_PART_REGEXP,
+                                        ')', TIME_MASKSEP_REGEXP, '$');
+    v_defmask9_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '(',
+                                           HHMMSSFS_PART_FI_REGEXP,
+                                           ')', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask10_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask10_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)?', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask11_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask11_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                           '($comp_month$)',
+                                           '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP,
+                                           DAYMM_REGEXP,
+                                           '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask12_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask12_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask13_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask13_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask14_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)'
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask14_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)'
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_FI_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_FI_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask15_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask15_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask16_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                         COMPYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask16_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)', TIME_MASKSEP_REGEXP,
+                                            COMPYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask17_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask17_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask18_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                         '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                         '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask18_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                            '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, '(?:', AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))?)|',
+                                            '(?:(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '(?=(?:[[:space:]\.,])+))))', TIME_MASKSEP_REGEXP,
+                                            '($comp_month$)',
+                                            TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP, '$');
+    v_defmask19_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_REGEXP, '(', HHMMSSFS_PART_REGEXP, ')?', TIME_MASKSEP_REGEXP,
+                                         '($comp_month$)',
+                                         '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                         FULLYEAR_REGEXP,
+                                         '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                         '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                         DAYMM_REGEXP,
+                                         '((?:(?:\s|\.|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_REGEXP, '))?', TIME_MASKSEP_REGEXP, '$');
+    v_defmask19_fi_regexp VARCHAR COLLATE "C" := pg_catalog.concat('^', TIME_MASKSEP_FI_REGEXP, '(', HHMMSSFS_PART_FI_REGEXP, ')?', TIME_MASKSEP_FI_REGEXP,
+                                            '($comp_month$)',
+                                            '(?:', MASKSEPTHREE_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)?', TIME_MASKSEP_REGEXP,
+                                            FULLYEAR_REGEXP,
+                                            '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                            '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP,
+                                            DAYMM_REGEXP,
+                                            '((?:(?:\s|,)+|', AMPM_REGEXP, ')(?:', HHMMSSFS_PART_FI_REGEXP, '))?', TIME_MASKSEP_FI_REGEXP, '$');
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
+BEGIN
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_srctimestring := pg_catalog.upper(pg_catalog.btrim(p_srctimestring));
+    v_culture := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(p_culture)), ''), 'EN-US');
+
+    v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
+
+    v_res_datatype := pg_catalog.upper(v_datatype_groups[1]);
+    v_scale := v_datatype_groups[2]::SMALLINT;
+
+    IF (v_res_datatype IS NULL) THEN
+        RAISE datatype_mismatch;
+    ELSIF (coalesce(v_scale, 0) NOT BETWEEN 0 AND 7)
+    THEN
+        RAISE interval_field_overflow;
+    ELSIF (v_scale IS NULL) THEN
+        v_scale := 7;
+    END IF;
+
+    v_dayparts := ARRAY(SELECT pg_catalog.upper(array_to_string(regexp_matches(v_srctimestring, '[AP]M|ص|م', 'gi'), '')));
+
+    IF (array_length(v_dayparts, 1) > 1) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(coalesce(nullif(CONVERSION_LANG, ''), p_culture));
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_parameter_value;
+    END;
+
+    v_compday_regexp := array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_names')),
+                                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_shortnames'))),
+                                                  ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'days_extrashortnames'))), '|');
+
+    v_weekdaynames := ARRAY(SELECT array_to_string(regexp_matches(v_srctimestring, v_compday_regexp, 'gi'), ''));
+
+    IF (array_length(v_weekdaynames, 1) > 1) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (v_weekdaynames[1] IS NOT NULL AND
+        v_srctimestring ~* pg_catalog.concat(WEEKDAYAMPM_START_REGEXP, '(', v_compday_regexp, ')', WEEKDAYAMPM_END_REGEXP))
+    THEN
+        v_srctimestring := pg_catalog.replace(v_srctimestring, v_weekdaynames[1], ' ');
+    END IF;
+
+    IF (v_srctimestring ~* ANNO_DOMINI_COMPREGEXP)
+    THEN
+        IF (v_culture !~ 'EN[-_]US|DA[-_]DK|SV[-_]SE|EN[-_]GB|HI[-_]IS') THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_srctimestring := regexp_replace(v_srctimestring,
+                                          ANNO_DOMINI_COMPREGEXP,
+                                          regexp_replace(array_to_string(regexp_matches(v_srctimestring, ANNO_DOMINI_COMPREGEXP, 'gi'), ''),
+                                                         ANNO_DOMINI_REGEXP, ' ', 'gi'),
+                                          'gi');
+    END IF;
+
+    v_date_format := coalesce(nullif(pg_catalog.upper(pg_catalog.btrim(DATE_FORMAT)), ''), v_lang_metadata_json ->> 'date_format');
+
+    v_compmonth_regexp :=
+        array_to_string(array_cat(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
+                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_names'))),
+                                  array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_extrashortnames')),
+                                            ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_extranames')))
+                                 ), '|');
+
+    IF ((v_srctimestring ~* v_defmask1_regexp AND v_culture <> 'FI') OR
+        (v_srctimestring ~* v_defmask1_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_srctimestring ~ pg_catalog.concat(CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                     CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP,
+                                     AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                     '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                     CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+            v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                WHEN 'FI' THEN v_defmask1_fi_regexp
+                                                                ELSE v_defmask1_regexp
+                                                             END, 'gi');
+        v_timestring := v_regmatch_groups[2];
+        v_correctnum := coalesce(v_regmatch_groups[1], v_regmatch_groups[3],
+                                 v_regmatch_groups[5], v_regmatch_groups[6]);
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('SV-SE', 'SV_SE', 'LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[4];
+            v_month := v_regmatch_groups[7];
+        ELSE
+            v_day := v_regmatch_groups[7];
+            v_month := v_regmatch_groups[4];
+        END IF;
+
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+        THEN
+            IF (v_day::SMALLINT > 30 OR
+                v_month::SMALLINT > 12) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_raw_year := to_char(sys.babelfish_conv_greg_to_hijri(current_date + 1), 'YYYY');
+            v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+            v_day := to_char(v_hijridate, 'DD');
+            v_month := to_char(v_hijridate, 'MM');
+            v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+        ELSE
+            v_year := to_char(current_date, 'YYYY')::SMALLINT;
+        END IF;
+
+    ELSIF ((v_srctimestring ~* v_defmask6_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask6_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_srctimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}',
+                                      '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                      '(?:', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '))', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                      '\d{3,4}', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                      TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                WHEN 'FI' THEN v_defmask6_fi_regexp
+                                                                ELSE v_defmask6_regexp
+                                                             END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_day := v_regmatch_groups[4];
+        v_month := v_regmatch_groups[3];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[2]::SMALLINT - 543
+                     ELSE v_regmatch_groups[2]::SMALLINT
+                  END;
+
+    ELSIF ((v_srctimestring ~* v_defmask2_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask2_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_srctimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}',
+                                      '(?:(?:', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?)|',
+                                      '(?:', TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?', TIME_MASKSEP_REGEXP,
+                                      AMPM_REGEXP, TIME_MASKSEP_REGEXP, CORRECTNUM_REGEXP, '?))', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                WHEN 'FI' THEN v_defmask2_fi_regexp
+                                                                ELSE v_defmask2_regexp
+                                                             END, 'gi');
+        v_timestring := v_regmatch_groups[2];
+        v_correctnum := coalesce(v_regmatch_groups[1], v_regmatch_groups[3], v_regmatch_groups[5],
+                                 v_regmatch_groups[6], v_regmatch_groups[8], v_regmatch_groups[9]);
+        v_day := '01';
+        v_month := v_regmatch_groups[7];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[4]::SMALLINT - 543
+                     ELSE v_regmatch_groups[4]::SMALLINT
+                  END;
+
+    ELSIF (v_srctimestring ~* v_defmask4_1_regexp OR
+           (v_srctimestring ~* v_defmask4_2_regexp AND v_culture !~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV') OR
+           (v_srctimestring ~* v_defmask9_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask9_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_srctimestring ~ pg_catalog.concat('\d+\s*\.?(?:,+|,*', AMPM_REGEXP, ')', TIME_MASKSEP_FI_REGEXP, '\.+', TIME_MASKSEP_REGEXP, '$|',
+                                     '\d+\s*\.', TIME_MASKSEP_FI_REGEXP, '\.', TIME_MASKSEP_FI_REGEXP, '$') AND
+            v_culture = 'FI')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF (v_srctimestring ~* v_defmask4_0_regexp) THEN
+            v_timestring := (regexp_matches(v_srctimestring, v_defmask4_0_regexp, 'gi'))[1];
+        ELSE
+            v_timestring := v_srctimestring;
+        END IF;
+
+        v_res_date := current_date;
+        v_day := to_char(v_res_date, 'DD');
+        v_month := to_char(v_res_date, 'MM');
+        v_year := to_char(v_res_date, 'YYYY')::SMALLINT;
+
+    ELSIF ((v_srctimestring ~* v_defmask3_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask3_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_srctimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?',
+                                      TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP, '|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                WHEN 'FI' THEN v_defmask3_fi_regexp
+                                                                ELSE v_defmask3_regexp
+                                                             END, 'gi');
+        v_timestring := v_regmatch_groups[1];
+        v_day := '01';
+        v_month := v_regmatch_groups[2];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[3]::SMALLINT - 543
+                     ELSE v_regmatch_groups[3]::SMALLINT
+                  END;
+
+    ELSIF ((v_srctimestring ~* v_defmask5_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask5_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_srctimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                      TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                      TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$|',
+                                      '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}\s*(?:\.)+|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, v_defmask5_regexp, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[4]::SMALLINT - 543
+                     ELSE v_regmatch_groups[4]::SMALLINT
+                  END;
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[2];
+            v_month := v_regmatch_groups[3];
+        ELSE
+            v_day := v_regmatch_groups[3];
+            v_month := v_regmatch_groups[2];
+        END IF;
+
+    ELSIF ((v_srctimestring ~* v_defmask7_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask7_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA') OR
+            (v_srctimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}',
+                                      MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{3,4}|',
+                                      '\d{3,4}', MASKSEPTWO_REGEXP, '?', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                      '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+             v_culture ~ 'DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                WHEN 'FI' THEN v_defmask7_fi_regexp
+                                                                ELSE v_defmask7_regexp
+                                                             END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+        v_day := v_regmatch_groups[4];
+        v_month := v_regmatch_groups[2];
+        v_year := CASE
+                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_regmatch_groups[3]::SMALLINT - 543
+                     ELSE v_regmatch_groups[3]::SMALLINT
+                  END;
+
+    ELSIF ((v_srctimestring ~* v_defmask8_regexp AND v_culture <> 'FI') OR
+           (v_srctimestring ~* v_defmask8_fi_regexp AND v_culture = 'FI'))
+    THEN
+        IF (v_srctimestring ~ pg_catalog.concat('\s*\d{1,2}\.\s*(?:\.|\d+(?!\d)\s*\.)', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}',
+                                     MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                     TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}|',
+                                     '\d{1,2}', MASKSEPTWO_REGEXP, TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}', MASKSEPTWO_REGEXP,
+                                     TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '\d{1,2}\s*(?:\.)+|',
+                                     '\d+\s*(?:\.)+', TIME_MASKSEP_REGEXP, AMPM_REGEXP, '?', TIME_MASKSEP_REGEXP, '$') AND
+            v_culture ~ 'FI|DE[-_]DE|NN[-_]NO|CS[-_]CZ|PL[-_]PL|RO[-_]RO|SK[-_]SK|SL[-_]SI|BG[-_]BG|RU[-_]RU|TR[-_]TR|ET[-_]EE|LV[-_]LV')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                WHEN 'FI' THEN v_defmask8_fi_regexp
+                                                                ELSE v_defmask8_regexp
+                                                             END, 'gi');
+        v_timestring := pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5]);
+
+        IF (v_date_format = 'DMY' OR
+            v_culture IN ('LV-LV', 'LV_LV'))
+        THEN
+            v_day := v_regmatch_groups[2];
+            v_month := v_regmatch_groups[3];
+            v_raw_year := v_regmatch_groups[4];
+        ELSIF (v_date_format = 'YMD')
+        THEN
+            v_day := v_regmatch_groups[4];
+            v_month := v_regmatch_groups[3];
+            v_raw_year := v_regmatch_groups[2];
+        ELSE
+            v_day := v_regmatch_groups[3];
+            v_month := v_regmatch_groups[2];
+            v_raw_year := v_regmatch_groups[4];
+        END IF;
+
+        IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+        THEN
+            IF (v_day::SMALLINT > 30 OR
+                v_month::SMALLINT > 12) THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            v_raw_year := sys.babelfish_get_full_year(v_raw_year, '14');
+            v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+            v_day := to_char(v_hijridate, 'DD');
+            v_month := to_char(v_hijridate, 'MM');
+            v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+
+        ELSIF (v_culture IN ('TH-TH', 'TH_TH')) THEN
+            v_year := sys.babelfish_get_full_year(v_raw_year)::SMALLINT - 43;
+        ELSE
+            v_year := sys.babelfish_get_full_year(v_raw_year, '', 29)::SMALLINT;
+        END IF;
+    ELSE
+        v_found := FALSE;
+    END IF;
+
+    WHILE (NOT v_found AND v_resmask_cnt < 20)
+    LOOP
+        v_resmask := pg_catalog.replace(CASE v_resmask_cnt
+                                WHEN 10 THEN v_defmask10_regexp
+                                WHEN 11 THEN v_defmask11_regexp
+                                WHEN 12 THEN v_defmask12_regexp
+                                WHEN 13 THEN v_defmask13_regexp
+                                WHEN 14 THEN v_defmask14_regexp
+                                WHEN 15 THEN v_defmask15_regexp
+                                WHEN 16 THEN v_defmask16_regexp
+                                WHEN 17 THEN v_defmask17_regexp
+                                WHEN 18 THEN v_defmask18_regexp
+                                WHEN 19 THEN v_defmask19_regexp
+                             END,
+                             '$comp_month$', v_compmonth_regexp);
+
+        v_resmask_fi := pg_catalog.replace(CASE v_resmask_cnt
+                                   WHEN 10 THEN v_defmask10_fi_regexp
+                                   WHEN 11 THEN v_defmask11_fi_regexp
+                                   WHEN 12 THEN v_defmask12_fi_regexp
+                                   WHEN 13 THEN v_defmask13_fi_regexp
+                                   WHEN 14 THEN v_defmask14_fi_regexp
+                                   WHEN 15 THEN v_defmask15_fi_regexp
+                                   WHEN 16 THEN v_defmask16_fi_regexp
+                                   WHEN 17 THEN v_defmask17_fi_regexp
+                                   WHEN 18 THEN v_defmask18_fi_regexp
+                                   WHEN 19 THEN v_defmask19_fi_regexp
+                                END,
+                                '$comp_month$', v_compmonth_regexp);
+
+        IF ((v_srctimestring ~* v_resmask AND v_culture <> 'FI') OR
+            (v_srctimestring ~* v_resmask_fi AND v_culture = 'FI'))
+        THEN
+            v_found := TRUE;
+            v_regmatch_groups := regexp_matches(v_srctimestring, CASE v_culture
+                                                                    WHEN 'FI' THEN v_resmask_fi
+                                                                    ELSE v_resmask
+                                                                 END, 'gi');
+            v_timestring := CASE
+                               WHEN v_resmask_cnt IN (10, 11, 12, 13) THEN pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[4])
+                               ELSE pg_catalog.concat(v_regmatch_groups[1], v_regmatch_groups[5])
+                            END;
+
+            IF (v_resmask_cnt = 10)
+            THEN
+                IF (v_regmatch_groups[3] = 'MAR' AND
+                    v_culture IN ('IT-IT', 'IT_IT'))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+
+                IF (v_date_format = 'YMD' AND v_culture NOT IN ('SV-SE', 'SV_SE', 'LV-LV', 'LV_LV'))
+                THEN
+                    v_day := '01';
+                    v_year := sys.babelfish_get_full_year(v_regmatch_groups[2], '', 29)::SMALLINT;
+                ELSE
+                    v_day := v_regmatch_groups[2];
+                    v_year := to_char(current_date, 'YYYY')::SMALLINT;
+                END IF;
+
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := to_char(sys.babelfish_conv_greg_to_hijri(current_date + 1), 'YYYY');
+
+            ELSIF (v_resmask_cnt = 11)
+            THEN
+                IF (v_date_format IN ('YMD', 'MDY') AND v_culture NOT IN ('SV-SE', 'SV_SE'))
+                THEN
+                    v_day := v_regmatch_groups[3];
+                    v_year := to_char(current_date, 'YYYY')::SMALLINT;
+                ELSE
+                    v_day := '01';
+                    v_year := CASE
+                                 WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_regmatch_groups[3])::SMALLINT - 43
+                                 ELSE sys.babelfish_get_full_year(v_regmatch_groups[3], '', 29)::SMALLINT
+                              END;
+                END IF;
+
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := sys.babelfish_get_full_year(pg_catalog.substring(v_year::TEXT, 3, 2), '14');
+
+            ELSIF (v_resmask_cnt = 12)
+            THEN
+                v_day := '01';
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 13)
+            THEN
+                v_day := '01';
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[3];
+
+            ELSIF (v_resmask_cnt IN (14, 15, 16))
+            THEN
+                IF (v_resmask_cnt = 14)
+                THEN
+                    v_left_part := v_regmatch_groups[4];
+                    v_right_part := v_regmatch_groups[3];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                ELSIF (v_resmask_cnt = 15)
+                THEN
+                    v_left_part := v_regmatch_groups[4];
+                    v_right_part := v_regmatch_groups[2];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                ELSE
+                    v_left_part := v_regmatch_groups[3];
+                    v_right_part := v_regmatch_groups[2];
+                    v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[4], v_lang_metadata_json);
+                END IF;
+
+                IF (char_length(v_left_part) <= 2)
+                THEN
+                    IF (v_date_format = 'YMD' AND v_culture NOT IN ('LV-LV', 'LV_LV'))
+                    THEN
+                        v_day := v_left_part;
+                        v_raw_year := sys.babelfish_get_full_year(v_right_part, '14');
+                        v_year := CASE
+                                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_right_part)::SMALLINT - 43
+                                     ELSE sys.babelfish_get_full_year(v_right_part, '', 29)::SMALLINT
+                                  END;
+                        BEGIN
+                            v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+                        EXCEPTION
+                        WHEN OTHERS THEN
+                            v_day := v_right_part;
+                            v_raw_year := sys.babelfish_get_full_year(v_left_part, '14');
+                            v_year := CASE
+                                         WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_left_part)::SMALLINT - 43
+                                         ELSE sys.babelfish_get_full_year(v_left_part, '', 29)::SMALLINT
+                                      END;
+                        END;
+                    END IF;
+
+                    IF (v_date_format IN ('MDY', 'DMY') OR v_culture IN ('LV-LV', 'LV_LV'))
+                    THEN
+                        v_day := v_right_part;
+                        v_raw_year := sys.babelfish_get_full_year(v_left_part, '14');
+                        v_year := CASE
+                                     WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_left_part)::SMALLINT - 43
+                                     ELSE sys.babelfish_get_full_year(v_left_part, '', 29)::SMALLINT
+                                  END;
+                        BEGIN
+                            v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+                        EXCEPTION
+                        WHEN OTHERS THEN
+                            v_day := v_left_part;
+                            v_raw_year := sys.babelfish_get_full_year(v_right_part, '14');
+                            v_year := CASE
+                                         WHEN v_culture IN ('TH-TH', 'TH_TH') THEN sys.babelfish_get_full_year(v_right_part)::SMALLINT - 43
+                                         ELSE sys.babelfish_get_full_year(v_right_part, '', 29)::SMALLINT
+                                      END;
+                        END;
+                    END IF;
+                ELSE
+                    v_day := v_right_part;
+                    v_raw_year := v_left_part;
+	            v_year := CASE
+                                 WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_left_part::SMALLINT - 543
+                                 ELSE v_left_part::SMALLINT
+                              END;
+                END IF;
+
+            ELSIF (v_resmask_cnt = 17)
+            THEN
+                v_day := v_regmatch_groups[4];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 18)
+            THEN
+                v_day := v_regmatch_groups[3];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[4], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[2];
+
+            ELSIF (v_resmask_cnt = 19)
+            THEN
+                v_day := v_regmatch_groups[4];
+                v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+                v_raw_year := v_regmatch_groups[3];
+            END IF;
+
+            IF (v_resmask_cnt NOT IN (10, 11, 14, 15, 16))
+            THEN
+                v_year := CASE
+                             WHEN v_culture IN ('TH-TH', 'TH_TH') THEN v_raw_year::SMALLINT - 543
+                             ELSE v_raw_year::SMALLINT
+                          END;
+            END IF;
+
+            IF (v_culture IN ('AR', 'AR-SA', 'AR_SA'))
+            THEN
+                IF (v_day::SMALLINT > 30 OR
+                    (v_resmask_cnt NOT IN (10, 11, 14, 15, 16) AND v_year NOT BETWEEN 1318 AND 1501) OR
+                    (v_resmask_cnt IN (14, 15, 16) AND v_raw_year::SMALLINT NOT BETWEEN 1318 AND 1501))
+                THEN
+                    RAISE invalid_datetime_format;
+                END IF;
+
+                v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_raw_year) - 1;
+
+                v_day := to_char(v_hijridate, 'DD');
+                v_month := to_char(v_hijridate, 'MM');
+                v_year := to_char(v_hijridate, 'YYYY')::SMALLINT;
+            END IF;
+        END IF;
+
+        v_resmask_cnt := v_resmask_cnt + 1;
+    END LOOP;
+
+    IF (NOT v_found) THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    v_res_date := make_date(v_year, v_month::SMALLINT, v_day::SMALLINT);
+
+    IF (v_weekdaynames[1] IS NOT NULL) THEN
+        v_weekdaynum := sys.babelfish_get_weekdaynum_by_name(v_weekdaynames[1], v_lang_metadata_json);
+
+        IF (date_part('dow', v_res_date)::SMALLINT <> v_weekdaynum) THEN
+            RAISE invalid_datetime_format;
+        END IF;
+    END IF;
+
+    IF (char_length(v_timestring) > 0 AND v_timestring NOT IN ('AM', 'ص', 'PM', 'م'))
+    THEN
+        IF (v_culture = 'FI') THEN
+            v_timestring := PG_CATALOG.translate(v_timestring, '.,', ': ');
+
+            IF (char_length(split_part(v_timestring, ':', 4)) > 0) THEN
+                v_timestring := regexp_replace(v_timestring, ':(?=\s*\d+\s*:?\s*(?:[AP]M|ص|م)?\s*$)', '.');
+            END IF;
+        END IF;
+
+        v_timestring := pg_catalog.replace(regexp_replace(v_timestring, '\.?[AP]M|ص|م|\s|\,|\.\D|[\.|:]$', '', 'gi'), ':.', ':');
+
+        BEGIN
+            v_hours := coalesce(split_part(v_timestring, ':', 1)::SMALLINT, 0);
+
+            IF ((v_dayparts[1] IN ('AM', 'ص') AND v_hours NOT BETWEEN 0 AND 12) OR
+                (v_dayparts[1] IN ('PM', 'م') AND v_hours NOT BETWEEN 1 AND 23))
+            THEN
+                RAISE invalid_datetime_format;
+            ELSIF (v_dayparts[1] = 'PM' AND v_hours < 12) THEN
+                v_hours := v_hours + 12;
+            ELSIF (v_dayparts[1] = 'AM' AND v_hours = 12) THEN
+                v_hours := v_hours - 12;
+            END IF;
+
+            v_minutes := coalesce(nullif(split_part(v_timestring, ':', 2), '')::SMALLINT, 0);
+            v_seconds := coalesce(nullif(split_part(v_timestring, ':', 3), ''), '0');
+
+            IF (v_seconds ~ '\.') THEN
+                v_fseconds := split_part(v_seconds, '.', 2);
+                v_seconds := split_part(v_seconds, '.', 1);
+            END IF;
+        EXCEPTION
+            WHEN OTHERS THEN
+            RAISE invalid_datetime_format;
+        END;
+    ELSIF (v_dayparts[1] IN ('PM', 'م'))
+    THEN
+        v_hours := 12;
+    END IF;
+
+    v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(rpad(v_fseconds, 9, '0'), v_scale);
+    v_seconds := pg_catalog.concat_ws('.', v_seconds, v_fseconds);
+
+    v_res_time := make_time(v_hours, v_minutes, v_seconds::NUMERIC);
+
+    RETURN v_res_time;
+EXCEPTION
+    WHEN invalid_datetime_format OR datetime_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Error converting string value ''%s'' into data type %s using culture ''%s''.',
+                                      p_srctimestring, v_res_datatype, p_culture),
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Source data type should be ''TIME'' or ''TIME(n)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_indicator_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid attributes specified for data type %s.', v_res_datatype),
+                    DETAIL := 'Use of incorrect scale value, which is not corresponding to specified data type.',
+                    HINT := 'Change data type scale component or select different data type and try again.';
+
+    WHEN interval_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_scale),
+                    DETAIL := 'Use of incorrect data type scale value during conversion process.',
+                    HINT := 'Change scale component of data type parameter to be in range [0..7] and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := CASE char_length(coalesce(CONVERSION_LANG, ''))
+                                  WHEN 0 THEN pg_catalog.format('The culture parameter ''%s'' provided in the function call is not supported.',
+                                                     p_culture)
+                                  ELSE pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                              CONVERSION_LANG)
+                               END,
+                    DETAIL := 'Passed incorrect value for "p_culture" parameter or compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Check "p_culture" input parameter value, correct it if needed, and try again. Also check CONVERSION_LANG constant value.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Supplied value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_round_fractseconds(IN p_fractseconds TEXT)
+RETURNS INTEGER
+AS
+$BODY$
+BEGIN
+    RETURN sys.babelfish_round_fractseconds(p_fractseconds::NUMERIC);
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', pg_catalog.btrim(p_fractseconds)),
+                    DETAIL := 'Passed argument value contains illegal characters.',
+                    HINT := 'Correct passed argument value, remove all illegal characters.';
+
+
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_sp_delete_jobschedule (
+  par_job_id integer = NULL::integer,
+  par_job_name varchar = NULL::character varying,
+  par_name varchar = NULL::character varying,
+  par_keep_schedule integer = 0,
+  par_automatic_post smallint = 1,
+  out returncode integer
+)
+RETURNS integer AS
+$body$
+DECLARE
+  var_retval INT;
+  var_sched_count INT;
+  var_schedule_id INT;
+  var_job_owner_sid CHAR(85);
+BEGIN
+  /* Remove any leading/trailing spaces from parameters */
+  SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_name)) INTO par_name;
+
+  /* Check that we can uniquely identify the job */
+  SELECT t.par_job_name
+       , t.par_job_id
+       , t.par_owner_sid
+       , t.returncode
+    FROM sys.babelfish_sp_verify_job_identifiers(
+         '@job_name'
+       , '@job_id'
+       , par_job_name
+       , par_job_id
+       , 'TEST'
+       , var_job_owner_sid
+       ) t
+    INTO par_job_name
+       , par_job_id
+       , var_job_owner_sid
+       , var_retval;
+
+  IF (var_retval <> 0) THEN /* Failure */
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (LOWER(pg_catalog.UPPER(par_name)) = LOWER('ALL'))
+  THEN
+    SELECT - 1 INTO var_schedule_id;
+
+    /* We use this in the call to sp_sqlagent_notify */
+    /* Delete the schedule(s) if it isn't being used by other jobs */
+    CREATE TEMPORARY TABLE "#temp_schedules_to_delete" (schedule_id INT NOT NULL)
+    /* If user requests that the schedules be removed (the legacy behavoir) */
+    /* make sure it isnt being used by other jobs */;
+
+    IF (par_keep_schedule = 0)
+    THEN
+      /* Get the list of schedules to delete */
+      INSERT INTO "#temp_schedules_to_delete"
+      SELECT DISTINCT schedule_id
+        FROM sys.sysschedules
+       WHERE (schedule_id IN (SELECT schedule_id
+                                FROM sys.sysjobschedules
+                               WHERE (job_id = par_job_id)));
+      /* make sure no other jobs use these schedules */
+      IF (EXISTS (SELECT *
+                    FROM sys.sysjobschedules
+                   WHERE (job_id <> par_job_id)
+                     AND (schedule_id IN (SELECT schedule_id
+                                            FROM "#temp_schedules_to_delete"))))
+      THEN /* Failure */
+        RAISE 'One or more schedules were not deleted because they are being used by at least one other job. Use "sp_detach_schedule" to remove schedules from a job.' USING ERRCODE := '50000';
+        returncode := 1;
+        RETURN;
+      END IF;
+    END IF;
+
+    /* OK to delete the jobschedule */
+    DELETE FROM sys.sysjobschedules
+     WHERE (job_id = par_job_id);
+
+    /* OK to delete the schedule - temp_schedules_to_delete is empty if @keep_schedule <> 0 */
+    DELETE FROM sys.sysschedules
+     WHERE schedule_id IN (SELECT schedule_id FROM "#temp_schedules_to_delete");
+  ELSE ---- IF (LOWER(UPPER(par_name)) = LOWER('ALL'))
+
+    -- Need to use sp_detach_schedule to remove this ambiguous schedule name
+    IF(var_sched_count > 1) /* Failure */
+    THEN
+      RAISE 'More than one schedule named "%" is attached to job "%". Use "sp_detach_schedule" to remove schedules from a job.', par_name, par_job_name  USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+    END IF;
+
+    --If user requests that the schedule be removed (the legacy behavoir)
+    --make sure it isnt being used by another job
+    IF (par_keep_schedule = 0)
+    THEN
+      IF(EXISTS(SELECT *
+                  FROM sys.sysjobschedules
+                 WHERE (schedule_id = var_schedule_id)
+                   AND (job_id <> par_job_id)))
+      THEN /* Failure */
+        RAISE 'Schedule "%" was not deleted because it is being used by at least one other job. Use "sp_detach_schedule" to remove schedules from a job.', par_name USING ERRCODE := '50000';
+        returncode := 1;
+        RETURN;
+      END IF;
+    END IF;
+
+    /* Delete the job schedule link first */
+    DELETE FROM sys.sysjobschedules
+     WHERE (job_id = par_job_id)
+       AND (schedule_id = var_schedule_id);
+
+    /* Delete schedule if required */
+    IF (par_keep_schedule = 0)
+    THEN
+      /* Now delete the schedule if required */
+      DELETE FROM sys.sysschedules
+       WHERE (schedule_id = var_schedule_id);
+    END IF;
+
+    SELECT t.returncode
+    FROM sys.babelfish_sp_aws_del_jobschedule(par_job_id, var_schedule_id) t
+    INTO var_retval;
+
+
+  END IF;
+
+  /* Update the job's version/last-modified information */
+  UPDATE sys.sysjobs
+     SET version_number = version_number + 1
+       -- , date_modified = GETDATE() /
+   WHERE job_id = par_job_id;
+
+  DROP TABLE IF EXISTS "#temp_schedules_to_delete";
+
+
+  /* 0 means success */
+  returncode := var_retval;
+  RETURN;
+END;
+$body$
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION sys.babelfish_sp_update_job (
+  par_job_id integer = NULL::integer,
+  par_job_name varchar = NULL::character varying,
+  par_new_name varchar = NULL::character varying,
+  par_enabled smallint = NULL::smallint,
+  par_description varchar = NULL::character varying,
+  par_start_step_id integer = NULL::integer,
+  par_category_name varchar = NULL::character varying,
+  par_owner_login_name varchar = NULL::character varying,
+  par_notify_level_eventlog integer = NULL::integer,
+  par_notify_level_email integer = NULL::integer,
+  par_notify_level_netsend integer = NULL::integer,
+  par_notify_level_page integer = NULL::integer,
+  par_notify_email_operator_name varchar = NULL::character varying,
+  par_notify_netsend_operator_name varchar = NULL::character varying,
+  par_notify_page_operator_name varchar = NULL::character varying,
+  par_delete_level integer = NULL::integer,
+  par_automatic_post smallint = 1,
+  out returncode integer
+)
+RETURNS integer AS
+$body$
+DECLARE
+    var_retval INT;
+    var_category_id INT;
+    var_notify_email_operator_id INT;
+    var_notify_netsend_operator_id INT;
+    var_notify_page_operator_id INT;
+    var_owner_sid CHAR(85);
+    var_alert_id INT;
+    var_cached_attribute_modified INT;
+    var_is_sysadmin INT;
+    var_current_owner VARCHAR(128);
+    var_enable_only_used INT;
+    var_x_new_name VARCHAR(128);
+    var_x_enabled SMALLINT;
+    var_x_description VARCHAR(512);
+    var_x_start_step_id INT;
+    var_x_category_name VARCHAR(128);
+    var_x_category_id INT;
+    var_x_owner_sid CHAR(85);
+    var_x_notify_level_eventlog INT;
+    var_x_notify_level_email INT;
+    var_x_notify_level_netsend INT;
+    var_x_notify_level_page INT;
+    var_x_notify_email_operator_name VARCHAR(128);
+    var_x_notify_netsnd_operator_name VARCHAR(128);
+    var_x_notify_page_operator_name VARCHAR(128);
+    var_x_delete_level INT;
+    var_x_originating_server_id INT;
+    var_x_master_server SMALLINT;
+BEGIN
+    /* Not updatable */
+    /* Remove any leading/trailing spaces from parameters (except @owner_login_name) */
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_job_name))
+        INTO par_job_name;
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_new_name))
+        INTO par_new_name;
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_description))
+        INTO par_description;
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_category_name))
+        INTO par_category_name;
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_notify_email_operator_name))
+        INTO par_notify_email_operator_name;
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_notify_netsend_operator_name))
+        INTO par_notify_netsend_operator_name;
+    SELECT
+        PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_notify_page_operator_name))
+        INTO par_notify_page_operator_name
+    /* Are we modifying an attribute which tsql agent caches? */;
+
+    IF ((par_new_name IS NOT NULL) OR (par_enabled IS NOT NULL) OR (par_start_step_id IS NOT NULL) OR (par_owner_login_name IS NOT NULL) OR (par_notify_level_eventlog IS NOT NULL) OR (par_notify_level_email IS NOT NULL) OR (par_notify_level_netsend IS NOT NULL) OR (par_notify_level_page IS NOT NULL) OR (par_notify_email_operator_name IS NOT NULL) OR (par_notify_netsend_operator_name IS NOT NULL) OR (par_notify_page_operator_name IS NOT NULL) OR (par_delete_level IS NOT NULL)) THEN
+        SELECT
+            1
+            INTO var_cached_attribute_modified;
+    ELSE
+        SELECT
+            0
+            INTO var_cached_attribute_modified;
+    END IF
+    /* Is @enable the only parameter used beside jobname and jobid? */;
+
+    IF ((par_enabled IS NOT NULL) AND (par_new_name IS NULL) AND (par_description IS NULL) AND (par_start_step_id IS NULL) AND (par_category_name IS NULL) AND (par_owner_login_name IS NULL) AND (par_notify_level_eventlog IS NULL) AND (par_notify_level_email IS NULL) AND (par_notify_level_netsend IS NULL) AND (par_notify_level_page IS NULL) AND (par_notify_email_operator_name IS NULL) AND (par_notify_netsend_operator_name IS NULL) AND (par_notify_page_operator_name IS NULL) AND (par_delete_level IS NULL)) THEN
+        SELECT
+            1
+            INTO var_enable_only_used;
+    ELSE
+        SELECT
+            0
+            INTO var_enable_only_used;
+    END IF;
+
+    IF (par_new_name = '') THEN
+        SELECT
+            NULL
+            INTO par_new_name;
+    END IF
+    /* Fill out the values for all non-supplied parameters from the existing values */;
+
+    IF (par_new_name IS NULL) THEN
+        SELECT
+            var_x_new_name
+            INTO par_new_name;
+    END IF;
+
+    IF (par_enabled IS NULL) THEN
+        SELECT
+            var_x_enabled
+            INTO par_enabled;
+    END IF;
+
+    IF (par_description IS NULL) THEN
+        SELECT
+            var_x_description
+            INTO par_description;
+    END IF;
+
+    IF (par_start_step_id IS NULL) THEN
+        SELECT
+            var_x_start_step_id
+            INTO par_start_step_id;
+    END IF;
+
+    IF (par_category_name IS NULL) THEN
+        SELECT
+            var_x_category_name
+            INTO par_category_name;
+    END IF;
+
+    IF (var_owner_sid IS NULL) THEN
+        SELECT
+            var_x_owner_sid
+            INTO var_owner_sid;
+    END IF;
+
+    IF (par_notify_level_eventlog IS NULL) THEN
+        SELECT
+            var_x_notify_level_eventlog
+            INTO par_notify_level_eventlog;
+    END IF;
+
+    IF (par_notify_level_email IS NULL) THEN
+        SELECT
+            var_x_notify_level_email
+            INTO par_notify_level_email;
+    END IF;
+
+    IF (par_notify_level_netsend IS NULL) THEN
+        SELECT
+            var_x_notify_level_netsend
+            INTO par_notify_level_netsend;
+    END IF;
+
+    IF (par_notify_level_page IS NULL) THEN
+        SELECT
+            var_x_notify_level_page
+            INTO par_notify_level_page;
+    END IF;
+
+    IF (par_notify_email_operator_name IS NULL) THEN
+        SELECT
+            var_x_notify_email_operator_name
+            INTO par_notify_email_operator_name;
+    END IF;
+
+    IF (par_notify_netsend_operator_name IS NULL) THEN
+        SELECT
+            var_x_notify_netsnd_operator_name
+            INTO par_notify_netsend_operator_name;
+    END IF;
+
+    IF (par_notify_page_operator_name IS NULL) THEN
+        SELECT
+            var_x_notify_page_operator_name
+            INTO par_notify_page_operator_name;
+    END IF;
+
+    IF (par_delete_level IS NULL) THEN
+        SELECT
+            var_x_delete_level
+            INTO par_delete_level;
+    END IF
+    /* Turn [nullable] empty string parameters into NULLs */;
+
+    IF (pg_catalog.LOWER(par_description) = pg_catalog.LOWER('')) THEN
+        SELECT
+            NULL
+            INTO par_description;
+    END IF;
+
+    IF (par_category_name = '') THEN
+        SELECT
+            NULL
+            INTO par_category_name;
+    END IF;
+
+    IF (par_notify_email_operator_name = '') THEN
+        SELECT
+            NULL
+            INTO par_notify_email_operator_name;
+    END IF;
+
+    IF (par_notify_netsend_operator_name = '') THEN
+        SELECT
+            NULL
+            INTO par_notify_netsend_operator_name;
+    END IF;
+
+    IF (par_notify_page_operator_name = '') THEN
+        SELECT
+            NULL
+            INTO par_notify_page_operator_name;
+    END IF
+    /* Check new values */;
+    SELECT
+        t.par_owner_sid, t.par_notify_level_email, t.par_notify_level_netsend, t.par_notify_level_page,
+        t.par_category_id, t.par_notify_email_operator_id, t.par_notify_netsend_operator_id, t.par_notify_page_operator_id, t.par_originating_server, t.ReturnCode
+        FROM sys.babelfish_sp_verify_job(par_job_id, par_new_name, par_enabled, par_start_step_id, par_category_name, var_owner_sid, par_notify_level_eventlog, par_notify_level_email, par_notify_level_netsend, par_notify_level_page, par_notify_email_operator_name, par_notify_netsend_operator_name, par_notify_page_operator_name, par_delete_level, var_category_id, var_notify_email_operator_id, var_notify_netsend_operator_id, var_notify_page_operator_id, NULL) t
+        INTO var_owner_sid, par_notify_level_email, par_notify_level_netsend, par_notify_level_page, var_category_id, var_notify_email_operator_id, var_notify_netsend_operator_id, var_notify_page_operator_id, var_retval;
+
+    IF (var_retval <> 0) THEN
+        ReturnCode := (1);
+        RETURN;
+    END IF
+    /* Failure */
+    /* BEGIN TRANSACTION */
+    /* If the job is being re-assigned, modify sysjobsteps.database_user_name as necessary */;
+
+    IF (par_owner_login_name IS NOT NULL) THEN
+        IF (EXISTS (SELECT
+            1
+            FROM sys.sysjobsteps
+            WHERE (job_id = par_job_id) AND (pg_catalog.LOWER(subsystem) = pg_catalog.LOWER('TSQL')))) THEN
+            /* The job is being re-assigned to an non-SA */
+            UPDATE sys.sysjobsteps
+            SET database_user_name = NULL
+                WHERE (job_id = par_job_id) AND (pg_catalog.LOWER(subsystem) = pg_catalog.LOWER('TSQL'));
+        END IF;
+    END IF;
+    UPDATE sys.sysjobs
+    SET name = par_new_name, enabled = par_enabled, description = par_description, start_step_id = par_start_step_id, category_id = var_category_id
+    /* Returned from sp_verify_job */, owner_sid = var_owner_sid, notify_level_eventlog = par_notify_level_eventlog, notify_level_email = par_notify_level_email, notify_level_netsend = par_notify_level_netsend, notify_level_page = par_notify_level_page, notify_email_operator_id = var_notify_email_operator_id
+    /* Returned from sp_verify_job */, notify_netsend_operator_id = var_notify_netsend_operator_id
+    /* Returned from sp_verify_job */, notify_page_operator_id = var_notify_page_operator_id
+    /* Returned from sp_verify_job */, delete_level = par_delete_level, version_number = version_number + 1
+    /* ,  -- Update the job's version */
+    /* date_modified              = GETDATE()            -- Update the job's last-modified information */
+        WHERE (job_id = par_job_id);
+    SELECT
+        0
+        INTO var_retval
+    /* @@error */
+    /* COMMIT TRANSACTION */;
+    ReturnCode := (var_retval);
+    RETURN
+    /* 0 means success */;
+END;
+$body$
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION sys.babelfish_sp_update_jobstep (
+  par_job_id integer = NULL::integer,
+  par_job_name varchar = NULL::character varying,
+  par_step_id integer = NULL::integer,
+  par_step_name varchar = NULL::character varying,
+  par_subsystem varchar = NULL::character varying,
+  par_command text = NULL::text,
+  par_additional_parameters text = NULL::text,
+  par_cmdexec_success_code integer = NULL::integer,
+  par_on_success_action smallint = NULL::smallint,
+  par_on_success_step_id integer = NULL::integer,
+  par_on_fail_action smallint = NULL::smallint,
+  par_on_fail_step_id integer = NULL::integer,
+  par_server varchar = NULL::character varying,
+  par_database_name varchar = NULL::character varying,
+  par_database_user_name varchar = NULL::character varying,
+  par_retry_attempts integer = NULL::integer,
+  par_retry_interval integer = NULL::integer,
+  par_os_run_priority integer = NULL::integer,
+  par_output_file_name varchar = NULL::character varying,
+  par_flags integer = NULL::integer,
+  par_proxy_id integer = NULL::integer,
+  par_proxy_name varchar = NULL::character varying,
+  out returncode integer
+)
+RETURNS integer AS
+$body$
+DECLARE
+    var_retval INT;
+    var_os_run_priority_code INT;
+    var_step_id_as_char VARCHAR(10);
+    var_new_step_name VARCHAR(128);
+    var_x_step_name VARCHAR(128);
+    var_x_subsystem VARCHAR(40);
+    var_x_command TEXT;
+    var_x_flags INT;
+    var_x_cmdexec_success_code INT;
+    var_x_on_success_action SMALLINT;
+    var_x_on_success_step_id INT;
+    var_x_on_fail_action SMALLINT;
+    var_x_on_fail_step_id INT;
+    var_x_server VARCHAR(128);
+    var_x_database_name VARCHAR(128);
+    var_x_database_user_name VARCHAR(128);
+    var_x_retry_attempts INT;
+    var_x_retry_interval INT;
+    var_x_os_run_priority INT;
+    var_x_output_file_name VARCHAR(200);
+    var_x_proxy_id INT;
+    var_x_last_run_outcome SMALLINT;
+    var_x_last_run_duration INT;
+    var_x_last_run_retries INT;
+    var_x_last_run_date INT;
+    var_x_last_run_time INT;
+    var_new_proxy_id INT;
+    var_subsystem_id INT;
+    var_auto_proxy_name VARCHAR(128);
+    var_job_owner_sid CHAR(85);
+    var_step_uid CHAR(85);
+BEGIN
+    SELECT NULL INTO var_new_proxy_id;
+    /* Remove any leading/trailing spaces from parameters */
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_step_name)) INTO par_step_name;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_subsystem)) INTO par_subsystem;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_command)) INTO par_command;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_server)) INTO par_server;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_database_name)) INTO par_database_name;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_database_user_name)) INTO par_database_user_name;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_output_file_name)) INTO par_output_file_name;
+    SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_proxy_name)) INTO par_proxy_name;
+    /* Make sure Dts is translated into new subsystem's name SSIS */
+    /* IF (@subsystem IS NOT NULL AND UPPER(@subsystem collate SQL_Latin1_General_CP1_CS_AS) = N'DTS') */
+    /* BEGIN */
+    /* SET @subsystem = N'SSIS' */
+    /* END */
+    SELECT
+        t.par_job_name, t.par_job_id, t.par_owner_sid, t.ReturnCode
+        FROM sys.babelfish_sp_verify_job_identifiers('@job_name'
+        /* @name_of_name_parameter */, '@job_id'
+        /* @name_of_id_parameter */, par_job_name
+        /* @job_name */, par_job_id
+        /* @job_id */, 'TEST'
+        /* @sqlagent_starting_test */, var_job_owner_sid)
+        INTO par_job_name, par_job_id, var_job_owner_sid, var_retval
+    /* @owner_sid */;
+
+    IF (var_retval <> 0) THEN
+        ReturnCode := (1);
+        RETURN;
+    END IF;
+    /* Failure */
+    /* Check that the step exists */
+
+    IF (NOT EXISTS (SELECT
+        *
+        FROM sys.sysjobsteps
+        WHERE (job_id = par_job_id) AND (step_id = par_step_id))) THEN
+        SELECT
+            CAST (par_step_id AS VARCHAR(10))
+            INTO var_step_id_as_char;
+        RAISE 'Error %, severity %, state % was raised. Message: %. Argument: %. Argument: %', '50000', 0, 0, 'The specified %s ("%s") does not exist.', '@step_id', var_step_id_as_char USING ERRCODE := '50000';
+        ReturnCode := (1);
+        RETURN;
+        /* Failure */
+    END IF;
+    /* Set the x_ (existing) variables */
+    SELECT
+        step_name, subsystem, command, flags, cmdexec_success_code, on_success_action, on_success_step_id, on_fail_action, on_fail_step_id, server, database_name, database_user_name, retry_attempts, retry_interval, os_run_priority, output_file_name, proxy_id, last_run_outcome, last_run_duration, last_run_retries, last_run_date, last_run_time
+        INTO var_x_step_name, var_x_subsystem, var_x_command, var_x_flags, var_x_cmdexec_success_code, var_x_on_success_action, var_x_on_success_step_id, var_x_on_fail_action, var_x_on_fail_step_id, var_x_server, var_x_database_name, var_x_database_user_name, var_x_retry_attempts, var_x_retry_interval, var_x_os_run_priority, var_x_output_file_name, var_x_proxy_id, var_x_last_run_outcome, var_x_last_run_duration, var_x_last_run_retries, var_x_last_run_date, var_x_last_run_time
+        FROM sys.sysjobsteps
+        WHERE (job_id = par_job_id) AND (step_id = par_step_id);
+
+    IF ((par_step_name IS NOT NULL) AND (par_step_name <> var_x_step_name)) THEN
+        SELECT
+            par_step_name
+            INTO var_new_step_name;
+    END IF;
+    /* Fill out the values for all non-supplied parameters from the existing values */
+
+    IF (par_step_name IS NULL) THEN
+        SELECT var_x_step_name INTO par_step_name;
+    END IF;
+
+    IF (par_subsystem IS NULL) THEN
+        SELECT var_x_subsystem INTO par_subsystem;
+    END IF;
+
+    IF (par_command IS NULL) THEN
+        SELECT var_x_command INTO par_command;
+    END IF;
+
+    IF (par_flags IS NULL) THEN
+        SELECT var_x_flags INTO par_flags;
+    END IF;
+
+    IF (par_cmdexec_success_code IS NULL) THEN
+        SELECT var_x_cmdexec_success_code INTO par_cmdexec_success_code;
+    END IF;
+
+    IF (par_on_success_action IS NULL) THEN
+        SELECT var_x_on_success_action INTO par_on_success_action;
+    END IF;
+
+    IF (par_on_success_step_id IS NULL) THEN
+        SELECT var_x_on_success_step_id INTO par_on_success_step_id;
+    END IF;
+
+    IF (par_on_fail_action IS NULL) THEN
+        SELECT var_x_on_fail_action INTO par_on_fail_action;
+    END IF;
+
+    IF (par_on_fail_step_id IS NULL) THEN
+        SELECT var_x_on_fail_step_id INTO par_on_fail_step_id;
+    END IF;
+
+    IF (par_server IS NULL) THEN
+        SELECT var_x_server INTO par_server;
+    END IF;
+
+    IF (par_database_name IS NULL) THEN
+        SELECT var_x_database_name INTO par_database_name;
+    END IF;
+
+    IF (par_database_user_name IS NULL) THEN
+        SELECT var_x_database_user_name INTO par_database_user_name;
+    END IF;
+
+    IF (par_retry_attempts IS NULL) THEN
+        SELECT var_x_retry_attempts INTO par_retry_attempts;
+    END IF;
+
+    IF (par_retry_interval IS NULL) THEN
+        SELECT var_x_retry_interval INTO par_retry_interval;
+    END IF;
+
+    IF (par_os_run_priority IS NULL) THEN
+        SELECT var_x_os_run_priority INTO par_os_run_priority;
+    END IF;
+
+    IF (par_output_file_name IS NULL) THEN
+        SELECT var_x_output_file_name INTO par_output_file_name;
+    END IF;
+
+    IF (par_proxy_id IS NULL) THEN
+        SELECT var_x_proxy_id INTO var_new_proxy_id;
+    END IF;
+    /* if an empty proxy_name is supplied the proxy is removed */
+
+    IF par_proxy_name = '' THEN
+        SELECT NULL INTO var_new_proxy_id;
+    END IF;
+    /* Turn [nullable] empty string parameters into NULLs */
+
+    IF (pg_catalog.LOWER(par_command) = pg_catalog.LOWER('')) THEN
+        SELECT NULL INTO par_command;
+    END IF;
+
+    IF (par_server = '') THEN
+        SELECT NULL INTO par_server;
+    END IF;
+
+    IF (par_database_name = '') THEN
+        SELECT NULL INTO par_database_name;
+    END IF;
+
+    IF (par_database_user_name = '') THEN
+        SELECT NULL INTO par_database_user_name;
+    END IF;
+
+    IF (pg_catalog.LOWER(par_output_file_name) = pg_catalog.LOWER('')) THEN
+        SELECT NULL INTO par_output_file_name;
+    END IF
+    /* Check new values */;
+    SELECT
+        t.par_database_name, t.par_database_user_name, t.ReturnCode
+        FROM sys.babelfish_sp_verify_jobstep(par_job_id, par_step_id, var_new_step_name, par_subsystem, par_command, par_server, par_on_success_action, par_on_success_step_id, par_on_fail_action, par_on_fail_step_id, par_os_run_priority, par_database_name, par_database_user_name, par_flags, par_output_file_name, var_new_proxy_id) t
+        INTO par_database_name, par_database_user_name, var_retval;
+
+    IF (var_retval <> 0) THEN
+        ReturnCode := (1);
+        RETURN;
+    END IF
+    /* Failure */
+    /* Update the job's version/last-modified information */;
+    UPDATE sys.sysjobs
+    SET version_number = version_number + 1
+    /* date_modified = GETDATE() */
+        WHERE (job_id = par_job_id)
+    /* Update the step */;
+    UPDATE sys.sysjobsteps
+    SET step_name = par_step_name, subsystem = par_subsystem, command = par_command, flags = par_flags, additional_parameters = par_additional_parameters, cmdexec_success_code = par_cmdexec_success_code, on_success_action = par_on_success_action, on_success_step_id = par_on_success_step_id, on_fail_action = par_on_fail_action, on_fail_step_id = par_on_fail_step_id, server = par_server, database_name = par_database_name, database_user_name = par_database_user_name, retry_attempts = par_retry_attempts, retry_interval = par_retry_interval, os_run_priority = par_os_run_priority, output_file_name = par_output_file_name, last_run_outcome = var_x_last_run_outcome, last_run_duration = var_x_last_run_duration, last_run_retries = var_x_last_run_retries, last_run_date = var_x_last_run_date, last_run_time = var_x_last_run_time, proxy_id = var_new_proxy_id
+        WHERE (job_id = par_job_id) AND (step_id = par_step_id);
+
+    SELECT step_uid
+    FROM sys.sysjobsteps
+    WHERE job_id = par_job_id AND step_id = par_step_id
+    INTO var_step_uid;
+
+    -- PERFORM sys.sp_jobstep_create_proc (var_step_uid);
+
+    ReturnCode := (0);
+    RETURN
+    /* Success */;
+END;
+$body$
+LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION sys.babelfish_sp_verify_jobstep (
+  par_job_id integer,
+  par_step_id integer,
+  par_step_name varchar,
+  par_subsystem varchar,
+  par_command text,
+  par_server varchar,
+  par_on_success_action smallint,
+  par_on_success_step_id integer,
+  par_on_fail_action smallint,
+  par_on_fail_step_id integer,
+  par_os_run_priority integer,
+  par_flags integer,
+  par_output_file_name varchar,
+  par_proxy_id integer,
+  out returncode integer
+)
+AS
+$body$
+DECLARE
+  var_max_step_id INT;
+  var_retval INT;
+  var_valid_values VARCHAR(50);
+  var_database_name_temp VARCHAR(258);
+  var_database_user_name_temp VARCHAR(256);
+  var_temp_command TEXT;
+  var_iPos INT;
+  var_create_count INT;
+  var_destroy_count INT;
+  var_is_olap_subsystem SMALLINT;
+  var_owner_sid CHAR(85);
+  var_owner_name VARCHAR(128);
+BEGIN
+  /* Remove any leading/trailing spaces from parameters */
+  SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_subsystem)) INTO par_subsystem;
+  SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_server)) INTO par_server;
+  SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_output_file_name)) INTO par_output_file_name;
+
+  /* Get current maximum step id */
+  SELECT COALESCE(MAX(step_id), 0)
+    INTO var_max_step_id
+    FROM sys.sysjobsteps
+   WHERE (job_id = par_job_id);
+
+  /* Check step id */
+  IF (par_step_id < 1) OR (par_step_id > var_max_step_id + 1)  /* Failure */
+  THEN
+    SELECT '1..' || CAST (var_max_step_id + 1 AS VARCHAR(1)) INTO var_valid_values;
+      RAISE 'The specified "%" is invalid (valid values are: %).', '@step_id', var_valid_values USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+  END IF;
+
+  /* Check step name */
+  IF (
+    EXISTS (
+      SELECT *
+        FROM sys.sysjobsteps
+       WHERE (job_id = par_job_id) AND (step_name = par_step_name)
+    )
+  )
+  THEN /* Failure */
+    RAISE 'The specified % ("%") already exists.', 'step_name', par_step_name USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Check on-success action/step */
+  IF (par_on_success_action <> 1) /* Quit Qith Success */
+    AND (par_on_success_action <> 2) /* Quit Qith Failure */
+    AND (par_on_success_action <> 3) /* Goto Next Step */
+    AND (par_on_success_action <> 4) /* Goto Step */
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', 'on_success_action', '1, 2, 3, 4' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (par_on_success_action = 4) AND ((par_on_success_step_id < 1) OR (par_on_success_step_id = par_step_id))
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are greater than 0 but excluding %ld).', 'on_success_step', par_step_id USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Check on-fail action/step */
+  IF (par_on_fail_action <> 1) /* Quit With Success */
+    AND (par_on_fail_action <> 2) /* Quit With Failure */
+    AND (par_on_fail_action <> 3) /* Goto Next Step */
+    AND (par_on_fail_action <> 4) /* Goto Step */
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', 'on_failure_action', '1, 2, 3, 4' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (par_on_fail_action = 4) AND ((par_on_fail_step_id < 1) OR (par_on_fail_step_id = par_step_id))
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are greater than 0 but excluding %).', 'on_failure_step', par_step_id USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Warn the user about forward references */
+  IF ((par_on_success_action = 4) AND (par_on_success_step_id > var_max_step_id))
+  THEN
+    RAISE 'Warning: Non-existent step referenced by %.', 'on_success_step_id' USING ERRCODE := '50000';
+  END IF;
+
+  IF ((par_on_fail_action = 4) AND (par_on_fail_step_id > var_max_step_id))
+  THEN
+    RAISE 'Warning: Non-existent step referenced by %.', '@on_fail_step_id' USING ERRCODE := '50000';
+  END IF;
+
+  /* Check run priority: must be a valid value to pass to SetThreadPriority: */
+  /* [-15 = IDLE, -1 = BELOW_NORMAL, 0 = NORMAL, 1 = ABOVE_NORMAL, 15 = TIME_CRITICAL] */
+  IF (par_os_run_priority NOT IN (- 15, - 1, 0, 1, 15))
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', '@os_run_priority', '-15, -1, 0, 1, 15' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Check flags */
+  IF ((par_flags < 0) OR (par_flags > 114)) THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', '@flags', '0..114' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (LOWER(pg_catalog.UPPER(par_subsystem)) <> LOWER('TSQL')) THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', '@subsystem', 'TSQL' USING ERRCODE := '50000';
+    returncode := (1);
+    RETURN;
+  END IF;
+
+  /* Success */
+  returncode := 0;
+  RETURN;
+END;
+$body$
+LANGUAGE 'plpgsql'
+STABLE;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_sp_verify_schedule (
+  par_schedule_id integer,
+  par_name varchar,
+  par_enabled smallint,
+  par_freq_type integer,
+  inout par_freq_interval integer,
+  inout par_freq_subday_type integer,
+  inout par_freq_subday_interval integer,
+  inout par_freq_relative_interval integer,
+  inout par_freq_recurrence_factor integer,
+  inout par_active_start_date integer,
+  inout par_active_start_time integer,
+  inout par_active_end_date integer,
+  inout par_active_end_time integer,
+  par_owner_sid char,
+  out returncode integer
+)
+RETURNS record AS
+$body$
+DECLARE
+  var_return_code INT;
+  var_isAdmin INT;
+BEGIN
+  /* Remove any leading/trailing spaces from parameters */
+  SELECT PG_CATALOG.LTRIM(PG_CATALOG.RTRIM(par_name)) INTO par_name;
+
+  /* Make sure that NULL input/output parameters - if NULL - are initialized to 0 */
+  SELECT COALESCE(par_freq_interval, 0) INTO par_freq_interval;
+  SELECT COALESCE(par_freq_subday_type, 0) INTO par_freq_subday_type;
+  SELECT COALESCE(par_freq_subday_interval, 0) INTO par_freq_subday_interval;
+  SELECT COALESCE(par_freq_relative_interval, 0) INTO par_freq_relative_interval;
+  SELECT COALESCE(par_freq_recurrence_factor, 0) INTO par_freq_recurrence_factor;
+  SELECT COALESCE(par_active_start_date, 0) INTO par_active_start_date;
+  SELECT COALESCE(par_active_start_time, 0) INTO par_active_start_time;
+  SELECT COALESCE(par_active_end_date, 0) INTO par_active_end_date;
+  SELECT COALESCE(par_active_end_time, 0) INTO par_active_end_time;
+
+  /* Verify name (we disallow schedules called 'ALL' since this has special meaning in sp_delete_jobschedules) */
+  SELECT 0 INTO var_isAdmin;
+
+  IF (
+    EXISTS (
+      SELECT *
+        FROM sys.sysschedules
+       WHERE (name = par_name)
+    )
+  )
+  THEN /* Failure */
+    RAISE 'The specified % ("%") already exists.', 'par_name', par_name USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+  END IF;
+
+  IF (pg_catalog.UPPER(par_name) = 'ALL')
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid.', 'name' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Verify enabled state */
+  IF (par_enabled <> 0) AND (par_enabled <> 1)
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', '@enabled', '0, 1' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Verify frequency type */
+  IF (par_freq_type = 2) /* OnDemand is no longer supported */
+  THEN /* Failure */
+    RAISE 'Frequency Type 0x2 (OnDemand) is no longer supported.' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (par_freq_type NOT IN (1, 4, 8, 16, 32, 64, 128))
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', 'freq_type', '1, 4, 8, 16, 32, 64, 128' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Verify frequency sub-day type */
+  IF (par_freq_subday_type <> 0) AND (par_freq_subday_type NOT IN (1, 2, 4, 8))
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', 'freq_subday_type', '1, 2, 4, 8' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  /* Default active start/end date/times (if not supplied, or supplied as NULLs or 0) */
+  IF (par_active_start_date = 0)
+  THEN
+    SELECT date_part('year', NOW()::TIMESTAMP) * 10000 + date_part('month', NOW()::TIMESTAMP) * 100 + date_part('day', NOW()::TIMESTAMP)
+      INTO par_active_start_date;
+  END IF;
+
+  /* This is an ISO format: "yyyymmdd" */
+  IF (par_active_end_date = 0)
+  THEN
+    /* December 31st 9999 */
+    SELECT 99991231 INTO par_active_end_date;
+  END IF;
+
+  IF (par_active_start_time = 0)
+  THEN
+    /* 12:00:00 am */
+    SELECT 000000 INTO par_active_start_time;
+  END IF;
+
+  IF (par_active_end_time = 0)
+  THEN
+    /* 11:59:59 pm */
+    SELECT 235959 INTO par_active_end_time;
+  END IF;
+
+  /* Verify active start/end dates */
+  IF (par_active_end_date = 0)
+  THEN
+    SELECT 99991231 INTO par_active_end_date;
+  END IF;
+
+  SELECT t.returncode
+    FROM sys.babelfish_sp_verify_job_date(par_active_end_date, 'active_end_date') t
+    INTO var_return_code;
+
+  IF (var_return_code <> 0)
+  THEN /* Failure */
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  SELECT t.returncode
+    FROM sys.babelfish_sp_verify_job_date(par_active_start_date, '@active_start_date') t
+    INTO var_return_code;
+
+  IF (var_return_code <> 0)
+  THEN /* Failure */
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (par_active_end_date < par_active_start_date)
+  THEN /* Failure */
+    RAISE '% cannot be before %.', 'active_end_date', 'active_start_date' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  SELECT t.returncode
+    FROM sys.babelfish_sp_verify_job_time(par_active_end_time, '@active_end_time') t
+    INTO var_return_code;
+
+  IF (var_return_code <> 0)
+  THEN /* Failure */
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  SELECT t.returncode
+    FROM sys.babelfish_sp_verify_job_time(par_active_start_time, '@active_start_time') t
+    INTO var_return_code;
+
+  IF (var_return_code <> 0)
+  THEN /* Failure */
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (par_active_start_time = par_active_end_time AND (par_freq_subday_type IN (2, 4, 8)))
+  THEN /* Failure */
+    RAISE 'The specified "%" is invalid (valid values are: %).', 'active_end_time', 'before or after active_start_time' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF ((par_freq_type = 1) /* FREQTYPE_ONETIME */
+    OR (par_freq_type = 64) /* FREQTYPE_AUTOSTART */
+    OR (par_freq_type = 128)) /* FREQTYPE_ONIDLE */
+  THEN /* Set standard defaults for non-required parameters */
+    SELECT 0 INTO par_freq_interval;
+    SELECT 0 INTO par_freq_subday_type;
+    SELECT 0 INTO par_freq_subday_interval;
+    SELECT 0 INTO par_freq_relative_interval;
+    SELECT 0 INTO par_freq_recurrence_factor;
+    /* Success */
+    returncode := 0;
+    RETURN;
+  END IF;
+
+  IF (par_freq_subday_type = 0) /* FREQSUBTYPE_ONCE */
+  THEN
+    SELECT 1 INTO par_freq_subday_type;
+  END IF;
+
+  IF ((par_freq_subday_type <> 1) /* FREQSUBTYPE_ONCE */
+    AND (par_freq_subday_type <> 2) /* FREQSUBTYPE_SECOND */
+    AND (par_freq_subday_type <> 4) /* FREQSUBTYPE_MINUTE */
+    AND (par_freq_subday_type <> 8)) /* FREQSUBTYPE_HOUR */
+  THEN /* Failure */
+    RAISE 'The schedule for this job is invalid (reason: The specified @freq_subday_type is invalid (valid values are: 0x1, 0x2, 0x4, 0x8).).' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF ((par_freq_subday_type <> 1) AND (par_freq_subday_interval < 1)) /* FREQSUBTYPE_ONCE and less than 1 interval */
+    OR ((par_freq_subday_type = 2) AND (par_freq_subday_interval < 10)) /* FREQSUBTYPE_SECOND and less than 10 seconds (see MIN_SCHEDULE_GRANULARITY in SqlAgent source code) */
+  THEN /* Failure */
+    RAISE 'The schedule for this job is invalid (reason: The specified @freq_subday_interval is invalid).' USING ERRCODE := '50000';
+    returncode := 1;
+    RETURN;
+  END IF;
+
+  IF (par_freq_type = 4) /* FREQTYPE_DAILY */
+  THEN
+    SELECT 0 INTO par_freq_recurrence_factor;
+
+    IF (par_freq_interval < 1) THEN /* Failure */
+      RAISE 'The schedule for this job is invalid (reason: @freq_interval must be at least 1 for a daily job.).' USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+    END IF;
+  END IF;
+
+  IF (par_freq_type = 8) /* FREQTYPE_WEEKLY */
+  THEN
+    IF (par_freq_interval < 1) OR (par_freq_interval > 127) /* (2^7)-1 [freq_interval is a bitmap (Sun=1..Sat=64)] */
+    THEN /* Failure */
+      RAISE 'The schedule for this job is invalid (reason: @freq_interval must be a valid day of the week bitmask [Sunday = 1 .. Saturday = 64] for a weekly job.).' USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+    END IF;
+  END IF;
+
+  IF (par_freq_type = 16) /* FREQTYPE_MONTHLY */
+  THEN
+    IF (par_freq_interval < 1) OR (par_freq_interval > 31)
+    THEN /* Failure */
+      RAISE 'The schedule for this job is invalid (reason: @freq_interval must be between 1 and 31 for a monthly job.).' USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+    END IF;
+  END IF;
+
+  IF (par_freq_type = 32) /* FREQTYPE_MONTHLYRELATIVE */
+  THEN
+    IF (par_freq_relative_interval <> 1) /* RELINT_1ST */
+      AND (par_freq_relative_interval <> 2) /* RELINT_2ND */
+      AND (par_freq_relative_interval <> 4) /* RELINT_3RD */
+      AND (par_freq_relative_interval <> 8) /* RELINT_4TH */
+      AND (par_freq_relative_interval <> 16) /* RELINT_LAST */
+    THEN /* Failure */
+      RAISE 'The schedule for this job is invalid (reason: @freq_relative_interval must be one of 1st (0x1), 2nd (0x2), 3rd [0x4], 4th (0x8) or Last (0x10).).' USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+    END IF;
+  END IF;
+
+  IF (par_freq_type = 32) /* FREQTYPE_MONTHLYRELATIVE */
+  THEN
+    IF (par_freq_interval <> 1) /* RELATIVE_SUN */
+      AND (par_freq_interval <> 2) /* RELATIVE_MON */
+      AND (par_freq_interval <> 3) /* RELATIVE_TUE */
+      AND (par_freq_interval <> 4) /* RELATIVE_WED */
+      AND (par_freq_interval <> 5) /* RELATIVE_THU */
+      AND (par_freq_interval <> 6) /* RELATIVE_FRI */
+      AND (par_freq_interval <> 7) /* RELATIVE_SAT */
+      AND (par_freq_interval <> 8) /* RELATIVE_DAY */
+      AND (par_freq_interval <> 9) /* RELATIVE_WEEKDAY */
+      AND (par_freq_interval <> 10) /* RELATIVE_WEEKENDDAY */
+    THEN /* Failure */
+      RAISE 'The schedule for this job is invalid (reason: @freq_interval must be between 1 and 10 (1 = Sunday .. 7 = Saturday, 8 = Day, 9 = Weekday, 10 = Weekend-day) for a monthly-relative job.).' USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+    END IF;
+  END IF;
+
+  IF ((par_freq_type = 8) /* FREQTYPE_WEEKLY */
+    OR (par_freq_type = 16) /* FREQTYPE_MONTHLY */
+    OR (par_freq_type = 32)) /* FREQTYPE_MONTHLYRELATIVE */
+    AND (par_freq_recurrence_factor < 1)
+  THEN /* Failure */
+    RAISE 'The schedule for this job is invalid (reason: @freq_recurrence_factor must be at least 1.).' USING ERRCODE := '50000';
+      returncode := 1;
+      RETURN;
+  END IF;
+  /* Success */
+  returncode := 0;
+  RETURN;
+END;
+$body$
+LANGUAGE 'plpgsql'
+STABLE;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_tomsbit(in_str VARCHAR)
+RETURNS SMALLINT
+AS
+$BODY$
+BEGIN
+  CASE
+    WHEN pg_catalog.LOWER(in_str) = 'true' OR in_str = '1' THEN RETURN 1;
+    WHEN pg_catalog.LOWER(in_str) = 'false' OR in_str = '0' THEN RETURN 0;
+    ELSE RETURN 0;
+  END CASE;
+END;
+$BODY$
+LANGUAGE 'plpgsql'
+STABLE;
+
+CREATE OR REPLACE FUNCTION sys.babelfish_split_object_name(
+    name TEXT, 
+    OUT db_name TEXT, 
+    OUT schema_name TEXT, 
+    OUT object_name TEXT)
+AS $$
+DECLARE
+    lower_object_name text;
+    names text[2];
+    counter int;
+    cur_pos int;
+BEGIN
+    lower_object_name = pg_catalog.lower(PG_CATALOG.rtrim(name));
+
+    counter = 1;
+    cur_pos = babelfish_get_name_delimiter_pos(lower_object_name);
+
+    -- Parse user input into names split by '.'
+    WHILE cur_pos > 0 LOOP
+        IF counter > 3 THEN
+            -- Too many names provided
+            RETURN;
+        END IF;
+
+        names[counter] = babelfish_remove_delimiter_pair(PG_CATALOG.rtrim(PG_CATALOG.left(lower_object_name, cur_pos - 1)));
+        
+        -- invalid name
+        IF names[counter] IS NULL THEN
+            RETURN;
+        END IF;
+
+        lower_object_name = substring(lower_object_name from cur_pos + 1);
+        counter = counter + 1;
+        cur_pos = babelfish_get_name_delimiter_pos(lower_object_name);
+    END LOOP;
+
+    CASE counter
+        WHEN 1 THEN
+            db_name = NULL;
+            schema_name = NULL;
+        WHEN 2 THEN
+            db_name = NULL;
+            schema_name = sys.babelfish_truncate_identifier(names[1]);
+        WHEN 3 THEN
+            db_name = sys.babelfish_truncate_identifier(names[1]);
+            schema_name = sys.babelfish_truncate_identifier(names[2]);
+        ELSE
+            RETURN;
+    END CASE;
+
+    -- Assign each name accordingly
+    object_name = sys.babelfish_truncate_identifier(babelfish_remove_delimiter_pair(PG_CATALOG.rtrim(lower_object_name)));
+END;
+$$
+LANGUAGE plpgsql
+STABLE;
+
+CREATE OR REPLACE FUNCTION sys.datetime2fromparts(IN p_year NUMERIC,
+                                                                IN p_month NUMERIC,
+                                                                IN p_day NUMERIC,
+                                                                IN p_hour NUMERIC,
+                                                                IN p_minute NUMERIC,
+                                                                IN p_seconds NUMERIC,
+                                                                IN p_fractions NUMERIC,
+                                                                IN p_precision NUMERIC)
+RETURNS sys.DATETIME2
+AS
+$BODY$
+DECLARE
+   v_fractions VARCHAR;
+   v_precision SMALLINT;
+   v_err_message VARCHAR;
+   v_calc_seconds NUMERIC;
+   v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+   v_string pg_catalog.text;
+BEGIN
+   v_fractions := floor(p_fractions)::INTEGER::VARCHAR;
+   v_precision := p_precision::SMALLINT;
+
+   IF (scale(p_precision) > 0) THEN
+      RAISE most_specific_type_mismatch;
+   ELSIF ((p_year::SMALLINT NOT BETWEEN 1 AND 9999) OR
+       (p_month::SMALLINT NOT BETWEEN 1 AND 12) OR
+       (p_day::SMALLINT NOT BETWEEN 1 AND 31) OR
+       (p_hour::SMALLINT NOT BETWEEN 0 AND 23) OR
+       (p_minute::SMALLINT NOT BETWEEN 0 AND 59) OR
+       (p_seconds::SMALLINT NOT BETWEEN 0 AND 59) OR
+       (p_fractions::SMALLINT NOT BETWEEN 0 AND 9999999) OR
+       (p_fractions::SMALLINT != 0 AND char_length(v_fractions) > v_precision))
+   THEN
+      RAISE invalid_datetime_format;
+   ELSIF (v_precision NOT BETWEEN 0 AND 7) THEN
+      RAISE invalid_parameter_value;
+   END IF;
+
+   v_calc_seconds := pg_catalog.format('%s.%s',
+                            floor(p_seconds)::SMALLINT,
+                            substring(rpad(lpad(v_fractions, v_precision, '0'), 7, '0'), 1, v_precision))::NUMERIC;
+
+   v_resdatetime := make_timestamp(floor(p_year)::SMALLINT,
+                         floor(p_month)::SMALLINT,
+                         floor(p_day)::SMALLINT,
+                         floor(p_hour)::SMALLINT,
+                         floor(p_minute)::SMALLINT,
+                         v_calc_seconds);
+
+   v_string := v_resdatetime::pg_catalog.text;
+
+   RETURN CAST(v_string AS sys.DATETIME2);
+EXCEPTION
+   WHEN most_specific_type_mismatch THEN
+      RAISE USING MESSAGE := 'Scale argument is not valid. Valid expressions for data type DATETIME2 scale argument are integer constants and integer constant expressions.',
+                  DETAIL := 'Use of incorrect "precision" parameter value during conversion process.',
+                  HINT := 'Change "precision" parameter to the proper value and try again.';
+
+   WHEN invalid_parameter_value THEN
+      RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_precision),
+                  DETAIL := 'Use of incorrect "precision" parameter value during conversion process.',
+                  HINT := 'Change "precision" parameter to the proper value and try again.';
+
+   WHEN invalid_datetime_format THEN
+      RAISE USING MESSAGE := 'Cannot construct data type DATETIME2, some of the arguments have values which are not valid.',
+                  DETAIL := 'Possible use of incorrect value of date or time part (which lies outside of valid range).',
+                  HINT := 'Check each input argument belongs to the valid range and try again.';
+
+   WHEN numeric_value_out_of_range THEN
+      GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+      v_err_message := pg_catalog.upper(split_part(v_err_message, ' ', 1));
+
+      RAISE USING MESSAGE := pg_catalog.format('Error while trying to cast to %s data type.', v_err_message),
+                  DETAIL := pg_catalog.format('Source value is out of %s data type range.', v_err_message),
+                  HINT := pg_catalog.format('Correct the source value you are trying to cast to %s data type and try again.',
+                                 v_err_message);
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.datetime2fromparts(IN p_year TEXT,
+                                                                IN p_month TEXT,
+                                                                IN p_day TEXT,
+                                                                IN p_hour TEXT,
+                                                                IN p_minute TEXT,
+                                                                IN p_seconds TEXT,
+                                                                IN p_fractions TEXT,
+                                                                IN p_precision TEXT)
+RETURNS TIMESTAMP WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_err_message VARCHAR;
+BEGIN
+    RETURN sys.datetime2fromparts(p_year::NUMERIC, p_month::NUMERIC, p_day::NUMERIC,
+                                                p_hour::NUMERIC, p_minute::NUMERIC, p_seconds::NUMERIC,
+                                                p_fractions::NUMERIC, p_precision::NUMERIC);
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'numeric\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', v_err_message),
+                    DETAIL := 'Supplied string value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.datetimefromparts(IN p_year NUMERIC,
+                                                               IN p_month NUMERIC,
+                                                               IN p_day NUMERIC,
+                                                               IN p_hour NUMERIC,
+                                                               IN p_minute NUMERIC,
+                                                               IN p_seconds NUMERIC,
+                                                               IN p_milliseconds NUMERIC)
+RETURNS TIMESTAMP WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_err_message VARCHAR;
+    v_calc_seconds NUMERIC;
+    v_milliseconds SMALLINT;
+    v_resdatetime TIMESTAMP WITHOUT TIME ZONE;
+BEGIN
+    -- Check if arguments are out of range
+    IF ((floor(p_year)::SMALLINT NOT BETWEEN 1753 AND 9999) OR
+        (floor(p_month)::SMALLINT NOT BETWEEN 1 AND 12) OR
+        (floor(p_day)::SMALLINT NOT BETWEEN 1 AND 31) OR
+        (floor(p_hour)::SMALLINT NOT BETWEEN 0 AND 23) OR
+        (floor(p_minute)::SMALLINT NOT BETWEEN 0 AND 59) OR
+        (floor(p_seconds)::SMALLINT NOT BETWEEN 0 AND 59) OR
+        (floor(p_milliseconds)::SMALLINT NOT BETWEEN 0 AND 999))
+    THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    v_milliseconds := sys.babelfish_round_fractseconds(p_milliseconds::INTEGER);
+
+    v_calc_seconds := pg_catalog.format('%s.%s',
+                             floor(p_seconds)::SMALLINT,
+                             CASE v_milliseconds
+                                WHEN 1000 THEN '0'
+                                ELSE lpad(v_milliseconds::VARCHAR, 3, '0')
+                             END)::NUMERIC;
+
+    v_resdatetime := make_timestamp(floor(p_year)::SMALLINT,
+                                    floor(p_month)::SMALLINT,
+                                    floor(p_day)::SMALLINT,
+                                    floor(p_hour)::SMALLINT,
+                                    floor(p_minute)::SMALLINT,
+                                    v_calc_seconds);
+    RETURN CASE
+              WHEN (v_milliseconds != 1000) THEN v_resdatetime
+              ELSE v_resdatetime + INTERVAL '1 second'
+           END;
+EXCEPTION
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := 'Cannot construct data type datetime, some of the arguments have values which are not valid.',
+                    DETAIL := 'Possible use of incorrect value of date or time part (which lies outside of valid range).',
+                    HINT := 'Check each input argument belongs to the valid range and try again.';
+
+    WHEN numeric_value_out_of_range THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := pg_catalog.upper(split_part(v_err_message, ' ', 1));
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to cast to %s data type.', v_err_message),
+                    DETAIL := pg_catalog.format('Source value is out of %s data type range.', v_err_message),
+                    HINT := pg_catalog.format('Correct the source value you are trying to cast to %s data type and try again.',
+                                   v_err_message);
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.datetimefromparts(IN p_year TEXT,
+                                                               IN p_month TEXT,
+                                                               IN p_day TEXT,
+                                                               IN p_hour TEXT,
+                                                               IN p_minute TEXT,
+                                                               IN p_seconds TEXT,
+                                                               IN p_milliseconds TEXT)
+RETURNS TIMESTAMP WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_err_message VARCHAR;
+BEGIN
+    RETURN sys.datetimefromparts(p_year::NUMERIC, p_month::NUMERIC, p_day::NUMERIC,
+                                               p_hour::NUMERIC, p_minute::NUMERIC,
+                                               p_seconds::NUMERIC, p_milliseconds::NUMERIC);
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'numeric\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', v_err_message),
+                    DETAIL := 'Supplied string value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.timefromparts(IN p_hour NUMERIC,
+                                                           IN p_minute NUMERIC,
+                                                           IN p_seconds NUMERIC,
+                                                           IN p_fractions NUMERIC,
+                                                           IN p_precision NUMERIC)
+RETURNS TIME WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_fractions VARCHAR;
+    v_precision SMALLINT;
+    v_err_message VARCHAR;
+    v_calc_seconds NUMERIC;
+BEGIN
+    v_fractions := floor(p_fractions)::INTEGER::VARCHAR;
+    v_precision := p_precision::SMALLINT;
+
+    IF (scale(p_precision) > 0) THEN
+        RAISE most_specific_type_mismatch;
+    ELSIF ((p_hour::SMALLINT NOT BETWEEN 0 AND 23) OR
+           (p_minute::SMALLINT NOT BETWEEN 0 AND 59) OR
+           (p_seconds::SMALLINT NOT BETWEEN 0 AND 59) OR
+           (p_fractions::SMALLINT NOT BETWEEN 0 AND 9999999) OR
+           (p_fractions::SMALLINT != 0 AND char_length(v_fractions) > v_precision))
+    THEN
+        RAISE invalid_datetime_format;
+    ELSIF (v_precision NOT BETWEEN 0 AND 7) THEN
+        RAISE numeric_value_out_of_range;
+    END IF;
+
+    v_calc_seconds := pg_catalog.format('%s.%s',
+                             floor(p_seconds)::SMALLINT,
+                             substring(rpad(lpad(v_fractions, v_precision, '0'), 7, '0'), 1, v_precision))::NUMERIC;
+
+    RETURN make_time(floor(p_hour)::SMALLINT,
+                     floor(p_minute)::SMALLINT,
+                     v_calc_seconds);
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Scale argument is not valid. Valid expressions for data type DATETIME2 scale argument are integer constants and integer constant expressions.',
+                    DETAIL := 'Use of incorrect "precision" parameter value during conversion process.',
+                    HINT := 'Change "precision" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_precision),
+                    DETAIL := 'Use of incorrect "precision" parameter value during conversion process.',
+                    HINT := 'Change "precision" parameter to the proper value and try again.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := 'Cannot construct data type time, some of the arguments have values which are not valid.',
+                    DETAIL := 'Possible use of incorrect value of time part (which lies outside of valid range).',
+                    HINT := 'Check each input argument belongs to the valid range and try again.';
+
+    WHEN numeric_value_out_of_range THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := pg_catalog.upper(split_part(v_err_message, ' ', 1));
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to cast to %s data type.', v_err_message),
+                    DETAIL := pg_catalog.format('Source value is out of %s data type range.', v_err_message),
+                    HINT := pg_catalog.format('Correct the source value you are trying to cast to %s data type and try again.',
+                                   v_err_message);
+END;
+$BODY$
+LANGUAGE plpgsql
+VOLATILE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.timefromparts(IN p_hour TEXT,
+                                                           IN p_minute TEXT,
+                                                           IN p_seconds TEXT,
+                                                           IN p_fractions TEXT,
+                                                           IN p_precision TEXT)
+RETURNS TIME WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_err_message VARCHAR;
+BEGIN
+    RETURN sys.timefromparts(p_hour::NUMERIC, p_minute::NUMERIC,
+                                           p_seconds::NUMERIC, p_fractions::NUMERIC,
+                                           p_precision::NUMERIC);
+EXCEPTION
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'numeric\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to NUMERIC data type.', v_err_message),
+                    DETAIL := 'Supplied string value contains illegal characters.',
+                    HINT := 'Correct supplied value, remove all illegal characters and try again.';
+END;
+$BODY$
+LANGUAGE plpgsql
+VOLATILE
+RETURNS NULL ON NULL INPUT;
+
+CREATE OR REPLACE FUNCTION sys.timezone(IN tzzone PG_CATALOG.TEXT , IN input_expr anyelement)
+RETURNS sys.datetimeoffset
+AS
+$BODY$
+DECLARE
+    tz_offset PG_CATALOG.TEXT;
+    tz_name PG_CATALOG.TEXT;
+    lower_tzn PG_CATALOG.TEXT;
+    prev_res PG_CATALOG.TEXT;
+    result PG_CATALOG.TEXT;
+    is_dstt bool;
+    tz_diff PG_CATALOG.TEXT;
+    input_expr_tx PG_CATALOG.TEXT;
+    input_expr_tmz TIMESTAMPTZ;
+BEGIN
+    IF input_expr IS NULL OR tzzone IS NULL THEN 
+    	RETURN NULL;
+    END IF;
+
+    lower_tzn := pg_catalog.lower(tzzone);
+    IF lower_tzn <> 'utc' THEN
+        tz_name := sys.babelfish_timezone_mapping(lower_tzn);
+    ELSE
+        tz_name := 'utc';
+    END IF;
+
+    IF tz_name = 'NULL' THEN
+        RAISE USING MESSAGE := format('Argument data type or the parameter %s provided to AT TIME ZONE clause is invalid.', tzzone);
+    END IF;
+
+    IF pg_typeof(input_expr) IN ('sys.smalldatetime'::regtype, 'sys.datetime'::regtype, 'sys.datetime2'::regtype) THEN
+        input_expr_tx := input_expr::TEXT;
+        input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
+
+        result := (SELECT input_expr_tmz AT TIME ZONE tz_name)::TEXT;
+        tz_diff := (SELECT result::TIMESTAMPTZ - input_expr_tmz)::TEXT;
+        if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
+            tz_diff := PG_CATALOG.concat('+',tz_diff);
+        END IF;
+        tz_offset := PG_CATALOG.left(tz_diff,6);
+        input_expr_tx := PG_CATALOG.concat(input_expr_tx,tz_offset);
+        return cast(input_expr_tx as sys.datetimeoffset);
+    ELSIF  pg_typeof(input_expr) = 'sys.DATETIMEOFFSET'::regtype THEN
+        input_expr_tx := input_expr::TEXT;
+        input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
+        result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
+        tz_diff := (SELECT result::TIMESTAMPTZ - input_expr_tmz)::TEXT;
+        if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
+            tz_diff := PG_CATALOG.concat('+',tz_diff);
+        END IF;
+        tz_offset := PG_CATALOG.left(tz_diff,6);
+        result := PG_CATALOG.concat(result,tz_offset);
+        return cast(result as sys.datetimeoffset);
+    ELSE
+        RAISE USING MESSAGE := 'Argument data type varchar is invalid for argument 1 of AT TIME ZONE function.'; 
+    END IF;
+       
+END;
+$BODY$
+LANGUAGE 'plpgsql' STABLE;
+
+CREATE OR REPLACE FUNCTION sys.has_perms_by_name(
+    securable SYS.SYSNAME, 
+    securable_class SYS.NVARCHAR(60), 
+    permission SYS.SYSNAME,
+    sub_securable SYS.SYSNAME DEFAULT NULL,
+    sub_securable_class SYS.NVARCHAR(60) DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+    db_name text COLLATE sys.database_default; 
+    bbf_schema_name text;
+    pg_schema text COLLATE sys.database_default;
+    implied_dbo_permissions boolean;
+    fully_supported boolean;
+    is_cross_db boolean := false;
+    object_name text COLLATE sys.database_default;
+    database_id smallint;
+    namespace_id oid;
+    userid oid;
+    object_type text;
+    function_signature text;
+    qualified_name text;
+    return_value integer;
+    cs_as_securable text COLLATE "C" := securable;
+    cs_as_securable_class text COLLATE "C" := securable_class;
+    cs_as_permission text COLLATE "C" := permission;
+    cs_as_sub_securable text COLLATE "C" := sub_securable;
+    cs_as_sub_securable_class text COLLATE "C" := sub_securable_class;
+BEGIN
+    return_value := NULL;
+
+    -- Lower-case to avoid case issues, remove trailing whitespace to match SQL SERVER behavior
+    -- Objects created in Babelfish are stored in lower-case in pg_class/pg_proc
+    cs_as_securable = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_securable));
+    cs_as_securable_class = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_securable_class));
+    cs_as_permission = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_permission));
+    cs_as_sub_securable = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_sub_securable));
+    cs_as_sub_securable_class = pg_catalog.lower(PG_CATALOG.rtrim(cs_as_sub_securable_class));
+
+    -- Assert that sub_securable and sub_securable_class are either both NULL or both defined
+    IF cs_as_sub_securable IS NOT NULL AND cs_as_sub_securable_class IS NULL THEN
+        RETURN NULL;
+    ELSIF cs_as_sub_securable IS NULL AND cs_as_sub_securable_class IS NOT NULL THEN
+        RETURN NULL;
+    -- If they are both defined, user must be evaluating column privileges.
+    -- Check that inputs are valid for column privileges: sub_securable_class must 
+    -- be column, securable_class must be object, and permission cannot be any.
+    ELSIF cs_as_sub_securable_class IS NOT NULL 
+            AND (cs_as_sub_securable_class != 'column' 
+                    OR cs_as_securable_class IS NULL 
+                    OR cs_as_securable_class != 'object' 
+                    OR cs_as_permission = 'any') THEN
+        RETURN NULL;
+
+    -- If securable is null, securable_class must be null
+    ELSIF cs_as_securable IS NULL AND cs_as_securable_class IS NOT NULL THEN
+        RETURN NULL;
+    -- If securable_class is null, securable must be null
+    ELSIF cs_as_securable IS NOT NULL AND cs_as_securable_class IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    IF cs_as_securable_class = 'server' THEN
+        -- SQL Server does not permit a securable_class value of 'server'.
+        -- securable_class should be NULL to evaluate server permissions.
+        RETURN NULL;
+    ELSIF cs_as_securable_class IS NULL THEN
+        -- NULL indicates a server permission. Set this variable so that we can
+        -- search for the matching entry in babelfish_has_perms_by_name_permissions
+        cs_as_securable_class = 'server';
+    END IF;
+
+    IF cs_as_sub_securable IS NOT NULL THEN
+        cs_as_sub_securable := babelfish_remove_delimiter_pair(cs_as_sub_securable);
+        IF cs_as_sub_securable IS NULL THEN
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    SELECT p.implied_dbo_permissions,p.fully_supported 
+    INTO implied_dbo_permissions,fully_supported 
+    FROM babelfish_has_perms_by_name_permissions p 
+    WHERE p.securable_type = cs_as_securable_class AND p.permission_name = cs_as_permission;
+    
+    IF implied_dbo_permissions IS NULL OR fully_supported IS NULL THEN
+        -- Securable class or permission is not valid, or permission is not valid for given securable
+        RETURN NULL;
+    END IF;
+
+    IF cs_as_securable_class = 'database' AND cs_as_securable IS NOT NULL THEN
+        db_name = babelfish_remove_delimiter_pair(cs_as_securable);
+        IF db_name IS NULL THEN
+            RETURN NULL;
+        ELSIF (SELECT COUNT(name) FROM sys.databases WHERE name = db_name) != 1 THEN
+            RETURN 0;
+        END IF;
+    ELSIF cs_as_securable_class = 'schema' THEN
+        bbf_schema_name = babelfish_remove_delimiter_pair(cs_as_securable);
+        IF bbf_schema_name IS NULL THEN
+            RETURN NULL;
+        ELSIF (SELECT COUNT(nspname) FROM sys.babelfish_namespace_ext ext
+                WHERE ext.orig_name = bbf_schema_name 
+                    AND ext.dbid = sys.db_id()) != 1 THEN
+            RETURN 0;
+        END IF;
+    END IF;
+
+    IF fully_supported = 'f' AND
+		(SELECT orig_username FROM sys.babelfish_authid_user_ext WHERE rolname = CURRENT_USER) = 'dbo' THEN
+        RETURN CAST(implied_dbo_permissions AS integer);
+    ELSIF fully_supported = 'f' THEN
+        RETURN 0;
+    END IF;
+
+    -- The only permissions that are fully supported belong to the OBJECT securable class.
+    -- The block above has dealt with all permissions that are not fully supported, so 
+    -- if we reach this point we know the securable class is OBJECT.
+    SELECT s.db_name, s.schema_name, s.object_name INTO db_name, bbf_schema_name, object_name 
+    FROM babelfish_split_object_name(cs_as_securable) s;
+
+    -- Invalid securable name
+    IF object_name IS NULL OR object_name = '' THEN
+        RETURN NULL;
+    END IF;
+
+    -- If schema was not specified, use the default
+    IF bbf_schema_name IS NULL OR bbf_schema_name = '' THEN
+        bbf_schema_name := sys.schema_name();
+    END IF;
+
+    database_id := (
+        SELECT CASE 
+            WHEN db_name IS NULL OR db_name = '' THEN (sys.db_id())
+            ELSE (sys.db_id(db_name))
+        END);
+
+	IF database_id <> sys.db_id() THEN
+        is_cross_db = true;
+	END IF;
+
+	userid := (
+        SELECT CASE
+            WHEN is_cross_db THEN sys.suser_id()
+            ELSE sys.user_id()
+        END);
+  
+    -- Translate schema name from bbf to postgres, e.g. dbo -> master_dbo
+    pg_schema := (SELECT nspname 
+                    FROM sys.babelfish_namespace_ext ext 
+                    WHERE ext.orig_name = bbf_schema_name 
+                        AND CAST(ext.dbid AS oid) = CAST(database_id AS oid));
+
+    IF pg_schema IS NULL THEN
+        -- Shared schemas like sys and pg_catalog do not exist in the table above.
+        -- These schemas do not need to be translated from Babelfish to Postgres
+        pg_schema := bbf_schema_name;
+    END IF;
+
+    -- Surround with double-quotes to handle names that contain periods/spaces
+    qualified_name := PG_CATALOG.concat('"', pg_schema, '"."', object_name, '"');
+
+    SELECT oid INTO namespace_id FROM pg_catalog.pg_namespace WHERE nspname = pg_schema COLLATE sys.database_default;
+
+    object_type := (
+        SELECT CASE
+            WHEN cs_as_sub_securable_class = 'column'
+                THEN CASE 
+                    WHEN (SELECT count(a.attname)
+                        FROM pg_attribute a
+                        INNER JOIN pg_class c ON c.oid = a.attrelid
+                        INNER JOIN pg_namespace s ON s.oid = c.relnamespace
+                        WHERE
+                        a.attname = cs_as_sub_securable COLLATE sys.database_default
+                        AND c.relname = object_name COLLATE sys.database_default
+                        AND s.nspname = pg_schema COLLATE sys.database_default
+                        AND NOT a.attisdropped
+                        AND (s.nspname IN (SELECT nspname FROM sys.babelfish_namespace_ext) OR s.nspname = 'sys')
+                        -- r = ordinary table, i = index, S = sequence, t = TOAST table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table
+                        AND c.relkind IN ('r', 'v', 'm', 'f', 'p')
+                        AND a.attnum > 0) = 1
+                                THEN 'column'
+                    ELSE NULL
+                END
+
+            WHEN (SELECT count(relname) 
+                    FROM pg_catalog.pg_class 
+                    WHERE relname = object_name COLLATE sys.database_default
+                        AND relnamespace = namespace_id) = 1
+                THEN 'table'
+
+            WHEN (SELECT count(proname) 
+                    FROM pg_catalog.pg_proc 
+                    WHERE proname = object_name COLLATE sys.database_default 
+                        AND pronamespace = namespace_id
+                        AND prokind = 'f') = 1
+                THEN 'function'
+                
+            WHEN (SELECT count(proname) 
+                    FROM pg_catalog.pg_proc 
+                    WHERE proname = object_name COLLATE sys.database_default
+                        AND pronamespace = namespace_id
+                        AND prokind = 'p') = 1
+                THEN 'procedure'
+            ELSE NULL
+        END
+    );
+    
+    -- Object was not found
+    IF object_type IS NULL THEN
+        RETURN 0;
+    END IF;
+  
+    -- Get signature for function-like objects
+    IF object_type IN('function', 'procedure') THEN
+        SELECT CAST(oid AS regprocedure) 
+            INTO function_signature 
+            FROM pg_catalog.pg_proc 
+            WHERE proname = object_name COLLATE sys.database_default
+                AND pronamespace = namespace_id;
+    END IF;
+
+    return_value := (
+        SELECT CASE
+            WHEN cs_as_permission = 'any' THEN babelfish_has_any_privilege(userid, object_type, pg_schema, object_name)
+
+            WHEN object_type = 'column'
+                THEN CASE
+                    WHEN cs_as_permission IN('insert', 'delete', 'execute') THEN NULL
+                    ELSE CAST(has_column_privilege(userid, qualified_name, cs_as_sub_securable, cs_as_permission) AS integer)
+                END
+
+            WHEN object_type = 'table'
+                THEN CASE
+                    WHEN cs_as_permission = 'execute' THEN 0
+                    ELSE CAST(has_table_privilege(userid, qualified_name, cs_as_permission) AS integer)
+                END
+
+            WHEN object_type = 'function'
+                THEN CASE
+                    WHEN cs_as_permission IN('select', 'execute')
+                        THEN CAST(has_function_privilege(userid, function_signature, 'execute') AS integer)
+                    WHEN cs_as_permission IN('update', 'insert', 'delete', 'references')
+                        THEN 0
+                    ELSE NULL
+                END
+
+            WHEN object_type = 'procedure'
+                THEN CASE
+                    WHEN cs_as_permission = 'execute'
+                        THEN CAST(has_function_privilege(userid, function_signature, 'execute') AS integer)
+                    WHEN cs_as_permission IN('select', 'update', 'insert', 'delete', 'references')
+                        THEN 0
+                    ELSE NULL
+                END
+
+            ELSE NULL
+        END
+    );
+
+    RETURN return_value;
+    EXCEPTION WHEN OTHERS THEN RETURN NULL;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION sys.has_perms_by_name(
+    securable sys.SYSNAME, 
+    securable_class sys.nvarchar(60), 
+    permission sys.SYSNAME, 
+    sub_securable sys.SYSNAME,
+    sub_securable_class sys.nvarchar(60)) TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.columnproperty(object_id OID, property NAME, property_name TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+STABLE STRICT
+AS $$
+DECLARE
+    extra_bytes CONSTANT INTEGER := 4;
+    return_value INTEGER;
+BEGIN
+	return_value:=
+        CASE pg_catalog.LOWER(property_name)
+            WHEN 'charmaxlen' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN a.atttypmod > 0 THEN a.atttypmod - extra_bytes
+                    ELSE NULL
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
+            WHEN 'allowsnull' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN a.attnotnull THEN 0
+                    ELSE 1
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
+            WHEN 'iscomputed' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN a.attgenerated != '' THEN 1
+                    ELSE 0
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id and (a.attname = property COLLATE sys.database_default))
+            WHEN 'columnid' COLLATE sys.database_default THEN
+                (SELECT a.attnum FROM pg_catalog.pg_attribute a
+                 WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
+            WHEN 'ordinal' COLLATE sys.database_default THEN
+                (SELECT b.count FROM (SELECT attname, row_number() OVER () AS count FROM pg_catalog.pg_attribute a
+                 WHERE a.attrelid = object_id AND attisdropped = false AND attnum > 0 ORDER BY a.attnum) AS b WHERE b.attname = property COLLATE sys.database_default)
+            WHEN 'isidentity' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN char_length(a.attidentity) > 0 THEN 1
+                    ELSE 0
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id and (a.attname = property COLLATE sys.database_default))
+            ELSE
+                NULL
+        END;
+    RETURN return_value::INTEGER;
+EXCEPTION 
+	WHEN others THEN
+ 		RETURN NULL;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION sys.columnproperty(object_id OID, property NAME, property_name TEXT) TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.json_modify(in expression sys.NVARCHAR,in path_json TEXT, in new_value ANYELEMENT, in escape bool)
+RETURNS sys.NVARCHAR
+AS
+$BODY$
+DECLARE
+    json_path TEXT;
+    json_path_convert TEXT;
+    new_jsonb_path TEXT[];
+    key_value_type TEXT;
+    path_split_array TEXT[];
+    comparison_string TEXT COLLATE "C";
+    len_array INTEGER;
+    word_count INTEGER;
+    create_if_missing BOOL = TRUE;
+    append_modifier BOOL = FALSE;
+    key_exists BOOL;
+    key_value JSONB;
+    json_expression JSONB = expression::JSONB;
+    json_new_value JSONB;
+    result_json sys.NVARCHAR;
+BEGIN
+    path_split_array = regexp_split_to_array(PG_CATALOG.btrim(path_json) COLLATE "C",'\s+');
+    word_count = array_length(path_split_array,1);
+    /* 
+     * This if else block is added to set the create_if_missing and append_modifier flags.
+     * These flags will be used to know the mode and if the optional modifier append is present in the input path_json.
+     * It is necessary as postgres functions do not directly take append and lax/strict mode in the jsonb_path.
+     * Comparisons for comparison_string are case-sensitive.    
+     */
+    IF word_count = 1 THEN
+        json_path = path_split_array[1];
+        create_if_missing = TRUE;
+        append_modifier = FALSE;
+    ELSIF word_count = 2 THEN 
+        json_path = path_split_array[2];
+        comparison_string = path_split_array[1]; -- append or lax/strict mode
+        IF comparison_string = 'append' THEN
+            append_modifier = TRUE;
+        ELSIF comparison_string = 'strict' THEN
+            create_if_missing = FALSE;
+        ELSIF comparison_string = 'lax' THEN
+            create_if_missing = TRUE;
+        ELSE
+            RAISE invalid_json_text;
+        END IF;
+    ELSIF word_count = 3 THEN
+        json_path = path_split_array[3];
+        comparison_string = path_split_array[1]; -- append mode 
+        IF comparison_string = 'append' THEN
+            append_modifier = TRUE;
+        ELSE
+            RAISE invalid_json_text;
+        END IF;
+        comparison_string = path_split_array[2]; -- lax/strict mode
+        IF comparison_string = 'strict' THEN
+            create_if_missing = FALSE;
+        ELSIF comparison_string = 'lax' THEN
+            create_if_missing = TRUE;
+        ELSE
+            RAISE invalid_json_text;
+        END IF;
+    ELSE
+        RAISE invalid_json_text;
+    END IF;
+
+    -- To convert input jsonpath to the required jsonb_path format
+    json_path_convert = regexp_replace(json_path, '\$\.|]|\$\[' , '' , 'ig'); -- To remove "$." and "]" sign from the string 
+    json_path_convert = regexp_replace(json_path_convert, '\.|\[' , ',' , 'ig'); -- To replace "." and "[" with "," to change into required format
+    new_jsonb_path = PG_CATALOG.CONCAT('{',json_path_convert,'}'); -- Final required format of path by jsonb_set
+
+    key_exists = jsonb_path_exists(json_expression,json_path::jsonpath); -- To check if key exist in the given path
+
+    IF escape THEN
+        json_new_value = new_value::JSONB;
+    ELSE
+        json_new_value = to_jsonb(new_value);
+    END IF;
+
+    --This if else block is to call the jsonb_set function based on the create_if_missing and append_modifier flags
+    IF append_modifier THEN 
+        IF key_exists THEN
+            key_value = jsonb_path_query_first(json_expression,json_path::jsonpath); -- To get the value of the key
+            key_value_type = jsonb_typeof(key_value);
+            IF key_value_type = 'array' THEN
+                len_array = jsonb_array_length(key_value);
+                /*
+                 * As jsonb_insert requires the index of the value to be inserted, so the below FORMAT function changes the path format into the required jsonb_insert path format.
+                 * Eg: JSON_MODIFY('{"name":"John","skills":["C#","SQL"]}','append $.skills','Azure'); -> converts the path from '$.skills' to '{skills,2}' instead of '{skills}'
+                 */
+                new_jsonb_path = FORMAT('%s,%s}',TRIM('}' FROM new_jsonb_path::TEXT),len_array);
+                IF new_value IS NULL THEN
+                    result_json = jsonb_insert(json_expression,new_jsonb_path,'null'); -- This needs to be done because "to_jsonb(coalesce(new_value, 'null'))" does not result in a JSON NULL
+                ELSE
+                    result_json = jsonb_insert(json_expression,new_jsonb_path,json_new_value);
+                END IF;
+            ELSE
+                IF NOT create_if_missing THEN
+                    RAISE sql_json_array_not_found;
+                ELSE
+                    result_json = json_expression;
+                END IF;
+            END IF;
+        ELSE
+            IF NOT create_if_missing THEN
+                RAISE sql_json_object_not_found;
+            ELSE
+                result_json = jsonb_insert(json_expression,new_jsonb_path,to_jsonb(array_agg(new_value))); -- array_agg is used to convert the new_value text into array format as we append functionality is being used
+            END IF;
+        END IF;
+    ELSE --When no append modifier is present
+        IF new_value IS NOT NULL THEN
+            IF key_exists OR create_if_missing THEN
+                result_json = jsonb_set_lax(json_expression,new_jsonb_path,json_new_value,create_if_missing);
+            ELSE
+                RAISE sql_json_object_not_found;
+            END IF;
+        ELSE
+            IF key_exists THEN
+                IF NOT create_if_missing THEN
+                    result_json = jsonb_set_lax(json_expression,new_jsonb_path,json_new_value);
+                ELSE
+                    result_json = jsonb_set_lax(json_expression,new_jsonb_path,json_new_value,create_if_missing,'delete_key');
+                END IF;
+            ELSE
+                IF NOT create_if_missing THEN
+                    RAISE sql_json_object_not_found;
+                ELSE
+                    result_json = jsonb_set_lax(json_expression,new_jsonb_path,json_new_value,FALSE);
+                END IF;
+            END IF;
+        END IF;
+    END IF;  -- If append_modifier block ends here
+    RETURN result_json;
+EXCEPTION
+    WHEN invalid_json_text THEN
+            RAISE USING MESSAGE = 'JSON path is not properly formatted',
+                        DETAIL = FORMAT('Unexpected keyword "%s" is found.',comparison_string),
+                        HINT = 'Change "modifier/mode" parameter to the proper value and try again.';
+    WHEN sql_json_array_not_found THEN
+            RAISE USING MESSAGE = 'array cannot be found in the specified JSON path',
+                        HINT = 'Change JSON path to target array property and try again.';
+    WHEN sql_json_object_not_found THEN
+            RAISE USING MESSAGE = 'property cannot be found on the specified JSON path';
+END;        
+$BODY$
+LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE FUNCTION sys.INDEXPROPERTY(IN object_id INT, IN index_or_statistics_name sys.nvarchar(128), IN property sys.varchar(128))
+RETURNS INT AS
+$BODY$
+DECLARE
+ret_val INT;
+BEGIN
+	index_or_statistics_name = LOWER(PG_CATALOG.btrim(index_or_statistics_name));
+	property = LOWER(PG_CATALOG.btrim(property));
+    SELECT INTO ret_val
+    CASE
+       
+        WHEN (SELECT CAST(type AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default) = 3 -- is XML index
+        THEN CAST(NULL AS int)
+	    
+        WHEN property = 'indexdepth'
+        THEN CAST(0 AS int)
+
+        WHEN property = 'indexfillfactor'
+        THEN (SELECT CAST(fill_factor AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+
+        WHEN property = 'indexid'
+        THEN (SELECT CAST(index_id AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+
+        WHEN property = 'isautostatistics'
+        THEN CAST(0 AS int)
+
+        WHEN property = 'isclustered'
+        THEN (SELECT CAST(CASE WHEN type = 1 THEN 1 ELSE 0 END AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'isdisabled'
+        THEN (SELECT CAST(is_disabled AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'isfulltextkey'
+        THEN CAST(0 AS int)
+        
+        WHEN property = 'ishypothetical'
+        THEN (SELECT CAST(is_hypothetical AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'ispadindex'
+        THEN (SELECT CAST(is_padded AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'ispagelockdisallowed'
+        THEN (SELECT CAST(CASE WHEN allow_page_locks = 1 THEN 0 ELSE 1 END AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'isrowlockdisallowed'
+        THEN (SELECT CAST(CASE WHEN allow_row_locks = 1 THEN 0 ELSE 1 END AS int) FROM sys.indexes i WHERE i.object_id=$1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'isstatistics'
+        THEN CAST(0 AS int)
+        
+        WHEN property = 'isunique'
+        THEN (SELECT CAST(is_unique AS int) FROM sys.indexes i WHERE i.object_id = $1 AND i.name = $2 COLLATE sys.database_default)
+        
+        WHEN property = 'iscolumnstore'
+        THEN CAST(0 AS int)
+        
+        WHEN property = 'isoptimizedforsequentialkey'
+        THEN CAST(0 AS int)
+    ELSE
+        CAST(NULL AS int)
+    END;
+RETURN ret_val;
+END;
+$BODY$
+LANGUAGE plpgsql STABLE;
+GRANT EXECUTE ON FUNCTION sys.INDEXPROPERTY(IN object_id INT, IN index_or_statistics_name sys.nvarchar(128),  IN property sys.varchar(128)) TO PUBLIC;
+
+CREATE OR REPLACE FUNCTION sys.COL_LENGTH(IN object_name TEXT, IN column_name TEXT)
+RETURNS SMALLINT AS $BODY$
+DECLARE
+    col_name TEXT;
+    object_id oid;
+    column_id INT;
+    column_length SMALLINT;
+    column_data_type TEXT;
+    typeid oid;
+    typelen INT;
+    typemod INT;
+BEGIN
+    -- Get the object ID for the provided object_name
+    object_id := sys.OBJECT_ID(object_name, 'U');
+    IF object_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- Truncate and normalize the column name
+    col_name := sys.babelfish_truncate_identifier(sys.babelfish_remove_delimiter_pair(pg_catalog.lower(column_name)));
+
+    -- Get the column ID, typeid, length, and typmod for the provided column_name
+    SELECT attnum, a.atttypid, a.attlen, a.atttypmod
+    INTO column_id, typeid, typelen, typemod
+    FROM pg_attribute a
+    WHERE attrelid = object_id AND pg_catalog.lower(attname) = col_name COLLATE sys.database_default;
+
+    IF column_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- Get the correct data type
+    column_data_type := sys.translate_pg_type_to_tsql(typeid);
+
+    IF column_data_type = 'sysname' THEN
+        column_length := 256;
+    ELSIF column_data_type IS NULL THEN
+
+        -- Check if it ia user-defined data type
+        SELECT sys.translate_pg_type_to_tsql(typbasetype), typlen, typtypmod 
+        INTO column_data_type, typelen, typemod
+        FROM pg_type
+        WHERE oid = typeid;
+
+        IF column_data_type = 'sysname' THEN
+            column_length := 256;
+        ELSE 
+            -- Calculate column length based on base type information
+            column_length := sys.tsql_type_max_length_helper(column_data_type, typelen, typemod);
+        END IF;
+    ELSE
+        -- Calculate column length based on base type information
+        column_length := sys.tsql_type_max_length_helper(column_data_type, typelen, typemod);
+    END IF;
+
+    RETURN column_length;
+END;
+$BODY$
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT;
+
+CREATE OR REPLACE PROCEDURE sys.sp_describe_cursor (INOUT "@cursor_return" refcursor,
+                                                   IN "@cursor_source" nvarchar(30),
+                                                   IN "@cursor_identity" nvarchar(30))
+AS $$
+DECLARE
+  cur refcursor;
+  cursor_source int;
+BEGIN
+  IF pg_catalog.lower("@cursor_source") = 'local' THEN
+    cursor_source := 1;
+  ELSIF pg_catalog.lower("@cursor_source") = 'global' THEN
+    cursor_source := 2;
+  ELSIF pg_catalog.lower("@cursor_source") = 'variable' THEN
+    cursor_source := 3;
+  ELSE
+    RAISE 'invalid @cursor_source: %', "@cursor_source";
+  END IF;
+
+  OPEN cur FOR EXECUTE 'SELECT reference_name::name, cursor_name::name, cursor_scope::smallint, status::smallint, model::smallint, concurrency::smallint, scrollable::smallint, open_status::smallint, cursor_rows::numeric(10,0), fetch_status::smallint, column_count::smallint, row_count::numeric(10,0), last_operation::smallint, cursor_handle::int FROM sys.babelfish_cursor_list($1) WHERE cursor_source = $1 and reference_name = $2' USING cursor_source, "@cursor_identity";
+
+  -- PG cursor evaluates the query at first fetch. We need to evaluate table function now because cursor_list() depeneds on "current" tsql_estate().
+  -- Running MOVE fowrard and backward to force evaluating sys.babelfish_cursor_list() now.
+  MOVE NEXT FROM cur;
+  MOVE PRIOR FROM cur;
+  SELECT cur INTO "@cursor_return";
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON PROCEDURE sys.sp_describe_cursor(
+	INOUT refcursor, IN nvarchar(30), IN nvarchar(30)
+) TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_babelfish_configure(IN "@option_name" varchar(128),  IN "@option_value" varchar(128), IN "@option_scope" varchar(128))
+AS $$
+DECLARE
+  normalized_name varchar(256);
+  default_value text;
+  value_type text;
+  enum_value text[];
+  cnt int;
+  cur refcursor;
+  guc_name varchar(256);
+  server boolean := false;
+  prev_user text;
+BEGIN
+  IF pg_catalog.lower("@option_name") like 'babelfishpg_tsql.%' collate "C" THEN
+    SELECT "@option_name" INTO normalized_name;
+  ELSE
+    SELECT pg_catalog.concat('babelfishpg_tsql.',"@option_name") INTO normalized_name;
+  END IF;
+
+  IF lower("@option_scope") = 'server' THEN
+    server := true;
+  ELSIF btrim("@option_scope") != '' THEN
+    RAISE EXCEPTION 'invalid option: %', "@option_scope";
+  END IF;
+
+  SELECT COUNT(*) INTO cnt FROM sys.babelfish_configurations_view where name collate "C" like normalized_name;
+  IF cnt = 0 THEN 
+    IF pg_catalog.LOWER(normalized_name) = 'babelfishpg_tsql.escape_hatch_unique_constraint' COLLATE C THEN
+      CALl sys.printarg('Config option babelfishpg_tsql.escape_hatch_unique_constraint has been deprecated, babelfish now supports unique constraints on nullable columns');
+    ELSE
+      RAISE EXCEPTION 'unknown configuration: %', normalized_name;
+    END IF;
+  ELSIF cnt > 1 AND (lower("@option_value") != 'ignore' AND lower("@option_value") != 'strict' 
+                AND lower("@option_value") != 'default') THEN
+    RAISE EXCEPTION 'unvalid option: %', lower("@option_value");
+  END IF;
+
+  OPEN cur FOR SELECT name FROM sys.babelfish_configurations_view where name collate "C" like normalized_name;
+  LOOP
+    FETCH NEXT FROM cur into guc_name;
+    exit when not found;
+
+    SELECT boot_val, vartype, enumvals INTO default_value, value_type, enum_value FROM pg_catalog.pg_settings WHERE name = guc_name;
+    IF lower("@option_value") = 'default' THEN
+        PERFORM pg_catalog.set_config(guc_name, default_value, 'false');
+    ELSIF lower("@option_value") = 'ignore' or lower("@option_value") = 'strict' THEN
+      IF value_type = 'enum' AND enum_value = '{"strict", "ignore"}' THEN
+        PERFORM pg_catalog.set_config(guc_name, "@option_value", 'false');
+      ELSE
+        CONTINUE;
+      END IF;
+    ELSE
+        PERFORM pg_catalog.set_config(guc_name, "@option_value", 'false');
+    END IF;
+    IF server THEN
+      SELECT current_user INTO prev_user;
+      PERFORM sys.babelfish_set_role(session_user);
+      IF lower("@option_value") = 'default' THEN
+        EXECUTE format('ALTER DATABASE %s SET %s = %s', CURRENT_DATABASE(), guc_name, default_value);
+      ELSIF lower("@option_value") = 'ignore' or lower("@option_value") = 'strict' THEN
+        IF value_type = 'enum' AND enum_value = '{"strict", "ignore"}' THEN
+          EXECUTE format('ALTER DATABASE %s SET %s = %s', CURRENT_DATABASE(), guc_name, "@option_value");
+        ELSE
+          CONTINUE;
+        END IF;
+      ELSE
+        -- store the setting in PG master database so that it can be applied to all bbf databases
+        EXECUTE format('ALTER DATABASE %s SET %s = %s', CURRENT_DATABASE(), guc_name, "@option_value");
+      END IF;
+      PERFORM sys.babelfish_set_role(prev_user);
+    END IF;
+  END LOOP;
+
+  CLOSE cur;
+
+END;
+$$ LANGUAGE plpgsql;
+GRANT EXECUTE ON PROCEDURE sys.sp_babelfish_configure(
+	IN varchar(128), IN varchar(128), IN varchar(128)
+) TO PUBLIC;
+
+create or replace view sys.tables as
+with tt_internal as MATERIALIZED
+(
+  select * from sys.table_types_internal
+)
+select
+  CAST(t.relname as sys._ci_sysname) as name
+  , CAST(t.oid as int) as object_id
+  , CAST(NULL as int) as principal_id
+  , CAST(t.relnamespace  as int) as schema_id
+  , 0 as parent_object_id
+  , CAST('U' as sys.bpchar(2)) as type
+  , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
+  , CAST((select PG_CATALOG.string_agg(
+                  case
+                  when option like 'bbf_rel_create_date=%%' then substring(option, 21)
+                  else NULL
+                  end, ',')
+          from unnest(t.reloptions) as option)
+        as sys.datetime) as create_date
+  , CAST((select PG_CATALOG.string_agg(
+                  case
+                  when option like 'bbf_rel_create_date=%%' then substring(option, 21)
+                  else NULL
+                  end, ',')
+          from unnest(t.reloptions) as option)
+        as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+  , case reltoastrelid when 0 then 0 else 1 end as lob_data_space_id
+  , CAST(NULL as int) as filestream_data_space_id
+  , CAST(relnatts as int) as max_column_id_used
+  , CAST(0 as sys.bit) as lock_on_bulk_load
+  , CAST(1 as sys.bit) as uses_ansi_nulls
+  , CAST(0 as sys.bit) as is_replicated
+  , CAST(0 as sys.bit) as has_replication_filter
+  , CAST(0 as sys.bit) as is_merge_published
+  , CAST(0 as sys.bit) as is_sync_tran_subscribed
+  , CAST(0 as sys.bit) as has_unchecked_assembly_data
+  , 0 as text_in_row_limit
+  , CAST(0 as sys.bit) as large_value_types_out_of_row
+  , CAST(0 as sys.bit) as is_tracked_by_cdc
+  , CAST(0 as sys.tinyint) as lock_escalation
+  , CAST('TABLE' as sys.nvarchar(60)) as lock_escalation_desc
+  , CAST(0 as sys.bit) as is_filetable
+  , CAST(0 as sys.tinyint) as durability
+  , CAST('SCHEMA_AND_DATA' as sys.nvarchar(60)) as durability_desc
+  , CAST(0 as sys.bit) is_memory_optimized
+  , case relpersistence when 't' then CAST(2 as sys.tinyint) else CAST(0 as sys.tinyint) end as temporal_type
+  , case relpersistence when 't' then CAST('SYSTEM_VERSIONED_TEMPORAL_TABLE' as sys.nvarchar(60)) else CAST('NON_TEMPORAL_TABLE' as sys.nvarchar(60)) end as temporal_type_desc
+  , CAST(null as integer) as history_table_id
+  , CAST(0 as sys.bit) as is_remote_data_archive_enabled
+  , CAST(0 as sys.bit) as is_external
+from pg_class t
+inner join sys.schemas sch on sch.schema_id = t.relnamespace
+left join tt_internal tt on t.oid = tt.typrelid
+where tt.typrelid is null
+and t.relkind = 'r'
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER');
+GRANT SELECT ON sys.tables TO PUBLIC;
+
+create or replace view sys.objects as
+select
+      CAST(t.name as sys.sysname) as name 
+    , CAST(t.object_id as int) as object_id
+    , CAST(t.principal_id as int) as principal_id
+    , CAST(t.schema_id as int) as schema_id
+    , CAST(t.parent_object_id as int) as parent_object_id
+    , CAST('U' as char(2)) as type
+    , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
+    , CAST(t.create_date as sys.datetime) as create_date
+    , CAST(t.modify_date as sys.datetime) as modify_date
+    , CAST(t.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(t.is_published as sys.bit) as is_published
+    , CAST(t.is_schema_published as sys.bit) as is_schema_published
+from  sys.tables t
+union all
+select
+      CAST(v.name as sys.sysname) as name
+    , CAST(v.object_id as int) as object_id
+    , CAST(v.principal_id as int) as principal_id
+    , CAST(v.schema_id as int) as schema_id
+    , CAST(v.parent_object_id as int) as parent_object_id
+    , CAST('V' as char(2)) as type
+    , CAST('VIEW' as sys.nvarchar(60)) as type_desc
+    , CAST(v.create_date as sys.datetime) as create_date
+    , CAST(v.modify_date as sys.datetime) as modify_date
+    , CAST(v.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(v.is_published as sys.bit) as is_published
+    , CAST(v.is_schema_published as sys.bit) as is_schema_published
+from  sys.views v
+union all
+select
+      CAST(f.name as sys.sysname) as name
+    , CAST(f.object_id as int) as object_id
+    , CAST(f.principal_id as int) as principal_id
+    , CAST(f.schema_id as int) as schema_id
+    , CAST(f.parent_object_id as int) as parent_object_id
+    , CAST('F' as char(2)) as type
+    , CAST('FOREIGN_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(f.create_date as sys.datetime) as create_date
+    , CAST(f.modify_date as sys.datetime) as modify_date
+    , CAST(f.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(f.is_published as sys.bit) as is_published
+    , CAST(f.is_schema_published as sys.bit) as is_schema_published
+ from sys.foreign_keys f
+union all
+select
+      CAST(p.name as sys.sysname) as name
+    , CAST(p.object_id as int) as object_id
+    , CAST(p.principal_id as int) as principal_id
+    , CAST(p.schema_id as int) as schema_id
+    , CAST(p.parent_object_id as int) as parent_object_id
+    , CAST('PK' as char(2)) as type
+    , CAST('PRIMARY_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(p.create_date as sys.datetime) as create_date
+    , CAST(p.modify_date as sys.datetime) as modify_date
+    , CAST(p.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(p.is_published as sys.bit) as is_published
+    , CAST(p.is_schema_published as sys.bit) as is_schema_published
+from sys.key_constraints p
+where p.type = 'PK'
+union all
+select
+      CAST(pr.name as sys.sysname) as name
+    , CAST(pr.object_id as int) as object_id
+    , CAST(pr.principal_id as int) as principal_id
+    , CAST(pr.schema_id as int) as schema_id
+    , CAST(pr.parent_object_id as int) as parent_object_id
+    , CAST(pr.type as char(2)) as type
+    , CAST(pr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(pr.create_date as sys.datetime) as create_date
+    , CAST(pr.modify_date as sys.datetime) as modify_date
+    , CAST(pr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(pr.is_published as sys.bit) as is_published
+    , CAST(pr.is_schema_published as sys.bit) as is_schema_published
+ from sys.procedures pr
+union all
+select
+      CAST(tr.name as sys.sysname) as name
+    , CAST(tr.object_id as int) as object_id
+    , CAST(NULL as int) as principal_id
+    , CAST(p.relnamespace as int) as schema_id
+    , CAST(tr.parent_id as int) as parent_object_id
+    , CAST(tr.type as char(2)) as type
+    , CAST(tr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(tr.create_date as sys.datetime) as create_date
+    , CAST(tr.modify_date as sys.datetime) as modify_date
+    , CAST(tr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(0 as sys.bit) as is_published
+    , CAST(0 as sys.bit) as is_schema_published
+  from sys.triggers tr
+  inner join pg_class p on p.oid = tr.parent_id
+union all 
+select
+    CAST(def.name as sys.sysname) as name
+  , CAST(def.object_id as int) as object_id
+  , CAST(def.principal_id as int) as principal_id
+  , CAST(def.schema_id as int) as schema_id
+  , CAST(def.parent_object_id as int) as parent_object_id
+  , CAST(def.type as char(2)) as type
+  , CAST(def.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(def.create_date as sys.datetime) as create_date
+  , CAST(def.modified_date as sys.datetime) as modify_date
+  , CAST(def.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(def.is_published as sys.bit) as is_published
+  , CAST(def.is_schema_published as sys.bit) as is_schema_published
+  from sys.default_constraints def
+union all
+select
+    CAST(chk.name as sys.sysname) as name
+  , CAST(chk.object_id as int) as object_id
+  , CAST(chk.principal_id as int) as principal_id
+  , CAST(chk.schema_id as int) as schema_id
+  , CAST(chk.parent_object_id as int) as parent_object_id
+  , CAST(chk.type as char(2)) as type
+  , CAST(chk.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(chk.create_date as sys.datetime) as create_date
+  , CAST(chk.modify_date as sys.datetime) as modify_date
+  , CAST(chk.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(chk.is_published as sys.bit) as is_published
+  , CAST(chk.is_schema_published as sys.bit) as is_schema_published
+  from sys.check_constraints chk
+union all
+select
+    CAST(p.relname as sys.sysname) as name
+  , CAST(p.oid as int) as object_id
+  , CAST(null as int) as principal_id
+  , CAST(s.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('SO' as char(2)) as type
+  , CAST('SEQUENCE_OBJECT' as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+from pg_class p
+inner join sys.schemas s on s.schema_id = p.relnamespace
+and p.relkind = 'S'
+union all
+select
+    CAST(('TT_' || tt.name collate "C" || '_' || tt.type_table_object_id) as sys.sysname) as name
+  , CAST(tt.type_table_object_id as int) as object_id
+  , CAST(tt.principal_id as int) as principal_id
+  , CAST(tt.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('TT' as char(2)) as type
+  , CAST('TABLE_TYPE' as sys.nvarchar(60)) as type_desc
+  , CAST((select PG_CATALOG.string_agg(
+                    case
+                    when option like 'bbf_rel_create_date=%%' then substring(option, 21)
+                    else NULL
+                    end, ',')
+          from unnest(c.reloptions) as option)
+     as sys.datetime) as create_date
+  , CAST((select PG_CATALOG.string_agg(
+                    case
+                    when option like 'bbf_rel_create_date=%%' then substring(option, 21)
+                    else NULL
+                    end, ',')
+          from unnest(c.reloptions) as option)
+     as sys.datetime) as modify_date
+  , CAST(1 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+from sys.table_types tt
+inner join pg_class c on tt.type_table_object_id = c.oid;
+GRANT SELECT ON sys.objects TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.syslanguages
+AS
+SELECT
+    lang_id AS langid,
+    CAST(pg_catalog.lower(lang_data_jsonb ->> 'date_format'::TEXT) AS SYS.NCHAR(3)) AS dateformat,
+    CAST(lang_data_jsonb -> 'date_first'::TEXT AS SYS.TINYINT) AS datefirst,
+    CAST(NULL AS INT) AS upgrade,
+    CAST(coalesce(lang_name_mssql, lang_name_pg) AS SYS.SYSNAME) AS name,
+    CAST(coalesce(lang_alias_mssql, lang_alias_pg) AS SYS.SYSNAME) AS alias,
+    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_names'::TEXT)), ',') AS SYS.NVARCHAR(372)) AS months,
+    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'months_shortnames'::TEXT)),',') AS SYS.NVARCHAR(132)) AS shortmonths,
+    CAST(array_to_string(ARRAY(SELECT jsonb_array_elements_text(lang_data_jsonb -> 'days_shortnames'::TEXT)),',') AS SYS.NVARCHAR(217)) AS days,
+    CAST(NULL AS INT) AS lcid,
+    CAST(NULL AS SMALLINT) AS msglangid
+FROM sys.babelfish_syslanguages;
+GRANT SELECT ON sys.syslanguages TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.servers
+AS
+SELECT
+  CAST(f.oid as int) AS server_id,
+  CAST(f.srvname as sys.sysname) AS name,
+  CAST('' as sys.sysname) AS product,
+  CAST('tds_fdw' as sys.sysname) AS provider,
+  CAST((select PG_CATALOG.string_agg(
+                  case
+                  when option like 'servername=%%' then substring(option, 12)
+                  else NULL
+                  end, ',')
+          from unnest(f.srvoptions) as option) as sys.nvarchar(4000)) AS data_source,
+  CAST(NULL as sys.nvarchar(4000)) AS location,
+  CAST(NULL as sys.nvarchar(4000)) AS provider_string,
+  CAST((select PG_CATALOG.string_agg(
+                  case
+                  when option like 'database=%%' then substring(option, 10)
+                  else NULL
+                  end, ',')
+          from unnest(f.srvoptions) as option) as sys.sysname) AS catalog,
+  CAST(s.connect_timeout as int) AS connect_timeout,
+  CAST(s.query_timeout as int) AS query_timeout,
+  CAST(1 as sys.bit) AS is_linked,
+  CAST(0 as sys.bit) AS is_remote_login_enabled,
+  CAST(0 as sys.bit) AS is_rpc_out_enabled,
+  CAST(1 as sys.bit) AS is_data_access_enabled,
+  CAST(0 as sys.bit) AS is_collation_compatible,
+  CAST(1 as sys.bit) AS uses_remote_collation,
+  CAST(NULL as sys.sysname) AS collation_name,
+  CAST(0 as sys.bit) AS lazy_schema_validation,
+  CAST(0 as sys.bit) AS is_system,
+  CAST(0 as sys.bit) AS is_publisher,
+  CAST(0 as sys.bit) AS is_subscriber,
+  CAST(0 as sys.bit) AS is_distributor,
+  CAST(0 as sys.bit) AS is_nonsql_subscriber,
+  CAST(1 as sys.bit) AS is_remote_proc_transaction_promotion_enabled,
+  CAST(NULL as sys.datetime) AS modify_date,
+  CAST(0 as sys.bit) AS is_rda_server
+FROM pg_foreign_server AS f
+LEFT JOIN pg_foreign_data_wrapper AS w ON f.srvfdw = w.oid
+LEFT JOIN sys.babelfish_server_options AS s on f.srvname = s.servername
+WHERE w.fdwname = 'tds_fdw';
+GRANT SELECT ON sys.servers TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.linked_logins
+AS
+SELECT
+  CAST(u.srvid as int) AS server_id,
+  CAST(0 as int) AS local_principal_id,
+  CAST(0 as sys.bit) AS uses_self_credential,
+  CAST((select PG_CATALOG.string_agg(
+                  case
+                  when option like 'username=%%' then substring(option, 10)
+                  else NULL
+                  end, ',')
+          from unnest(u.umoptions) as option) as sys.sysname) AS remote_name,
+  CAST(NULL as sys.datetime) AS modify_date
+FROM pg_user_mappings AS U
+LEFT JOIN pg_foreign_server AS f ON u.srvid = f.oid
+LEFT JOIN pg_foreign_data_wrapper AS w ON f.srvfdw = w.oid
+WHERE w.fdwname = 'tds_fdw';
+GRANT SELECT ON sys.linked_logins TO PUBLIC;
+
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();
 

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -78,3 +78,4 @@ Unexpected drop found for procedure sys.babelfish_update_user_catalog_for_guest_
 Unexpected drop found for procedure sys.create_xp_qv_in_master_dbo in file babelfishpg_tsql--1.1.0--1.2.0.sql
 Unexpected drop found for procedure sys.sp_babelfish_grant_usage_to_all in file babelfishpg_tsql--1.1.0--1.2.0.sql
 Unexpected drop found for table "#temp_schedules_to_delete" in file babelfishpg_tsql--3.6.0--3.7.0.sql
+Unexpected drop found for table "#temp_schedules_to_delete" in file babelfishpg_tsql--3.8.0--3.9.0.sql


### PR DESCRIPTION
## Description

### 1. Issues
- As an effort to fix string functions, we introduced various function definitions is sys schema, but there are a few places where we overlooked to prepend PG_CATALOG in the function calls inside system view/functions which may cause mVU/MVU failures due to error while executing upgrade scripts due to invalid argument type.
- Affected functions were - RTRIM, STRING_AGG, SUBSTRING, LOWER.

### 2. Changes made to fix the issues
- Prepended appropriate namespace at suitable function calls as a proactive measure to prevent m/MVU failures, Since, invalid datatypes for sys function definitions which can cause issue will now be redirected to pg_catalog function definitions and will work correctly as before.

cherry-picked: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3138
Task: BABEL- 5362
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**

* **Memory tests -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).