### PR TITLE
 Use AccessExclusiveLock for truncating Babelfish catalogs

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1376,10 +1376,10 @@ void
 clean_up_bbf_server_def()
 {
 	/* Fetch the relation */
-	Relation bbf_servers_def_rel = table_open(get_bbf_servers_def_oid(), RowExclusiveLock);
+	Relation bbf_servers_def_rel = table_open(get_bbf_servers_def_oid(), AccessExclusiveLock);
 	/* Truncate the relation */
 	heap_truncate_one_rel(bbf_servers_def_rel);
-	table_close(bbf_servers_def_rel, RowExclusiveLock);
+	table_close(bbf_servers_def_rel, AccessExclusiveLock);
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2624,12 +2624,12 @@ babelfish_truncate_domain_mapping_table_internal(PG_FUNCTION_ARGS)
 				 errmsg("Current login %s does not have permission to remove domain mapping entry",
 						GetUserNameFromId(GetSessionUserId(), true))));
 
-	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), RowExclusiveLock);
+	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), AccessExclusiveLock);
 
 	/* Truncate the relation */
 	heap_truncate_one_rel(bbf_domain_mapping_rel);
 
-	table_close(bbf_domain_mapping_rel, RowExclusiveLock);
+	table_close(bbf_domain_mapping_rel, AccessExclusiveLock);
 	return (Datum) 0;
 }
 

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -76,6 +76,38 @@ int#!#varchar
 ~~END~~
 
 
+-- Invalid server name (Should throw error)
+SELECT * FROM invalid_server.master.dbo.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "invalid_server" does not exist)~~
+
+
+-- Invalid database name (Should throw error)
+SELECT * FROM bbf_fpn_server.invalid_db.dbo.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "invalid_db_dbo.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- Invalid schema name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.invalid_schema.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- Invalid object name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.dbo.invalid_fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
 -- four part object is a procedure (Should throw error)
 EXEC bbf_fpn_server.master.dbo.sp_linkedserver
 GO

--- a/test/JDBC/expected/single_db/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/single_db/four-part-names-vu-verify.out
@@ -76,6 +76,38 @@ int#!#varchar
 ~~END~~
 
 
+-- Invalid server name (Should throw error)
+SELECT * FROM invalid_server.master.dbo.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: server "invalid_server" does not exist)~~
+
+
+-- Invalid database name (Should throw error)
+SELECT * FROM bbf_fpn_server.invalid_db.dbo.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "invalid_db_dbo.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- Invalid schema name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.invalid_schema.fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
+-- Invalid object name (Should throw error)
+SELECT * FROM bbf_fpn_server.master.dbo.invalid_fpn_table
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+
+
 -- four part object is a procedure (Should throw error)
 EXEC bbf_fpn_server.master.dbo.sp_linkedserver
 GO

--- a/test/JDBC/expected/single_db/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/single_db/four-part-names-vu-verify.out
@@ -89,7 +89,7 @@ SELECT * FROM bbf_fpn_server.invalid_db.dbo.fpn_table
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "invalid_db_dbo.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: database "invalid_db" does not exist. Make sure that the name is entered correctly., Server: BABELFISH, Process: , Line: 1, Level: 16)~~
 
 
 -- Invalid schema name (Should throw error)

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -501,4 +501,5 @@ ignore#!#pgr_zzz_clean_up
 ignore#!#BABEL-3292
 ignore#!#BABEL-3512
 ignore#!#babel_collection
-ignore#!#BABEL-SP_TABLE_PRIVILEGES # getting timed out (TODO: BABEL-5353)
+# getting timed out (TODO: BABEL-5353)
+ignore#!#BABEL-SP_TABLE_PRIVILEGES

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,15 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+four-part-names-vu-prepare
+four-part-names-vu-verify
+four-part-names-vu-cleanup
+BABEL-4168-vu-prepare
+BABEL-4168-vu-verify
+BABEL-4168-vu-cleanup
+openquery-vu-prepare
+openquery-vu-verify
+openquery-vu-cleanup
 
 ignore#!#BABEL-1435
 ignore#!#BABEL-1446
@@ -501,13 +509,4 @@ ignore#!#pgr_zzz_clean_up
 ignore#!#BABEL-3292
 ignore#!#BABEL-3512
 ignore#!#babel_collection
-ignore#!#four-part-names-vu-prepare
-ignore#!#four-part-names-vu-verify
-ignore#!#four-part-names-vu-cleanup
-ignore#!#BABEL-4168-vu-prepare
-ignore#!#BABEL-4168-vu-verify
-ignore#!#BABEL-4168-vu-cleanup
-ignore#!#openquery-vu-prepare
-ignore#!#openquery-vu-verify
-ignore#!#openquery-vu-cleanup
 ignore#!#BABEL-SP_TABLE_PRIVILEGES # getting timed out (TODO: BABEL-5353)

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,15 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-four-part-names-vu-prepare
-four-part-names-vu-verify
-four-part-names-vu-cleanup
-BABEL-4168-vu-prepare
-BABEL-4168-vu-verify
-BABEL-4168-vu-cleanup
-openquery-vu-prepare
-openquery-vu-verify
-openquery-vu-cleanup
+all
 
 ignore#!#BABEL-1435
 ignore#!#BABEL-1446

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -249,7 +249,7 @@ nested_trigger_with_dml
 newid
 objectpropertyex
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_11/schedule
+++ b/test/JDBC/upgrade/15_11/schedule
@@ -249,7 +249,7 @@ nested_trigger_with_dml
 newid
 objectpropertyex
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -233,7 +233,7 @@ nested_trigger_with_dml
 newid_before_14_12_or_15_7_or_16_3
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd
+openquery_upgrd
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -236,7 +236,7 @@ nested_trigger_with_dml
 newid_before_14_12_or_15_7_or_16_3
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -243,7 +243,7 @@ nested_trigger_with_dml
 newid_before_14_12_or_15_7_or_16_3
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -249,7 +249,7 @@ nested_trigger_with_dml
 newid_before_14_12_or_15_7_or_16_3
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -250,7 +250,7 @@ nested_trigger_with_dml
 newid_before_15_8_or_16_4
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -249,7 +249,7 @@ nested_trigger_with_dml
 newid
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -248,7 +248,7 @@ nested_trigger_with_dml
 newid_before_14_12_or_15_7_or_16_3
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -251,7 +251,7 @@ nested_trigger_with_dml
 newid_before_14_12_or_15_7_or_16_3
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -252,7 +252,7 @@ nested_trigger_with_dml
 newid_before_15_8_or_16_4
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -253,7 +253,7 @@ nested_trigger_with_dml
 newid
 objectpropertyex-before-16_5-or-15_9
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition_before_16_5
 rowcount

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -254,7 +254,7 @@ nested_trigger_with_dml
 newid
 objectpropertyex
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition
 rowcount

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -254,7 +254,7 @@ nested_trigger_with_dml
 newid
 objectpropertyex
 openjson
-#openquery_upgrd_before_15_4
+openquery_upgrd_before_15_4
 orderby
 routines_definition
 rowcount

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -186,14 +186,12 @@ Could not find upgrade tests for procedure sys.sp_describe_cursor
 Could not find upgrade tests for procedure sys.sp_oledb_ro_usrname
 Could not find upgrade tests for procedure sys.sp_prepare
 Could not find upgrade tests for procedure sys.sp_reset_connection
-Could not find upgrade tests for procedure sys.sp_serveroption
 Could not find upgrade tests for procedure sys.sp_unprepare
 Could not find upgrade tests for procedure sys.sp_updatestats
 Could not find upgrade tests for table sys.babelfish_configurations
 Could not find upgrade tests for table sys.babelfish_helpcollation
 Could not find upgrade tests for table sys.babelfish_partition_function
 Could not find upgrade tests for table sys.babelfish_partition_scheme
-Could not find upgrade tests for table sys.babelfish_server_options
 Could not find upgrade tests for table sys.babelfish_syslanguages
 Could not find upgrade tests for table sys.service_settings
 Could not find upgrade tests for table sys.spt_datatype_info_table


### PR DESCRIPTION
### Description

When truncating certain Babelfish catalogs, we use the
heap_truncate_one_rel function which expects the caller to hold the
AccessExclusiveLock on the catalog.

This commit updates the lock used for opening/closing the catalog from
RowExclusiveLock to AccessExclusiveLock.

Task: BABEL-5439
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).