### PR TITLE
fix crash in fn_listextendedproperty

### DIFF
--- a/contrib/babelfishpg_tsql/src/extendedproperty.c
+++ b/contrib/babelfishpg_tsql/src/extendedproperty.c
@@ -1170,7 +1170,10 @@ get_extended_property_from_tuple(Relation relation, HeapTuple tuple,
 	values[2] = datumCopy(datum, false, -1);
 	datum = heap_getattr(tuple, Anum_bbf_extended_properties_value,
 						 RelationGetDescr(relation), &isnull);
-	values[3] = datumCopy(datum, false, -1);
+	if (!isnull)
+		values[3] = datumCopy(datum, false, -1);
+	else
+		nulls[3] = true;
 
 	return true;
 }

--- a/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-vu-verify.out
+++ b/test/JDBC/expected/BABEL-EXTENDEDPROPERTY-vu-verify.out
@@ -72,6 +72,25 @@ TYPE#!#babel_extended_property_v3_type#!#type property1#!#type property1 before
 ~~END~~
 
 
+-- BABEL-5087
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @level0type = N'SCHEMA',
+    @level0name = N'babel_extended_property_v3_schema',
+    @level1type = N'table',
+    @level1name = N'babel_extended_property_v3_table';
+GO
+
+SELECT  * FROM fn_listextendedproperty(NULL, 'SCHEMA', N'babel_extended_property_v3_schema', 'TABLE', N'babel_extended_property_v3_table', NULL, NULL);
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#sql_variant
+TABLE#!#babel_extended_property_v3_table#!#MS_Description#!#<NULL>
+TABLE#!#babel_extended_property_v3_table#!#table property1#!#table property1 value
+TABLE#!#babel_extended_property_v3_table#!#table property2#!#table property2 value
+~~END~~
+
+
 -- list all extended properties
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties ORDER BY class, class_desc, name, value;
 GO
@@ -81,6 +100,7 @@ tinyint#!#nvarchar#!#int#!#int#!#varchar#!#sql_variant
 1#!#OBJECT_OR_COLUMN#!#1#!#1#!#column property1#!#column property1 value
 1#!#OBJECT_OR_COLUMN#!#1#!#1#!#COLUMN PROPERTY2 "{\)#!#COLUMN PROPERTY2 VALUE "{\)   
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#function property1#!#function property1 value
+1#!#OBJECT_OR_COLUMN#!#1#!#0#!#MS_Description#!#<NULL>
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#procedure property1#!#procedure property1 value
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#sequence property1#!#sequence property1 value
 1#!#OBJECT_OR_COLUMN#!#1#!#0#!#table property1#!#table property1 value

--- a/test/JDBC/input/BABEL-EXTENDEDPROPERTY-vu-verify.sql
+++ b/test/JDBC/input/BABEL-EXTENDEDPROPERTY-vu-verify.sql
@@ -25,6 +25,18 @@ GO
 SELECT * FROM fn_listextendedproperty(NULL, 'schema', 'babel_extended_property_v3_schema', 'type', NULL, NULL, NULL) ORDER BY objtype, objname, name, value;
 GO
 
+-- BABEL-5087
+EXEC sp_addextendedproperty
+    @name = N'MS_Description',
+    @level0type = N'SCHEMA',
+    @level0name = N'babel_extended_property_v3_schema',
+    @level1type = N'table',
+    @level1name = N'babel_extended_property_v3_table';
+GO
+
+SELECT  * FROM fn_listextendedproperty(NULL, 'SCHEMA', N'babel_extended_property_v3_schema', 'TABLE', N'babel_extended_property_v3_table', NULL, NULL);
+GO
+
 -- list all extended properties
 SELECT class, class_desc, IIF(major_id > 0, 1, 0) AS major_id, minor_id, name, value FROM sys.extended_properties ORDER BY class, class_desc, name, value;
 GO


### PR DESCRIPTION
### Description

Properly handle nullable column when fetching tuple from sys.babelfish_extended_properties catalog.

### Issues Resolved

[BABEL-5087]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).