### PR TITLE
Update BABEL-1444 and Test-sp_reset_connection expected files

### DIFF
--- a/test/JDBC/expected/parallel_query/BABEL-1444.out
+++ b/test/JDBC/expected/parallel_query/BABEL-1444.out
@@ -66,7 +66,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -98,7 +98,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+db1_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -135,7 +135,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+db1_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -168,7 +168,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -200,7 +200,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -233,7 +233,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -271,7 +271,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -303,7 +303,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+db1_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -340,7 +340,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+db1_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -373,7 +373,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -405,7 +405,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');
@@ -438,7 +438,7 @@ SELECT current_setting('role');
 GO
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 SELECT current_setting('search_path');

--- a/test/JDBC/expected/parallel_query/Test-sp_reset_connection.out
+++ b/test/JDBC/expected/parallel_query/Test-sp_reset_connection.out
@@ -688,7 +688,7 @@ master_dbo, "$user", sys, pg_catalog
 
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 
 
@@ -722,6 +722,6 @@ master_dbo, "$user", sys, pg_catalog
 
 ~~START~~
 text
-none
+master_dbo
 ~~END~~
 

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -29,6 +29,3 @@ ignore#!#BABEL-SP_TABLE_PRIVILEGES
 ignore#!#ISC-Columns-vu-verify
 ignore#!#four-part-names-vu-verify
 
-# TODO: BABEL-5425 
-ignore#!#BABEL-1444
-ignore#!#Test-sp_reset_connection


### PR DESCRIPTION


### Description
After recent engine fixes, setting of role started giving expected output in case of parallel query enabled environment. This commit updates those test files expected output in case of parallel query enabled run.

Issues Resolved
Task: BABEL-5425

Authored-by: Harsh Lunagariya <lunharsh@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).