### PR TITLE
Performance improvement for queries having join between TABLE_CONSTRAINTS and KEY_COLUMN_USAGE views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -493,16 +493,27 @@ CREATE VIEW information_schema_tsql.tables AS
 
 GRANT SELECT ON information_schema_tsql.tables TO PUBLIC;
 
-/*
- * TABLE_CONSTRAINTS view
- */
-
-CREATE VIEW information_schema_tsql.table_constraints AS
-    SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
-           CAST(extc.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+CREATE OR REPLACE FUNCTION information_schema_tsql.table_constraints_internal()
+RETURNS TABLE (
+    "CONSTRAINT_CATALOG" sys.nvarchar(128),
+    "CONSTRAINT_SCHEMA" sys.nvarchar(128),
+    "CONSTRAINT_NAME" sys.sysname,
+    "TABLE_CATALOG" sys.nvarchar(128),
+    "TABLE_SCHEMA" sys.nvarchar(128),
+    "TABLE_NAME" sys.sysname,
+    "CONSTRAINT_TYPE" sys.varchar(11),
+    "IS_DEFERRABLE" sys.varchar(2),
+    "INITIALLY_DEFERRED" sys.varchar(2)
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+    SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+           CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
            CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME",
-           CAST(nr.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
-           CAST(extr.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+           CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+           CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
            CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
            CAST(
              CASE c.contype WHEN 'c' THEN 'CHECK'
@@ -512,22 +523,38 @@ CREATE VIEW information_schema_tsql.table_constraints AS
              AS sys.varchar(11)) COLLATE sys.database_default AS "CONSTRAINT_TYPE",
            CAST('NO' AS sys.varchar(2)) AS "IS_DEFERRABLE",
            CAST('NO' AS sys.varchar(2)) AS "INITIALLY_DEFERRED"
-
-    FROM sys.pg_namespace_ext nc LEFT OUTER JOIN sys.babelfish_namespace_ext extc ON nc.nspname = extc.nspname,
-         sys.pg_namespace_ext nr LEFT OUTER JOIN sys.babelfish_namespace_ext extr ON nr.nspname = extr.nspname,
-         pg_constraint c,
-         pg_class r
-
-    WHERE nc.oid = c.connamespace AND nr.oid = r.relnamespace
-          AND c.conrelid = r.oid
-          AND c.contype NOT IN ('t', 'x')
+    FROM 
+        pg_constraint c
+        INNER JOIN pg_class r ON c.conrelid = r.oid
+        INNER JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
+        INNER JOIN sys.babelfish_namespace_ext ext ON nsp.nspname = ext.nspname AND ext.dbid = sys.db_id()
+    WHERE 
+        c.contype IN ('c', 'f', 'p', 'u')
           AND r.relkind IN ('r', 'p')
           AND relispartition = false
-          AND (NOT pg_is_other_temp_schema(nr.oid))
           AND (pg_has_role(r.relowner, 'USAGE')
                OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-               OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )
-		  AND  extc.dbid = sys.db_id();
+               OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES') );
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
+/*
+ * TABLE_CONSTRAINTS view
+ */
+
+CREATE OR REPLACE VIEW information_schema_tsql.table_constraints AS
+    SELECT 
+        CAST("CONSTRAINT_CATALOG" AS sys.nvarchar(128)),
+        CAST("CONSTRAINT_SCHEMA" AS sys.nvarchar(128)),
+        CAST("CONSTRAINT_NAME" AS sys.sysname),
+        CAST("TABLE_CATALOG" AS sys.nvarchar(128)),
+        CAST("TABLE_SCHEMA" AS sys.nvarchar(128)),
+        CAST("TABLE_NAME" AS sys.sysname),
+        CAST("CONSTRAINT_TYPE" AS sys.varchar(11)),
+        CAST("IS_DEFERRABLE" AS sys.varchar(2)),
+        CAST("INITIALLY_DEFERRED" AS sys.varchar(2))
+    FROM information_schema_tsql.table_constraints_internal();
 
 GRANT SELECT ON information_schema_tsql.table_constraints TO PUBLIC;
 
@@ -823,10 +850,10 @@ GRANT SELECT ON information_schema_tsql.sequences TO PUBLIC;
 
 CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 	SELECT
-		CAST(nc.dbname AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+		CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
 		CAST(c.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
-		CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 		CAST(r.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
 		CAST(a.attname AS sys.nvarchar(128)) AS "COLUMN_NAME",
@@ -834,14 +861,13 @@ CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 	FROM
 		pg_constraint c 
 		JOIN pg_class r ON r.oid = c.conrelid AND c.contype in ('p','u','f') AND r.relkind in ('r','p') AND r.relispartition = false
-		JOIN sys.pg_namespace_ext nc ON nc.oid = c.connamespace AND r.relnamespace = nc.oid 
-		JOIN sys.babelfish_namespace_ext ext ON ext.nspname = nc.nspname AND ext.dbid = sys.db_id()
+		JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
+		JOIN sys.babelfish_namespace_ext ext ON ext.nspname = nsp.nspname AND ext.dbid = sys.db_id()
 		CROSS JOIN unnest(c.conkey) WITH ORDINALITY AS ak(j,ord) 
 		LEFT JOIN pg_attribute a ON a.attrelid = r.oid AND a.attnum = ak.j		
 	WHERE
 		pg_has_role(r.relowner, 'USAGE'::text) 
   		OR has_column_privilege(r.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text)
-		AND NOT pg_is_other_temp_schema(nc.oid)
 	;
 GRANT SELECT ON information_schema_tsql.key_column_usage TO PUBLIC;
 

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -854,7 +854,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 		CAST(db_name AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
 		CAST(c.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
-		CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		CAST(db_name AS sys.nvarchar(128)) AS "TABLE_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 		CAST(r.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
 		CAST(a.attname AS sys.nvarchar(128)) AS "COLUMN_NAME",

--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -509,10 +509,10 @@ AS
 $$
 BEGIN
     RETURN QUERY
-    SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+    SELECT CAST(db_name AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
            CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
            CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME",
-           CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+           CAST(db_name AS sys.nvarchar(128)) AS "TABLE_CATALOG",
            CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
            CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
            CAST(
@@ -528,6 +528,7 @@ BEGIN
         INNER JOIN pg_class r ON c.conrelid = r.oid
         INNER JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
         INNER JOIN sys.babelfish_namespace_ext ext ON nsp.nspname = ext.nspname AND ext.dbid = sys.db_id()
+        , sys.db_name() AS db_name
     WHERE 
         c.contype IN ('c', 'f', 'p', 'u')
           AND r.relkind IN ('r', 'p')
@@ -850,7 +851,7 @@ GRANT SELECT ON information_schema_tsql.sequences TO PUBLIC;
 
 CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 	SELECT
-		CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+		CAST(db_name AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
 		CAST(c.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
 		CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
@@ -864,7 +865,8 @@ CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 		JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
 		JOIN sys.babelfish_namespace_ext ext ON ext.nspname = nsp.nspname AND ext.dbid = sys.db_id()
 		CROSS JOIN unnest(c.conkey) WITH ORDINALITY AS ak(j,ord) 
-		LEFT JOIN pg_attribute a ON a.attrelid = r.oid AND a.attnum = ak.j		
+		LEFT JOIN pg_attribute a ON a.attrelid = r.oid AND a.attnum = ak.j
+		, sys.db_name() AS db_name
 	WHERE
 		pg_has_role(r.relowner, 'USAGE'::text) 
   		OR has_column_privilege(r.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -10067,10 +10067,10 @@ AS
 $$
 BEGIN
     RETURN QUERY
-    SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+    SELECT CAST(db_name AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
            CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
            CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME",
-           CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+           CAST(db_name AS sys.nvarchar(128)) AS "TABLE_CATALOG",
            CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
            CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
            CAST(
@@ -10086,6 +10086,7 @@ BEGIN
         INNER JOIN pg_class r ON c.conrelid = r.oid
         INNER JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
         INNER JOIN sys.babelfish_namespace_ext ext ON nsp.nspname = ext.nspname AND ext.dbid = sys.db_id()
+        , sys.db_name() AS db_name
     WHERE 
         c.contype IN ('c', 'f', 'p', 'u')
           AND r.relkind IN ('r', 'p')
@@ -10114,7 +10115,7 @@ GRANT SELECT ON information_schema_tsql.table_constraints TO PUBLIC;
 
 CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 	SELECT
-		CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+		CAST(db_name AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
 		CAST(c.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
 		CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
@@ -10128,7 +10129,8 @@ CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 		JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
 		JOIN sys.babelfish_namespace_ext ext ON ext.nspname = nsp.nspname AND ext.dbid = sys.db_id()
 		CROSS JOIN unnest(c.conkey) WITH ORDINALITY AS ak(j,ord) 
-		LEFT JOIN pg_attribute a ON a.attrelid = r.oid AND a.attnum = ak.j		
+		LEFT JOIN pg_attribute a ON a.attrelid = r.oid AND a.attnum = ak.j
+		, sys.db_name() AS db_name
 	WHERE
 		pg_has_role(r.relowner, 'USAGE'::text) 
   		OR has_column_privilege(r.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -10118,7 +10118,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
 		CAST(db_name AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
 		CAST(c.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
-		CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		CAST(db_name AS sys.nvarchar(128)) AS "TABLE_CATALOG",
 		CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 		CAST(r.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
 		CAST(a.attname AS sys.nvarchar(128)) AS "COLUMN_NAME",

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -10051,6 +10051,90 @@ $body$
 LANGUAGE 'plpgsql'
 STABLE;
 
+CREATE OR REPLACE FUNCTION information_schema_tsql.table_constraints_internal()
+RETURNS TABLE (
+    "CONSTRAINT_CATALOG" sys.nvarchar(128),
+    "CONSTRAINT_SCHEMA" sys.nvarchar(128),
+    "CONSTRAINT_NAME" sys.sysname,
+    "TABLE_CATALOG" sys.nvarchar(128),
+    "TABLE_SCHEMA" sys.nvarchar(128),
+    "TABLE_NAME" sys.sysname,
+    "CONSTRAINT_TYPE" sys.varchar(11),
+    "IS_DEFERRABLE" sys.varchar(2),
+    "INITIALLY_DEFERRED" sys.varchar(2)
+)
+AS
+$$
+BEGIN
+    RETURN QUERY
+    SELECT CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+           CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+           CAST(c.conname AS sys.sysname) AS "CONSTRAINT_NAME",
+           CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+           CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+           CAST(r.relname AS sys.sysname) AS "TABLE_NAME",
+           CAST(
+             CASE c.contype WHEN 'c' THEN 'CHECK'
+                            WHEN 'f' THEN 'FOREIGN KEY'
+                            WHEN 'p' THEN 'PRIMARY KEY'
+                            WHEN 'u' THEN 'UNIQUE' END
+             AS sys.varchar(11)) COLLATE sys.database_default AS "CONSTRAINT_TYPE",
+           CAST('NO' AS sys.varchar(2)) AS "IS_DEFERRABLE",
+           CAST('NO' AS sys.varchar(2)) AS "INITIALLY_DEFERRED"
+    FROM 
+        pg_constraint c
+        INNER JOIN pg_class r ON c.conrelid = r.oid
+        INNER JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
+        INNER JOIN sys.babelfish_namespace_ext ext ON nsp.nspname = ext.nspname AND ext.dbid = sys.db_id()
+    WHERE 
+        c.contype IN ('c', 'f', 'p', 'u')
+          AND r.relkind IN ('r', 'p')
+          AND relispartition = false
+          AND (pg_has_role(r.relowner, 'USAGE')
+               OR has_table_privilege(r.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+               OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES') );
+END;
+$$
+LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE VIEW information_schema_tsql.table_constraints AS
+    SELECT 
+        CAST("CONSTRAINT_CATALOG" AS sys.nvarchar(128)),
+        CAST("CONSTRAINT_SCHEMA" AS sys.nvarchar(128)),
+        CAST("CONSTRAINT_NAME" AS sys.sysname),
+        CAST("TABLE_CATALOG" AS sys.nvarchar(128)),
+        CAST("TABLE_SCHEMA" AS sys.nvarchar(128)),
+        CAST("TABLE_NAME" AS sys.sysname),
+        CAST("CONSTRAINT_TYPE" AS sys.varchar(11)),
+        CAST("IS_DEFERRABLE" AS sys.varchar(2)),
+        CAST("INITIALLY_DEFERRED" AS sys.varchar(2))
+    FROM information_schema_tsql.table_constraints_internal();
+
+GRANT SELECT ON information_schema_tsql.table_constraints TO PUBLIC;
+
+CREATE OR REPLACE VIEW information_schema_tsql.key_column_usage AS
+	SELECT
+		CAST(sys.db_name() AS sys.nvarchar(128)) AS "CONSTRAINT_CATALOG",
+		CAST(ext.orig_name AS sys.nvarchar(128)) AS "CONSTRAINT_SCHEMA",
+		CAST(c.conname AS sys.nvarchar(128)) AS "CONSTRAINT_NAME",
+		CAST(sys.db_name() AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+		CAST(r.relname AS sys.nvarchar(128)) AS "TABLE_NAME",
+		CAST(a.attname AS sys.nvarchar(128)) AS "COLUMN_NAME",
+		CAST(ord AS int) AS "ORDINAL_POSITION"	
+	FROM
+		pg_constraint c 
+		JOIN pg_class r ON r.oid = c.conrelid AND c.contype in ('p','u','f') AND r.relkind in ('r','p') AND r.relispartition = false
+		JOIN pg_namespace nsp ON r.relnamespace = nsp.oid
+		JOIN sys.babelfish_namespace_ext ext ON ext.nspname = nsp.nspname AND ext.dbid = sys.db_id()
+		CROSS JOIN unnest(c.conkey) WITH ORDINALITY AS ak(j,ord) 
+		LEFT JOIN pg_attribute a ON a.attrelid = r.oid AND a.attnum = ak.j		
+	WHERE
+		pg_has_role(r.relowner, 'USAGE'::text) 
+  		OR has_column_privilege(r.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text)
+	;
+GRANT SELECT ON information_schema_tsql.key_column_usage TO PUBLIC;
+
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();
 

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -1,6 +1,7 @@
 Could not find tests for function assemblyproperty
 Could not find tests for function bbf_string_agg_finalfn_nvarchar
 Could not find tests for function bbf_string_agg_finalfn_varchar
+Could not find tests for function information_schema_tsql.table_constraints_internal
 Could not find tests for function pltsql_call_handler
 Could not find tests for function pltsql_inline_handler
 Could not find tests for function pltsql_validator
@@ -94,6 +95,7 @@ Could not find upgrade tests for function assemblyproperty
 Could not find upgrade tests for function bbf_string_agg_finalfn_nvarchar
 Could not find upgrade tests for function bbf_string_agg_finalfn_varchar
 Could not find upgrade tests for function connectionproperty
+Could not find upgrade tests for function information_schema_tsql.table_constraints_internal
 Could not find upgrade tests for function pltsql_call_handler
 Could not find upgrade tests for function pltsql_inline_handler
 Could not find upgrade tests for function pltsql_validator

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -61,6 +61,7 @@ Collation sys.ukrainian_ci_as
 Collation sys.ukrainian_cs_as
 Collation sys.vietnamese_ci_ai
 Collation sys.vietnamese_ci_as
+Function information_schema_tsql.table_constraints_internal()
 Function sys."char"(integer)
 Function sys."decimal"(sys."nchar",integer,boolean)
 Function sys."isnull"(bigint,bigint)


### PR DESCRIPTION
### Description
This commit addresses poor performance issues in queries that join the TABLE_CONSTRAINTS and KEY_COLUMN_USAGE views. The problem was caused by inaccurate row estimates resulting from a CASE expression in the TABLE_CONSTRAINTS view, leading to suboptimal query plans.



Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)
### Issues Resolved

Task: BABEL-5427 

### Test Scenarios Covered ###
Test are already present for modified views.

### Performance Result
1. Improvement for query having join between TABLE_CONSTRAINTS and KEY_COLUMN_USAGE:

| Objects | Before (ms) | After (ms) | Improvement % |
|---------|-------------|------------|---------------|
| 1181 tables and primary key constraints  | 4781 | 87 | 98.18% |
| 3000 tables and primary key constraints | 33011 | 98 | 99.70% |
| 3000 tables, primary key, unique and check constraints | 14173 | 116 | 99.18% |

2 Improvement for different queries:

| Objects | Query | Before (ms) | After (ms) | Improvement % |
|---------|-------|-------------|------------|---------------|
| 1181 tables and primary key constraints | SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS | 29 | 32.2 | -11.03% |
| ^ | SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = 't456' | 38 | 33.6 | 11.58% |
| ^ | SELECT * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = 'dbo' | 13.8 | 16.8 | -21.74% |
| ^ | SELECT * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_TYPE = 'PRIMARY KEY' | 24.4 | 16.6 | 31.97% |
| ^ | SELECT * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE | 22 | 20.2 | 8.18% |
| ^ | SELECT * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_NAME = 't456' | 8 | 6.4 | 20% |
| ^ | SELECT * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = 'dbo' | 21.4 | 19.2 | 10.28% |
| 3000 tables, primary key, unique and check constraints | SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS | 105.2 | 128 | -21.67% |
| ^ | SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = 't456' | 79.8 | 58.2 | 27.07% |
| ^ | SELECT * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = 'dbo' | 77.8 | 100.6 | -29.31% |
| ^ | SELECT * from INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_TYPE = 'PRIMARY KEY' | 61.4 | 53.2 | 13.36% |
| ^ | SELECT * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE | 71.4 | 65.6 | 8.12% |
| ^ | SELECT * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_NAME = 't456' | 12 | 10 | 16.67% |
| ^ | SELECT * from INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = 'dbo' | 75.6 | 67.2 | 11.11% |

### NOTE: We don't observe ANY degradation if we have 100 user schemas

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).