### PR TITLE
Update  RESTORE behaviour for LIKE operator for CS_AI collation

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -1326,6 +1326,24 @@ has_ilike_node(Node *expr)
 	return false;
 }
 
+bool
+has_like_node(Node *expr)
+{
+	OpExpr	   *op;
+
+	Assert(IsA(expr, OpExpr));
+
+	op = (OpExpr *) expr;
+	for (int i = 0; i < TOTAL_LIKE_OP_COUNT; i++)
+	{
+		if (strcmp(get_opname(op->opno), like_ilike_table[i].like_op_name) == 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 Datum
 is_collated_ci_as_internal(PG_FUNCTION_ARGS)
 {
@@ -1625,6 +1643,7 @@ get_collation_callbacks(void)
 		collation_callbacks_var.find_cs_as_collation_internal = &find_cs_as_collation;
 		collation_callbacks_var.find_collation_internal = &find_collation;
 		collation_callbacks_var.has_ilike_node = &has_ilike_node;
+		collation_callbacks_var.has_like_node = &has_like_node;
 		collation_callbacks_var.translate_bbf_collation_to_tsql_collation = &translate_bbf_collation_to_tsql_collation;
 		collation_callbacks_var.translate_tsql_collation_to_bbf_collation = &translate_tsql_collation_to_bbf_collation;
 		collation_callbacks_var.set_db_collation = &set_db_collation;

--- a/contrib/babelfishpg_common/src/collation.h
+++ b/contrib/babelfishpg_common/src/collation.h
@@ -113,6 +113,8 @@ typedef struct collation_callbacks
 
 	bool		(*has_ilike_node) (Node *expr);
 
+	bool		(*has_like_node) (Node *expr);
+
 	const char *(*translate_bbf_collation_to_tsql_collation) (const char *collname);
 
 	const char *(*translate_tsql_collation_to_bbf_collation) (const char *collname);
@@ -147,6 +149,7 @@ extern const char *translate_bbf_collation_to_tsql_collation(const char *collnam
 extern const char *translate_tsql_collation_to_bbf_collation(const char *collname);
 Oid			get_oid_from_collidx(int collidx);
 extern bool has_ilike_node(Node *expr);
+extern bool has_like_node(Node *expr);
 extern Oid	babelfish_define_type_default_collation(Oid typeNamespace);
 extern void	set_db_collation(Oid db_coll);
 

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -942,9 +942,14 @@ transform_likenode(Node *node)
 		 * by a user. So, it is safe to go ahead with replacing the ci_as
 		 * collation with a corresponding cs_as one if an ILIKE node is found
 		 * during dump and restore.
+		 * For CS_AI collation, we keep the LIKE operator but convert it to
+		 * CS_AS by adding a call to remove_accents_internal*. During restore,
+		 * it will take the same code path and will try to add a new call to
+		 * remove_accents_internal* on top of current node. So, we take care
+		 * of that case here.
 		 */
 		init_and_check_collation_callbacks();
-		if ((*collation_callbacks_ptr->has_ilike_node) (node) && babelfish_dump_restore)
+		if (babelfish_dump_restore && ((*collation_callbacks_ptr->has_ilike_node) (node) || (*collation_callbacks_ptr->has_like_node) (node)))
 		{
 			int			collidx_of_cs_as;
 
@@ -965,6 +970,13 @@ transform_likenode(Node *node)
 				/* If a collation is not specified, use the default one */
 				op->inputcollid = DEFAULT_COLLATION_OID;
 			}
+
+			/*
+			 * If this has a like node, then it is CS collation
+			 * So we can return from here directly
+			 */
+			if ((*collation_callbacks_ptr->has_like_node) (node))
+				return node;
 		}
 
 		if (OidIsValid(like_entry.like_oid) &&

--- a/contrib/babelfishpg_tsql/src/collation.h
+++ b/contrib/babelfishpg_tsql/src/collation.h
@@ -82,6 +82,8 @@ typedef struct collation_callbacks
 
 	bool		(*has_ilike_node) (Node *expr);
 
+	bool		(*has_like_node) (Node *expr);
+
 	const char *(*translate_bbf_collation_to_tsql_collation) (const char *collname);
 
 	const char *(*translate_tsql_collation_to_bbf_collation) (const char *collname);


### PR DESCRIPTION
### Description
We introduced the support for LIKE operator for AI collations for Latin characters from versions 15.7 and 16.3 onwards. We use function remove_accents_internal to remove accents from the characters to find the base character. To improve the performance further, we introduced a cached version of remove_accents_internal function named remove_accents_internal_using_cache from 15.8 and 16.4 onwards. 

In cases where there is CHECK constraint in the table definition for CS_AI, we observed that after upgrade from any version before 15.8 to 16.latest, the INSERT was failing on the table as another call to remove_accents_internal_using_cache was getting added on top of current node during restore. This issue is only observed for CS_AI as we do not modify the LIKE operator whereas for CI_AI we modify LIKE to ILIKE and BETWEEN operators. 

We fix this issue by checking whether the incoming LIKE operator is for CS_AI. If yes, then we update the collation information for the OpExpr for that node and return from there directly. In this way, during restore we won't go in the code path where we add extra call to remove_accents_internal* on already modified node. 


### Issues Resolved ###
BABEL-5471
Cherry-picked from: [3fe245b3a16b47ddc05642f23c26a238f7641a04](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/3fe245b3a16b47ddc05642f23c26a238f7641a04)

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).