### PR TITLE
Fix timezone offset in case of non-default timezone

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1196,8 +1196,7 @@ BEGIN
         input_expr_tx := input_expr::TEXT;
         input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
 
-        result := (SELECT input_expr_tmz AT TIME ZONE tz_name)::TEXT;
-        tz_diff := (SELECT result::TIMESTAMPTZ - input_expr_tmz)::TEXT;
+        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
         if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
             tz_diff := PG_CATALOG.concat('+',tz_diff);
         END IF;
@@ -1208,7 +1207,7 @@ BEGIN
         input_expr_tx := input_expr::TEXT;
         input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
         result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
-        tz_diff := (SELECT result::TIMESTAMPTZ - input_expr_tmz)::TEXT;
+        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
         if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
             tz_diff := PG_CATALOG.concat('+',tz_diff);
         END IF;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -2540,8 +2540,7 @@ BEGIN
         input_expr_tx := input_expr::TEXT;
         input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
 
-        result := (SELECT input_expr_tmz AT TIME ZONE tz_name)::TEXT;
-        tz_diff := (SELECT result::TIMESTAMPTZ - input_expr_tmz)::TEXT;
+        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
         if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
             tz_diff := PG_CATALOG.concat('+',tz_diff);
         END IF;
@@ -2552,7 +2551,7 @@ BEGIN
         input_expr_tx := input_expr::TEXT;
         input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
         result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
-        tz_diff := (SELECT result::TIMESTAMPTZ - input_expr_tmz)::TEXT;
+        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
         if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
             tz_diff := PG_CATALOG.concat('+',tz_diff);
         END IF;

--- a/test/JDBC/expected/ATTIMEZONE-dep-vu-verify.out
+++ b/test/JDBC/expected/ATTIMEZONE-dep-vu-verify.out
@@ -44,3 +44,83 @@ datetimeoffset
 
 ~~ERROR (Message: Argument data type varchar is invalid for argument 1 of AT TIME ZONE function.)~~
 
+
+Select convert(datetime2,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+~~START~~
+datetimeoffset
+2002-01-01 02:01:00.0000000 -05:00
+~~END~~
+
+
+Select convert(datetime2,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+~~START~~
+datetimeoffset
+9999-12-31 15:59:59.0000000 +01:00
+~~END~~
+
+
+Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+~~START~~
+datetimeoffset
+2001-12-31 21:01:00.0000000 -05:00
+~~END~~
+
+
+Select convert(datetimeoffset,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+~~START~~
+datetimeoffset
+9999-12-31 16:59:59.0000000 +01:00
+~~END~~
+
+
+select set_config('timezone', 'Asia/Kolkata', false);
+GO
+~~START~~
+text
+Asia/Kolkata
+~~END~~
+
+
+Select convert(datetime2,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+~~START~~
+datetimeoffset
+2002-01-01 02:01:00.0000000 -05:00
+~~END~~
+
+
+Select convert(datetime2,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+~~START~~
+datetimeoffset
+9999-12-31 15:59:59.0000000 +01:00
+~~END~~
+
+
+Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+~~START~~
+datetimeoffset
+2001-12-31 21:01:00.0000000 -05:00
+~~END~~
+
+
+Select convert(datetimeoffset,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+~~START~~
+datetimeoffset
+9999-12-31 16:59:59.0000000 +01:00
+~~END~~
+
+
+select set_config('timezone', 'UTC', false);
+GO
+~~START~~
+text
+UTC
+~~END~~
+

--- a/test/JDBC/input/ATTIMEZONE-dep-vu-verify.sql
+++ b/test/JDBC/input/ATTIMEZONE-dep-vu-verify.sql
@@ -15,3 +15,33 @@ GO
 
 SELECT ATTIMEZONE_dep_vu_prepare_f2()
 GO
+
+Select convert(datetime2,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+
+Select convert(datetime2,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+
+Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+
+Select convert(datetimeoffset,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+
+select set_config('timezone', 'Asia/Kolkata', false);
+GO
+
+Select convert(datetime2,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+
+Select convert(datetime2,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+
+Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
+GO
+
+Select convert(datetimeoffset,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+
+select set_config('timezone', 'UTC', false);
+GO


### PR DESCRIPTION
## Description

### 1. Issue
- When the default timezone is not `UTC` then the result shows incorrect timezone offset value with `AT TIME ZONE` property. This is due to the fact that the timezone offset which is calculated using input_expr_tmz which is text explicitly converted to TIMESTAMPTZ which takes into account the current session timezone setting which produces this timezone difference in the output.

### 2. Changes made to fix the issue
- We will now calculate the timezone offset with absolute value of timezone that is by subtracting the datetime value in current timezone with the value in UTC timezone.
```
# Previous output (incorrect)
1> Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
2> go
timezone                                     
---------------------------------------------
           2001-12-31 21:01:00.0000000 -05:00

(1 rows affected)
1> select set_config('timezone', 'Asia/Kolkata', false)
2> go
set_config                                                                                                                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Asia/Kolkata                                                                                                                                                                                                                                                    

(1 rows affected)
1> Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
2> go
timezone                                     
---------------------------------------------
           2001-12-31 21:01:00.0000000 -10:30
```
```
# Current output (Correct)
1> Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
2> go
timezone                                     
---------------------------------------------
           2001-12-31 21:01:00.0000000 -05:00

(1 rows affected)
1> select set_config('timezone', 'Asia/Kolkata', false)
2> go
set_config                                                                                                                                                                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Asia/Kolkata                                                                                                                                                                                                                                                    

(1 rows affected)
1> Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'eastern standard time';
2> go
timezone                                     
---------------------------------------------
           2001-12-31 21:01:00.0000000 -05:00
```
- Added test cases for the issue.

Task: BABEL- 5316
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)



### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**

* **Memory tests -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).