### PR TITLE
Remove GUC for setting migration mode for BABEL-4279 and test_search_path testfiles

### DIFF
--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_search_path.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_search_path.out
@@ -1,26 +1,3 @@
-CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
-GO
-INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-~~ROW COUNT: 1~~
-
-
--- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
-
 -- check if correct schema is present in search path
 CREATE DATABASE ["BABEL_5111.db"]
 GO
@@ -354,26 +331,4 @@ DROP DATABASE ["BABEL_5111.db"]
 GO
 
 DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
-GO
-
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
-
-Drop Table IF EXISTS babelfish_migration_mode_table
 GO

--- a/test/JDBC/expected/single_db/BABEL-4279.out
+++ b/test/JDBC/expected/single_db/BABEL-4279.out
@@ -80,7 +80,7 @@ SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_
 GO
 ~~START~~
 text
- SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM """test_babel_4279_d.1""_test_babel_4279_s1".test_babel_4279_st1;
+ SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
 ~~END~~
 
 
@@ -88,7 +88,7 @@ SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_
 GO
 ~~START~~
 text
- SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM """test_babel_4279_d.1""_test_babel_4279_s1".test_babel_4279_st1;
+ SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
 ~~END~~
 
 
@@ -256,7 +256,7 @@ SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_
 GO
 ~~START~~
 text
- SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM """test_babel_4279_d.1""_test_babel_4279_s1".test_babel_4279_st1;
+ SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
 ~~END~~
 
 
@@ -264,7 +264,7 @@ SELECT pg_catalog.pg_get_viewdef(oid, true) FROM pg_class WHERE relname = 'test_
 GO
 ~~START~~
 text
- SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM """test_babel_4279_d.1""_test_babel_4279_s1".test_babel_4279_st1;
+ SELECT "abc.nfds" AS "ABC.nfds"<newline>   FROM test_babel_4279_s1.test_babel_4279_st1;
 ~~END~~
 
 

--- a/test/JDBC/expected/test_search_path.out
+++ b/test/JDBC/expected/test_search_path.out
@@ -1,26 +1,3 @@
-CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
-GO
-INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-~~ROW COUNT: 1~~
-
-
--- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
-
 -- check if correct schema is present in search path
 CREATE DATABASE ["BABEL_5111.db"]
 GO
@@ -354,26 +331,4 @@ DROP DATABASE ["BABEL_5111.db"]
 GO
 
 DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
-GO
-
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
-
-Drop Table IF EXISTS babelfish_migration_mode_table
 GO

--- a/test/JDBC/input/BABEL-4279.mix
+++ b/test/JDBC/input/BABEL-4279.mix
@@ -1,15 +1,4 @@
--- tsql
-CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
-GO
-INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-
--- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
-GO
-
+-- single_db_mode_expected
 -- tsql
 CREATE TABLE test_babel_4279_t1([ABC.nfds] INT, [DEf.j] INT);
 GO
@@ -331,16 +320,4 @@ DROP FUNCTION tvf_t3
 GO
 
 DROP TABLE t3
-GO
-
-SELECT set_config('role', 'jdbc_user', false);
-GO
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-
-Drop Table IF EXISTS babelfish_migration_mode_table
 GO

--- a/test/JDBC/input/test_search_path.sql
+++ b/test/JDBC/input/test_search_path.sql
@@ -1,14 +1,3 @@
-CREATE TABLE babelfish_migration_mode_table (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
-GO
-INSERT INTO babelfish_migration_mode_table SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-
--- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
-GO
-
 -- check if correct schema is present in search path
 CREATE DATABASE ["BABEL_5111.db"]
 GO
@@ -266,16 +255,4 @@ DROP DATABASE ["BABEL_5111.db"]
 GO
 
 DROP DATABASE ["龙漫远; 龍漫遠.¢£€¥"]
-GO
-
-SELECT set_config('role', 'jdbc_user', false);
-GO
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_table WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-
-Drop Table IF EXISTS babelfish_migration_mode_table
 GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -12,14 +12,12 @@ all
 
 ignore#!#BABEL-1435
 ignore#!#BABEL-1446
-ignore#!#BABEL-4279
 ignore#!#TestSpatialPoint-vu-prepare
 ignore#!#TestSpatialPoint-vu-verify
 ignore#!#TestSpatialPoint-vu-cleanup
 ignore#!#babelfish_migration_mode-vu-prepare
 ignore#!#babelfish_migration_mode-vu-verify
 ignore#!#babelfish_migration_mode-vu-cleanup
-ignore#!#test_search_path
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -8,5 +8,6 @@ ignore#!#test_db_collation-vu-cleanup
 ignore#!#BABEL-CROSS-DB
 ignore#!#BABEL-SYS-DATABASES
 ignore#!#Test-sp_reset_connection
+ignore#!#test_search_path
 
 


### PR DESCRIPTION
### Description
As part of https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3096, we ignored these files to revisit the migration mode testing.

With this commit we have:
* Removed GUC for setting migration mode to multi-db for BABEL-4279 and test_search_path testfiles.

* Separated BABEL-4279 testfile for single-db and multi-db migration mode.
