### PR TITLE
Bump version of maven commons-io and github actions

### DIFF
--- a/.github/composite-actions/check-babelfish-inconsistency/action.yml
+++ b/.github/composite-actions/check-babelfish-inconsistency/action.yml
@@ -12,7 +12,7 @@ runs:
         FROM pg_proc
         WHERE proname = 'check_for_inconsistent_metadata';" | grep -o 'exists\|not_exists')
 
-        echo "::set-output name=function_exists::$function_exists"
+        echo "function_exists=$function_exists" >> $GITHUB_OUTPUT
         echo "Check Babelfish metadata inconsistency function exists: $function_exists"
         
         # If the function exists, run the metadata inconsistency check

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -79,11 +79,11 @@ runs:
           tar_dir="latest"
         fi
         export inputFilesPath=upgrade/$tar_dir/verification_cleanup/$base_dir
-        mvn test
+        mvn -B -ntp test
         export inputFilesPath=input
         for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" upgrade/$base_dir/schedule); do
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-verify\\n$filename-vu-cleanup/g" upgrade/$base_dir/schedule
         done
         export scheduleFile=upgrade/$base_dir/schedule
-        mvn test
+        mvn -B -ntp test
       shell: bash      

--- a/.github/composite-actions/run-jdbc-tests/action.yml
+++ b/.github/composite-actions/run-jdbc-tests/action.yml
@@ -22,9 +22,9 @@ runs:
           cd test/JDBC/
           if [[ '${{ inputs.migration_mode }}' == 'single-db' ]];then
             export isSingleDbMode=true
-            mvn test
+            mvn -B -ntp test
             unset isSingleDbMode
           else
-            mvn test
+            mvn -B -ntp test
           fi
       shell: bash

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -61,7 +61,7 @@ runs:
           export inputFilesPath=upgrade/singledb/verification_cleanup
         fi
 
-        mvn test
+        mvn -B -ntp test
         export inputFilesPath=input
 
         # Skip test BABEL-404 for previous versions while testing dump/restore since it specifies
@@ -74,7 +74,7 @@ runs:
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-verify\\n$filename-vu-cleanup/g" upgrade/$base_dir/schedule
         done
         export scheduleFile=upgrade/$base_dir/schedule
-        mvn test
+        mvn -B -ntp test
       shell: bash
 
     - name: Cleanup babelfish database

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -191,7 +191,7 @@ runs:
         fi
 
         export inputFilesPath=upgrade/$base_dir/preparation
-        mvn test
+        mvn -B -ntp test
 
         # Skip test BABEL-404 for previous versions while testing dump/restore since it specifies
         # contraint column ordering which is expected to fail after fix for BABEL-4888
@@ -211,7 +211,7 @@ runs:
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-prepare/g" upgrade/$base_dir/schedule
         done
         export scheduleFile=upgrade/$base_dir/schedule
-        mvn test
+        mvn -B -ntp test
       shell: bash
 
     - uses: actions/checkout@v2

--- a/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
+++ b/.github/workflows/jdbc-tests-with-non-default-server-collation.yml
@@ -64,7 +64,7 @@ jobs:
           cd test/JDBC/
           # set env variable serverCollationName to current server collation name
           export serverCollationName=${{ env.SERVER_COLLATION_NAME }}
-          mvn test
+          mvn -B -ntp test
           # reset env variable
           unset serverCollationName
 

--- a/.github/workflows/jdbc-tests-with-parallel-query.yml
+++ b/.github/workflows/jdbc-tests-with-parallel-query.yml
@@ -62,7 +62,7 @@ jobs:
           cd test/JDBC/
           # set env variable isParallelQueryMode to true to let jdbc know not to run tests of file parallel_query_jdbc_schedule
           export isParallelQueryMode=true
-          mvn test
+          mvn -B -ntp test
           # reset env variable
           unset isParallelQueryMode
 

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -223,7 +223,7 @@ jobs:
           cd test/JDBC/
           # temporarily ignore test BABEL-2086
           echo 'ignore#!#BABEL-2086' >> jdbc_schedule
-          mvn test
+          mvn -B -ntp test
      
       - name: Upload Postgres log
         if: always() && steps.jdbc.outcome == 'failure'

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -146,7 +146,7 @@ jobs:
           export PATH=~/${{env.INSTALL_DIR}}/bin:$PATH
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           cd test/JDBC/
-          mvn test
+          mvn -B -ntp test
 
       - name: Upload Log
         if: always() && steps.jdbc.outcome == 'failure'

--- a/.github/workflows/pg_dump-restore-test.yml
+++ b/.github/workflows/pg_dump-restore-test.yml
@@ -23,7 +23,7 @@ jobs:
           dump_format: itm[itm.length - 1]['dump-format'], \
           type: itm[itm.length - 1]['type']})); \
           console.log(JSON.stringify(p));")
-          echo "::set-output name=dump-restore-path-list::$DUMP_RESTORE_PATH_LIST"
+          echo "dump-restore-path-list=$DUMP_RESTORE_PATH_LIST" >> $GITHUB_OUTPUT
 
   run-dump-restore-test:
     needs: generate-dump-restore-tests
@@ -45,24 +45,24 @@ jobs:
         id: read-base-and-final-version
         if: always() && steps.install-yq.outcome == 'success'
         run: > 
-          echo "::set-output name=base-version::$(
+          echo "base-version=$(
             yq '."dump-restore-version"[${{ matrix.upgrade-path.id }}][0].version' ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml
-          )" && 
-          echo "::set-output name=final-version::$(
+          )"  >> $GITHUB_OUTPUT &&
+          echo "final-version=$(
             yq '."dump-restore-version"[${{ matrix.upgrade-path.id }}][-1].version' ${{ github.workspace }}/.github/configuration/dump-restore-test-configuration.yml
-          )"
+          )" >> $GITHUB_OUTPUT
 
       - name: Find Engine and Extension Branches for Base Version ${{ steps.read-base-and-final-version.outputs.base-version }}
         id: find-branch
         if: always() && steps.read-base-and-final-version.outcome == 'success'
         run: >
-          echo "::set-output name=base-engine-branch::$(
+          echo "base-engine-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".engine_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-extension-branch::$(
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-extension-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".extension_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-dir::$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))"
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-dir=$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))" >> $GITHUB_OUTPUT
 
       - name: Setup Base Version ${{ steps.read-base-and-final-version.outputs.base-version }} and Run Preparation Tests
         id: setup-base-version

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -16,7 +16,7 @@ jobs:
           config="'$(yq -o=json ${{ github.workspace }}/.github/configuration/upgrade-test-configuration.yml)'"
           config=$(echo $config | sed "s/\"/\\\\\"/g")
           UPGRADE_PATH_LIST=$(node -e "let k = JSON.parse($config); let p = k['upgrade-version'].map((itm, index) => ({ id: index, path: itm['upgrade-path'].map(i => i.version.toString().replace(/[.]/g, \"_\")), server_collation_name: itm['babelfishpg_tsql_server_collation_name'] ? itm['babelfishpg_tsql_server_collation_name'] : \"default\", title: itm['upgrade-path'].map(i => i.version.toString().replace(/[.]/g, \"_\")).join(\"-\") + (itm['babelfishpg_tsql_server_collation_name'] ? (\" with server-collation - \" + itm['babelfishpg_tsql_server_collation_name'] + \" \") : \"\"), last_version: itm['upgrade-path'][itm['upgrade-path'].length - 1].version.toString().replace(/[.]/g, \"_\") })); console.log(JSON.stringify(p));")
-          echo "::set-output name=upgrade-path-list::$UPGRADE_PATH_LIST"
+          echo "upgrade-path-list=$UPGRADE_PATH_LIST" >> $GITHUB_OUTPUT
 
   run-version-upgrade-test:
     needs: generate-version-upgrade-tests
@@ -38,24 +38,24 @@ jobs:
         id: read-base-and-final-version
         if: always() && steps.install-yq.outcome == 'success'
         run: > 
-          echo "::set-output name=base-version::$(
+          echo "base-version=$(
             yq '."upgrade-version"[${{ matrix.upgrade-path.id }}]."upgrade-path"[0].version' ${{ github.workspace }}/.github/configuration/upgrade-test-configuration.yml
-          )" && 
-          echo "::set-output name=final-version::$(
+          )" >> $GITHUB_OUTPUT &&
+          echo "final-version=$(
             yq '."upgrade-version"[${{ matrix.upgrade-path.id }}]."upgrade-path"[-1].version' ${{ github.workspace }}/.github/configuration/upgrade-test-configuration.yml
-          )"
+          )" >> $GITHUB_OUTPUT
 
       - name: Find Engine and Extension Branches for Base Version ${{ steps.read-base-and-final-version.outputs.base-version }}
         id: find-branch
         if: always() && steps.read-base-and-final-version.outcome == 'success'
         run: >
-          echo "::set-output name=base-engine-branch::$(
+          echo "base-engine-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".engine_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-extension-branch::$(
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-extension-branch=$(
             yq '."${{ steps.read-base-and-final-version.outputs.base-version }}".extension_branch' ${{ github.workspace }}/.github/template/version-branch-template.yml
-          )" &&
-          echo "::set-output name=base-dir::$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))"
+          )" >> $GITHUB_OUTPUT &&
+          echo "base-dir=$(echo psql$(awk -F. '{print $1}' <<< ${{ steps.read-base-and-final-version.outputs.base-version }}))" >> $GITHUB_OUTPUT
 
       - name: Setup Base Version ${{ steps.read-base-and-final-version.outputs.base-version }} and Run Preparation Tests
         id: setup-base-version

--- a/test/JDBC/pom.xml
+++ b/test/JDBC/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### Description

This PR contains the following changes
1. Bump version of maven commons-io from 2.7 to 2.14
2. Replace uses of set output command in github actions with >> $GITHUB_OUTPUT

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Issues Resolved

[NO JIRA]

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).