### PR TITLE
db_datawriter should have update privilege on sequences

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -1409,11 +1409,12 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 	/* Grant ALTER DEFAULT PRIVILEGES on schema owner and dbo user. */
 	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT SELECT ON TABLES TO dummy; ");
 	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT INSERT, UPDATE, DELETE ON TABLES TO dummy; ");
+	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT UPDATE ON SEQUENCES TO dummy; ");
 	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT TRUNCATE ON TABLES TO dummy; ");
 
 	stmt_list = raw_parser(query.data, RAW_PARSE_DEFAULT);
 
-	Assert(list_length(stmt_list) == 7);
+	Assert(list_length(stmt_list) == 8);
 
 	ScanKeyInit(&key,
 				Anum_namespace_ext_dbid,
@@ -1450,6 +1451,8 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 
 		stmts = parsetree_nth_stmt(stmt_list, i++);
 		update_AlterDefaultPrivilegesStmt(stmts, schema_name, schema_owner, dbo_user, db_datareader, NULL);
+		stmts = parsetree_nth_stmt(stmt_list, i++);
+		update_AlterDefaultPrivilegesStmt(stmts, schema_name, schema_owner, dbo_user, db_datawriter, NULL);
 		stmts = parsetree_nth_stmt(stmt_list, i++);
 		update_AlterDefaultPrivilegesStmt(stmts, schema_name, schema_owner, dbo_user, db_datawriter, NULL);
 		stmts = parsetree_nth_stmt(stmt_list, i++);

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -1403,6 +1403,7 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 	initStringInfo(&query);
 	appendStringInfo(&query, "GRANT SELECT ON ALL TABLES IN SCHEMA dummy TO dummy; ");
 	appendStringInfo(&query, "GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA dummy TO dummy; ");
+	appendStringInfo(&query, "GRANT UPDATE ON ALL SEQUENCES IN SCHEMA dummy TO dummy; ");
 	appendStringInfo(&query, "GRANT TRUNCATE ON ALL TABLES IN SCHEMA dummy TO dummy; ");
 	appendStringInfo(&query, "GRANT CREATE ON SCHEMA dummy TO dummy ; ");
 
@@ -1414,7 +1415,7 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 
 	stmt_list = raw_parser(query.data, RAW_PARSE_DEFAULT);
 
-	Assert(list_length(stmt_list) == 8);
+	Assert(list_length(stmt_list) == 9);
 
 	ScanKeyInit(&key,
 				Anum_namespace_ext_dbid,
@@ -1442,6 +1443,8 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 		/* Replace dummy elements in parsetree with real values */
 		stmts = parsetree_nth_stmt(stmt_list, i++);
 		update_GrantStmt(stmts, schema_name, NULL, db_datareader, NULL);
+		stmts = parsetree_nth_stmt(stmt_list, i++);
+		update_GrantStmt(stmts, schema_name, NULL, db_datawriter, NULL);
 		stmts = parsetree_nth_stmt(stmt_list, i++);
 		update_GrantStmt(stmts, schema_name, NULL, db_datawriter, NULL);
 		stmts = parsetree_nth_stmt(stmt_list, i++);

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -2527,7 +2527,7 @@ exec_database_roles_subcmds(const char *schema)
 	char		*schema_owner;
 	const char	*dbname = get_current_pltsql_db_name();
 	List		*stmt_list;
-	int 		expected_stmts = 4;
+	int 		expected_stmts = 5;
 	ListCell	*parsetree_item;
 	Node		*stmts;
 	int		i=0;
@@ -2550,6 +2550,7 @@ exec_database_roles_subcmds(const char *schema)
 	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT SELECT ON TABLES TO dummy; ");
 	/* Grant privileges to db_datawriter */
 	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT INSERT, UPDATE, DELETE ON TABLES TO dummy; ");
+	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT UPDATE ON SEQUENCES TO dummy; ");
 	/* Grant privileges to db_ddladmin */
 	appendStringInfo(&query, "ALTER DEFAULT PRIVILEGES FOR ROLE dummy, dummy IN SCHEMA dummy GRANT TRUNCATE ON TABLES TO dummy; ");
 	appendStringInfo(&query, "GRANT CREATE ON SCHEMA dummy TO dummy ; ");
@@ -2564,6 +2565,8 @@ exec_database_roles_subcmds(const char *schema)
 	stmts = parsetree_nth_stmt(stmt_list, i++);
 	update_AlterDefaultPrivilegesStmt(stmts, schema, schema_owner, dbo_role, db_datareader, NULL);
 
+	stmts = parsetree_nth_stmt(stmt_list, i++);
+	update_AlterDefaultPrivilegesStmt(stmts, schema, schema_owner, dbo_role, db_datawriter, NULL);
 	stmts = parsetree_nth_stmt(stmt_list, i++);
 	update_AlterDefaultPrivilegesStmt(stmts, schema, schema_owner, dbo_role, db_datawriter, NULL);
 

--- a/test/JDBC/expected/datareader_datawriter-vu-cleanup.out
+++ b/test/JDBC/expected/datareader_datawriter-vu-cleanup.out
@@ -40,6 +40,33 @@ void
 use db_roles_db1
 go
 
+drop sequence db_roles_schema_1.before_sq1;
+go
+
+drop sequence db_roles_schema_1.after_sq1;
+go
+
+drop sequence db_roles_schema_1.after_sq2;
+go
+
+drop sequence db_roles_schema_2.before_created_by_dbo_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_dbo_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_dbo_sq2;
+go
+
+drop sequence db_roles_schema_2.before_created_by_u2_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_u2_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_u2_sq2;
+go
+
 drop table db_roles_schema_1.before_t1;
 go
 

--- a/test/JDBC/expected/datareader_datawriter-vu-prepare.out
+++ b/test/JDBC/expected/datareader_datawriter-vu-prepare.out
@@ -27,10 +27,16 @@ go
 create table db_roles_schema_1.before_t1(a int);
 go
 
+create sequence db_roles_schema_1.before_sq1 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_1.before_v1 as select 2;
 go
 
 create table db_roles_schema_2.before_created_by_dbo_t1(a int);
+go
+
+create sequence db_roles_schema_2.before_created_by_dbo_sq1 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.before_created_by_dbo_v1 as select 2;
@@ -44,6 +50,9 @@ use db_roles_db1;
 go
 
 create table db_roles_schema_2.before_created_by_u2_t1(a int);
+go
+
+create sequence db_roles_schema_2.before_created_by_u2_sq1 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.before_created_by_u2_v1 as select 2;

--- a/test/JDBC/expected/datareader_datawriter-vu-verify.out
+++ b/test/JDBC/expected/datareader_datawriter-vu-verify.out
@@ -184,6 +184,14 @@ int
 ~~END~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_1.before_sq1; -- allowed
+go
+~~START~~
+bigint
+1
+~~END~~
+
+
 insert into db_roles_schema_1.before_t1 values(1); -- allowed
 go
 ~~ROW COUNT: 1~~

--- a/test/JDBC/expected/datareader_datawriter-vu-verify.out
+++ b/test/JDBC/expected/datareader_datawriter-vu-verify.out
@@ -59,6 +59,9 @@ go
 create table db_roles_schema_2.after_created_by_u2_t1(a int);
 go
 
+create sequence db_roles_schema_2.after_created_by_u2_sq1 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_2.after_created_by_u2_v1 as select 1;
 go
 
@@ -72,10 +75,16 @@ go
 create table db_roles_schema_1.after_t1(a int);
 go
 
+create sequence db_roles_schema_1.after_sq1 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_1.after_v1 as select 2;
 go
 
 create table db_roles_schema_2.after_created_by_dbo_t1(a int);
+go
+
+create sequence db_roles_schema_2.after_created_by_dbo_sq1 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.after_created_by_dbo_v1 as select 2;
@@ -90,10 +99,16 @@ go
 create table db_roles_schema_1.after_t2(a int);
 go
 
+create sequence db_roles_schema_1.after_sq2 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_1.after_v2 as select 2;
 go
 
 create table db_roles_schema_2.after_created_by_dbo_t2(a int);
+go
+
+create sequence db_roles_schema_2.after_created_by_dbo_sq2 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.after_created_by_dbo_v2 as select 2;
@@ -107,6 +122,9 @@ use db_roles_db1;
 go
 
 create table db_roles_schema_2.after_created_by_u2_t2(a int);
+go
+
+create sequence db_roles_schema_2.after_created_by_u2_sq2 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.after_created_by_u2_v2 as select 1;
@@ -131,6 +149,22 @@ select * from db_roles_schema_1.after_t2; -- allowed
 go
 ~~START~~
 int
+~~END~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq1; -- allowed
+go
+~~START~~
+bigint
+1
+~~END~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq2; -- allowed
+go
+~~START~~
+bigint
+1
 ~~END~~
 
 
@@ -172,6 +206,14 @@ int
 ~~END~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_dbo_sq1; -- allowed
+go
+~~START~~
+bigint
+1
+~~END~~
+
+
 select * from db_roles_schema_2.before_created_by_dbo_v1; -- allowed
 go
 ~~START~~
@@ -199,6 +241,14 @@ select * from db_roles_schema_2.after_created_by_dbo_t1; -- allowed
 go
 ~~START~~
 int
+~~END~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq1; -- allowed
+go
+~~START~~
+bigint
+1
 ~~END~~
 
 
@@ -232,6 +282,14 @@ int
 ~~END~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq2; -- allowed
+go
+~~START~~
+bigint
+1
+~~END~~
+
+
 select * from db_roles_schema_2.after_created_by_dbo_v2; -- allowed
 go
 ~~START~~
@@ -259,6 +317,14 @@ select * from db_roles_schema_2.before_created_by_u2_t1; -- allowed
 go
 ~~START~~
 int
+~~END~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_u2_sq1; -- allowed
+go
+~~START~~
+bigint
+1
 ~~END~~
 
 
@@ -292,6 +358,14 @@ int
 ~~END~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq2; -- allowed
+go
+~~START~~
+bigint
+1
+~~END~~
+
+
 select * from db_roles_schema_2.after_created_by_u2_v2; -- allowed
 go
 ~~START~~
@@ -319,6 +393,14 @@ select * from db_roles_schema_2.after_created_by_u2_t1; -- allowed
 go
 ~~START~~
 int
+~~END~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq1; -- allowed
+go
+~~START~~
+bigint
+1
 ~~END~~
 
 
@@ -379,11 +461,38 @@ go
 ~~ERROR (Message: permission denied for table after_t2)~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq1;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence after_sq1)~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq2;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence after_sq2)~~
+
+
 select * from db_roles_schema_1.before_t1; -- not allowed
 go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for table before_t1)~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_1.before_sq1;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence before_sq1)~~
 
 
 select * from db_roles_schema_1.after_v1;  -- not allowed
@@ -477,6 +586,15 @@ go
 ~~ERROR (Message: permission denied for table before_created_by_dbo_t1)~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_dbo_sq1;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence before_created_by_dbo_sq1)~~
+
+
 select * from db_roles_schema_2.before_created_by_dbo_v1; -- not allowed
 go
 ~~ERROR (Code: 33557097)~~
@@ -510,6 +628,15 @@ go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for table after_created_by_dbo_t1)~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq1;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence after_created_by_dbo_sq1)~~
 
 
 select * from db_roles_schema_2.after_created_by_dbo_v1; -- not allowed
@@ -547,6 +674,15 @@ go
 ~~ERROR (Message: permission denied for table after_created_by_dbo_t2)~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq2;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence after_created_by_dbo_sq2)~~
+
+
 select * from db_roles_schema_2.after_created_by_dbo_v2; -- not allowed
 go
 ~~ERROR (Code: 33557097)~~
@@ -580,6 +716,15 @@ go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for table before_created_by_u2_t1)~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_u2_sq1;  -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence before_created_by_u2_sq1)~~
 
 
 select * from db_roles_schema_2.before_created_by_u2_v1; -- not allowed
@@ -617,6 +762,15 @@ go
 ~~ERROR (Message: permission denied for table after_created_by_u2_t1)~~
 
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq1; -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence after_created_by_u2_sq1)~~
+
+
 select * from db_roles_schema_2.after_created_by_u2_v1; -- not allowed
 go
 ~~ERROR (Code: 33557097)~~
@@ -650,6 +804,15 @@ go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for table after_created_by_u2_t2)~~
+
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq2; -- not allowed
+go
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence after_created_by_u2_sq2)~~
 
 
 select * from db_roles_schema_2.after_created_by_u2_v2; -- not allowed

--- a/test/JDBC/input/datareader_datawriter-vu-cleanup.mix
+++ b/test/JDBC/input/datareader_datawriter-vu-cleanup.mix
@@ -22,6 +22,33 @@ go
 use db_roles_db1
 go
 
+drop sequence db_roles_schema_1.before_sq1;
+go
+
+drop sequence db_roles_schema_1.after_sq1;
+go
+
+drop sequence db_roles_schema_1.after_sq2;
+go
+
+drop sequence db_roles_schema_2.before_created_by_dbo_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_dbo_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_dbo_sq2;
+go
+
+drop sequence db_roles_schema_2.before_created_by_u2_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_u2_sq1;
+go
+
+drop sequence db_roles_schema_2.after_created_by_u2_sq2;
+go
+
 drop table db_roles_schema_1.before_t1;
 go
 

--- a/test/JDBC/input/datareader_datawriter-vu-prepare.mix
+++ b/test/JDBC/input/datareader_datawriter-vu-prepare.mix
@@ -27,10 +27,16 @@ go
 create table db_roles_schema_1.before_t1(a int);
 go
 
+create sequence db_roles_schema_1.before_sq1 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_1.before_v1 as select 2;
 go
 
 create table db_roles_schema_2.before_created_by_dbo_t1(a int);
+go
+
+create sequence db_roles_schema_2.before_created_by_dbo_sq1 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.before_created_by_dbo_v1 as select 2;
@@ -44,6 +50,9 @@ use db_roles_db1;
 go
 
 create table db_roles_schema_2.before_created_by_u2_t1(a int);
+go
+
+create sequence db_roles_schema_2.before_created_by_u2_sq1 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.before_created_by_u2_v1 as select 2;

--- a/test/JDBC/input/datareader_datawriter-vu-verify.mix
+++ b/test/JDBC/input/datareader_datawriter-vu-verify.mix
@@ -126,6 +126,9 @@ go
 select * from db_roles_schema_1.after_v2; -- allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_1.before_sq1; -- allowed
+go
+
 insert into db_roles_schema_1.before_t1 values(1); -- allowed
 go
 

--- a/test/JDBC/input/datareader_datawriter-vu-verify.mix
+++ b/test/JDBC/input/datareader_datawriter-vu-verify.mix
@@ -29,6 +29,9 @@ go
 create table db_roles_schema_2.after_created_by_u2_t1(a int);
 go
 
+create sequence db_roles_schema_2.after_created_by_u2_sq1 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_2.after_created_by_u2_v1 as select 1;
 go
 
@@ -42,10 +45,16 @@ go
 create table db_roles_schema_1.after_t1(a int);
 go
 
+create sequence db_roles_schema_1.after_sq1 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_1.after_v1 as select 2;
 go
 
 create table db_roles_schema_2.after_created_by_dbo_t1(a int);
+go
+
+create sequence db_roles_schema_2.after_created_by_dbo_sq1 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.after_created_by_dbo_v1 as select 2;
@@ -60,10 +69,16 @@ go
 create table db_roles_schema_1.after_t2(a int);
 go
 
+create sequence db_roles_schema_1.after_sq2 start with 1 increment by 1 ;
+go
+
 create view db_roles_schema_1.after_v2 as select 2;
 go
 
 create table db_roles_schema_2.after_created_by_dbo_t2(a int);
+go
+
+create sequence db_roles_schema_2.after_created_by_dbo_sq2 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.after_created_by_dbo_v2 as select 2;
@@ -77,6 +92,9 @@ use db_roles_db1;
 go
 
 create table db_roles_schema_2.after_created_by_u2_t2(a int);
+go
+
+create sequence db_roles_schema_2.after_created_by_u2_sq2 start with 1 increment by 1 ;
 go
 
 create view db_roles_schema_2.after_created_by_u2_v2 as select 1;
@@ -94,6 +112,12 @@ select * from db_roles_schema_1.after_t1; -- allowed
 go
 
 select * from db_roles_schema_1.after_t2; -- allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq1; -- allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq2; -- allowed
 go
 
 select * from db_roles_schema_1.after_v1; -- allowed
@@ -114,6 +138,9 @@ go
 select * from db_roles_schema_2.before_created_by_dbo_t1; -- allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_dbo_sq1; -- allowed
+go
+
 select * from db_roles_schema_2.before_created_by_dbo_v1; -- allowed
 go
 
@@ -127,6 +154,9 @@ delete from db_roles_schema_2.before_created_by_dbo_t1 where a = 2; -- allowed
 go
 
 select * from db_roles_schema_2.after_created_by_dbo_t1; -- allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq1; -- allowed
 go
 
 select * from db_roles_schema_2.after_created_by_dbo_v1; -- allowed
@@ -144,6 +174,9 @@ go
 select * from db_roles_schema_2.after_created_by_dbo_t2; -- allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq2; -- allowed
+go
+
 select * from db_roles_schema_2.after_created_by_dbo_v2; -- allowed
 go
 
@@ -157,6 +190,9 @@ delete from db_roles_schema_2.after_created_by_dbo_t2 where a = 2; -- allowed
 go
 
 select * from db_roles_schema_2.before_created_by_u2_t1; -- allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_u2_sq1; -- allowed
 go
 
 select * from db_roles_schema_2.before_created_by_u2_v1; -- allowed
@@ -174,6 +210,9 @@ go
 select * from db_roles_schema_2.after_created_by_u2_t2; -- allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq2; -- allowed
+go
+
 select * from db_roles_schema_2.after_created_by_u2_v2; -- allowed
 go
 
@@ -187,6 +226,9 @@ delete from db_roles_schema_2.after_created_by_u2_t2 where a = 2; -- allowed
 go
 
 select * from db_roles_schema_2.after_created_by_u2_t1; -- allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq1; -- allowed
 go
 
 select * from db_roles_schema_2.after_created_by_u2_v1; -- allowed
@@ -227,7 +269,16 @@ go
 select * from db_roles_schema_1.after_t2;  -- not allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq1;  -- not allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_1.after_sq2;  -- not allowed
+go
+
 select * from db_roles_schema_1.before_t1; -- not allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_1.before_sq1;  -- not allowed
 go
 
 select * from db_roles_schema_1.after_v1;  -- not allowed
@@ -269,6 +320,9 @@ go
 select * from db_roles_schema_2.before_created_by_dbo_t1; -- not allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_dbo_sq1;  -- not allowed
+go
+
 select * from db_roles_schema_2.before_created_by_dbo_v1; -- not allowed
 go
 
@@ -282,6 +336,9 @@ delete from db_roles_schema_2.before_created_by_dbo_t1 where a = 2; -- not allow
 go
 
 select * from db_roles_schema_2.after_created_by_dbo_t1; -- not allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq1;  -- not allowed
 go
 
 select * from db_roles_schema_2.after_created_by_dbo_v1; -- not allowed
@@ -299,6 +356,9 @@ go
 select * from db_roles_schema_2.after_created_by_dbo_t2; -- not allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_dbo_sq2;  -- not allowed
+go
+
 select * from db_roles_schema_2.after_created_by_dbo_v2; -- not allowed
 go
 
@@ -312,6 +372,9 @@ delete from db_roles_schema_2.after_created_by_dbo_t2 where a = 2; -- not allowe
 go
 
 select * from db_roles_schema_2.before_created_by_u2_t1; -- not allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_2.before_created_by_u2_sq1;  -- not allowed
 go
 
 select * from db_roles_schema_2.before_created_by_u2_v1; -- not allowed
@@ -329,6 +392,9 @@ go
 select * from db_roles_schema_2.after_created_by_u2_t1; -- not allowed
 go
 
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq1; -- not allowed
+go
+
 select * from db_roles_schema_2.after_created_by_u2_v1; -- not allowed
 go
 
@@ -342,6 +408,9 @@ delete from db_roles_schema_2.after_created_by_u2_t1 where a = 2; -- not allowed
 go
 
 select * from db_roles_schema_2.after_created_by_u2_t2; -- not allowed
+go
+
+SELECT NEXT VALUE FOR db_roles_schema_2.after_created_by_u2_sq2; -- not allowed
 go
 
 select * from db_roles_schema_2.after_created_by_u2_v2; -- not allowed


### PR DESCRIPTION
### Description

T-SQL allows member of db_datawriter to get next value from sequence.

### Issues Resolved

Task: BABEL-5356
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).