### PR TITLE
Fix error handling for already created functions that could give syntax error in newer releases

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5034,7 +5034,7 @@ Datum
 pltsql_call_handler(PG_FUNCTION_ARGS)
 {
 	bool		nonatomic;
-	PLtsql_function *func;
+	PLtsql_function *func = NULL;
 	PLtsql_execstate *save_cur_estate;
 	Datum		retval;
 	int			rc;
@@ -5155,6 +5155,11 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	PG_FINALLY();
 	{
 		sql_dialect = saved_dialect;
+
+		/* If func is NULL then we have encountered a parser error. */
+		if (!func)
+			terminate_batch(true /* send_error */ , true /* compile_error */ , current_spi_stack_depth);
+
 	}
 	PG_END_TRY();
 


### PR DESCRIPTION
### Description
Our code assumes that function once created will never give syntax error. But certain fixes like 5251e4ab81c2b71b17b1e90a79847cec252b8e25 where we disallow declaring reserved @@var, functions could have been created in earlier releases which will give syntax error while executing on a version with this commit. While throwing this syntax error at time of execution of function we have not cleaned up the contexts and aborted well which leads to a crash while executing a subsequent query.
To fix this we call terminate_batch for compile errors when we get parser syntax error.

In this [PR](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3240/commits) We were crashing due to this [in this action](https://github.com/babelfish-for-postgresql/babelfish_extensions/actions/runs/12293685480/job/34306890777) and by adding this commit we are not crashing anymore.

### Issues Resolved
BABEL-5455

### Test Scenarios Covered ###
In this [PR](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3240/commits) We were crashing due to this [in this action](https://github.com/babelfish-for-postgresql/babelfish_extensions/actions/runs/12293685480/job/34306890777) and by adding this commit we are not crashing anymore.



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).