### PR TITLE
Fixed unexpected error print by insert execute

### DIFF
--- a/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
@@ -781,3 +781,20 @@ drop type user_defined_sch.test_tbl_type
 go
 drop schema user_defined_sch
 go
+
+-- BABEL-5306
+create table t_5306 (id int)
+GO
+
+create proc p_5306 (@output INT OUTPUT) as SET @output = 1;
+GO
+
+DECLARE @i int
+insert into t_5306 exec p_5306 @output = @i
+GO
+
+drop table t_5306
+GO
+
+drop procedure p_5306
+GO

--- a/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
@@ -305,3 +305,20 @@ drop type user_defined_sch.test_tbl_type
 go
 drop schema user_defined_sch
 go
+
+-- BABEL-5306
+create table t_5306 (id int)
+GO
+
+create proc p_5306 (@output INT OUTPUT) as SET @output = 1;
+GO
+
+DECLARE @i int
+insert into t_5306 exec p_5306 @output = @i
+GO
+
+drop table t_5306
+GO
+
+drop procedure p_5306
+GO


### PR DESCRIPTION
Insert Execute will print unexpected error msg like : 'procedure returned null record' when the procedure executed return 0 rows of records.

This commit fixed this issue that will let the insert execute finish normaly without printing out error message in such case.

Task: BABEL-5306

### Check List
- [ x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).