### PR TITLE
Fix alter table drop column drops trigger on the table

### DIFF
--- a/contrib/babelfishpg_tsql/src/tablecmds.c
+++ b/contrib/babelfishpg_tsql/src/tablecmds.c
@@ -130,7 +130,7 @@ lookup_and_drop_triggers(ObjectAccessType access, Oid classId,
 		return;
 
 	/* We only want to execute this function for the DROP TABLE case */
-	if (classId != RelationRelationId || access != OAT_DROP)
+	if (classId != RelationRelationId || access != OAT_DROP || subId != 0)
 		return;
 
 	/*

--- a/test/JDBC/expected/alter_table.out
+++ b/test/JDBC/expected/alter_table.out
@@ -70,3 +70,36 @@ GO
 
 drop table trans2
 GO
+
+--------------------------- BABEL-5417 ---------------------------
+------- DROP COLUMN SHOULD NOT DROP TRIGGERS ON THE TABLE --------
+CREATE TABLE babel_5417(a int, b int);
+GO
+CREATE TRIGGER babel_5417_trg
+ON babel_5417
+AFTER INSERT AS SELECT 1
+GO
+SELECT tgname FROM pg_trigger WHERE tgname LIKE 'babel_5417%';
+GO
+~~START~~
+varchar
+babel_5417_trg
+~~END~~
+
+ALTER TABLE babel_5417 DROP COLUMN a
+GO
+SELECT tgname FROM pg_trigger WHERE tgname LIKE 'babel_5417%';
+GO
+~~START~~
+varchar
+babel_5417_trg
+~~END~~
+
+DROP TABLE babel_5417
+GO
+SELECT tgname FROM pg_trigger WHERE tgname LIKE 'babel_5417%';
+GO
+~~START~~
+varchar
+~~END~~
+

--- a/test/JDBC/expected/db_owner-vu-verify.out
+++ b/test/JDBC/expected/db_owner-vu-verify.out
@@ -305,16 +305,6 @@ go
 alter procedure dbo.dbowner__p0 as select 20
 go
 
--- BABEL-5417: Trigger gets dropped if we drop a column in table
-create trigger dbo.dbowner__trg0
-on dbo.dbowner__t0
-after insert
-as
-begin
-    select 'New row inserted'
-end
-go
-
 -- Member of db_owner role should be allowed to rename objects
 exec sp_rename 'dbo.dbowner__t0.x', 'x_renamed', 'column'
 go

--- a/test/JDBC/input/alter_table.sql
+++ b/test/JDBC/input/alter_table.sql
@@ -44,3 +44,24 @@ GO
 
 drop table trans2
 GO
+
+--------------------------- BABEL-5417 ---------------------------
+------- DROP COLUMN SHOULD NOT DROP TRIGGERS ON THE TABLE --------
+CREATE TABLE babel_5417(a int, b int);
+GO
+CREATE TRIGGER babel_5417_trg
+ON babel_5417
+AFTER INSERT AS SELECT 1
+GO
+SELECT tgname FROM pg_trigger WHERE tgname LIKE 'babel_5417%';
+GO
+ALTER TABLE babel_5417 DROP COLUMN a
+GO
+SELECT tgname FROM pg_trigger WHERE tgname LIKE 'babel_5417%';
+GO
+DROP TABLE babel_5417
+GO
+SELECT tgname FROM pg_trigger WHERE tgname LIKE 'babel_5417%';
+GO
+------------------------------------------------------------------
+------------------------------------------------------------------

--- a/test/JDBC/input/db_owner-vu-verify.mix
+++ b/test/JDBC/input/db_owner-vu-verify.mix
@@ -135,16 +135,6 @@ go
 alter procedure dbo.dbowner__p0 as select 20
 go
 
--- BABEL-5417: Trigger gets dropped if we drop a column in table
-create trigger dbo.dbowner__trg0
-on dbo.dbowner__t0
-after insert
-as
-begin
-    select 'New row inserted'
-end
-go
-
 -- Member of db_owner role should be allowed to rename objects
 exec sp_rename 'dbo.dbowner__t0.x', 'x_renamed', 'column'
 go


### PR DESCRIPTION
### Description

In postgres trigger and functions are two different objects. You first define a function and then use it in your trigger definition. In babelfish we handle this internally so that for users it feels like a single object. As part of this internal handing we also drop the function created for this trigger as part of post object access hook. Currently the condition for DROP TABLE was incomplete and even for DROP COLUMN we would drop the triggers associated with the table.
As a fix add another condition to only execute this internal drop of triggers for DROP TABLE.

### Issues Resolved

[BABEL-5417]

### Cherry picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3225

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).