### PR TITLE
Fix output files for pg_hint_plan tests

### DIFF
--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -533,17 +533,18 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Append
-        ->  Bitmap Heap Scan on babel_3292_t1
-              Recheck Cond: (b1 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
-                    Index Cond: (b1 = 1)
-        ->  Bitmap Heap Scan on babel_3292_t2
-              Recheck Cond: (b2 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
-                    Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+        ->  Append
+              ->  Bitmap Heap Scan on babel_3292_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+                          Index Cond: (b1 = 1)
+              ->  Bitmap Heap Scan on babel_3292_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -557,15 +558,16 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Append
-        ->  Bitmap Heap Scan on babel_3292_t1
-              Recheck Cond: (b1 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
-                    Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+        ->  Append
+              ->  Bitmap Heap Scan on babel_3292_t1
+                    Recheck Cond: (b1 = 1)
+                    ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+                          Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -579,15 +581,16 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                 
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-              Index Cond: (b1 = 1)
-        ->  Bitmap Heap Scan on babel_3292_t2
-              Recheck Cond: (b2 = 1)
-              ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
-                    Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+                    Index Cond: (b1 = 1)
+              ->  Bitmap Heap Scan on babel_3292_t2
+                    Recheck Cond: (b2 = 1)
+                    ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -601,13 +604,14 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                    where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-              Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+                    Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -621,13 +625,14 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                                                                           
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-              Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+                    Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1057,13 +1062,14 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2                                    where b2 = 1
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-              Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: t1.a1, t1.b1, t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                    Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1077,13 +1083,14 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2                                    where b2 = 1
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-              Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: t1.a1, t1.b1, t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                    Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1097,13 +1104,14 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                           
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-              Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: t1.a1, t1.b1, t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                    Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1117,13 +1125,14 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1                                                                                                            
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Append
-        ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-              Index Cond: (b1 = 1)
-        ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
-              Index Cond: (b2 = 1)
+Unique
+  ->  Sort
+        Sort Key: t1.a1, t1.b1, t1.c1
+        ->  Append
+              ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                    Index Cond: (b1 = 1)
+              ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+                    Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/BABEL-3512.out
+++ b/test/JDBC/expected/BABEL-3512.out
@@ -239,13 +239,14 @@ Query Text: EXEC babel_3512_proc_4
   ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
         Index Cond: (b1 = 3)
   Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1                                    WHERE b1 = 1 UNION SELECT * FROM babel_3512_t2                                    WHERE b2 = 1
-  ->  HashAggregate
-        Group Key: babel_3512_t1.a1, babel_3512_t1.b1, babel_3512_t1.c1
-        ->  Append
-              ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
-                    Index Cond: (b1 = 1)
-              ->  Index Scan using index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9 on babel_3512_t2
-                    Index Cond: (b2 = 1)
+  ->  Unique
+        ->  Sort
+              Sort Key: babel_3512_t1.a1, babel_3512_t1.b1, babel_3512_t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9 on babel_3512_t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/parallel_query/BABEL-3292.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3292.out
@@ -590,19 +590,21 @@ go
 ~~START~~
 text
 Query Text: select * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Bitmap Heap Scan on babel_3292_t1
-                    Recheck Cond: (b1 = 1)
-                    ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
-                          Index Cond: (b1 = 1)
-              ->  Parallel Bitmap Heap Scan on babel_3292_t2
-                    Recheck Cond: (b2 = 1)
-                    ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
-                          Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+              ->  Append
+                    ->  Bitmap Heap Scan on babel_3292_t1
+                          Recheck Cond: (b1 = 1)
+                          ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+                                Index Cond: (b1 = 1)
+                    ->  Bitmap Heap Scan on babel_3292_t2
+                          Recheck Cond: (b2 = 1)
+                          ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                                Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -616,17 +618,19 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Bitmap Heap Scan on babel_3292_t1
-                    Recheck Cond: (b1 = 1)
-                    ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
-                          Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+              ->  Append
+                    ->  Bitmap Heap Scan on babel_3292_t1
+                          Recheck Cond: (b1 = 1)
+                          ->  Bitmap Index Scan on index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736
+                                Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -640,17 +644,19 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                 
-HashAggregate
-  Group Key: babel_3292_t2.a2, babel_3292_t2.b2, babel_3292_t2.c2
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Bitmap Heap Scan on babel_3292_t2
-                    Recheck Cond: (b2 = 1)
-                    ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
-                          Index Cond: (b2 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-                    Index Cond: (b1 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+                          Index Cond: (b1 = 1)
+                    ->  Bitmap Heap Scan on babel_3292_t2
+                          Recheck Cond: (b2 = 1)
+                          ->  Bitmap Index Scan on index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434
+                                Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -664,15 +670,17 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1                                    where b1 = 1 UNION select * from babel_3292_t2                                    where b2 = 1
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-                    Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -686,15 +694,17 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(babel_3292_t1 index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from babel_3292_t1 where b1 = 1 UNION select * from babel_3292_t2 where b2 = 1                                                                                                                           
-HashAggregate
-  Group Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
-                    Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: babel_3292_t1.a1, babel_3292_t1.b1, babel_3292_t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_t1_b1babel_329eaeb7a8893929b580f3d762dc8499736 on babel_3292_t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1172,15 +1182,17 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2                                    where b2 = 1
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-                    Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: t1.a1, t1.b1, t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1194,15 +1206,17 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1                                           where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2                                    where b2 = 1
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-                    Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: t1.a1, t1.b1, t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1216,15 +1230,17 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(babel_3292_t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 where b2 = 1                                                                                                                                                           
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-                    Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: t1.a1, t1.b1, t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~
@@ -1238,15 +1254,17 @@ go
 ~~START~~
 text
 Query Text: select/*+ indexscan(t1 index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297) indexscan(t2 index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434) */ * from tempdb.babel_3292_schema.t1 t1 where b1 = 1 UNION select * from tempdb.dbo.babel_3292_t2 t2 where b2 = 1                                                                                                            
-HashAggregate
-  Group Key: t1.a1, t1.b1, t1.c1
-  ->  Gather
-        Workers Planned: 2
-        ->  Parallel Append
-              ->  Parallel Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
-                    Index Cond: (b1 = 1)
-              ->  Parallel Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
-                    Index Cond: (b2 = 1)
+Gather
+  Workers Planned: 1
+  Single Copy: true
+  ->  Unique
+        ->  Sort
+              Sort Key: t1.a1, t1.b1, t1.c1
+              ->  Append
+                    ->  Index Scan using index_babel_3292_schema_t1_b1t15233a6e220046e22743bc3bf322e4297 on t1
+                          Index Cond: (b1 = 1)
+                    ->  Index Scan using index_babel_3292_t2_b2babel_3297b13d7f53f3b499d8db9cc07605bd434 on babel_3292_t2 t2
+                          Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/parallel_query/BABEL-3512.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3512.out
@@ -257,15 +257,17 @@ Query Text: EXEC babel_3512_proc_4
         ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
               Index Cond: (b1 = 3)
   Query Text: SELECT/*+ indexscan(babel_3512_t1 index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a) indexscan(babel_3512_t2 index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9) */ * FROM babel_3512_t1                                    WHERE b1 = 1 UNION SELECT * FROM babel_3512_t2                                    WHERE b2 = 1
-  ->  HashAggregate
-        Group Key: babel_3512_t1.a1, babel_3512_t1.b1, babel_3512_t1.c1
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Append
-                    ->  Parallel Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
-                          Index Cond: (b1 = 1)
-                    ->  Parallel Index Scan using index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9 on babel_3512_t2
-                          Index Cond: (b2 = 1)
+  ->  Gather
+        Workers Planned: 1
+        Single Copy: true
+        ->  Unique
+              ->  Sort
+                    Sort Key: babel_3512_t1.a1, babel_3512_t1.b1, babel_3512_t1.c1
+                    ->  Append
+                          ->  Index Scan using index_babel_3512_t1_b1babel_351c4a7795e05c8f14a17174b8ca33d439a on babel_3512_t1
+                                Index Cond: (b1 = 1)
+                          ->  Index Scan using index_babel_3512_t2_b2babel_351e39a010b48f9dda93369af0e37b7b7e9 on babel_3512_t2
+                                Index Cond: (b2 = 1)
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -497,8 +497,5 @@ ignore#!#pgr_select_into
 ignore#!#pgr_select
 ignore#!#pgr_zzz_clean_up
 
-# Ignoring some test temporarily to get clean tests
-ignore#!#BABEL-3292
-ignore#!#BABEL-3512
 # getting timed out (TODO: BABEL-5353)
 ignore#!#BABEL-SP_TABLE_PRIVILEGES


### PR DESCRIPTION
### Description

With the new community merges, there were output diffs for `pg_hint_plan` jdbc tests. This commit updates the output file with correct expected output.

### Issues Resolved

Task: BABEL-5405

### Test Scenarios Covered ###
* **Use case based -** y


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).