### PR TITLE
Modify upgrade scripts to obtain correct server level collation during upgrade

### DIFF
--- a/.github/configuration/upgrade-test-configuration.yml
+++ b/.github/configuration/upgrade-test-configuration.yml
@@ -250,6 +250,19 @@ upgrade-version: [{
 {
   upgrade-path: [
     {
+      version: 15.2,
+      upgrade-type: null
+    },
+    {
+      version: target.latest,
+      upgrade-type: major
+    }
+  ],
+  babelfishpg_tsql_server_collation_name: chinese_prc_ci_as
+},
+{
+  upgrade-path: [
+    {
       version: 16.1,
       upgrade-type: null,
     },

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.0.0--3.1.0.sql
@@ -31,6 +31,36 @@ end
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 -- Removes a member object from the extension. The object is not dropped, only disassociated from the extension.
 -- It is a temporary procedure for use by the upgrade script. Will be dropped at the end of the upgrade.
 CREATE OR REPLACE PROCEDURE babelfish_remove_object_from_extension(obj_type varchar, qualified_obj_name varchar) AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.1.0--3.2.0.sql
@@ -31,6 +31,36 @@ end
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 CREATE TABLE sys.babelfish_server_options (
 	servername sys.SYSNAME NOT NULL PRIMARY KEY COLLATE "C",
 	query_timeout INT

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.2.0--3.3.0.sql
@@ -31,6 +31,36 @@ end
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 CREATE OR REPLACE PROCEDURE sys.sp_execute_postgresql(IN "@postgresStmt" sys.nvarchar)
 AS 'babelfishpg_tsql', 'sp_execute_postgresql' LANGUAGE C;
 GRANT EXECUTE on PROCEDURE sys.sp_execute_postgresql(IN sys.nvarchar) TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.3.0--3.4.0.sql
@@ -37,6 +37,35 @@ LANGUAGE plpgsql;
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
 
 CREATE OR REPLACE VIEW sys.asymmetric_keys
 AS

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.0.0--4.1.0.sql
@@ -37,6 +37,37 @@ LANGUAGE plpgsql;
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 CREATE OR REPLACE FUNCTION sys.bbf_log(IN arg1 FLOAT)
 RETURNS FLOAT  AS 'babelfishpg_tsql','numeric_log_natural' LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;
 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.1.0--4.2.0.sql
@@ -31,6 +31,36 @@ end
 $$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 -- BABELFISH_SCHEMA_PERMISSIONS
 CREATE TABLE IF NOT EXISTS sys.babelfish_schema_permissions (
   dbid smallint NOT NULL,

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
@@ -38,6 +38,36 @@ LANGUAGE plpgsql;
  * final behaviour.
  */
 
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
+
 -- Babelfish catalog tables are marked system tables and postgres does not normally allow modification on
 -- system tables so need to temporarily set allow_system_table_mods to update the primary key of babelfish_function_ext.
 SET allow_system_table_mods = ON;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.3.0--4.4.0.sql
@@ -37,6 +37,35 @@ LANGUAGE plpgsql;
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
 
 -- This is a temporary procedure which is only meant to be called during upgrade
 CREATE OR REPLACE PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins()

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -10,6 +10,35 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
  * So make sure that any SQL statement (DDL/DML) being added here can be executed multiple times without affecting
  * final behaviour.
  */
+CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
+LANGUAGE C
+AS 'babelfishpg_common', 'babelfish_update_server_collation_name';
+
+DO
+LANGUAGE plpgsql
+$$
+BEGIN
+    -- Check if the GUC is empty
+    IF current_setting('babelfishpg_tsql.restored_server_collation_name', true) <> '' THEN
+        -- Call the function to update the collation
+        EXECUTE 'SELECT sys.babelfish_update_server_collation_name()';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION sys.babelfish_update_server_collation_name();
+
+-- reset babelfishpg_tsql.restored_server_collation_name GUC
+do
+language plpgsql
+$$
+    declare
+        query text;
+    begin
+        query := pg_catalog.format('alter database %s reset babelfishpg_tsql.restored_server_collation_name', CURRENT_DATABASE());
+        execute query;
+    end;
+$$;
 
 -- This is a temporary procedure which is only meant to be called during upgrade
 CREATE OR REPLACE PROCEDURE sys.babelfish_revoke_guest_from_mapped_logins()

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -27,6 +27,10 @@ Unexpected drop found for function sys.babelfish_update_server_collation_name in
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.10.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.11.0--3.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--2.12.0--3.0.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.0.0--3.1.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.1.0--3.2.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.2.0--3.3.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.3.0--3.4.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.4.0--4.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.5.0--4.0.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--3.6.0--4.0.0.sql
@@ -39,6 +43,10 @@ Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collati
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.4.0--3.0.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.5.0--3.0.0.sql
 Unexpected drop found for function sys.babelfishpg_tsql_get_babel_server_collation_oid in file babelfishpg_tsql--2.6.0--3.0.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.0.0--4.1.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.1.0--4.2.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.2.0--4.3.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.3.0--4.4.0.sql
 Unexpected drop found for function sys.pg_extension_config_remove in file babelfishpg_tsql--3.1.0--3.2.0.sql
 Unexpected drop found for operator sys.+ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql

--- a/test/python/expected/sql_validation_framework/expected_drop.out
+++ b/test/python/expected/sql_validation_framework/expected_drop.out
@@ -47,6 +47,7 @@ Unexpected drop found for function sys.babelfish_update_server_collation_name in
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.1.0--4.2.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.2.0--4.3.0.sql
 Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.3.0--4.4.0.sql
+Unexpected drop found for function sys.babelfish_update_server_collation_name in file babelfishpg_tsql--4.4.0--4.5.0.sql
 Unexpected drop found for function sys.pg_extension_config_remove in file babelfishpg_tsql--3.1.0--3.2.0.sql
 Unexpected drop found for operator sys.+ in file babelfishpg_common--1.1.0--1.2.0.sql
 Unexpected drop found for operator sys./ in file babelfishpg_common--1.1.0--1.2.0.sql


### PR DESCRIPTION
### Description
In all MVU sql scripts, we update the server collation name and reset the restored_server_collation_name GUC. During the upgrade from 15.2 --> latest (16), the upgrade started failing for non-default server collation like chinese_prc_ci_as as we did not have correct collation information and the collation of columns of views were trying to get updated. This is because, we never updated the collation related information in any of the upgrade script post 15.2, hence it was always picking the default value which is bbf_unicode_cp1_ci_as. 
The issue may come up in case when user is performing upgrade from some version of 15 (before 15.6) to latest if we have defines some view which contains collatable column in upgrade script and the server level collation is different than default collation.

We address the issue by updating the collation related information in the necessary upgrade scripts. 


### Issues Resolved ###
BABEL-5415
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).