### PR TITLE
Don't merge!! Temp file for testing engine codes commit!!

### DIFF
--- a/tmp_file
+++ b/tmp_file
@@ -1,0 +1,1 @@
+Don't merge!! Temp file for testing engine codes commit!!


### PR DESCRIPTION
ExecProcessReturning is unexpectedly called twice for psql
 request causing overflow error

Description
-----------
In community postgresql, ExecProcessReturning is called once after the
main process of ExecInsert. But due to some merging errors related to
Babelfish and T-SQL, this function is wrongly called twice for psql
requests. At the first call, the xmax is not initialized causing
unexpected error raising.

The first intention of these pieces of codes is to call it in the
first place only for T-SQL(CR-52326143). And then got wrongly
cherry-picked in CR-57250041. Finally, the condition check gets
removed in CR-65026879. We should keep the first intention of the
codes, which also makes it consistent with the behaviour in
ExecUpdate.

Task: BABEL-5343
Signed-off-by: Bo Li <zboli@amazon.com>