### PR TITLE
Update README to use newer Java version

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -9,7 +9,7 @@ runs:
         curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
         sudo apt-get update --fix-missing -y
-        sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python3-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison mssql-tools unixodbc-dev libsybdb5 freetds-dev freetds-common gdal-bin libgdal-dev libgeos-dev gdb libkrb5-dev
+        sudo apt-get install uuid-dev openjdk-21-jre libicu-dev libxml2-dev openssl libssl-dev python3-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison mssql-tools unixodbc-dev libsybdb5 freetds-dev freetds-common gdal-bin libgdal-dev libgeos-dev gdb libkrb5-dev
         sudo apt install -y ccache
         sudo apt-get install lcov
         sudo /usr/sbin/update-ccache-symlinks

--- a/INSTALLING.md.tmpl
+++ b/INSTALLING.md.tmpl
@@ -29,7 +29,7 @@ sudo apt-get update && sudo apt install -y --no-install-recommends \
   cmake lld apt-utils libossp-uuid-dev gnulib bison \
   xsltproc icu-devtools libicu66 \
   libicu-dev gawk \
-  curl openjdk-8-jre openssl \
+  curl openjdk-21-jre openssl \
   g++ libssl-dev python-dev libpq-dev \
   pkg-config libutfcpp-dev \
   gnupg unixodbc-dev net-tools unzip

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -27,7 +27,7 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     You'll also need to install `gcc`, `gcc-c++`, `java` and `bison`.
     
     ```
-    sudo apt-get install uuid-dev openjdk-8-jre \
+    sudo apt-get install uuid-dev openjdk-21-jre \
                         libicu-dev libxml2-dev openssl libssl-dev python-dev \
                         libossp-uuid-dev libpq-dev pkg-config g++ build-essential bison 
     ```


### PR DESCRIPTION
### Description

Updating the README to use a newer Java version. The Antlr version update requires Java 8 at minimum to build. 

For Ubuntu, I verified the version `openjdk-21-jre` was available by using a clean Ubuntu install. 

For the RHEL version we typically develop on, the default version of Java available is `openjdk-17`, so that doesn't need changing.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).