### PR TITLE
Fix is_srvrolemember output for login same as specified server role

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2190,6 +2190,9 @@ BEGIN
     
     ELSIF role = 'public' COLLATE sys.database_default THEN
     	RETURN 1;
+
+	ELSEIF role = login THEN
+		RETURN 0;
 	
  	ELSIF role COLLATE sys.database_default IN ('sysadmin', 'securityadmin', 'dbcreator') THEN
 	  	has_role = (pg_has_role(login::TEXT, role::TEXT, 'MEMBER')

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -382,6 +382,7 @@ FROM pg_catalog.pg_roles AS Base INNER JOIN sys.babelfish_authid_login_ext AS Ex
 WHERE Ext.type = 'R'
 AND bbf_is_member_of_role_nosuper(sys.suser_id(), Base.oid);
 GRANT SELECT ON sys.login_token TO PUBLIC;
+
 CREATE OR REPLACE FUNCTION is_srvrolemember(role sys.SYSNAME, login sys.SYSNAME DEFAULT suser_name())
 RETURNS INTEGER AS
 $$
@@ -402,6 +403,9 @@ BEGIN
     
     ELSIF role = 'public' COLLATE sys.database_default THEN
     	RETURN 1;
+
+    ELSEIF role = login THEN
+		RETURN 0;
 	
  	ELSIF role COLLATE sys.database_default IN ('sysadmin', 'securityadmin', 'dbcreator') THEN
 	  	has_role = (pg_has_role(login::TEXT, role::TEXT, 'MEMBER')

--- a/test/JDBC/expected/dbcreator_role-vu-verify.out
+++ b/test/JDBC/expected/dbcreator_role-vu-verify.out
@@ -32,6 +32,31 @@ int
 ~~END~~
 
 
+select is_srvrolemember('dbcreator','dbcreator')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select is_srvrolemember('sysadmin','sysadmin')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- should return NULL for invalid login
+select is_srvrolemember('l1', 'l1')
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
 alter login dbcreator_login1 with password='123'
 go
 

--- a/test/JDBC/expected/securityadmin_role-vu-verify.out
+++ b/test/JDBC/expected/securityadmin_role-vu-verify.out
@@ -15,6 +15,14 @@ int
 ~~END~~
 
 
+select is_srvrolemember('securityadmin','securityadmin')
+go
+~~START~~
+int
+0
+~~END~~
+
+
 alter login securityadmin_login1 with password='123'
 go
 

--- a/test/JDBC/expected/single_db/dbcreator_role-vu-verify.out
+++ b/test/JDBC/expected/single_db/dbcreator_role-vu-verify.out
@@ -32,6 +32,31 @@ int
 ~~END~~
 
 
+select is_srvrolemember('dbcreator','dbcreator')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select is_srvrolemember('sysadmin','sysadmin')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- should return NULL for invalid login
+select is_srvrolemember('l1', 'l1')
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
 alter login dbcreator_login1 with password='123'
 go
 

--- a/test/JDBC/input/dbcreator_role-vu-verify.mix
+++ b/test/JDBC/input/dbcreator_role-vu-verify.mix
@@ -13,6 +13,16 @@ go
 select is_srvrolemember('dbcreator', 'securityadmin')
 go
 
+select is_srvrolemember('dbcreator','dbcreator')
+go
+
+select is_srvrolemember('sysadmin','sysadmin')
+go
+
+-- should return NULL for invalid login
+select is_srvrolemember('l1', 'l1')
+go
+
 alter login dbcreator_login1 with password='123'
 go
 

--- a/test/JDBC/input/securityadmin_role-vu-verify.mix
+++ b/test/JDBC/input/securityadmin_role-vu-verify.mix
@@ -5,6 +5,9 @@ go
 select is_srvrolemember('securityadmin', 'sysadmin')
 go
 
+select is_srvrolemember('securityadmin','securityadmin')
+go
+
 alter login securityadmin_login1 with password='123'
 go
 


### PR DESCRIPTION
### Description

Earlier `is_srvrolemember` was returning 1 for login same as specified server role.

With this commit, now it will return expected output.