### PR TITLE
Optimize DDL export framework execution time

### DIFF
--- a/test/python/SMO_script.ps1
+++ b/test/python/SMO_script.ps1
@@ -63,7 +63,7 @@ if($script_flag -eq $var_one)
     # Scripting standard database objects.
     foreach ($CurrentObject in $Objects)
     {
-        if (-not $CurrentObject.IsSystemObject )
+        if ($CurrentObject.schema -ne $schm -and -not $CurrentObject.IsSystemObject )
         {
             $Scripter.Script($CurrentObject);
             Write-Output "GO`n" 


### PR DESCRIPTION
### Description
Previously, the DDL export framework was taking over 20 minutes to run the `ddl_all_objects.sql` test, while other tests completed within a minute. Upon further investigation, we found that we were not filtering out objects in the 'sys' schema before checking IsSystemObject. This resulted in executing a query for each object present in the 'sys' schema to determine whether it was a system object or not.

This commit adds a schema filter before the IsSystemObject check in the SMO script. By first excluding objects in the 'sys' schema, we avoid unnecessary IsSystemObject checks on system objects, significantly reducing execution time of framework.

Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)

### Issues Resolved

Task: BABEL-5473


### Execution time of Python Worflow
Before : ~ 33 minutes
After: ~ 12 minutes

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).