### PR TITLE
Update test files by removing set_config calls

### DIFF
--- a/test/JDBC/expected/BABEL-1435.out
+++ b/test/JDBC/expected/BABEL-1435.out
@@ -160,29 +160,6 @@ GO
 DROP DATABASE db1;
 GO
 
--- Set current_user for testing db mode
-IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'jdbc_user', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-ELSE
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'babeltestuser', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-GO
-~~START~~
-int
-<NULL>
-~~END~~
-
 
 -- test multi-db mode 
 SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);

--- a/test/JDBC/expected/BABEL-1446.out
+++ b/test/JDBC/expected/BABEL-1446.out
@@ -87,21 +87,6 @@ int
 
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
-
 CREATE DATABASE db1;
 GO
 

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -295,6 +295,7 @@ single-db
 ~~END~~
 
 
+
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -294,8 +294,6 @@ text
 single-db
 ~~END~~
 
-
-
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO

--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -96,22 +96,6 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 ~~START~~
@@ -247,20 +231,6 @@ int
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
-~~START~~
-text
-single-db
-~~END~~
 
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
@@ -277,22 +247,6 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: role "dbo" does not exist)~~
-
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-~~START~~
-text
-multi-db
-~~END~~
 
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
@@ -323,13 +277,6 @@ GO
 
 DROP DATABASE babelfish_migration_mode_db2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
 
 
 SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
@@ -379,25 +326,6 @@ varchar#!#int
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases

--- a/test/JDBC/input/BABEL-1435.sql
+++ b/test/JDBC/input/BABEL-1435.sql
@@ -58,24 +58,6 @@ GO
 DROP DATABASE db1;
 GO
 
--- Set current_user for testing db mode
-IF (SELECT 1 FROM pg_roles WHERE rolname='jdbc_user') = 1
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'jdbc_user', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-ELSE
-BEGIN
-	WITH SET_CTE
-	AS
-	(SELECT set_config('role', 'babeltestuser', false))
-	SELECT NULL
-	FROM SET_CTE
-END
-GO
 
 -- test multi-db mode 
 SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);

--- a/test/JDBC/input/BABEL-1446.sql
+++ b/test/JDBC/input/BABEL-1446.sql
@@ -52,11 +52,6 @@ AND "member" = (SELECT oid FROM pg_roles WHERE rolname = 'db_owner');
 GO
 
 -- test multi-db mode
-SELECT set_config('role', 'jdbc_user', false);
-GO
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false);
-GO
-
 CREATE DATABASE db1;
 GO
 

--- a/test/JDBC/input/ownership/babelfish_migration_mode-vu-verify.mix
+++ b/test/JDBC/input/ownership/babelfish_migration_mode-vu-verify.mix
@@ -36,12 +36,6 @@ INSERT INTO babelfish_migration_mode_catalog_status
 SELECT 'sys.babelfish_authid_user_ext', COUNT(*) FROM sys.babelfish_authid_user_ext
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 
@@ -110,23 +104,12 @@ GO
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 
 -- should fail
 USE babelfish_migration_mode_db2
-GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
 GO
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
@@ -148,11 +131,6 @@ GO
 DROP DATABASE babelfish_migration_mode_db2
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
@@ -175,15 +153,6 @@ EXEC babelfish_migration_mode_compare
 GO
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
-GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
 GO
 
 INSERT INTO babelfish_migration_mode_catalog_status2 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -10,13 +10,10 @@
 
 all
 
-ignore#!#BABEL-1435
-ignore#!#BABEL-1446
 ignore#!#BABEL-4279
-ignore#!#babelfish_migration_mode-vu-prepare
-ignore#!#babelfish_migration_mode-vu-verify
-ignore#!#babelfish_migration_mode-vu-cleanup
 ignore#!#test_search_path
+
+# BABEL-SP_FKEYS test is very slow and causing github action timeout.
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
 ignore#!#insertbulk

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -124,6 +124,7 @@ BABEL-ROLE
 babelfish_sysdatabases
 babelfish_namespace_ext
 babelfish_authid_login_ext
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 babel_char

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -185,6 +185,7 @@ BABEL-ROLE
 babelfish_sysdatabases
 babelfish_namespace_ext
 babelfish_authid_login_ext
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 BABEL-EXTENDEDPROPERTY

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -215,6 +215,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -214,6 +214,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -214,6 +214,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -211,6 +211,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -173,6 +173,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -171,6 +171,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 collation_tests_arabic
 collation_tests_greek

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -215,6 +215,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -152,6 +152,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 select-strip-parens-before-14-10
 BABEL-3147-before-16_3-or-15_7-or-14_12

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -163,6 +163,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -172,6 +172,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -172,6 +172,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -173,6 +173,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic


### PR DESCRIPTION
### Description

As part of https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3096, we restricted setting of few configurations like role, migration mode etc. We ignored few files temporarily to get us unblocked.
This commit fixes 3 such test files:
1. BABEL-1435 
2. BABEL-1446 
3. babelfish_migration-mode-vu-*


Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).