### PR TITLE
Update physical database name from jdbc_testdb to babelfish_db (#3243)

### DIFF
--- a/.github/composite-actions/build-install-pgaudit-extension/action.yml
+++ b/.github/composite-actions/build-install-pgaudit-extension/action.yml
@@ -23,8 +23,8 @@ runs:
         echo "everything set"
 
         ~/${{ inputs.install_dir }}/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
-        sudo PGPASSWORD=12345678 ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "CREATE EXTENSION pgaudit;"
-        sudo PGPASSWORD=12345678 ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "ALTER SYSTEM SET pgaudit.log = 'all';"
+        sudo PGPASSWORD=12345678 ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "CREATE EXTENSION pgaudit;"
+        sudo PGPASSWORD=12345678 ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "ALTER SYSTEM SET pgaudit.log = 'all';"
 
       shell: bash
       

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -85,14 +85,14 @@ runs:
           echo "Starting to dump whole Babelfish physical database"
           if [[ '${{ inputs.type }}' == 'full' ]];then
             # Perform the complete dump
-            $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords -f pg_dump_globals.sql > ~/upgrade/error.log
-            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --file="pg_dump.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database babelfish_db --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords -f pg_dump_globals.sql > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --file="pg_dump.archive" --dbname=babelfish_db > ~/upgrade/error.log
           else
             # First perform the schema-only dump and then perform the data-only dump to produce a complete dump
-            $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords -f pg_dump_globals_so.sql > ~/upgrade/error.log
-            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --file="pg_dump_so.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database babelfish_db --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords -f pg_dump_globals_so.sql > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --file="pg_dump_so.archive" --dbname=babelfish_db > ~/upgrade/error.log
 
-            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --file="pg_dump_do.archive" --dbname=jdbc_testdb > ~/upgrade/error.log
+            $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --file="pg_dump_do.archive" --dbname=babelfish_db > ~/upgrade/error.log
           fi
         else
           echo "Starting to dump all the Babelfish logical databases"
@@ -102,28 +102,28 @@ runs:
                 pg_has_role(rolname, 'sysadmin', 'member') AS is_sysadmin_member \
                 FROM sys.babelfish_authid_login_ext \
                 WHERE rolname NOT IN ('jdbc_user', 'sysadmin', 'bbf_role_admin', 'test@ABC');"
-          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/logins_file.txt
+          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/logins_file.txt
 
           # Get the list of Babelfish user and login mapping in a file
           query="SELECT u.orig_username, l.orig_loginname, database_name \
                 FROM sys.babelfish_authid_user_ext u INNER JOIN sys.babelfish_authid_login_ext l \
                 ON u.login_name = l.rolname WHERE u.login_name != '' ORDER BY orig_username;"
-          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/users_file.txt
+          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/users_file.txt
 
           # Get the list of domain mappings in a file
           query="SELECT netbios_domain_name, fq_domain_name FROM sys.babelfish_domain_mapping;"
-          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/domains_file.txt
+          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/domains_file.txt
 
           # Get the list of all foreign servers in a file
           query="SELECT fs.srvname, fs.srvoptions, um.umoptions, so.query_timeout, so.connect_timeout \
                 FROM pg_foreign_server fs \
                 INNER JOIN sys.babelfish_server_options so ON fs.srvname = so.servername \
                 LEFT JOIN pg_user_mappings um ON fs.srvname = um.srvname;"
-          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/servers_file.txt
+          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/servers_file.txt
 
           # Get the list of all the Babelfish logical datababses in a file
           query="SELECT name FROM sys.babelfish_sysdatabases ORDER BY name DESC;"
-          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "$query" > ~/upgrade/databases_file.txt
+          ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/databases_file.txt
 
           # Loop through the list of all the Babelfish logical database and dump them one by one.
           while IFS= read -r db; do
@@ -131,19 +131,19 @@ runs:
             db_trimmed="$(echo "${db}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             if [[ '${{ inputs.type }}' == 'full' ]];then
               # Perform the complete dump
-              $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
-              $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed".archive --dbname=jdbc_testdb > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database babelfish_db --username jdbc_user --roles-only --quote-all-identifiers --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed".archive --dbname=babelfish_db > ~/upgrade/error.log
             else
               # First perform the schema-only dump and then perform the data-only dump to produce a complete dump
-              $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database jdbc_testdb --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
-             $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_so.archive --dbname=jdbc_testdb > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dumpall -h localhost --database babelfish_db --username jdbc_user --roles-only --quote-all-identifiers --schema-only --no-role-passwords --bbf-database-name="$db_trimmed" -f pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
+             $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --schema-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_so.archive --dbname=babelfish_db > ~/upgrade/error.log
 
-              $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_do.archive --dbname=jdbc_testdb > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user $DUMP_OPTS --quote-all-identifiers --data-only --bbf-database-name="$db_trimmed" --file=pg_dump_"$db_trimmed"_do.archive --dbname=babelfish_db > ~/upgrade/error.log
             fi
           done < <(tail -n +3 ~/upgrade/databases_file.txt | head -n -2)
 
           # Also dump the objects in PUBLIC schema.
-          $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user --quote-all-identifiers --schema=public --schema-only --file=pg_dump_public.sql --dbname=jdbc_testdb > ~/upgrade/error_public_schema.log
+          $DUMP_RESTORE_UTILS_PATH/pg_dump -h localhost --username jdbc_user --quote-all-identifiers --schema=public --schema-only --file=pg_dump_public.sql --dbname=babelfish_db > ~/upgrade/error_public_schema.log
         fi
 
         # Stop old server and start the new.
@@ -153,29 +153,29 @@ runs:
         echo 'Database dump complete.'
 
         # Create and initialise Babelfish extensions in the new server to perform restore.
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -v tsql_port="1433" -f .github/scripts/create_extension.sql
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode=${{inputs.migration_mode}} -v tsql_port="1433" -f .github/scripts/create_extension.sql
 
         if [[ ${{ inputs.database_level }} == false ]];then
           echo "Starting to restore whole Babelfish physical database"
           if [[ '${{ inputs.type }}' == 'full' ]];then
             echo 'Restoring from pg_dumpall'
-            sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals.sql > ~/upgrade/error.log
+            sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals.sql > ~/upgrade/error.log
             echo 'Restoring from pg_dump'
             if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
             else
-              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d babelfish_db -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump.archive > ~/upgrade/error.log
             fi
           else
             echo 'Restoring from pg_dumpall'
-            sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_so.sql > ~/upgrade/error.log
+            sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_so.sql > ~/upgrade/error.log
             echo 'Restoring from pg_dump'
             if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
-              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
             else
-              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
-              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d babelfish_db -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_so.archive > ~/upgrade/error.log
+              $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d babelfish_db -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_do.archive > ~/upgrade/error.log
             fi
           fi
         else
@@ -186,29 +186,29 @@ runs:
             db_trimmed="$(echo -e "${db}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             echo "Restoring $db_trimmed"
             if [[ '${{ inputs.type }}' == 'full' ]];then
-              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed".sql > ~/upgrade/error.log
               if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
+                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
               else
-                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
+                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d babelfish_db -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed".archive > ~/upgrade/error.log
               fi
             else
-              sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
+              sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_globals_"$db_trimmed"_so.sql > ~/upgrade/error.log
               if [[ '${{ inputs.dump_format }}' == 'plain' ]];then
-                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
-                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
+                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
+                sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user --single-transaction -f ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
               else
-                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
-                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d jdbc_testdb -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
+                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d babelfish_db -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_so.archive > ~/upgrade/error.log
+                $DUMP_RESTORE_UTILS_PATH/pg_restore -h localhost -d babelfish_db -U jdbc_user --single-transaction ~/upgrade/dump/pg_dump_"$db_trimmed"_do.archive > ~/upgrade/error.log
               fi
             fi
           done < <(tail -n +3 ~/upgrade/databases_file.txt | head -n -2)
 
           # Create rds_ad role
-          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "CREATE ROLE rds_ad NOSUPERUSER NOLOGIN NOCREATEROLE INHERIT NOREPLICATION;"
+          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "CREATE ROLE rds_ad NOSUPERUSER NOLOGIN NOCREATEROLE INHERIT NOREPLICATION;"
 
           # Create tds_fdw extension
-          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d jdbc_testdb -U jdbc_user -c "CREATE EXTENSION IF NOT EXISTS tds_fdw;"
+          sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "CREATE EXTENSION IF NOT EXISTS tds_fdw;"
 
           # Re-create windows login [abc\test]
           # This is the only special role which needs to created before re-creating
@@ -319,7 +319,7 @@ runs:
           done < <(tail -n +3 ~/upgrade/servers_file.txt | head -n -2)
 
           # Restore the objects in PUBLIC schema.
-          sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -h localhost -d jdbc_testdb -U jdbc_user -f ~/upgrade/dump/pg_dump_public.sql &> ~/upgrade/error_public_schema.log
+          sudo PGPASSWORD=12345678 $DUMP_RESTORE_UTILS_PATH/psql -h localhost -d babelfish_db -U jdbc_user -f ~/upgrade/dump/pg_dump_public.sql &> ~/upgrade/error_public_schema.log
         fi
         echo 'Database restore complete.'
         rm -rf ~/upgrade/dump

--- a/.github/composite-actions/install-and-run-odbc/action.yml
+++ b/.github/composite-actions/install-and-run-odbc/action.yml
@@ -59,6 +59,6 @@ runs:
           PSQL_BABEL_DB_PORT=5432 \
           PSQL_BABEL_DB_USER=jdbc_user \
           PSQL_BABEL_DB_PASSWORD=12345678 \
-          PSQL_BABEL_DB_NAME=jdbc_testdb \
+          PSQL_BABEL_DB_NAME=babelfish_db \
           ./build/main
       shell: bash

--- a/.github/composite-actions/install-extensions/action.yml
+++ b/.github/composite-actions/install-extensions/action.yml
@@ -67,7 +67,7 @@ runs:
         fi
         ~/${{inputs.install_dir}}/bin/pg_ctl -c -D ~/${{inputs.install_dir}}/$DATADIR/ -l logfile start
         cd ~/work/babelfish_extensions/babelfish_extensions/
-        sudo ~/${{inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -p ${{inputs.psql_port}} -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -v tsql_port=${{inputs.tsql_port}} -v parallel_query_mode=${{inputs.parallel_query_mode}} -f .github/scripts/create_extension.sql
+        sudo ~/${{inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -p ${{inputs.psql_port}} -v user="jdbc_user" -v db="babelfish_db" -v migration_mode=${{inputs.migration_mode}} -v tsql_port=${{inputs.tsql_port}} -v parallel_query_mode=${{inputs.parallel_query_mode}} -f .github/scripts/create_extension.sql
         ~/${{inputs.install_dir}}/bin/pg_ctl -c -D ~/${{inputs.install_dir}}/$DATADIR/ -l logfile restart
         sqlcmd -S localhost,${{inputs.tsql_port}} -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
       shell: bash

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -56,10 +56,10 @@ runs:
         ulimit -c unlimited
         cd ~
         ~/${{ inputs.install_dir }}/bin/pg_ctl -c -D ~/${{ inputs.install_dir }}/data/ -l logfile restart
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "\dx"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "\dx"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash
 
@@ -69,8 +69,8 @@ runs:
       id: change-migration-mode
       if: always() && inputs.is_final_ver == 'true'
       run: |
-        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
-        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
+        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
+        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "SELECT pg_reload_conf();"
       shell: bash
 
     - name: Run JDBC Verify Tests

--- a/.github/composite-actions/run-pg-upgrade/action.yml
+++ b/.github/composite-actions/run-pg-upgrade/action.yml
@@ -37,14 +37,14 @@ runs:
         echo 'Updating babelfish extensions...'
         cd ~/work/babelfish_extensions/babelfish_extensions/
         ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile start
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER EXTENSION babelfishpg_common UPDATE;"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER EXTENSION babelfishpg_tsql UPDATE;"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "\dx"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION babelfishpg_common UPDATE;"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION babelfishpg_tsql UPDATE;"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
         echo 'Reset bbf database settings...'
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = '${{inputs.migration_mode}}';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "SELECT pg_reload_conf();"
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           sudo echo "babelfishpg_tsql.server_collation_name = '${{ inputs.server_collation_name }}'" >> ~/${{ inputs.pg_new_dir }}/data/postgresql.conf
           ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data/ -l ~/${{ inputs.pg_new_dir }}/data/logfile restart

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -81,5 +81,5 @@ runs:
       id: cleanup
       if: always() && steps.jdbc-verify-tests.outcome == 'success' && inputs.is_final_ver == 'true'
       run: |
-        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+        sudo ~/${{ inputs.pg_new_dir }}/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
       shell: bash

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -41,6 +41,7 @@ runs:
         touch dummy_schedule
         echo "all" > dummy_schedule
         export scheduleFile=dummy_schedule
+        export physicalDatabaseName=babelfish_db
         export isUpgradeTestMode=false
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           export serverCollationName=${{ inputs.server_collation_name }}

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -143,16 +143,16 @@ runs:
         fi
         ~/${{ inputs.install_dir }}/bin/pg_ctl -c -D ~/${{ inputs.install_dir }}/data/ -l logfile restart
         sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -c "CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -c "DROP DATABASE IF EXISTS jdbc_testdb;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -c "CREATE DATABASE jdbc_testdb OWNER jdbc_user;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "set allow_system_table_mods = on;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE EXTENSION "babelfishpg_tds" CASCADE;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "GRANT ALL ON SCHEMA sys to jdbc_user;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER USER jdbc_user CREATEDB;"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CALL sys.initialize_babelfish('jdbc_user');"
-        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "\dx"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -c "DROP DATABASE IF EXISTS babelfish_db;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -c "CREATE DATABASE babelfish_db OWNER jdbc_user;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "set allow_system_table_mods = on;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CREATE EXTENSION "babelfishpg_tds" CASCADE;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "GRANT ALL ON SCHEMA sys to jdbc_user;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER USER jdbc_user CREATEDB;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "SELECT pg_reload_conf();"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CALL sys.initialize_babelfish('jdbc_user');"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash
 
@@ -160,8 +160,8 @@ runs:
       id: change-migration-mode
       if: ${{ inputs.migration_mode == 'multi-db' }} && always()
       run: |
-        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
-        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
+        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
+        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "SELECT pg_reload_conf();"
       shell: bash
 
     - if: ${{ inputs.extension_branch != 'latest' && inputs.dump_restore == 'true' }}
@@ -245,7 +245,7 @@ runs:
         provider="PostgreSQL Unicode" \
         fileGenerator_URL=localhost \
         fileGenerator_port=5432 \
-        fileGenerator_databaseName=jdbc_testdb \
+        fileGenerator_databaseName=babelfish_db \
         fileGenerator_user=jdbc_user \
         fileGenerator_password=12345678 \
         LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/odbc/ \

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -182,6 +182,7 @@ runs:
         cd test/JDBC/
         echo "all" > dummy_schedule
         export scheduleFile=dummy_schedule
+        export physicalDatabaseName=babelfish_db
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           export serverCollationName=${{ inputs.server_collation_name }}
         fi

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -81,8 +81,8 @@ jobs:
         id: re-install-extensions
         if: always() && steps.install-extensions.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql
           sqlcmd -S localhost -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
       
       - name: Run Python Tests

--- a/.github/workflows/jdbc-tests-db-collation.yml
+++ b/.github/workflows/jdbc-tests-db-collation.yml
@@ -61,8 +61,8 @@ jobs:
           export PATH=/opt/mssql-tools/bin:$PATH
           export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
-          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "update sys.babelfish_sysdatabases set default_collation = '${{env.DATABASE_COLLATION_NAME}}' where name = 'master';"
-          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "select default_collation from sys.babelfish_sysdatabases where name = 'master';"
+          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "update sys.babelfish_sysdatabases set default_collation = '${{env.DATABASE_COLLATION_NAME}}' where name = 'master';"
+          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "select default_collation from sys.babelfish_sysdatabases where name = 'master';"
           cd test/JDBC/
           export isdbCollationMode=true
           mvn -B -ntp test
@@ -81,8 +81,8 @@ jobs:
         id: setup-pub-sub
         if: always() && steps.start-secondary.outcome == 'success'
         run: |
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE PUBLICATION my_pub;"
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=jdbc_testdb password=12345678' PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CREATE PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=babelfish_db password=12345678' PUBLICATION my_pub;"
 
       - name: Run Replication Tests
         id: replication
@@ -91,8 +91,8 @@ jobs:
         run: |
           export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
-          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "update sys.babelfish_sysdatabases set default_collation = '${{env.DATABASE_COLLATION_NAME}}' where name = 'master';"
-          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "select default_collation from sys.babelfish_sysdatabases where name = 'master';"
+          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "update sys.babelfish_sysdatabases set default_collation = '${{env.DATABASE_COLLATION_NAME}}' where name = 'master';"
+          sudo ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "select default_collation from sys.babelfish_sysdatabases where name = 'master';"
           cd test/JDBC/
           export isdbCollationMode=true
           export inputFilesPath=replication
@@ -103,7 +103,7 @@ jobs:
         id: cleanup
         if: always() && steps.replication.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
 
       - name: Upload Log
         if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -99,8 +99,8 @@ jobs:
         id: setup-pub-sub
         if: always() && steps.start-secondary.outcome == 'success'
         run: |
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE PUBLICATION my_pub;"
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=jdbc_testdb password=12345678' PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CREATE PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=babelfish_db password=12345678' PUBLICATION my_pub;"
 
       - name: Run Replication Tests
         id: replication
@@ -114,7 +114,7 @@ jobs:
         id: cleanup
         if: always() && steps.replication.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
 
       - name: Upload Log
         if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')

--- a/.github/workflows/jdbc-tests-single-db-mode.yml
+++ b/.github/workflows/jdbc-tests-single-db-mode.yml
@@ -75,8 +75,8 @@ jobs:
         id: setup-pub-sub
         if: always() && steps.start-secondary.outcome == 'success'
         run: |
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE PUBLICATION my_pub;"
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=jdbc_testdb password=12345678' PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CREATE PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=babelfish_db password=12345678' PUBLICATION my_pub;"
 
       - name: Run Replication Tests
         id: replication
@@ -91,7 +91,7 @@ jobs:
         id: cleanup
         if: always() && steps.replication.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
 
       - name: Upload Log
         if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')

--- a/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
+++ b/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
@@ -82,8 +82,8 @@ jobs:
         id: setup-pub-sub
         if: always() && steps.start-secondary.outcome == 'success'
         run: |
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE PUBLICATION my_pub;"
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=jdbc_testdb password=12345678' PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CREATE PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=babelfish_db password=12345678' PUBLICATION my_pub;"
 
       - name: Run Replication Tests
         id: replication
@@ -97,7 +97,7 @@ jobs:
         id: cleanup
         if: always() && steps.replication.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
 
       - name: Upload Log
         if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')

--- a/.github/workflows/jdbc-tests-with-parallel-query.yml
+++ b/.github/workflows/jdbc-tests-with-parallel-query.yml
@@ -70,7 +70,7 @@ jobs:
         id: cleanup
         if: always() && steps.install-extensions.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -74,8 +74,8 @@ jobs:
         id: setup-pub-sub
         if: always() && steps.start-secondary.outcome == 'success'
         run: |
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "CREATE PUBLICATION my_pub;"
-          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=jdbc_testdb password=12345678' PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "CREATE PUBLICATION my_pub;"
+          ~/${{env.INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -p 5433 -c "CREATE SUBSCRIPTION my_sub CONNECTION 'host=localhost port=5432 user=jdbc_user dbname=babelfish_db password=12345678' PUBLICATION my_pub;"
 
       - name: Run Replication Tests
         id: replication
@@ -89,7 +89,7 @@ jobs:
         id: cleanup
         if: always() && steps.replication.outcome == 'success'
         run: |
-          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
 
       - name: Upload Log
         if: always() && (steps.jdbc.outcome == 'failure' || steps.replication.outcome == 'failure')

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -124,7 +124,7 @@ jobs:
           } > pg_hba.conf
           ~/${{env.OLD_INSTALL_DIR}}/bin/pg_ctl -c -D ~/${{env.OLD_INSTALL_DIR}}/data -l ~/${{env.OLD_INSTALL_DIR}}/data/logfile restart
           cd ~/work/babelfish_extensions/babelfish_extensions/
-          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode="multi-db" -v tsql_port="1433" -f .github/scripts/create_extension.sql
+          sudo ~/${{env.OLD_INSTALL_DIR}}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port="1433" -f .github/scripts/create_extension.sql
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
         shell: bash
 

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -139,12 +139,12 @@ jobs:
           ulimit -c unlimited
           cd ~
           ~/psql/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "\dx"
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE; ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -c "\dx"
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE; ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET track_functions = 'pl';"
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "SELECT pg_reload_conf();"
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
 
       - name: Run JDBC Tests

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -106,12 +106,12 @@ jobs:
           sudo make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config install
         shell: bash
 
+      - uses: actions/checkout@v2
+
       - name: Install extensions
         id: install-extensions-older
         if: always() && steps.build-tds_fdw-extension.outcome == 'success'
         uses: ./.github/composite-actions/install-extensions
-        
-      - uses: actions/checkout@v2
 
       - name: Build and run tests for Postgres engine using latest engine
         id: build-modified-postgres-newer

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
         if: always() && steps.build-babelfishpg_unit.outcome == 'success'
         timeout-minutes: 60
         run: |
-          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d jdbc_testdb -U runner -f .github/scripts/unit_tests.sql > >(tee ~/psql/output.out) 2>&1
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -f .github/scripts/unit_tests.sql > >(tee ~/psql/output.out) 2>&1
           count=$(awk -F '|' '$2 ~ /fail/'  ~/psql/output.out  | wc -l)
           if [ "$count" -gt 0 ]; then
             echo "Tests failed: $count"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -110,7 +110,7 @@ if [ ! $TARGET_WS ]; then
 fi
 echo "Target Workspace: $TARGET_WS"
 
-TEST_DB="jdbc_testdb"
+TEST_DB="babelfish_db"
 
 cd $TARGET_WS
 if [ ! -d "./postgresql_modified_for_babelfish" ]; then
@@ -198,10 +198,10 @@ pg_dump() {
 
     if [[ ! $2 ]];then
         $1/postgres/bin/pg_dumpall --username jdbc_user --roles-only --quote-all-identifiers --verbose -f pg_dump_globals.sql 2>error.log
-        $1/postgres/bin/pg_dump --create --username jdbc_user --column-inserts --quote-all-identifiers --verbose --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
+        $1/postgres/bin/pg_dump --create --username jdbc_user --column-inserts --quote-all-identifiers --verbose --file="pg_dump.sql" --dbname=babelfish_db 2>>error.log
     else
         $1/postgres/bin/pg_dumpall --username jdbc_user --roles-only --quote-all-identifiers --verbose --bbf-database-name=$2 -f pg_dump_globals.sql 2>error.log
-        $1/postgres/bin/pg_dump --username jdbc_user --column-inserts --quote-all-identifiers --verbose --bbf-database-name=$2 --file="pg_dump.sql" --dbname=jdbc_testdb 2>>error.log
+        $1/postgres/bin/pg_dump --username jdbc_user --column-inserts --quote-all-identifiers --verbose --bbf-database-name=$2 --file="pg_dump.sql" --dbname=babelfish_db 2>>error.log
     fi
     stop $1
 }
@@ -213,15 +213,15 @@ restore() {
     rm -f error.log
     echo "Restoring from pg_dumpall"
     $2/postgres/bin/psql -d postgres -U $USER -f $1/postgres/pg_dump_globals.sql 2>error.log
-    $2/postgres/bin/psql -d postgres -U $USER -c "CREATE DATABASE jdbc_testdb OWNER jdbc_user;"
+    $2/postgres/bin/psql -d postgres -U $USER -c "CREATE DATABASE babelfish_db OWNER jdbc_user;"
 
     echo "Restoring from pg_dump"
     if [[ ! $3 ]];then
         $2/postgres/bin/psql -d postgres -U jdbc_user -f $1/postgres/pg_dump.sql 2>>error.log
-        $2/postgres/bin/psql -d jdbc_testdb -U jdbc_user -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
-        $2/postgres/bin/psql -d jdbc_testdb -U jdbc_user -c "SELECT pg_reload_conf();"
+        $2/postgres/bin/psql -d babelfish_db -U jdbc_user -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';"
+        $2/postgres/bin/psql -d babelfish_db -U jdbc_user -c "SELECT pg_reload_conf();"
     else
-        $2/postgres/bin/psql -d jdbc_testdb -U jdbc_user -f $1/postgres/pg_dump.sql 2>>error.log
+        $2/postgres/bin/psql -d babelfish_db -U jdbc_user -f $1/postgres/pg_dump.sql 2>>error.log
     fi
 }
 
@@ -391,7 +391,7 @@ elif [ "$1" == "pg_upgrade" ]; then
     bin/psql -d $TEST_DB -U $USER -c \
         "ALTER EXTENSION babelfishpg_common UPDATE; ALTER EXTENSION babelfishpg_tsql UPDATE;"
     bin/psql -d $TEST_DB -U $USER -c \
-        "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
+        "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';"
     bin/psql -d $TEST_DB -U $USER -c \
         "SELECT pg_reload_conf();"
     exit 0

--- a/test/JDBC/cleanup.sh
+++ b/test/JDBC/cleanup.sh
@@ -1,12 +1,12 @@
 echo "===================================== CLEANING UP ======================================"
 psql -d postgres -U "$USER" << EOF
-\c jdbc_testdb
+\c babelfish_db
 CALL sys.remove_babelfish();
 ALTER SYSTEM RESET babelfishpg_tsql.database_name;
 ALTER SYSTEM RESET babelfishpg_tsql.migration_mode;
 SELECT pg_reload_conf();
 \c postgres
-DROP DATABASE jdbc_testdb WITH (FORCE);
+DROP DATABASE babelfish_db WITH (FORCE);
 DROP OWNED BY jdbc_user;
 DROP USER jdbc_user;
 EOF

--- a/test/JDBC/expected/BABEL-VERSION.out
+++ b/test/JDBC/expected/BABEL-VERSION.out
@@ -280,14 +280,14 @@ GO
 ~~WARNING (Message: babelfishpg_tds.product_version cannot be set. Please enter 4 valid numbers separated by '.'   Server SQLState: 01000)~~
 
 
-ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.version = "test";
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.version = "test";
 GO
 ~~WARNING (Code: 0)~~
 
 ~~WARNING (Message: Product version setting by babelfishpg_tds.product_version GUC will have no effect on @@VERSION  Server SQLState: 01000)~~
 
 
-ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.version = "default";
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.version = "default";
 GO
 
 Alter system set babelfishpg_tds.product_version = "16.4.3000.6";

--- a/test/JDBC/expected/db_accessadmin-vu-verify.out
+++ b/test/JDBC/expected/db_accessadmin-vu-verify.out
@@ -570,13 +570,13 @@ CREATE SCHEMA babel_5136_s1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 CREATE SCHEMA babel_5136_s1 AUTHORIZATION babel_5136_u1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 -- Should not be able to drop a database
 DROP DATABASE babel_5136

--- a/test/JDBC/expected/db_ddladmin-vu-verify.out
+++ b/test/JDBC/expected/db_ddladmin-vu-verify.out
@@ -134,13 +134,13 @@ CREATE SCHEMA babel_5116_sch1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 CREATE SCHEMA babel_5116_sch1 AUTHORIZATION babel_5116_r1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 
 CREATE PARTITION FUNCTION babel_5116_pf1 (datetime)

--- a/test/JDBC/expected/dbcreator_role-vu-verify.out
+++ b/test/JDBC/expected/dbcreator_role-vu-verify.out
@@ -691,7 +691,7 @@ create schema perm_denied_scm
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 
 create view perm_denied_v1 as select 1;

--- a/test/JDBC/expected/latest__verification_cleanup__13_5__bbf_view_def-vu-verify.out
+++ b/test/JDBC/expected/latest__verification_cleanup__13_5__bbf_view_def-vu-verify.out
@@ -9,8 +9,8 @@ SELECT * FROM bbf_view_def_upgrade_vu_prepare_dep_view WHERE "TABLE_NAME" LIKE '
 GO
 ~~START~~
 varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
-jdbc_testdb#!#master_dbo#!#bbf_view_def_upgrade_vu_prepare_dep_view#!#<NULL>#!#NONE#!#NO#!#NO#!#NO#!#NO#!#NO
-jdbc_testdb#!#master_dbo#!#bbf_view_def_upgrade_vu_prepare_view#!#<NULL>#!#NONE#!#NO#!#NO#!#NO#!#NO#!#NO
+babelfish_db#!#master_dbo#!#bbf_view_def_upgrade_vu_prepare_dep_view#!#<NULL>#!#NONE#!#NO#!#NO#!#NO#!#NO#!#NO
+babelfish_db#!#master_dbo#!#bbf_view_def_upgrade_vu_prepare_view#!#<NULL>#!#NONE#!#NO#!#NO#!#NO#!#NO#!#NO
 ~~END~~
 
 

--- a/test/JDBC/expected/ownership_restrictions_from_pg_su_user.out
+++ b/test/JDBC/expected/ownership_restrictions_from_pg_su_user.out
@@ -1,7 +1,7 @@
 -- tsql
 -- This test file checks the changes which are ignored in the tod run
 -- As tod will not be able to create an SUPERUSER
--- and testing on jdbc_testdb(where bbf is initialized) is not possible
+-- and testing on babelfish_db(where bbf is initialized) is not possible
 CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '12345678';
 GO
 
@@ -22,7 +22,7 @@ GO
 -- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
 -- connection limit and valid until should be working fine
 -- and the rest of alter role operations should throw an error.
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ALL IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -30,7 +30,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -38,7 +38,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_ROLE IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -46,7 +46,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -54,7 +54,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE SESSION_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -62,7 +62,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -74,7 +74,7 @@ GO
 -- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
 -- connection limit and valid until should be working fine
 -- and the rest of alter role operations should throw an error.
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ALL IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -82,7 +82,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -90,7 +90,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_ROLE IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -98,7 +98,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -106,7 +106,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE SESSION_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 
@@ -114,7 +114,7 @@ GO
     Server SQLState: 42501)~~
 
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 ~~ERROR (Code: 0)~~
 

--- a/test/JDBC/expected/securityadmin_role-vu-verify.out
+++ b/test/JDBC/expected/securityadmin_role-vu-verify.out
@@ -801,7 +801,7 @@ create schema perm_denied_scm
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 
 create view perm_denied_v1 as select 1;

--- a/test/JDBC/expected/single_db/db_accessadmin-vu-verify.out
+++ b/test/JDBC/expected/single_db/db_accessadmin-vu-verify.out
@@ -570,13 +570,13 @@ CREATE SCHEMA babel_5136_s1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 CREATE SCHEMA babel_5136_s1 AUTHORIZATION babel_5136_u1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 -- Should not be able to drop a database
 DROP DATABASE babel_5136

--- a/test/JDBC/expected/single_db/db_ddladmin-vu-verify.out
+++ b/test/JDBC/expected/single_db/db_ddladmin-vu-verify.out
@@ -134,13 +134,13 @@ CREATE SCHEMA babel_5116_sch1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 CREATE SCHEMA babel_5116_sch1 AUTHORIZATION babel_5116_r1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 
 CREATE PARTITION FUNCTION babel_5116_pf1 (datetime)

--- a/test/JDBC/expected/single_db/dbcreator_role-vu-verify.out
+++ b/test/JDBC/expected/single_db/dbcreator_role-vu-verify.out
@@ -690,7 +690,7 @@ create schema perm_denied_scm
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: permission denied for database jdbc_testdb)~~
+~~ERROR (Message: permission denied for database babelfish_db)~~
 
 
 create view perm_denied_v1 as select 1;

--- a/test/JDBC/init.sh
+++ b/test/JDBC/init.sh
@@ -22,17 +22,17 @@ if [[ $parallel_query_mode = false ]]; then
 echo "============================== CREATING USER AND DATABASE =============================="
 psql -U "$USER" -d postgres -a << EOF
 CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;
-DROP DATABASE IF EXISTS jdbc_testdb;
-CREATE DATABASE jdbc_testdb OWNER jdbc_user;
-\c jdbc_testdb
+DROP DATABASE IF EXISTS babelfish_db;
+CREATE DATABASE babelfish_db OWNER jdbc_user;
+\c babelfish_db
 CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE;
 GRANT ALL ON SCHEMA sys to jdbc_user;
 ALTER USER jdbc_user CREATEDB;
-\c jdbc_testdb
-ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';
+\c babelfish_db
+ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 SELECT pg_reload_conf();
-\c jdbc_testdb
+\c babelfish_db
 show babelfishpg_tsql.database_name;
 CALL sys.initialize_babelfish('jdbc_user');
 EOF
@@ -44,14 +44,14 @@ if [[ $parallel_query_mode = true ]]; then
 echo "============================== CREATING USER AND DATABASE =============================="
 psql -U "$USER" -d postgres -a << EOF
 CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;
-DROP DATABASE IF EXISTS jdbc_testdb;
-CREATE DATABASE jdbc_testdb OWNER jdbc_user;
-\c jdbc_testdb
+DROP DATABASE IF EXISTS babelfish_db;
+CREATE DATABASE babelfish_db OWNER jdbc_user;
+\c babelfish_db
 CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE;
 GRANT ALL ON SCHEMA sys to jdbc_user;
 ALTER USER jdbc_user CREATEDB;
-\c jdbc_testdb
-ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';
+\c babelfish_db
+ALTER SYSTEM SET babelfishpg_tsql.database_name = 'babelfish_db';
 ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';
 ALTER SYSTEM SET parallel_setup_cost = 0;
 ALTER SYSTEM SET parallel_tuple_cost = 0;
@@ -60,7 +60,7 @@ ALTER SYSTEM SET min_parallel_table_scan_size = 0;
 ALTER SYSTEM SET debug_parallel_query = 1;
 ALTER SYSTEM SET max_parallel_workers_per_gather = 4;
 SELECT pg_reload_conf();
-\c jdbc_testdb
+\c babelfish_db
 show babelfishpg_tsql.database_name;
 CALL sys.initialize_babelfish('jdbc_user');
 EOF

--- a/test/JDBC/input/BABEL-VERSION.mix
+++ b/test/JDBC/input/BABEL-VERSION.mix
@@ -84,10 +84,10 @@ GO
 Alter system set babelfishpg_tds.product_version = " ";
 GO
 
-ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.version = "test";
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.version = "test";
 GO
 
-ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.version = "default";
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.version = "default";
 GO
 
 Alter system set babelfishpg_tds.product_version = "16.4.3000.6";

--- a/test/JDBC/input/ownership_restrictions_from_pg_su_user.mix
+++ b/test/JDBC/input/ownership_restrictions_from_pg_su_user.mix
@@ -1,7 +1,7 @@
 -- tsql
 -- This test file checks the changes which are ignored in the tod run
 -- As tod will not be able to create an SUPERUSER
--- and testing on jdbc_testdb(where bbf is initialized) is not possible
+-- and testing on babelfish_db(where bbf is initialized) is not possible
 CREATE LOGIN ownership_restrictions_from_pg_login1 WITH password = '12345678';
 GO
 
@@ -22,44 +22,44 @@ GO
 -- If tsql login connected through psql Alter ROLE of an bbf created logins/user/roles for password,
 -- connection limit and valid until should be working fine
 -- and the rest of alter role operations should throw an error.
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ALL IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_ROLE IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE SESSION_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
 -- psql user=ownership_restrictions_from_pg_test_user password=12345678
 -- For plain psql user Alter ROLE of an bbf created logins/user/roles for password,
 -- connection limit and valid until should be working fine
 -- and the rest of alter role operations should throw an error.
-ALTER ROLE ALL IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ALL IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE master_ownership_restrictions_from_pg_role1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE CURRENT_ROLE IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_ROLE IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE CURRENT_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE CURRENT_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE SESSION_USER IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE SESSION_USER IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
-ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE jdbc_testdb set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
+ALTER ROLE ownership_restrictions_from_pg_login1 IN DATABASE babelfish_db set babelfishpg_tsql.ownership_restrictions_from_pg_test_variable = 101;
 GO
 
 -- psql user=ownership_restrictions_from_pg_test_su_user password=12345678

--- a/test/JDBC/input/pg_regress/load_aggtest.sh
+++ b/test/JDBC/input/pg_regress/load_aggtest.sh
@@ -1,5 +1,5 @@
 echo "-----copy aggtest table from /data/agg.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/agg.data'
 COPY master_dbo.aggtest FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_emp.sh
+++ b/test/JDBC/input/pg_regress/load_emp.sh
@@ -1,5 +1,5 @@
 echo "-----copy emp table from /data/emp.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/emp.data'
 COPY master_dbo.emp FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_onek.sh
+++ b/test/JDBC/input/pg_regress/load_onek.sh
@@ -1,5 +1,5 @@
 echo "-----copy onek table from /data/onek.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/onek.data'
 COPY master_dbo.onek FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_person.sh
+++ b/test/JDBC/input/pg_regress/load_person.sh
@@ -1,5 +1,5 @@
 echo "-----copy person table from /data/person.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/person.data'
 COPY master_dbo.person FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_road.sh
+++ b/test/JDBC/input/pg_regress/load_road.sh
@@ -1,5 +1,5 @@
 echo "-----copy road table from /data/streets.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/streets.data'
 COPY master_dbo.road FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_stud_emp.sh
+++ b/test/JDBC/input/pg_regress/load_stud_emp.sh
@@ -1,5 +1,5 @@
 echo "-----copy stud_emp table from /data/stud_emp.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/stud_emp.data'
 COPY master_dbo.stud_emp FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_student.sh
+++ b/test/JDBC/input/pg_regress/load_student.sh
@@ -1,5 +1,5 @@
 echo "-----copy student table from /data/student.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/student.data'
 COPY master_dbo.student FROM :'filename';

--- a/test/JDBC/input/pg_regress/load_tenk.sh
+++ b/test/JDBC/input/pg_regress/load_tenk.sh
@@ -1,5 +1,5 @@
 echo "-----copy tenk1 table from /data/tenk.data-----"
-PGPASSWORD=12345678 psql -U jdbc_user -d jdbc_testdb -a << EOF
+PGPASSWORD=12345678 psql -U jdbc_user -d babelfish_db -a << EOF
 \getenv pg_src PG_SRC
 \set filename :pg_src '/src/test/regress/data/tenk.data'
 COPY master_dbo.tenk1 FROM :'filename';

--- a/test/JDBC/sql_expected/BABEL-IDENTITY.out
+++ b/test/JDBC/sql_expected/BABEL-IDENTITY.out
@@ -162,7 +162,7 @@ SET IDENTITY_INSERT dbo.test_table2 ON;
 go
 ~~ERROR (Code: 8107)~~
 
-~~ERROR (Message: IDENTITY_INSERT is already ON for table 'jdbc_testdb.master_dbo.test_table1')~~
+~~ERROR (Message: IDENTITY_INSERT is already ON for table 'babelfish_db.master_dbo.test_table1')~~
 
 SET IDENTITY_INSERT dbo.test_table1 OFF;
 go

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCTempTable.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCTempTable.java
@@ -179,7 +179,7 @@ public class JDBCTempTable {
          * the OID buffer.
          */
         Statement alter_guc = psql.createStatement();
-        alter_guc.execute("ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.temp_oid_buffer_size = 0");
+        alter_guc.execute("ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0");
 
         if (check_oids_equal_helper(num_connections)) {
             bw.write("OID check failed! Oids were equal after disabling guc.");
@@ -189,7 +189,7 @@ public class JDBCTempTable {
         /*
          * TEST: Ensure that we can create up to (and no more) than the oid buffer size.
          */
-        alter_guc.execute("ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.temp_oid_buffer_size = 3");
+        alter_guc.execute("ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 3");
 
         /* We need a new connection here to pick up the updated guc. */
         Connection c2 = DriverManager.getConnection(connectionString);
@@ -237,7 +237,7 @@ public class JDBCTempTable {
         c2.close();
 
         /* Restore GUC after tests. */
-        alter_guc.execute("ALTER DATABASE jdbc_testdb SET babelfishpg_tsql.temp_oid_buffer_size = 65536");
+        alter_guc.execute("ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536");
         psql.close();
         c.close();
     }

--- a/test/JDBC/src/main/resources/config.txt
+++ b/test/JDBC/src/main/resources/config.txt
@@ -3,7 +3,7 @@ URL = localhost
 tsql_port = 1433
 psql_port = 5432
 databaseName = master
-physicalDatabaseName = jdbc_testdb
+physicalDatabaseName = babelfish_db
 user = jdbc_user
 password = 12345678
 


### PR DESCRIPTION
Before this commit, physical database name was jdbc_testdb.

With this commit, 
* physical database name has been changed to babelfish_db to make it uniform.
* Minor version upgrade and pg_dump and restore WF contains following changes:
       * Checked out to latest version before running prepare script to get physical dbname from latest.
       * Exported physicalDatabaseName as babelfish_db for pg_dump restore WF for version other than latest.

Signed-off-by: abanju@amazon.com