### PR TITLE
Use AccessExclusiveLock for truncating Babelfish catalogs

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1301,10 +1301,10 @@ void
 clean_up_bbf_server_def()
 {
 	/* Fetch the relation */
-	Relation bbf_servers_def_rel = table_open(get_bbf_servers_def_oid(), RowExclusiveLock);
+	Relation bbf_servers_def_rel = table_open(get_bbf_servers_def_oid(), AccessExclusiveLock);
 	/* Truncate the relation */
 	heap_truncate_one_rel(bbf_servers_def_rel);
-	table_close(bbf_servers_def_rel, RowExclusiveLock);
+	table_close(bbf_servers_def_rel, AccessExclusiveLock);
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2455,12 +2455,12 @@ babelfish_truncate_domain_mapping_table_internal(PG_FUNCTION_ARGS)
 				 errmsg("Current login %s does not have permission to remove domain mapping entry",
 						GetUserNameFromId(GetSessionUserId(), true))));
 
-	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), RowExclusiveLock);
+	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), AccessExclusiveLock);
 
 	/* Truncate the relation */
 	heap_truncate_one_rel(bbf_domain_mapping_rel);
 
-	table_close(bbf_domain_mapping_rel, RowExclusiveLock);
+	table_close(bbf_domain_mapping_rel, AccessExclusiveLock);
 	return (Datum) 0;
 }
 


### PR DESCRIPTION
### Description

When truncating certain Babelfish catalogs, we use the
heap_truncate_one_rel function which expects the caller to hold the
AccessExclusiveLock on the catalog.

This commit updates the lock used for opening/closing the catalog from
RowExclusiveLock to AccessExclusiveLock.

Task: BABEL-5439
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).