### PR TITLE
Fix transaction leak when DMLs contains a non pltsql language function which calls another non tsql function inside try catch

### DIFF
--- a/test/JDBC/expected/TestBasicInterop.out
+++ b/test/JDBC/expected/TestBasicInterop.out
@@ -186,3 +186,31 @@ GO
 -- psql
 DROP PROCEDURE pg_interop_proc_sp_exec
 GO
+
+-- tsql
+CREATE TABLE babel_5446 (Test INT NULL)
+GO
+INSERT INTO babel_5446 SELECT ISNUMERIC('test') AS my_isnumeric
+GO
+~~ROW COUNT: 1~~
+
+SELECT @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+INSERT INTO babel_5446 SELECT ISNUMERIC('test') AS my_isnumeric
+SELECT @@trancount
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+0
+~~END~~
+
+DROP TABLE babel_5446
+GO

--- a/test/JDBC/input/interoperability/TestBasicInterop.mix
+++ b/test/JDBC/input/interoperability/TestBasicInterop.mix
@@ -127,3 +127,17 @@ GO
 -- psql
 DROP PROCEDURE pg_interop_proc_sp_exec
 GO
+
+-- tsql
+CREATE TABLE babel_5446 (Test INT NULL)
+GO
+INSERT INTO babel_5446 SELECT ISNUMERIC('test') AS my_isnumeric
+GO
+SELECT @@trancount
+GO
+
+INSERT INTO babel_5446 SELECT ISNUMERIC('test') AS my_isnumeric
+SELECT @@trancount
+GO
+DROP TABLE babel_5446
+GO


### PR DESCRIPTION
### Description

When DMLs are executed outside a user transaction block, babelfish starts an implicit transaction to handle errors inside triggers. This is done irrespective of whether the statement actually fires a trigger.
Now if the DML calls a non pltsql function which in calls another non tsql func or procedure inside a try catch, we do not properly decrement the `pltsql_sys_func_entry_count` variable properly. So the return value of `pltsql_support_tsql_transactions()` is different at beginning of the DML compared to after the end of the statement. This difference leads to babelfish not commit the implict transaction block.
As a fix, store the value of pltsql_support_tsql_transactions() at start of execution of DML and just reuse it for after execution.

### Issues Resolved

[BABEL-5446]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).