### PR TITLE
Do not allow predefined server roles to be members of each other (#3292)

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -1946,6 +1946,12 @@ check_alter_server_stmt(GrantRoleStmt *stmt)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("'sysadmin' role cannot be granted to login: a user is already created in database '%s'", db_name)));
 
+	/* Restrict adding fixed server roles as member*/
+	if (IS_BBF_FIXED_SERVER_ROLE(grantee_name))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("Cannot use the special principal '%s'", grantee_name)));
+
 	/*
 	 * could not drop the last member of sysadmin excluding bbf_role_admin,
 	 * which always needs to be its member.

--- a/test/JDBC/expected/dbcreator_role-vu-verify.out
+++ b/test/JDBC/expected/dbcreator_role-vu-verify.out
@@ -565,6 +565,77 @@ go
 create role dummy_role
 go
 
+-- Do not allow predefined server roles to be members of each other
+Alter server role sysadmin add member securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'securityadmin')~~
+
+
+Alter server role sysadmin add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role securityadmin add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role securityadmin add member securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'securityadmin')~~
+
+
+Alter server role dbcreator add member securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'securityadmin')~~
+
+
+Alter server role dbcreator add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role dbcreator add member sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'sysadmin')~~
+
+
+Alter server role securityadmin add member sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'sysadmin')~~
+
+
+Alter server role dbcreator add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role sysadmin add member sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'sysadmin')~~
+
+
 -- terminate-tsql-conn
 
 -- tsql user=dbcreator_login1 password=123

--- a/test/JDBC/expected/single_db/dbcreator_role-vu-verify.out
+++ b/test/JDBC/expected/single_db/dbcreator_role-vu-verify.out
@@ -564,6 +564,77 @@ go
 create role dummy_role
 go
 
+-- Do not allow predefined server roles to be members of each other
+Alter server role sysadmin add member securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'securityadmin')~~
+
+
+Alter server role sysadmin add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role securityadmin add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role securityadmin add member securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'securityadmin')~~
+
+
+Alter server role dbcreator add member securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'securityadmin')~~
+
+
+Alter server role dbcreator add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role dbcreator add member sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'sysadmin')~~
+
+
+Alter server role securityadmin add member sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'sysadmin')~~
+
+
+Alter server role dbcreator add member dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbcreator')~~
+
+
+Alter server role sysadmin add member sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'sysadmin')~~
+
+
 -- terminate-tsql-conn
 
 -- tsql user=dbcreator_login1 password=123

--- a/test/JDBC/input/dbcreator_role-vu-verify.mix
+++ b/test/JDBC/input/dbcreator_role-vu-verify.mix
@@ -398,6 +398,37 @@ go
 create role dummy_role
 go
 
+-- Do not allow predefined server roles to be members of each other
+Alter server role sysadmin add member securityadmin
+go
+
+Alter server role sysadmin add member dbcreator
+go
+
+Alter server role securityadmin add member dbcreator
+go
+
+Alter server role securityadmin add member securityadmin
+go
+
+Alter server role dbcreator add member securityadmin
+go
+
+Alter server role dbcreator add member dbcreator
+go
+
+Alter server role dbcreator add member sysadmin
+go
+
+Alter server role securityadmin add member sysadmin
+go
+
+Alter server role dbcreator add member dbcreator
+go
+
+Alter server role sysadmin add member sysadmin
+go
+
 -- terminate-tsql-conn
 
 -- tsql user=dbcreator_login1 password=123


### PR DESCRIPTION

Earlier fixed server-level roles could made members of each other. 

With this commit, we blocked making predefined server-level roles members of each other.

Task: BABEL-5484