### PR TITLE
Ignore sp_columns_100 in parallel jdbc mode

### DIFF
--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Set env variables and build extensions
         id: build-extensions-newer
-        if: always() && steps.build-modified-postgres-newer == 'success'
+        if: always() && steps.build-modified-postgres-newer.outcome == 'success'
         uses: ./.github/composite-actions/build-extensions
 
       - name: Build PostGIS Extension

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Set env variables and build extensions
         id: build-extensions-newer
-        if: always() && steps.compile-new-antlr.outcome == 'success'
+        if: always() && steps.build-modified-postgres-newer == 'success'
         uses: ./.github/composite-actions/build-extensions
 
       - name: Build PostGIS Extension

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -28,5 +28,6 @@ ignore#!#BABEL-3013
 ignore#!#BABEL-SP_TABLE_PRIVILEGES
 ignore#!#ISC-Columns-vu-verify
 ignore#!#four-part-names-vu-verify
-ignore#!#sp_columns_100 #TODO: BABEL-5472
+#TODO: BABEL-5472
+ignore#!#sp_columns_100
 

--- a/test/JDBC/parallel_query_jdbc_schedule
+++ b/test/JDBC/parallel_query_jdbc_schedule
@@ -28,4 +28,5 @@ ignore#!#BABEL-3013
 ignore#!#BABEL-SP_TABLE_PRIVILEGES
 ignore#!#ISC-Columns-vu-verify
 ignore#!#four-part-names-vu-verify
+ignore#!#sp_columns_100 #TODO: BABEL-5472
 


### PR DESCRIPTION
### Description

Temporarily ignore sp_columns_100 test in jdbc test
parallel query mode since it is taking too long too run
Issue will be fixed with  BABEL-5472

Also fix minor version upgrade yml, we removed the
step `compile-new-antlr.outcome` but did not update
the yml file properly.

### Issues Resolved

[No JIRA]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).