### PR TITLE
Fix flakiness in db_ddladmin tests

### DIFF
--- a/test/JDBC/expected/db_ddladmin-vu-verify.out
+++ b/test/JDBC/expected/db_ddladmin-vu-verify.out
@@ -866,10 +866,10 @@ babel_5116_v1                                                    #!#master_dbo
 SELECT CAST(r.rolname AS CHAR(30)), CAST(object_name(objid) AS char(22)), deptype FROM pg_depend d
     JOIN pg_roles r ON (d.refobjid = r.oid)
     WHERE
-        object_name(objid) LIKE 'babel_5116%' AND
-        refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid') AND
-        r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%' AND
-        NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
+        object_name(objid) LIKE 'babel_5116%'
+        AND refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid')
+        AND classid != (SELECT oid FROM pg_class WHERE relname = 'pg_namespace')
+        AND r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%'
         AND (r.rolname LIKE '%dbo%' OR r.rolname LIKE '%db_ddladmin%')
     ORDER BY deptype, r.rolname, object_name(objid);
 GO
@@ -881,12 +881,12 @@ char#!#char#!#varchar
 SELECT CAST(r.rolname AS CHAR(30)), CAST(object_name(objid) AS char(22)), deptype FROM pg_shdepend d
     JOIN pg_roles r ON (d.refobjid = r.oid)
     WHERE
-        object_name(objid) LIKE 'babel_5116%' AND
-        refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid') AND
-        r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%' AND
-        NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
+        object_name(objid) LIKE 'babel_5116%'
+        AND refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid')
+        AND classid != (SELECT oid FROM pg_class WHERE relname = 'pg_namespace')
+        AND r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%'
+        AND NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
         AND (r.rolname LIKE '%dbo%' OR r.rolname LIKE '%db_ddladmin%') AND deptype!= 'i'
-        AND (r.rolname NOT IN ('ad_db_db_ddladmin', 'alter_db_db_ddladmin'))
     ORDER BY deptype, r.rolname, object_name(objid);
 GO
 ~~START~~

--- a/test/JDBC/expected/single_db/db_ddladmin-vu-verify.out
+++ b/test/JDBC/expected/single_db/db_ddladmin-vu-verify.out
@@ -866,10 +866,10 @@ babel_5116_v1                                                    #!#master_dbo
 SELECT CAST(r.rolname AS CHAR(30)), CAST(object_name(objid) AS char(22)), deptype FROM pg_depend d
     JOIN pg_roles r ON (d.refobjid = r.oid)
     WHERE
-        object_name(objid) LIKE 'babel_5116%' AND
-        refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid') AND
-        r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%' AND
-        NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
+        object_name(objid) LIKE 'babel_5116%'
+        AND refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid')
+        AND classid != (SELECT oid FROM pg_class WHERE relname = 'pg_namespace')
+        AND r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%'
         AND (r.rolname LIKE '%dbo%' OR r.rolname LIKE '%db_ddladmin%')
     ORDER BY deptype, r.rolname, object_name(objid);
 GO
@@ -881,12 +881,12 @@ char#!#char#!#varchar
 SELECT CAST(r.rolname AS CHAR(30)), CAST(object_name(objid) AS char(22)), deptype FROM pg_shdepend d
     JOIN pg_roles r ON (d.refobjid = r.oid)
     WHERE
-        object_name(objid) LIKE 'babel_5116%' AND
-        refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid') AND
-        r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%' AND
-        NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
+        object_name(objid) LIKE 'babel_5116%'
+        AND refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid')
+        AND classid != (SELECT oid FROM pg_class WHERE relname = 'pg_namespace')
+        AND r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%'
+        AND NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
         AND (r.rolname LIKE '%dbo%' OR r.rolname LIKE '%db_ddladmin%') AND deptype!= 'i'
-        AND (r.rolname NOT IN ('ad_db_db_ddladmin', 'alter_db_db_ddladmin'))
     ORDER BY deptype, r.rolname, object_name(objid);
 GO
 ~~START~~

--- a/test/JDBC/input/fixed_roles/db_ddladmin-vu-verify.mix
+++ b/test/JDBC/input/fixed_roles/db_ddladmin-vu-verify.mix
@@ -430,10 +430,10 @@ GO
 SELECT CAST(r.rolname AS CHAR(30)), CAST(object_name(objid) AS char(22)), deptype FROM pg_depend d
     JOIN pg_roles r ON (d.refobjid = r.oid)
     WHERE
-        object_name(objid) LIKE 'babel_5116%' AND
-        refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid') AND
-        r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%' AND
-        NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
+        object_name(objid) LIKE 'babel_5116%'
+        AND refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid')
+        AND classid != (SELECT oid FROM pg_class WHERE relname = 'pg_namespace')
+        AND r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%'
         AND (r.rolname LIKE '%dbo%' OR r.rolname LIKE '%db_ddladmin%')
     ORDER BY deptype, r.rolname, object_name(objid);
 GO
@@ -441,12 +441,12 @@ GO
 SELECT CAST(r.rolname AS CHAR(30)), CAST(object_name(objid) AS char(22)), deptype FROM pg_shdepend d
     JOIN pg_roles r ON (d.refobjid = r.oid)
     WHERE
-        object_name(objid) LIKE 'babel_5116%' AND
-        refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid') AND
-        r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%' AND
-        NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
+        object_name(objid) LIKE 'babel_5116%'
+        AND refclassid = (SELECT oid FROM pg_class WHERE relname = 'pg_authid')
+        AND classid != (SELECT oid FROM pg_class WHERE relname = 'pg_namespace')
+        AND r.rolname NOT LIKE '%datareader%' AND r.rolname NOT LIKE '%datawriter%'
+        AND NOT (object_name(objid) = 'babel_5116_tabletype1' AND deptype = 'a')
         AND (r.rolname LIKE '%dbo%' OR r.rolname LIKE '%db_ddladmin%') AND deptype!= 'i'
-        AND (r.rolname NOT IN ('ad_db_db_ddladmin', 'alter_db_db_ddladmin'))
     ORDER BY deptype, r.rolname, object_name(objid);
 GO
 


### PR DESCRIPTION
### Description

Fix flakiness in db_ddladmin tests

Post MVU it is possible that a relation has a same oid as
that of a schema which was a source of flakiness. As a 
fix skip schema entries in pg_shdepend catalog.

### Issues Resolved

[NO JIRA]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).