### PR TITLE
Bump version of maven commons-io and github actions 

### DIFF
--- a/.github/composite-actions/check-babelfish-inconsistency/action.yml
+++ b/.github/composite-actions/check-babelfish-inconsistency/action.yml
@@ -12,7 +12,7 @@ runs:
         FROM pg_proc
         WHERE proname = 'check_for_inconsistent_metadata';" | grep -o 'exists\|not_exists')
 
-        echo "::set-output name=function_exists::$function_exists"
+        echo "function_exists=$function_exists" >> $GITHUB_OUTPUT
         echo "Check Babelfish metadata inconsistency function exists: $function_exists"
         
         # If the function exists, run the metadata inconsistency check

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Download CSV report from previous run
         if: (github.event_name == 'schedule')
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           name: csv_${{github.ref_name}}
           path: contrib/

--- a/.github/workflows/pg_dump-restore-test.yml
+++ b/.github/workflows/pg_dump-restore-test.yml
@@ -23,7 +23,7 @@ jobs:
           dump_format: itm[itm.length - 1]['dump-format'], \
           type: itm[itm.length - 1]['type']})); \
           console.log(JSON.stringify(p));")
-          echo "::set-output name=dump-restore-path-list::$DUMP_RESTORE_PATH_LIST"
+          echo "dump-restore-path-list=$DUMP_RESTORE_PATH_LIST" >> $GITHUB_OUTPUT
 
   run-dump-restore-test:
     needs: generate-dump-restore-tests
@@ -45,24 +45,24 @@ jobs:
         id: read-base-and-final-version
         if: always() && steps.install-yq.outcome == 'success'
         run: > 
-          echo "::set-output name=base-version::$(
+          echo "base-version=$(
             yq '."dump-restore-version"[${{ matrix.upgrade-path.id }}][0].version' ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml
-          )" && 
-          echo "::set-output name=final-version::$(
+          )"  >> $GITHUB_OUTPUT &&
+          echo "final-version=$(
             yq '."dump-restore-version"[${{ matrix.upgrade-path.id }}][-1].version' ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml
-          )"
+          )" >> $GITHUB_OUTPUT
 
       - name: Find Engine and Extension Branches for Base Version ${{ steps.read-base-and-final-version.outputs.base-version }}
         id: find-branch
         if: always() && steps.read-base-and-final-version.outcome == 'success'
         run: >
-          echo "::set-output name=base-engine-branch::$(
+          echo "base-engine-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".engine_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-extension-branch::$(
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-extension-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".extension_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-dir::$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))"
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-dir=$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))" >> $GITHUB_OUTPUT
 
       - name: Setup Base Version ${{ steps.read-base-and-final-version.outputs.base-version }} and Run Preparation Tests
         id: setup-base-version

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -16,7 +16,7 @@ jobs:
           config="'$(yq -o=json ${{ github.workspace }}/.github/configuration/upgrade-test-configuration.yml)'"
           config=$(echo $config | sed "s/\"/\\\\\"/g")
           UPGRADE_PATH_LIST=$(node -e "let k = JSON.parse($config); let p = k['upgrade-version'].map((itm, index) => ({ id: index, path: itm['upgrade-path'].map(i => i.version.toString().replace(/[.]/g, \"_\")), server_collation_name: itm['babelfishpg_tsql_server_collation_name'] ? itm['babelfishpg_tsql_server_collation_name'] : \"default\", title: itm['upgrade-path'].map(i => i.version.toString().replace(/[.]/g, \"_\")).join(\"-\") + (itm['babelfishpg_tsql_server_collation_name'] ? (\" with server-collation - \" + itm['babelfishpg_tsql_server_collation_name'] + \" \") : \"\"), last_version: itm['upgrade-path'][itm['upgrade-path'].length - 1].version.toString().replace(/[.]/g, \"_\") })); console.log(JSON.stringify(p));")
-          echo "::set-output name=upgrade-path-list::$UPGRADE_PATH_LIST"
+          echo "upgrade-path-list=$UPGRADE_PATH_LIST" >> $GITHUB_OUTPUT
 
   run-version-upgrade-test:
     needs: generate-version-upgrade-tests
@@ -38,24 +38,24 @@ jobs:
         id: read-base-and-final-version
         if: always() && steps.install-yq.outcome == 'success'
         run: > 
-          echo "::set-output name=base-version::$(
+          echo "base-version=$(
             yq '."upgrade-version"[${{ matrix.upgrade-path.id }}]."upgrade-path"[0].version' ${{ github.workspace }}/.github/configuration/upgrade-test-configuration.yml
-          )" && 
-          echo "::set-output name=final-version::$(
+          )" >> $GITHUB_OUTPUT &&
+          echo "final-version=$(
             yq '."upgrade-version"[${{ matrix.upgrade-path.id }}]."upgrade-path"[-1].version' ${{ github.workspace }}/.github/configuration/upgrade-test-configuration.yml
-          )"
+          )" >> $GITHUB_OUTPUT
 
       - name: Find Engine and Extension Branches for Base Version ${{ steps.read-base-and-final-version.outputs.base-version }}
         id: find-branch
         if: always() && steps.read-base-and-final-version.outcome == 'success'
         run: >
-          echo "::set-output name=base-engine-branch::$(
+          echo "base-engine-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".engine_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-extension-branch::$(
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-extension-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".extension_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-dir::$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))"
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-dir=$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))" >> $GITHUB_OUTPUT
 
       - name: Setup Base Version ${{ steps.read-base-and-final-version.outputs.base-version }} and Run Preparation Tests
         id: setup-base-version

--- a/test/JDBC/pom.xml
+++ b/test/JDBC/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/test/JDBC/pom.xml
+++ b/test/JDBC/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### Description

This PR contains the following changes
1. Bump version of maven commons-io from 2.7 to 2.14
2. Use github action dawidd6/action-download-artifact v6 instead of v2
3. Replace uses of set output command in github actions with >> $GITHUB_OUTPUT

### Issues Resolved

[NO JIRA]

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).