### PR TITLE
Update test files by removing set_config calls

### DIFF
--- a/test/JDBC/expected/BABEL-1435.out
+++ b/test/JDBC/expected/BABEL-1435.out
@@ -175,29 +175,6 @@ GO
 DROP DATABASE db1;
 GO
 
--- Set current_user for testing db mode
-IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'jdbc_user', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-ELSE
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'babeltestuser', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-GO
-~~START~~
-int
-<NULL>
-~~END~~
-
 
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO

--- a/test/JDBC/expected/BABEL-1446.out
+++ b/test/JDBC/expected/BABEL-1446.out
@@ -87,14 +87,6 @@ int
 
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
 CREATE DATABASE db1;
 GO
 

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -270,6 +270,7 @@ GO
 
 
 
+
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -96,14 +96,6 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 ~~START~~
@@ -240,27 +232,11 @@ int
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
 
 
 -- should fail in single-db
 USE babelfish_migration_mode_db2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
@@ -290,13 +266,6 @@ GO
 
 DROP DATABASE babelfish_migration_mode_db2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
 
 
 
@@ -332,25 +301,6 @@ varchar#!#int
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -269,8 +269,6 @@ GO
 
 
 
-
-
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO

--- a/test/JDBC/expected/single_db/BABEL-1435.out
+++ b/test/JDBC/expected/single_db/BABEL-1435.out
@@ -183,29 +183,6 @@ GO
 DROP DATABASE db1;
 GO
 
--- Set current_user for testing db mode
-IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'jdbc_user', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-ELSE
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'babeltestuser', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-GO
-~~START~~
-int
-<NULL>
-~~END~~
-
 
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO

--- a/test/JDBC/expected/single_db/BABEL-1446.out
+++ b/test/JDBC/expected/single_db/BABEL-1446.out
@@ -87,14 +87,6 @@ int
 
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
 CREATE DATABASE db1;
 GO
 

--- a/test/JDBC/expected/single_db/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/single_db/babelfish_migration_mode-vu-verify.out
@@ -96,14 +96,6 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 ~~START~~
@@ -247,14 +239,6 @@ int
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
 
 
 -- should fail in single-db
@@ -263,14 +247,6 @@ GO
 ~~ERROR (Code: 911)~~
 
 ~~ERROR (Message: database "babelfish_migration_mode_db2" does not exist)~~
-
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
 
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
@@ -310,13 +286,6 @@ GO
 ~~ERROR (Message: database "babelfish_migration_mode_db2" does not exist)~~
 
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
 
 
 
@@ -351,25 +320,6 @@ varchar#!#int
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases

--- a/test/JDBC/expected/single_db/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/single_db/babelfish_migration_mode-vu-verify.out
@@ -289,6 +289,7 @@ GO
 
 
 
+
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO

--- a/test/JDBC/expected/single_db/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/single_db/babelfish_migration_mode-vu-verify.out
@@ -288,8 +288,6 @@ GO
 
 
 
-
-
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO

--- a/test/JDBC/input/BABEL-1435.sql
+++ b/test/JDBC/input/BABEL-1435.sql
@@ -67,24 +67,6 @@ GO
 DROP DATABASE db1;
 GO
 
--- Set current_user for testing db mode
-IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'jdbc_user', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-ELSE
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'babeltestuser', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-GO
 
 SELECT name FROM sys.sysdatabases ORDER BY name;
 GO

--- a/test/JDBC/input/BABEL-1446.sql
+++ b/test/JDBC/input/BABEL-1446.sql
@@ -53,9 +53,6 @@ AND "member" = (SELECT oid FROM pg_roles WHERE rolname = 'db_owner');
 GO
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-
 CREATE DATABASE db1;
 GO
 

--- a/test/JDBC/input/ownership/babelfish_migration_mode-vu-verify.mix
+++ b/test/JDBC/input/ownership/babelfish_migration_mode-vu-verify.mix
@@ -37,9 +37,6 @@ INSERT INTO babelfish_migration_mode_catalog_status
 SELECT 'sys.babelfish_authid_user_ext', COUNT(*) FROM sys.babelfish_authid_user_ext
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 
@@ -109,16 +106,10 @@ GO
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
 
 
 -- should fail in single-db
 USE babelfish_migration_mode_db2
-GO
-
-SELECT set_config('role', 'jdbc_user', false)
 GO
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
@@ -138,9 +129,6 @@ DROP DATABASE babelfish_migration_mode_db1
 GO
 
 DROP DATABASE babelfish_migration_mode_db2
-GO
-
-SELECT set_config('role', 'jdbc_user', false)
 GO
 
 
@@ -163,15 +151,6 @@ EXEC babelfish_migration_mode_compare
 GO
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
-GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
 GO
 
 INSERT INTO babelfish_migration_mode_catalog_status2 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -10,12 +10,6 @@
 
 all
 
-ignore#!#BABEL-1435
-ignore#!#BABEL-1446
-ignore#!#babelfish_migration_mode-vu-prepare
-ignore#!#babelfish_migration_mode-vu-verify
-ignore#!#babelfish_migration_mode-vu-cleanup
-
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -5,4 +5,3 @@
 ignore#!#Test-sp_reset_connection
 ignore#!#test_search_path
 
-

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -76,6 +76,7 @@ babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext
 babelfish_cast_floor
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -82,6 +82,7 @@ babel_datatype_sqlvariant
 BABEL-EXTENDEDPROPERTY-before-15_4
 babelfish_authid_login_ext
 babelfish_cast_floor
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -105,6 +105,7 @@ babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -103,6 +103,7 @@ babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -103,6 +103,7 @@ babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -102,6 +102,7 @@ babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -177,6 +177,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -178,6 +178,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -177,6 +177,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -177,6 +177,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -177,6 +177,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -108,6 +108,7 @@ babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -107,6 +107,7 @@ babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -122,6 +122,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -133,6 +133,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -131,6 +131,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -177,6 +177,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -121,6 +121,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -151,6 +151,7 @@ babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
 check_for_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -132,6 +132,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -142,6 +142,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -144,6 +144,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string-before-15-5-or-14-10

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -147,6 +147,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -150,6 +150,7 @@ babelfish_authid_user_ext
 babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -151,6 +151,7 @@ babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
 check_for_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -151,6 +151,7 @@ babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
 check_for_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -151,6 +151,7 @@ babelfish_cast_floor
 babelfish_inconsistent_metadata
 babelfish_integrity_checker
 check_for_inconsistent_metadata
+babelfish_migration_mode
 babelfish_namespace_ext
 babelfish_sysdatabases
 babel_function_string


### PR DESCRIPTION
### Description

As part of https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3096, we restricted setting of few configurations like role, migration mode etc. We ignored few files temporarily to get us unblocked.
This commit fixes 3 such test files:
1. BABEL-1435 
2. BABEL-1446 
3. babelfish_migration-mode-vu-*


Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).