### PR TITLE
Fix the issue about Like collation not properly transformed (#3141)

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1010,8 +1010,13 @@ pltsql_predicate_transformer(Node *expr)
 
 	if (IsA(expr, OpExpr))
 	{
-		/* Singleton predicate */
-		return transform_likenode(expr);
+		Node *ret = transform_likenode(expr);
+		if (expr == ret)
+			/* If it's not a like Opexpr, then walk through args */
+			return expression_tree_mutator(expr, pgtsql_expression_tree_mutator, NULL);
+		else 
+			/* Singleton predicate */
+			return ret;
 	}
 	else
 	{

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -73,6 +73,13 @@ int#!#nvarchar#!#nvarchar
 ~~END~~
 
 
-
-
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc = 'A'  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7839#!#KING#!#A
+~~END~~
 

--- a/test/JDBC/expected/BABEL-4046-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4046-vu-verify.out
@@ -83,3 +83,82 @@ int#!#nvarchar#!#nvarchar
 7839#!#KING#!#A
 ~~END~~
 
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc > 'A' order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7369#!#SMITH#!#BOSTON
+7499#!#ALLEN#!#CHICAGO
+7521#!#WARD#!#CHICAGO
+7698#!#BLAKE#!#BOSTON
+7782#!#CLARK#!#NEW YORK
+7788#!#SCOTT#!#NEW YORK
+~~END~~
+
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc < 'Z'  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7369#!#SMITH#!#BOSTON
+7499#!#ALLEN#!#CHICAGO
+7521#!#WARD#!#CHICAGO
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7698#!#BLAKE#!#BOSTON
+7782#!#CLARK#!#NEW YORK
+7788#!#SCOTT#!#NEW YORK
+7839#!#KING#!#A
+~~END~~
+
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc >= 'A'  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7369#!#SMITH#!#BOSTON
+7499#!#ALLEN#!#CHICAGO
+7521#!#WARD#!#CHICAGO
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7698#!#BLAKE#!#BOSTON
+7782#!#CLARK#!#NEW YORK
+7788#!#SCOTT#!#NEW YORK
+7839#!#KING#!#A
+~~END~~
+
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc <= 'W'  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7369#!#SMITH#!#BOSTON
+7499#!#ALLEN#!#CHICAGO
+7521#!#WARD#!#CHICAGO
+7566#!#JONES#!#A
+7654#!#MARTIN#!#A
+7698#!#BLAKE#!#BOSTON
+7782#!#CLARK#!#NEW YORK
+7788#!#SCOTT#!#NEW YORK
+7839#!#KING#!#A
+~~END~~
+
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc1, 
+	CASE WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C') ELSE baseloc END AS baseloc2,
+	deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc1, DM.baseloc2 from EMP_T DM where DM.baseloc1 < DM.baseloc2  order by DM.empno
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar#!#nvarchar
+7566#!#JONES#!#A#!#AUSTIN
+7654#!#MARTIN#!#A#!#AUSTIN
+7839#!#KING#!#A#!#AUSTIN
+~~END~~
+
+

--- a/test/JDBC/input/BABEL-4046-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4046-vu-verify.sql
@@ -35,6 +35,6 @@ GO
 	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc in (select baseloc from t4)  order by DM.empno
 GO
 
-
-
-
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc = 'A'  order by DM.empno
+GO

--- a/test/JDBC/input/BABEL-4046-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4046-vu-verify.sql
@@ -38,3 +38,26 @@ GO
 ;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
 	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc = 'A'  order by DM.empno
 GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc > 'A' order by DM.empno
+GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc < 'Z'  order by DM.empno
+GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc >= 'A'  order by DM.empno
+GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc, deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc from EMP_T DM where DM.baseloc <= 'W'  order by DM.empno
+GO
+
+;with EMP_T AS ( select empno, ename, CASE WHEN baseloc LIKE 'AUS%' THEN REPLACE(baseloc,'AUSTIN','A') ELSE baseloc END AS baseloc1, 
+	CASE WHEN baseloc LIKE 'CHI%' THEN REPLACE(baseloc,'CHICAGO','C') ELSE baseloc END AS baseloc2,
+	deptno from t3)
+	select DM.empno, DM.ename, DM.baseloc1, DM.baseloc2 from EMP_T DM where DM.baseloc1 < DM.baseloc2  order by DM.empno
+GO
+


### PR DESCRIPTION

There is a missing condition for transforming an OpExpr when the like node is in the ars list of OpExpr

Task: BABEL-5397, BABEL-5424

Cherry-pick from commit : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3141

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).