### PR TITLE
Disallow declaring reserved @@variable names

### DIFF
--- a/test/JDBC/expected/atatuservar-vu-verify.out
+++ b/test/JDBC/expected/atatuservar-vu-verify.out
@@ -3513,13 +3513,6 @@ int#!#int
 123#!#1
 ~~END~~
 
-declare @@lock_timeout int=123 select @@lock_timeout, lock_timeout()
-go
-~~START~~
-int#!#int
--1#!#-1
-~~END~~
-
 declare @@rand int=123 select @@rand, case when rand() <= 0 then 'too small, <= 0' when rand() >= 1 then ' too large, >= 1' else 'correct, >0 && <1' end
 go
 ~~START~~
@@ -3590,7 +3583,6 @@ declare @@db_id int=123 select @@db_id, db_id('master')
 declare @@db_name int=123 select @@db_name, db_name()
 declare @@exp int=123 select @@exp, exp(1)
 declare @@sign int=123 select @@sign, sign(1)
-declare @@lock_timeout int=123 select @@lock_timeout, lock_timeout()
 declare @@rand int=123 select @@rand, case when rand() <= 0 then 'too small, <= 0' when rand() >= 1 then ' too large, >= 1' else 'correct, >0 && <1' end
 declare @@trigger_nestlevel int=123 select @@trigger_nestlevel, trigger_nestlevel()
 declare @@atn2 int=123 select @@atn2, atn2(1,0)
@@ -3654,11 +3646,6 @@ int#!#int
 ~~END~~
 
 ~~START~~
-int#!#int
--1#!#-1
-~~END~~
-
-~~START~~
 int#!#varchar
 123#!#correct, >0 && <1
 ~~END~~
@@ -3712,7 +3699,6 @@ declare @@db_id int=123
 declare @@db_name int=123 
 declare @@exp int=123 
 declare @@sign int=123 
-declare @@lock_timeout int=123 
 declare @@rand int=123 
 declare @@trigger_nestlevel int=123 
 declare @@atn2 int=123 
@@ -3721,14 +3707,14 @@ declare @@datediff int=123
 declare @@datediff_big int=123 
 declare @@dateadd int=123 
 declare @@datename int=123 
-return @@xact_state + @@error_line + @@error_message + @@error_number + @@error_procedure + @@error_state + @@db_id + @@db_name + @@exp + @@sign + @@lock_timeout + @@rand + @@trigger_nestlevel + @@atn2 + @@datepart + @@datediff + @@datediff_big + @@dateadd + @@datename 
+return @@xact_state + @@error_line + @@error_message + @@error_number + @@error_procedure + @@error_state + @@db_id + @@db_name + @@exp + @@sign + @@rand + @@trigger_nestlevel + @@atn2 + @@datepart + @@datediff + @@datediff_big + @@dateadd + @@datename 
 end
 go
 select dbo.f1_sysfunctions_atatuservar()
 go
 ~~START~~
 int
-2213
+2214
 ~~END~~
 
 
@@ -3744,7 +3730,6 @@ declare @@db_id int=123 select @@db_id, db_id('master')
 declare @@db_name int=123 select @@db_name, db_name()
 declare @@exp int=123 select @@exp, exp(1)
 declare @@sign int=123 select @@sign, sign(1)
-declare @@lock_timeout int=123 select @@lock_timeout, lock_timeout()
 declare @@rand int=123 select @@rand, case when rand() <= 0 then 'too small, <= 0' when rand() >= 1 then ' too large, >= 1' else 'correct, >0 && <1' end
 declare @@trigger_nestlevel int=123 select @@trigger_nestlevel, trigger_nestlevel()
 declare @@atn2 int=123 select @@atn2, atn2(1,0)
@@ -3805,11 +3790,6 @@ int#!#float
 ~~START~~
 int#!#int
 123#!#1
-~~END~~
-
-~~START~~
-int#!#int
--1#!#-1
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/declare_atatglobalvars-vu-cleanup.out
+++ b/test/JDBC/expected/declare_atatglobalvars-vu-cleanup.out
@@ -1,0 +1,10 @@
+drop function f2_declare_atatglobalvars
+go
+drop procedure p2_declare_atatglobalvars
+go
+drop procedure p3_declare_atatglobalvars
+go
+drop table t1_declare_atatglobalvars
+go
+drop type tt_declare_atatglobalvars
+go

--- a/test/JDBC/expected/declare_atatglobalvars-vu-prepare.out
+++ b/test/JDBC/expected/declare_atatglobalvars-vu-prepare.out
@@ -1,0 +1,8 @@
+create table t1_declare_atatglobalvars (a int)
+go
+insert t1_declare_atatglobalvars values (1), (2)
+go
+~~ROW COUNT: 2~~
+
+create type tt_declare_atatglobalvars as table (a int)
+go

--- a/test/JDBC/expected/declare_atatglobalvars-vu-verify.out
+++ b/test/JDBC/expected/declare_atatglobalvars-vu-verify.out
@@ -1,0 +1,479 @@
+declare @@cursor_rows int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@cursor_rows'.)~~
+
+declare @@datefirst int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@datefirst'.)~~
+
+declare @@DBTS int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@DBTS'.)~~
+
+declare @@error int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@error'.)~~
+
+declare @@pgerror int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@pgerror': this is a reserved variable name in Babelfish.)~~
+
+declare @@fetch_status int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@fetch_status'.)~~
+
+declare @@IDENTITY int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@IDENTITY'.)~~
+
+declare @@language varchar(100)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@language'.)~~
+
+declare @@LOCK_TIMEOUT int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@LOCK_TIMEOUT'.)~~
+
+declare @@max_connections int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_connections'.)~~
+
+declare @@max_precision int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_precision'.)~~
+
+declare @@nestlevel int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@nestlevel'.)~~
+
+declare @@options int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@options'.)~~
+
+declare @@procid int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@procid'.)~~
+
+declare @@rowcount int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@rowcount'.)~~
+
+declare @@servername varchar(100)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@servername'.)~~
+
+declare @@servicename varchar(100)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@servicename'.)~~
+
+declare @@spid int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@spid'.)~~
+
+declare @@trancount int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@trancount'.)~~
+
+declare @@version varchar(100)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@version'.)~~
+
+declare @@microsoftversion int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@microsoftversion'.)~~
+
+declare @@connections int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@connections'.)~~
+
+declare @@cpu_busy int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@cpu_busy'.)~~
+
+declare @@idle int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@idle'.)~~
+
+declare @@io_busy int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@io_busy'.)~~
+
+declare @@langid int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@langid'.)~~
+
+declare @@packet_errors int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@packet_errors'.)~~
+
+declare @@pack_received int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@pack_received'.)~~
+
+declare @@pack_sent int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@pack_sent'.)~~
+
+declare @@remserver varchar(100)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@remserver'.)~~
+
+declare @@textsize int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@textsize'.)~~
+
+declare @@timeticks int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@timeticks'.)~~
+
+declare @@total_errors int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@total_errors'.)~~
+
+declare @@total_read int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@total_read'.)~~
+
+declare @@total_write int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@total_write'.)~~
+
+
+
+declare @@myvar int, @@spid int
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@spid'.)~~
+
+declare @@spid table(a int)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@spid'.)~~
+
+
+create procedure p1_declare_atatglobalvars
+as
+declare @@spid int=123
+select @@spid
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@spid'.)~~
+
+create procedure p1_declare_atatglobalvars
+as
+declare @@DATEFIRST int=123
+select @@datefirst
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@DATEFIRST'.)~~
+
+create procedure p1_declare_atatglobalvars
+as
+declare @@myvar int=123, @@nestlevel int=123
+select @@nestlevel
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@nestlevel'.)~~
+
+
+create procedure p1_declare_atatglobalvars
+@@identity int
+as
+return 0
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@identity'.)~~
+
+
+create procedure p1_declare_atatglobalvars
+@@myparam int, @@options int = -1, @@myparam2 int
+as
+return 0
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@options'.)~~
+
+
+create procedure p1_declare_atatglobalvars 
+@@dbts tt_declare_atatglobalvars readonly
+as
+return 0
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@dbts'.)~~
+
+
+create function f1_declare_atatglobalvars() 
+returns int 
+as 
+begin
+declare @@max_precision int
+return 0 
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_precision'.)~~
+
+
+create function f1_declare_atatglobalvars() 
+returns int 
+as 
+begin
+declare @@myvar int=123, @@max_precision int
+return 0 
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_precision'.)~~
+
+
+create function f1_declare_atatglobalvars(@@fetch_status int) 
+returns int 
+as 
+begin 
+return 0 
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@fetch_status'.)~~
+
+
+create function f1_declare_atatglobalvars(@@myparam int, @@fetch_status int, @@myparam2 int) 
+returns int 
+as 
+begin 
+return 0 
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@fetch_status'.)~~
+
+
+create function f1_declare_atatglobalvars() 
+returns @@rowcount table(a int)
+as begin 
+return 
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@rowcount'.)~~
+
+
+create trigger tr1 on t1_declare_atatglobalvars for insert
+as
+begin
+declare @@procid int
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@procid'.)~~
+
+
+create trigger tr1 on t1_declare_atatglobalvars for insert
+as
+begin
+declare @@myvar int, @@procid int, @@myvar2 int
+end
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@procid'.)~~
+
+
+-- verify @@rowcount etc. still work orrectly (NB. this is just a brief test, other test cases already exist for these)
+select a from t1_declare_atatglobalvars order by a
+select @@rowcount as rc, @@nestlevel as nl, @@trancount as tc, @@error as err, @@pgerror as pgerr
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#varchar
+2#!#0#!#0#!#0#!#00000
+~~END~~
+
+
+create procedure p2_declare_atatglobalvars
+as
+select a from t1_declare_atatglobalvars order by a
+select @@rowcount as rc, @@nestlevel as nl, @@trancount as tc, @@error as err, @@pgerror as pgerr
+go
+exec p2_declare_atatglobalvars
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#varchar
+2#!#1#!#0#!#0#!#00000
+~~END~~
+
+begin tran
+exec p2_declare_atatglobalvars
+rollback
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#varchar
+2#!#1#!#1#!#0#!#00000
+~~END~~
+
+
+-- non-zero @@PGERROR:
+select 1/0
+go
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+select @@error as err, @@pgerror as pgerr
+go
+~~START~~
+int#!#varchar
+8134#!#22012
+~~END~~
+
+
+create procedure p3_declare_atatglobalvars @@myparam int
+as
+select @@myparam
+go
+exec p3_declare_atatglobalvars @@max_precision
+go
+~~START~~
+int
+38
+~~END~~
+
+exec p3_declare_atatglobalvars @@myparam=@@max_precision
+go
+~~START~~
+int
+38
+~~END~~
+
+
+create function f2_declare_atatglobalvars(@@myparam int) 
+returns int 
+as 
+begin 
+return @@myparam
+end
+go
+select dbo.f2_declare_atatglobalvars(@@max_precision)
+go
+~~START~~
+int
+38
+~~END~~
+
+
+declare @@pgerror2 int=123 select @@pgerror2
+go
+~~START~~
+int
+123
+~~END~~
+
+declare @@spid_ int=123 select @@spid_
+go
+~~START~~
+int
+123
+~~END~~
+

--- a/test/JDBC/expected/declare_atatglobalvars_upgrade-before-16_5-vu-cleanup.out
+++ b/test/JDBC/expected/declare_atatglobalvars_upgrade-before-16_5-vu-cleanup.out
@@ -1,0 +1,6 @@
+drop table t1_declare_atatglobalvars_upgrade
+go
+drop procedure p1_declare_atatglobalvars_upgrade
+go
+drop function f1_declare_atatglobalvars_upgrade
+go

--- a/test/JDBC/expected/declare_atatglobalvars_upgrade-before-16_5-vu-prepare.out
+++ b/test/JDBC/expected/declare_atatglobalvars_upgrade-before-16_5-vu-prepare.out
@@ -1,0 +1,54 @@
+create table t1_declare_atatglobalvars_upgrade(a int)
+go
+insert t1_declare_atatglobalvars_upgrade values (1), (2)
+go
+~~ROW COUNT: 2~~
+
+
+-- these objects can be created and executed without error in previous Babelfish releases,
+-- but they will fail once this fix is active.
+create procedure p1_declare_atatglobalvars_upgrade
+as
+declare @@max_precision int=123
+select @@max_precision
+go
+exec p1_declare_atatglobalvars_upgrade
+go
+~~START~~
+tinyint
+38
+~~END~~
+
+
+create function f1_declare_atatglobalvars_upgrade() 
+returns int 
+as 
+begin
+declare @@max_precision int=123
+return @@max_precision
+end
+go
+select dbo.f1_declare_atatglobalvars_upgrade() 
+go
+~~START~~
+int
+38
+~~END~~
+
+
+create trigger tr1 on t1_declare_atatglobalvars_upgrade for insert
+as
+begin
+declare @@max_precision int
+select @@max_precision
+end
+go
+insert into t1_declare_atatglobalvars_upgrade values(3)
+go
+~~START~~
+tinyint
+38
+~~END~~
+
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/declare_atatglobalvars_upgrade-before-16_5-vu-verify.out
+++ b/test/JDBC/expected/declare_atatglobalvars_upgrade-before-16_5-vu-verify.out
@@ -1,0 +1,20 @@
+insert into t1_declare_atatglobalvars_upgrade values(4)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_precision'.)~~
+
+exec p1_declare_atatglobalvars_upgrade
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_precision'.)~~
+
+select dbo.f1_declare_atatglobalvars_upgrade() 
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near '@@max_precision'.)~~
+

--- a/test/JDBC/input/atatuservar-vu-verify.sql
+++ b/test/JDBC/input/atatuservar-vu-verify.sql
@@ -1741,8 +1741,6 @@ declare @@exp int=123 select @@exp, exp(1)
 go
 declare @@sign int=123 select @@sign, sign(1)
 go
-declare @@lock_timeout int=123 select @@lock_timeout, lock_timeout()
-go
 declare @@rand int=123 select @@rand, case when rand() <= 0 then 'too small, <= 0' when rand() >= 1 then ' too large, >= 1' else 'correct, >0 && <1' end
 go
 declare @@trigger_nestlevel int=123 select @@trigger_nestlevel, trigger_nestlevel()
@@ -1773,7 +1771,6 @@ declare @@db_id int=123 select @@db_id, db_id('master')
 declare @@db_name int=123 select @@db_name, db_name()
 declare @@exp int=123 select @@exp, exp(1)
 declare @@sign int=123 select @@sign, sign(1)
-declare @@lock_timeout int=123 select @@lock_timeout, lock_timeout()
 declare @@rand int=123 select @@rand, case when rand() <= 0 then 'too small, <= 0' when rand() >= 1 then ' too large, >= 1' else 'correct, >0 && <1' end
 declare @@trigger_nestlevel int=123 select @@trigger_nestlevel, trigger_nestlevel()
 declare @@atn2 int=123 select @@atn2, atn2(1,0)
@@ -1800,7 +1797,6 @@ declare @@db_id int=123
 declare @@db_name int=123 
 declare @@exp int=123 
 declare @@sign int=123 
-declare @@lock_timeout int=123 
 declare @@rand int=123 
 declare @@trigger_nestlevel int=123 
 declare @@atn2 int=123 
@@ -1809,7 +1805,7 @@ declare @@datediff int=123
 declare @@datediff_big int=123 
 declare @@dateadd int=123 
 declare @@datename int=123 
-return @@xact_state + @@error_line + @@error_message + @@error_number + @@error_procedure + @@error_state + @@db_id + @@db_name + @@exp + @@sign + @@lock_timeout + @@rand + @@trigger_nestlevel + @@atn2 + @@datepart + @@datediff + @@datediff_big + @@dateadd + @@datename 
+return @@xact_state + @@error_line + @@error_message + @@error_number + @@error_procedure + @@error_state + @@db_id + @@db_name + @@exp + @@sign + @@rand + @@trigger_nestlevel + @@atn2 + @@datepart + @@datediff + @@datediff_big + @@dateadd + @@datename 
 end
 go
 select dbo.f1_sysfunctions_atatuservar()
@@ -1827,7 +1823,6 @@ declare @@db_id int=123 select @@db_id, db_id('master')
 declare @@db_name int=123 select @@db_name, db_name()
 declare @@exp int=123 select @@exp, exp(1)
 declare @@sign int=123 select @@sign, sign(1)
-declare @@lock_timeout int=123 select @@lock_timeout, lock_timeout()
 declare @@rand int=123 select @@rand, case when rand() <= 0 then 'too small, <= 0' when rand() >= 1 then ' too large, >= 1' else 'correct, >0 && <1' end
 declare @@trigger_nestlevel int=123 select @@trigger_nestlevel, trigger_nestlevel()
 declare @@atn2 int=123 select @@atn2, atn2(1,0)

--- a/test/JDBC/input/declare_atatglobalvars-vu-cleanup.sql
+++ b/test/JDBC/input/declare_atatglobalvars-vu-cleanup.sql
@@ -1,0 +1,10 @@
+drop function f2_declare_atatglobalvars
+go
+drop procedure p2_declare_atatglobalvars
+go
+drop procedure p3_declare_atatglobalvars
+go
+drop table t1_declare_atatglobalvars
+go
+drop type tt_declare_atatglobalvars
+go

--- a/test/JDBC/input/declare_atatglobalvars-vu-prepare.sql
+++ b/test/JDBC/input/declare_atatglobalvars-vu-prepare.sql
@@ -1,0 +1,6 @@
+create table t1_declare_atatglobalvars (a int)
+go
+insert t1_declare_atatglobalvars values (1), (2)
+go
+create type tt_declare_atatglobalvars as table (a int)
+go

--- a/test/JDBC/input/declare_atatglobalvars-vu-verify.sql
+++ b/test/JDBC/input/declare_atatglobalvars-vu-verify.sql
@@ -1,0 +1,212 @@
+declare @@cursor_rows int
+go
+declare @@datefirst int
+go
+declare @@DBTS int
+go
+declare @@error int
+go
+declare @@pgerror int
+go
+declare @@fetch_status int
+go
+declare @@IDENTITY int
+go
+declare @@language varchar(100)
+go
+declare @@LOCK_TIMEOUT int
+go
+declare @@max_connections int
+go
+declare @@max_precision int
+go
+declare @@nestlevel int
+go
+declare @@options int
+go
+declare @@procid int
+go
+declare @@rowcount int
+go
+declare @@servername varchar(100)
+go
+declare @@servicename varchar(100)
+go
+declare @@spid int
+go
+declare @@trancount int
+go
+declare @@version varchar(100)
+go
+declare @@microsoftversion int
+go
+declare @@connections int
+go
+declare @@cpu_busy int
+go
+declare @@idle int
+go
+declare @@io_busy int
+go
+declare @@langid int
+go
+declare @@packet_errors int
+go
+declare @@pack_received int
+go
+declare @@pack_sent int
+go
+declare @@remserver varchar(100)
+go
+declare @@textsize int
+go
+declare @@timeticks int
+go
+declare @@total_errors int
+go
+declare @@total_read int
+go
+declare @@total_write int
+go
+
+
+declare @@myvar int, @@spid int
+go
+declare @@spid table(a int)
+go
+
+create procedure p1_declare_atatglobalvars
+as
+declare @@spid int=123
+select @@spid
+go
+create procedure p1_declare_atatglobalvars
+as
+declare @@DATEFIRST int=123
+select @@datefirst
+go
+create procedure p1_declare_atatglobalvars
+as
+declare @@myvar int=123, @@nestlevel int=123
+select @@nestlevel
+go
+
+create procedure p1_declare_atatglobalvars
+@@identity int
+as
+return 0
+go
+
+create procedure p1_declare_atatglobalvars
+@@myparam int, @@options int = -1, @@myparam2 int
+as
+return 0
+go
+
+create procedure p1_declare_atatglobalvars 
+@@dbts tt_declare_atatglobalvars readonly
+as
+return 0
+go
+
+create function f1_declare_atatglobalvars() 
+returns int 
+as 
+begin
+declare @@max_precision int
+return 0 
+end
+go
+
+create function f1_declare_atatglobalvars() 
+returns int 
+as 
+begin
+declare @@myvar int=123, @@max_precision int
+return 0 
+end
+go
+
+create function f1_declare_atatglobalvars(@@fetch_status int) 
+returns int 
+as 
+begin 
+return 0 
+end
+go
+
+create function f1_declare_atatglobalvars(@@myparam int, @@fetch_status int, @@myparam2 int) 
+returns int 
+as 
+begin 
+return 0 
+end
+go
+
+create function f1_declare_atatglobalvars() 
+returns @@rowcount table(a int)
+as begin 
+return 
+end
+go
+
+create trigger tr1 on t1_declare_atatglobalvars for insert
+as
+begin
+declare @@procid int
+end
+go
+
+create trigger tr1 on t1_declare_atatglobalvars for insert
+as
+begin
+declare @@myvar int, @@procid int, @@myvar2 int
+end
+go
+
+-- verify @@rowcount etc. still work orrectly (NB. this is just a brief test, other test cases already exist for these)
+select a from t1_declare_atatglobalvars order by a
+select @@rowcount as rc, @@nestlevel as nl, @@trancount as tc, @@error as err, @@pgerror as pgerr
+go
+
+create procedure p2_declare_atatglobalvars
+as
+select a from t1_declare_atatglobalvars order by a
+select @@rowcount as rc, @@nestlevel as nl, @@trancount as tc, @@error as err, @@pgerror as pgerr
+go
+exec p2_declare_atatglobalvars
+go
+begin tran
+exec p2_declare_atatglobalvars
+rollback
+go
+
+-- non-zero @@PGERROR:
+select 1/0
+go
+select @@error as err, @@pgerror as pgerr
+go
+
+create procedure p3_declare_atatglobalvars @@myparam int
+as
+select @@myparam
+go
+exec p3_declare_atatglobalvars @@max_precision
+go
+exec p3_declare_atatglobalvars @@myparam=@@max_precision
+go
+
+create function f2_declare_atatglobalvars(@@myparam int) 
+returns int 
+as 
+begin 
+return @@myparam
+end
+go
+select dbo.f2_declare_atatglobalvars(@@max_precision)
+go
+
+declare @@pgerror2 int=123 select @@pgerror2
+go
+declare @@spid_ int=123 select @@spid_
+go

--- a/test/JDBC/input/declare_atatglobalvars_upgrade-before-16_5-vu-cleanup.sql
+++ b/test/JDBC/input/declare_atatglobalvars_upgrade-before-16_5-vu-cleanup.sql
@@ -1,0 +1,6 @@
+drop table t1_declare_atatglobalvars_upgrade
+go
+drop procedure p1_declare_atatglobalvars_upgrade
+go
+drop function f1_declare_atatglobalvars_upgrade
+go

--- a/test/JDBC/input/declare_atatglobalvars_upgrade-before-16_5-vu-prepare.sql
+++ b/test/JDBC/input/declare_atatglobalvars_upgrade-before-16_5-vu-prepare.sql
@@ -1,0 +1,35 @@
+create table t1_declare_atatglobalvars_upgrade(a int)
+go
+insert t1_declare_atatglobalvars_upgrade values (1), (2)
+go
+
+-- these objects can be created and executed without error in previous Babelfish releases,
+-- but they will fail once this fix is active.
+create procedure p1_declare_atatglobalvars_upgrade
+as
+declare @@max_precision int=123
+select @@max_precision
+go
+exec p1_declare_atatglobalvars_upgrade
+go
+
+create function f1_declare_atatglobalvars_upgrade() 
+returns int 
+as 
+begin
+declare @@max_precision int=123
+return @@max_precision
+end
+go
+select dbo.f1_declare_atatglobalvars_upgrade() 
+go
+
+create trigger tr1 on t1_declare_atatglobalvars_upgrade for insert
+as
+begin
+declare @@max_precision int
+select @@max_precision
+end
+go
+insert into t1_declare_atatglobalvars_upgrade values(3)
+go

--- a/test/JDBC/input/declare_atatglobalvars_upgrade-before-16_5-vu-verify.sql
+++ b/test/JDBC/input/declare_atatglobalvars_upgrade-before-16_5-vu-verify.sql
@@ -1,0 +1,6 @@
+insert into t1_declare_atatglobalvars_upgrade values(4)
+go
+exec p1_declare_atatglobalvars_upgrade
+go
+select dbo.f1_declare_atatglobalvars_upgrade() 
+go

--- a/test/JDBC/input/sp_columns_100.sql
+++ b/test/JDBC/input/sp_columns_100.sql
@@ -1,4 +1,4 @@
--- sla_for_parallel_query_enforced 1500000
+-- sla_for_parallel_query_enforced 2000000
 -- create tables with most of the datatypes
 create table var(a char(10), b nchar(9), c nvarchar(8), d varchar(7), e text, f ntext, g varbinary(10), h binary(9), i image, j xml)
 go

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -478,6 +478,9 @@ ignore#!#BABEL-5119_before_16_5-vu-cleanup
 ignore#!#BABEL-5059_before_16_5-vu-prepare
 ignore#!#BABEL-5059_before_16_5-vu-verify
 ignore#!#BABEL-5059_before_16_5-vu-cleanup
+ignore#!#declare_atatglobalvars_upgrade-before-16_5-vu-cleanup
+ignore#!#declare_atatglobalvars_upgrade-before-16_5-vu-prepare
+ignore#!#declare_atatglobalvars_upgrade-before-16_5-vu-verify
 
 # Assertion failure in pg-stat-statements BABEL-5391
 ignore#!#Test-sp_execute_postgresql

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -559,6 +559,7 @@ db_ddladmin
 db_securityadmin
 xml_exist-before-16_5
 BABEL-CASE_EXPR-before-16_5-or-15_9
+declare_atatglobalvars_upgrade-before-16_5
 BABEL-5186
 BABEL-2736-before-16_5
 securityadmin_role

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -576,6 +576,7 @@ GRANT_SCHEMA-before-15_9-16_5
 BABEL-CASE_EXPR-before-16_5-or-15_9
 charindex_replace_patindex
 dbcreator_role
+declare_atatglobalvars_upgrade-before-16_5
 BABEL-5186
 BABEL-2736-before-16_5
 securityadmin_role


### PR DESCRIPTION
### Description

Now that variables named `@@myvar` are supported (see [PR #3073](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3073)), we should also address the issue of being able to declare a user-defined variable with the same name as a predefined global `@@` variable, for example `@@SPID`.
Babelfish has always allowed such declarations even though referencing the declared variable would actually reference the predefined global `@@variable`, thus producing a wrong result. For example:

```
1> declare @@spid int = 123
2> select @@spid
3> go
spid
-----------
      20902     <===== WRONG!
```
      
This fix does not allow predefined `@@` global variables to be used as user-defined variables or parameters, and will raise a syntax error as expected in T-SQL.
A special case is the `@@PGERROR` variable which was introduced by Babelfish: when declaring a variable with this name, the error message will additionally point out that `@@PGERROR` is a reserved name in Babelfish. 


Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

BABEL-5388: Disallow declaring reserved @@variable names


### Test Scenarios Covered ###
- Use case based - Yes

- Boundary conditions - Yes

- Arbitrary inputs - N/A

- Negative test cases - Yes

- Minor version upgrade tests - Yes

- Major version upgrade tests - N/A

- Performance tests - N/A

- Tooling impact - N/A

- Client tests - N/A

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).