### PR TITLE
Add logic to remove guest membership from logins having mapped user

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
@@ -11,6 +11,16 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
  * final behaviour.
  */
 
+-- This is a temporary procedure which is only meant to be called during upgrade
+CREATE OR REPLACE PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins()
+LANGUAGE C
+AS 'babelfishpg_tsql', 'revoke_guest_from_mapped_logins';
+
+CALL sys.babelfish_revoke_guest_from_mapped_logins();
+
+-- Drop this procedure after it gets executed once.
+DROP PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins();
+
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();
 

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -66,6 +66,7 @@ Unexpected drop found for procedure sys.babelfish_drop_deprecated_view in file b
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--2.1.0--2.2.0.sql
 Unexpected drop found for procedure sys.babelfish_remove_object_from_extension in file babelfishpg_tsql--3.0.0--3.1.0.sql
 Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--3.7.0--3.8.0.sql
+Unexpected drop found for procedure sys.babelfish_revoke_guest_from_mapped_logins in file babelfishpg_tsql--3.8.0--3.9.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_common--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.2.0--2.3.0.sql
 Unexpected drop found for procedure sys.babelfish_update_collation_to_default in file babelfishpg_tsql--2.3.0--3.0.0.sql


### PR DESCRIPTION
### Description
Add upgrade logic to remove guest membership from logins having mapped user
in babelfishpg_tsql--3.8.0--3.9.0 upgrade script.

Task: BABEL-5438
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).