### PR TITLE
Update sp_helpuser for database role

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2207,7 +2207,7 @@ BEGIN
 		LEFT OUTER JOIN sys.babelfish_sysdatabases AS Bsdb ON Bsdb.name = DB_NAME()
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
-		AND (Ext1.type != 'R' OR Ext1.type != 'A')
+		AND Ext1.type != 'R'
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		ORDER BY UserName, RoleName;
 	END
@@ -2252,7 +2252,7 @@ BEGIN
 					AND database_name = DB_NAME()
 					AND type != 'R')
 	BEGIN
-		SELECT DISTINCT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
 			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN 'db_owner' 
 					WHEN Ext2.orig_username IS NULL THEN 'public' 
 					ELSE Ext2.orig_username END 
@@ -2277,7 +2277,7 @@ BEGIN
 		LEFT OUTER JOIN sys.babelfish_sysdatabases AS Bsdb ON Bsdb.name = DB_NAME()
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
-		AND (Ext1.type != 'R' OR Ext1.type != 'A')
+		AND Ext1.type != 'R'
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		AND (Ext1.orig_username = @name_in_db OR pg_catalog.lower(Ext1.orig_username) = pg_catalog.lower(@name_in_db))
 		ORDER BY UserName, RoleName;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -556,7 +556,7 @@ BEGIN
 		LEFT OUTER JOIN sys.babelfish_sysdatabases AS Bsdb ON Bsdb.name = DB_NAME()
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
-		AND (Ext1.type != 'R' OR Ext1.type != 'A')
+		AND Ext1.type != 'R'
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		ORDER BY UserName, RoleName;
 	END
@@ -601,7 +601,7 @@ BEGIN
 					AND database_name = DB_NAME()
 					AND type != 'R')
 	BEGIN
-		SELECT DISTINCT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
+		SELECT CAST(Ext1.orig_username AS SYS.SYSNAME) AS 'UserName',
 			   CAST(CASE WHEN Ext1.orig_username = 'dbo' THEN 'db_owner' 
 					WHEN Ext2.orig_username IS NULL THEN 'public' 
 					ELSE Ext2.orig_username END 
@@ -626,7 +626,7 @@ BEGIN
 		LEFT OUTER JOIN sys.babelfish_sysdatabases AS Bsdb ON Bsdb.name = DB_NAME()
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
-		AND (Ext1.type != 'R' OR Ext1.type != 'A')
+		AND Ext1.type != 'R'
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		AND (Ext1.orig_username = @name_in_db OR pg_catalog.lower(Ext1.orig_username) = pg_catalog.lower(@name_in_db))
 		ORDER BY UserName, RoleName;

--- a/test/JDBC/expected/datareader_datawriter.out
+++ b/test/JDBC/expected/datareader_datawriter.out
@@ -261,15 +261,13 @@ go
 -- Insert the results of sp_helpuser into the temporary table
 INSERT INTO #UserRoles EXEC sp_helpuser;
 go
-~~ROW COUNT: 8~~
+~~ROW COUNT: 6~~
 
 -- Select the desired fields from the temporary table
 SELECT userName, roleName FROM #UserRoles WHERE roleName IN ('db_datareader', 'db_datawriter');
 go
 ~~START~~
 varchar#!#varchar
-db_roles_r1#!#db_datareader
-db_roles_r1#!#db_datawriter
 db_roles_u1#!#db_datareader
 db_roles_u1#!#db_datawriter
 ~~END~~

--- a/test/JDBC/expected/single_db/datareader_datawriter.out
+++ b/test/JDBC/expected/single_db/datareader_datawriter.out
@@ -261,15 +261,13 @@ go
 -- Insert the results of sp_helpuser into the temporary table
 INSERT INTO #UserRoles EXEC sp_helpuser;
 go
-~~ROW COUNT: 8~~
+~~ROW COUNT: 6~~
 
 -- Select the desired fields from the temporary table
 SELECT userName, roleName FROM #UserRoles WHERE roleName IN ('db_datareader', 'db_datawriter');
 go
 ~~START~~
 varchar#!#varchar
-db_roles_r1#!#db_datareader
-db_roles_r1#!#db_datawriter
 db_roles_u1#!#db_datareader
 db_roles_u1#!#db_datawriter
 ~~END~~


### PR DESCRIPTION
### Description

If a database role is a member of another database role, those role memberships should not show that as a part of sp_helpuser.

### Issues Resolved

Task: BABEL-5440, BABEL-5443
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).