### PR TITLE
Update is_fixed_role column in babelfish catalog for logins and use

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -382,7 +382,7 @@ CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.default_database_name END AS SY
 CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
 CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.credential_id END AS INT) AS credential_id,
 CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.owning_principal_id END AS INT) AS owning_principal_id,
-CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.is_fixed_role END AS sys.BIT) AS is_fixed_role
+CAST(Ext.is_fixed_role AS sys.BIT) AS is_fixed_role
 FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname
 WHERE (pg_has_role(suser_id(), 'sysadmin'::TEXT, 'MEMBER') 
   OR pg_has_role(suser_id(), 'securityadmin'::TEXT, 'MEMBER')

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -212,6 +212,7 @@ $$;
 CREATE OR REPLACE FUNCTION sys.bbf_is_member_of_role_nosuper(OID, OID)
 RETURNS BOOLEAN AS 'babelfishpg_tsql', 'bbf_is_member_of_role_nosuper'
 LANGUAGE C STABLE STRICT PARALLEL SAFE;
+
 -- SERVER_PRINCIPALS
 CREATE OR REPLACE VIEW sys.server_principals
 AS SELECT
@@ -234,7 +235,7 @@ CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.default_database_name END AS SY
 CAST(Ext.default_language_name AS SYS.SYSNAME) AS default_language_name,
 CAST(CASE WHEN Ext.type = 'R' THEN NULL ELSE Ext.credential_id END AS INT) AS credential_id,
 CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.owning_principal_id END AS INT) AS owning_principal_id,
-CAST(CASE WHEN Ext.type = 'R' THEN 1 ELSE Ext.is_fixed_role END AS sys.BIT) AS is_fixed_role
+CAST(Ext.is_fixed_role AS sys.BIT) AS is_fixed_role
 FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname
 WHERE (pg_has_role(suser_id(), 'sysadmin'::TEXT, 'MEMBER') 
   OR pg_has_role(suser_id(), 'securityadmin'::TEXT, 'MEMBER')
@@ -258,6 +259,7 @@ CAST(NULL AS INT) AS credential_id,
 CAST(1 AS INT) AS owning_principal_id,
 CAST(0 AS sys.BIT) AS is_fixed_role;
 GRANT SELECT ON sys.server_principals TO PUBLIC;
+
 -- login_token
 CREATE OR REPLACE VIEW sys.login_token
 AS SELECT

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -182,11 +182,18 @@ CREATE OR REPLACE VIEW information_schema_tsql.table_constraints AS
 
 GRANT SELECT ON information_schema_tsql.table_constraints TO PUBLIC;
 
+-- At this point, there will be only one server role which is sysadmin.
+UPDATE sys.babelfish_authid_login_ext SET is_fixed_role = 1 WHERE rolename = 'sysadmin';
+
+UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 1 WHERE orig_username = 'db_owner';
+UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 0 WHERE orig_username != 'db_owner';
+
 CREATE OR REPLACE PROCEDURE sys.create_db_roles_during_upgrade()
 LANGUAGE C
 AS 'babelfishpg_tsql', 'create_db_roles_during_upgrade';
 CALL sys.create_db_roles_during_upgrade();
 DROP PROCEDURE sys.create_db_roles_during_upgrade();
+
 DO
 LANGUAGE plpgsql
 $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -183,7 +183,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.table_constraints AS
 GRANT SELECT ON information_schema_tsql.table_constraints TO PUBLIC;
 
 -- At this point, there will be only one server role which is sysadmin.
-UPDATE sys.babelfish_authid_login_ext SET is_fixed_role = 1 WHERE rolename = 'sysadmin';
+UPDATE sys.babelfish_authid_login_ext SET is_fixed_role = 1 WHERE rolname = 'sysadmin';
 
 UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 1 WHERE orig_username = 'db_owner';
 UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 0 WHERE orig_username != 'db_owner';

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -185,6 +185,7 @@ GRANT SELECT ON information_schema_tsql.table_constraints TO PUBLIC;
 -- At this point, there will be only one server role which is sysadmin.
 UPDATE sys.babelfish_authid_login_ext SET is_fixed_role = 1 WHERE rolname = 'sysadmin';
 
+-- At this point, there will be only one database fixed role which is db_owner.
 UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 1 WHERE orig_username = 'db_owner';
 UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 0 WHERE orig_username != 'db_owner';
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -1610,7 +1610,7 @@ create_db_roles_in_database(const char *dbname, List *parsetree_list)
 
 /*
 * This function is only being used during upgrade to v4.4.0
-* to create database roles db_accessadmin for each database
+* to create database roles for each database
 */
 PG_FUNCTION_INFO_V1(create_db_roles_during_upgrade);
 Datum

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2004,18 +2004,18 @@ extern bool insert_bulk_check_constraints;
 #define DB_DDLADMIN "db_ddladmin"
 
 #define IS_BBF_BUILT_IN_DB(dbname) \
-    (strcmp(dbname, "master") == 0 || \
-     strcmp(dbname, "tempdb") == 0 || \
-     strcmp(dbname, "msdb") == 0)
+    ((strlen(dbname) == 6 && strncmp(dbname, "master", 6) == 0)|| \
+     (strlen(dbname) == 6 && strncmp(dbname, "tempdb", 6) == 0)|| \
+     (strlen(dbname) == 4 && strncmp(dbname, "msdb", 4) == 0))
 
 #define IS_FIXED_DB_PRINCIPAL(rolname) \
-	(strcmp(rolname, DBO) == 0 || \
-	 strcmp(rolname, DB_OWNER) == 0 || \
-	 strcmp(rolname, DB_ACCESSADMIN) == 0 || \
-	 strcmp(rolname, DB_SECURITYADMIN) == 0 || \
-	 strcmp(rolname, DB_DATAREADER) == 0 || \
-	 strcmp(rolname, DB_DATAWRITER) == 0 || \
-	 strcmp(rolname, DB_DDLADMIN) == 0)
+	((strlen(rolname) == 3 && strncmp(rolname, DBO, 3) == 0) || \
+	 (strlen(rolname) == 8 && strncmp(rolname, DB_OWNER, 8) == 0) || \
+	 (strlen(rolname) == 14 && strncmp(rolname, DB_ACCESSADMIN, 14) == 0) || \
+	 (strlen(rolname) == 16 && strncmp(rolname, DB_SECURITYADMIN, 16) == 0) || \
+	 (strlen(rolname) == 13 && strncmp(rolname, DB_DATAREADER, 13) == 0) || \
+	 (strlen(rolname) == 13 && strncmp(rolname, DB_DATAWRITER, 13) == 0) || \
+	 (strlen(rolname) == 11 && strncmp(rolname, DB_DDLADMIN, 11) == 0))
 
 /**********************************************************************
  * Function declarations

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1257,7 +1257,7 @@ add_to_bbf_authid_user_ext(const char *user_name,
 	else
 		new_record_user_ext[USER_EXT_TYPE] = CStringGetTextDatum("S");
 	new_record_user_ext[USER_EXT_OWNING_PRINCIPAL_ID] = Int32GetDatum(-1);	/* placeholder */
-	if (strcmp(orig_user_name, DBO) != 0 && IS_FIXED_DB_PRINCIPAL(orig_user_name))
+	if (strncmp(orig_user_name, DBO, 3) != 0 && IS_FIXED_DB_PRINCIPAL(orig_user_name))
 		new_record_user_ext[USER_EXT_IS_FIXED_ROLE] = Int32GetDatum(1);
 	else
 		new_record_user_ext[USER_EXT_IS_FIXED_ROLE] = Int32GetDatum(0);

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -157,7 +157,10 @@ create_bbf_authid_login_ext(CreateRoleStmt *stmt)
 
 	new_record_login_ext[LOGIN_EXT_CREDENTIAL_ID] = Int32GetDatum(-1);	/* placeholder */
 	new_record_login_ext[LOGIN_EXT_OWNING_PRINCIPAL_ID] = Int32GetDatum(-1);	/* placeholder */
-	new_record_login_ext[LOGIN_EXT_IS_FIXED_ROLE] = Int32GetDatum(0);
+	if (IS_BBF_FIXED_SERVER_ROLE(stmt->role))
+		new_record_login_ext[LOGIN_EXT_IS_FIXED_ROLE] = Int32GetDatum(1);
+	else
+		new_record_login_ext[LOGIN_EXT_IS_FIXED_ROLE] = Int32GetDatum(0);
 	new_record_login_ext[LOGIN_EXT_CREATE_DATE] = TimestampTzGetDatum(GetSQLCurrentTimestamp(-1));
 	new_record_login_ext[LOGIN_EXT_MODIFY_DATE] = TimestampTzGetDatum(GetSQLCurrentTimestamp(-1));
 	new_record_login_ext[LOGIN_EXT_DEFAULT_DATABASE_NAME] = CStringGetTextDatum(default_database);
@@ -1254,7 +1257,10 @@ add_to_bbf_authid_user_ext(const char *user_name,
 	else
 		new_record_user_ext[USER_EXT_TYPE] = CStringGetTextDatum("S");
 	new_record_user_ext[USER_EXT_OWNING_PRINCIPAL_ID] = Int32GetDatum(-1);	/* placeholder */
-	new_record_user_ext[USER_EXT_IS_FIXED_ROLE] = Int32GetDatum(-1);	/* placeholder */
+	if (strcmp(orig_user_name, DBO) != 0 && IS_FIXED_DB_PRINCIPAL(orig_user_name))
+		new_record_user_ext[USER_EXT_IS_FIXED_ROLE] = Int32GetDatum(1);
+	else
+		new_record_user_ext[USER_EXT_IS_FIXED_ROLE] = Int32GetDatum(0);
 	new_record_user_ext[USER_EXT_AUTHENTICATION_TYPE] = Int32GetDatum(-1);	/* placeholder */
 	new_record_user_ext[USER_EXT_DEFAULT_LANGUAGE_LCID] = Int32GetDatum(-1);	/* placeholder */
 	new_record_user_ext[USER_EXT_ALLOW_ENCRYPTED_VALUE_MODIFICATIONS] = Int32GetDatum(-1);	/* placeholder */

--- a/test/JDBC/expected/datareader_datawriter.out
+++ b/test/JDBC/expected/datareader_datawriter.out
@@ -239,19 +239,19 @@ go
 alter role db_datawriter add member db_roles_r1; 
 go
 
-select count(*) from sys.database_principals where name like '%db_datareader%';
+select name, is_fixed_role from sys.database_principals where name like '%db_datareader%' order by name;
 go
 ~~START~~
-int
-1
+varchar#!#bit
+db_datareader#!#1
 ~~END~~
 
 
-select count(*) from sys.database_principals where name like '%db_datawriter%';
+select name, is_fixed_role from sys.database_principals where name like '%db_datawriter%' order by name;
 go
 ~~START~~
-int
-1
+varchar#!#bit
+db_datawriter#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/single_db/datareader_datawriter.out
+++ b/test/JDBC/expected/single_db/datareader_datawriter.out
@@ -239,19 +239,19 @@ go
 alter role db_datawriter add member db_roles_r1; 
 go
 
-select count(*) from sys.database_principals where name like '%db_datareader%';
+select name, is_fixed_role from sys.database_principals where name like '%db_datareader%' order by name;
 go
 ~~START~~
-int
-1
+varchar#!#bit
+db_datareader#!#1
 ~~END~~
 
 
-select count(*) from sys.database_principals where name like '%db_datawriter%';
+select name, is_fixed_role from sys.database_principals where name like '%db_datawriter%' order by name;
 go
 ~~START~~
-int
-1
+varchar#!#bit
+db_datawriter#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/sys_database_principals_dep-vu-verify.out
+++ b/test/JDBC/expected/sys_database_principals_dep-vu-verify.out
@@ -2,8 +2,8 @@ SELECT * FROM database_principals_dep_vu_prepare_view
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#varchar#!#bit#!#int#!#varchar#!#bit
-database_principals_dep_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
-database_principals_dep_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
+database_principals_dep_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
 ~~END~~
 
 
@@ -11,8 +11,8 @@ EXEC database_principals_dep_vu_prepare_proc
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#varchar#!#bit#!#int#!#varchar#!#bit
-database_principals_dep_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
-database_principals_dep_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
+database_principals_dep_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-prepare.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-prepare.out
@@ -40,7 +40,7 @@ ORDER BY name;
 GO
 ~~START~~
 nvarchar#!#bit
-db_owner#!#0
-dbo#!#0
+db_owner#!#1
+dbo#!#1
 ~~END~~
 

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-prepare.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-prepare.out
@@ -34,3 +34,13 @@ RETURN (SELECT COUNT(*) FROM sys.database_principals WHERE name LIKE '%database_
 END
 GO
 
+SELECT name, is_fixed_role FROM sys.database_principals
+WHERE name IN ('dbo', 'db_owner')
+ORDER BY name;
+GO
+~~START~~
+nvarchar#!#bit
+db_owner#!#0
+dbo#!#0
+~~END~~
+

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
@@ -35,3 +35,13 @@ database_principals_dep_for_13_x_vu_prepare_user2
 ~~END~~
 
 
+SELECT name, is_fixed_role FROM sys.database_principals
+WHERE name IN ('dbo', 'db_owner')
+ORDER BY name;
+GO
+~~START~~
+varchar#!#bit
+db_owner#!#1
+dbo#!#0
+~~END~~
+

--- a/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_database_principals_dep_for_13_x-vu-verify.out
@@ -2,8 +2,8 @@ SELECT * FROM database_principals_dep_for_13_x_vu_prepare_view
 GO
 ~~START~~
 nvarchar#!#char#!#nvarchar#!#nvarchar#!#bit#!#int#!#nvarchar#!#bit
-database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
-database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
+database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
 ~~END~~
 
 
@@ -11,8 +11,8 @@ EXEC database_principals_dep_for_13_x_vu_prepare_proc
 GO
 ~~START~~
 varchar#!#char#!#nvarchar#!#varchar#!#bit#!#int#!#varchar#!#bit
-database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
-database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#1#!#-1#!#English#!#1
+database_principals_dep_for_13_x_vu_prepare_user1#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
+database_principals_dep_for_13_x_vu_prepare_user2#!#S#!#SQL_USER#!#dbo#!#0#!#-1#!#English#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-prepare.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-prepare.out
@@ -35,6 +35,5 @@ GO
 ~~START~~
 varchar#!#bit
 jdbc_user#!#0
-sysadmin#!#1
 ~~END~~
 

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-prepare.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-prepare.out
@@ -28,3 +28,13 @@ RETURN (SELECT COUNT(*) FROM sys.server_principals WHERE name LIKE '%sys_server_
 END
 GO
 
+SELECT name, is_fixed_role FROM sys.server_principals
+WHERE name IN ('sysadmin', 'jdbc_user')
+ORDER BY name
+GO
+~~START~~
+varchar#!#bit
+jdbc_user#!#0
+sysadmin#!#1
+~~END~~
+

--- a/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-verify.out
+++ b/test/JDBC/expected/sys_server_principals_dep_for_13_x-vu-verify.out
@@ -35,3 +35,13 @@ sys_server_principals_dep_for_13_x_vu_prepare_login2
 ~~END~~
 
 
+SELECT name, is_fixed_role FROM sys.server_principals
+WHERE name IN ('sysadmin', 'jdbc_user')
+ORDER BY name
+GO
+~~START~~
+varchar#!#bit
+jdbc_user#!#0
+sysadmin#!#1
+~~END~~
+

--- a/test/JDBC/input/datareader_datawriter.mix
+++ b/test/JDBC/input/datareader_datawriter.mix
@@ -168,10 +168,10 @@ go
 alter role db_datawriter add member db_roles_r1; 
 go
 
-select count(*) from sys.database_principals where name like '%db_datareader%';
+select name, is_fixed_role from sys.database_principals where name like '%db_datareader%' order by name;
 go
 
-select count(*) from sys.database_principals where name like '%db_datawriter%';
+select name, is_fixed_role from sys.database_principals where name like '%db_datawriter%' order by name;
 go
 
 -- Test sp_helpuser

--- a/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-prepare.sql
@@ -34,3 +34,7 @@ RETURN (SELECT COUNT(*) FROM sys.database_principals WHERE name LIKE '%database_
 END
 GO
 
+SELECT name, is_fixed_role FROM sys.database_principals
+WHERE name IN ('dbo', 'db_owner')
+ORDER BY name;
+GO

--- a/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_database_principals_dep_for_13_x-vu-verify.sql
@@ -12,3 +12,7 @@ WHERE name LIKE '%database_principals_dep_for_13_x_vu_prepare_%'
 ORDER BY name
 GO
 
+SELECT name, is_fixed_role FROM sys.database_principals
+WHERE name IN ('dbo', 'db_owner')
+ORDER BY name;
+GO

--- a/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-prepare.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-prepare.sql
@@ -28,3 +28,7 @@ RETURN (SELECT COUNT(*) FROM sys.server_principals WHERE name LIKE '%sys_server_
 END
 GO
 
+SELECT name, is_fixed_role FROM sys.server_principals
+WHERE name IN ('sysadmin', 'jdbc_user')
+ORDER BY name
+GO

--- a/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-verify.sql
+++ b/test/JDBC/input/ownership/sys_server_principals_dep_for_13_x-vu-verify.sql
@@ -12,3 +12,7 @@ WHERE name LIKE 'sys_server_principals_dep_for_13_x_vu_prepare_login%'
 ORDER BY name
 GO
 
+SELECT name, is_fixed_role FROM sys.server_principals
+WHERE name IN ('sysadmin', 'jdbc_user')
+ORDER BY name
+GO


### PR DESCRIPTION
### Description

Update the is_fixed_role column in babelfish catalogs `babelfish_authid_login_ext` and `babelfish_authid_user_ext` for fixed database and server roles.

### Issues Resolved

Task: BABEL-5333
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).