### PR TITLE
Added upgrade script babelfishpg_common--3.8.0--4.0.0.sql

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.8.0--4.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.8.0--4.0.0.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '4.0.0'" to load this file. \quit

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.8.0--5.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.8.0--5.0.0.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '5.0.0'" to load this file. \quit

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.8.0--5.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.8.0--5.0.0.sql
@@ -1,2 +1,0 @@
--- complain if script is sourced in psql, rather than via ALTER EXTENSION
-\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '5.0.0'" to load this file. \quit


### PR DESCRIPTION
### Description

In this [PR](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3191), we have bumped babelfishpg_common extension version from 3.7.0 to 3.8.0 due to which we are facing issue in upgrade from version 15.11(BABEL_3_X_DEV) to 17.latest(BABEL_5_X_DEV) as there is no upgrade script from 3.8.0 to 4.0.0 to facilitate the upgrade from version 15.11(BABEL_3_X_DEV) to 17.latest(BABEL_5_X_DEV). To resolve this problem, I have created and added a new upgrade script 'babelfishpg_common--3.8.0--4.0.0.sql'. This script provides the necessary upgrade path, ensuring a smooth transition between these versions.

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).