### PR TITLE
Renamed deprecated objects in upgrade script babelfishpg_tsql--3.8.0--3.9.0.sql from deprecated_in_5_0_0 to deprecated_in_3_9_0

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
@@ -9546,7 +9546,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.replicate(ANYELEMENT, INTEGER) RENAME TO replicate_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.replicate(ANYELEMENT, INTEGER) RENAME TO replicate_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9557,7 +9557,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.replicate(NTEXT, INTEGER) RENAME TO replicate_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.replicate(NTEXT, INTEGER) RENAME TO replicate_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9568,7 +9568,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.replicate(sys.NCHAR, INTEGER) RENAME TO replicate_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.replicate(sys.NCHAR, INTEGER) RENAME TO replicate_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9590,16 +9590,16 @@ END;
 $BODY$
 LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'replicate_any_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'replicate_ntext_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'replicate_nchar_deprecated_in_5_0_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'replicate_any_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'replicate_ntext_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'replicate_nchar_deprecated_in_3_9_0'); 
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.substring(NTEXT, INTEGER, INTEGER) RENAME TO substring_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.substring(NTEXT, INTEGER, INTEGER) RENAME TO substring_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9610,7 +9610,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.substring(sys.BPCHAR, INTEGER, INTEGER) RENAME TO substring_bpchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.substring(sys.BPCHAR, INTEGER, INTEGER) RENAME TO substring_bpchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9621,7 +9621,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.substring(sys.NCHAR, INTEGER, INTEGER) RENAME TO substring_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.substring(sys.NCHAR, INTEGER, INTEGER) RENAME TO substring_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9632,7 +9632,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.substring(sys.VARBINARY, INTEGER, INTEGER) RENAME TO substring_varbinary_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.substring(sys.VARBINARY, INTEGER, INTEGER) RENAME TO substring_varbinary_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9643,7 +9643,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.substring(ANYELEMENT, INTEGER, INTEGER) RENAME TO substring_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.substring(ANYELEMENT, INTEGER, INTEGER) RENAME TO substring_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9655,18 +9655,18 @@ CREATE OR REPLACE FUNCTION sys.substring(string sys.bbf_varbinary, i INTEGER, j 
 RETURNS sys.VARBINARY
 AS 'babelfishpg_tsql', 'tsql_varbinary_substr' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_ntext_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_bpchar_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_nchar_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_varbinary_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_any_deprecated_in_5_0_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_ntext_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_bpchar_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_nchar_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_varbinary_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'substring_any_deprecated_in_3_9_0'); 
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.upper(ANYELEMENT) RENAME TO upper_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.upper(ANYELEMENT) RENAME TO upper_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9677,7 +9677,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.upper(sys.NCHAR) RENAME TO upper_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.upper(sys.NCHAR) RENAME TO upper_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9688,7 +9688,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.upper(NTEXT) RENAME TO upper_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.upper(NTEXT) RENAME TO upper_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9704,16 +9704,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'upper_any_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'upper_ntext_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'upper_nchar_deprecated_in_5_0_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'upper_any_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'upper_ntext_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'upper_nchar_deprecated_in_3_9_0');
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.lower(ANYELEMENT) RENAME TO lower_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.lower(ANYELEMENT) RENAME TO lower_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9724,7 +9724,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.lower(sys.NCHAR) RENAME TO lower_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.lower(sys.NCHAR) RENAME TO lower_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9735,7 +9735,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.lower(NTEXT) RENAME TO lower_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.lower(NTEXT) RENAME TO lower_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9751,16 +9751,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'lower_any_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'lower_ntext_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'lower_nchar_deprecated_in_5_0_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'lower_any_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'lower_ntext_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'lower_nchar_deprecated_in_3_9_0');
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.TRIM(ANYELEMENT) RENAME TO trim_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.TRIM(ANYELEMENT) RENAME TO trim_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9771,7 +9771,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.TRIM(sys.BPCHAR) RENAME TO trim_bpchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.TRIM(sys.BPCHAR) RENAME TO trim_bpchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9782,7 +9782,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.TRIM(sys.NCHAR) RENAME TO trim_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.TRIM(sys.NCHAR) RENAME TO trim_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9820,16 +9820,16 @@ END;
 $BODY$
 LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'trim_any_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'trim_bpchar_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'trim_nchar_deprecated_in_5_0_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'trim_any_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'trim_bpchar_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'trim_nchar_deprecated_in_3_9_0');
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.LTRIM(ANYELEMENT) RENAME TO ltrim_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LTRIM(ANYELEMENT) RENAME TO ltrim_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9840,7 +9840,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.LTRIM(sys.BPCHAR) RENAME TO ltrim_bpchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LTRIM(sys.BPCHAR) RENAME TO ltrim_bpchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9851,7 +9851,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.LTRIM(sys.NCHAR) RENAME TO ltrim_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LTRIM(sys.NCHAR) RENAME TO ltrim_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9862,24 +9862,24 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.LTRIM(NTEXT) RENAME TO ltrim_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LTRIM(NTEXT) RENAME TO ltrim_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
     RAISE WARNING '%', exception_message;
 END;
 $$;
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_any_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_bpchar_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_nchar_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_ntext_deprecated_in_5_0_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_any_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_bpchar_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_nchar_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'ltrim_ntext_deprecated_in_3_9_0');
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RTRIM(ANYELEMENT) RENAME TO rtrim_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.RTRIM(ANYELEMENT) RENAME TO rtrim_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9890,7 +9890,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RTRIM(sys.BPCHAR) RENAME TO rtrim_bpchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.RTRIM(sys.BPCHAR) RENAME TO rtrim_bpchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9901,7 +9901,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RTRIM(sys.NCHAR) RENAME TO rtrim_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.RTRIM(sys.NCHAR) RENAME TO rtrim_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9912,58 +9912,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RTRIM(NTEXT) RENAME TO rtrim_ntext_deprecated_in_5_0_0;
-EXCEPTION WHEN OTHERS THEN
-    GET STACKED DIAGNOSTICS
-    exception_message = MESSAGE_TEXT;
-    RAISE WARNING '%', exception_message;
-END;
-$$;
-
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_any_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_bpchar_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_nchar_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_ntext_deprecated_in_5_0_0');
-
-
-DO $$
-DECLARE
-    exception_message text;
-BEGIN
-    ALTER FUNCTION sys.LEFT(ANYELEMENT, INTEGER) RENAME TO left_any_deprecated_in_5_0_0;
-EXCEPTION WHEN OTHERS THEN
-    GET STACKED DIAGNOSTICS
-    exception_message = MESSAGE_TEXT;
-    RAISE WARNING '%', exception_message;
-END;
-$$;
-DO $$
-DECLARE
-    exception_message text;
-BEGIN
-    ALTER FUNCTION sys.LEFT(sys.BPCHAR, INTEGER) RENAME TO left_bpchar_deprecated_in_5_0_0;
-EXCEPTION WHEN OTHERS THEN
-    GET STACKED DIAGNOSTICS
-    exception_message = MESSAGE_TEXT;
-    RAISE WARNING '%', exception_message;
-END;
-$$;
-DO $$
-DECLARE
-    exception_message text;
-BEGIN
-    ALTER FUNCTION sys.LEFT(sys.NCHAR, INTEGER) RENAME TO left_nchar_deprecated_in_5_0_0;
-EXCEPTION WHEN OTHERS THEN
-    GET STACKED DIAGNOSTICS
-    exception_message = MESSAGE_TEXT;
-    RAISE WARNING '%', exception_message;
-END;
-$$;
-DO $$
-DECLARE
-    exception_message text;
-BEGIN
-    ALTER FUNCTION sys.LEFT(NTEXT, INTEGER) RENAME TO left_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.RTRIM(NTEXT) RENAME TO rtrim_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9971,17 +9920,17 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_any_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_bpchar_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_nchar_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_ntext_deprecated_in_5_0_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_any_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_bpchar_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_nchar_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'rtrim_ntext_deprecated_in_3_9_0');
 
 
 DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RIGHT(ANYELEMENT, INTEGER) RENAME TO right_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LEFT(ANYELEMENT, INTEGER) RENAME TO left_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -9992,7 +9941,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RIGHT(sys.BPCHAR, INTEGER) RENAME TO right_bpchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LEFT(sys.BPCHAR, INTEGER) RENAME TO left_bpchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -10003,7 +9952,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RIGHT(sys.NCHAR, INTEGER) RENAME TO right_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LEFT(sys.NCHAR, INTEGER) RENAME TO left_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -10014,7 +9963,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.RIGHT(NTEXT, INTEGER) RENAME TO right_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.LEFT(NTEXT, INTEGER) RENAME TO left_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -10022,10 +9971,61 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_any_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_bpchar_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_nchar_deprecated_in_5_0_0'); 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_ntext_deprecated_in_5_0_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_any_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_bpchar_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_nchar_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'left_ntext_deprecated_in_3_9_0'); 
+
+
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    ALTER FUNCTION sys.RIGHT(ANYELEMENT, INTEGER) RENAME TO right_any_deprecated_in_3_9_0;
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    ALTER FUNCTION sys.RIGHT(sys.BPCHAR, INTEGER) RENAME TO right_bpchar_deprecated_in_3_9_0;
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    ALTER FUNCTION sys.RIGHT(sys.NCHAR, INTEGER) RENAME TO right_nchar_deprecated_in_3_9_0;
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    ALTER FUNCTION sys.RIGHT(NTEXT, INTEGER) RENAME TO right_ntext_deprecated_in_3_9_0;
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_any_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_bpchar_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_nchar_deprecated_in_3_9_0'); 
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'right_ntext_deprecated_in_3_9_0'); 
 
 
 CREATE OR REPLACE FUNCTION sys.translate(string TEXT, characters TEXT, translations TEXT)
@@ -10175,7 +10175,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.reverse(ANYELEMENT) RENAME TO reverse_any_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.reverse(ANYELEMENT) RENAME TO reverse_any_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -10186,7 +10186,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.reverse(sys.NCHAR) RENAME TO reverse_nchar_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.reverse(sys.NCHAR) RENAME TO reverse_nchar_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -10197,7 +10197,7 @@ DO $$
 DECLARE
     exception_message text;
 BEGIN
-    ALTER FUNCTION sys.reverse(NTEXT) RENAME TO reverse_ntext_deprecated_in_5_0_0;
+    ALTER FUNCTION sys.reverse(NTEXT) RENAME TO reverse_ntext_deprecated_in_3_9_0;
 EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS
     exception_message = MESSAGE_TEXT;
@@ -10215,9 +10215,9 @@ END;
 $BODY$
 LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
 
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'reverse_any_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'reverse_nchar_deprecated_in_5_0_0');
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'reverse_ntext_deprecated_in_5_0_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'reverse_any_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'reverse_nchar_deprecated_in_3_9_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'reverse_ntext_deprecated_in_3_9_0');
 
 
 CREATE OR REPLACE AGGREGATE sys.string_agg(TEXT, TEXT) (


### PR DESCRIPTION
### Description
Functions deprecated in upgrade script `babelfishpg_tsql--3.8.0--3.9.0.sql` should be named as `*_deprecated_in_3_9_0`. Although in cherry-pick PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3251, we missed updating this change. This PR will fix this issue.

### Issues Resolved
NO JIRA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).