### PR TITLE
Fix sys.columnproperty ordinal 

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -3172,8 +3172,8 @@ BEGIN
                 (SELECT a.attnum FROM pg_catalog.pg_attribute a
                  WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
             WHEN 'ordinal' COLLATE sys.database_default THEN
-                (SELECT b.count FROM (SELECT attname, row_number() OVER () AS count FROM pg_catalog.pg_attribute a
-                 WHERE a.attrelid = object_id AND attisdropped = false AND attnum > 0 ORDER BY a.attnum) AS b WHERE b.attname = property COLLATE sys.database_default)
+                (SELECT b.count FROM (SELECT attname, row_number() OVER (ORDER BY a.attnum) AS count FROM pg_catalog.pg_attribute a
+                 WHERE a.attrelid = object_id AND attisdropped = false AND attnum > 0) AS b WHERE b.attname = property COLLATE sys.database_default)
             WHEN 'isidentity' COLLATE sys.database_default THEN (SELECT
                 CASE
                     WHEN char_length(a.attidentity) > 0 THEN 1

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -11431,6 +11431,54 @@ CREATE OR REPLACE AGGREGATE sys.string_agg(TEXT, TEXT) (
     PARALLEL = SAFE
 );
 
+CREATE OR REPLACE FUNCTION sys.columnproperty(object_id OID, property NAME, property_name TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+STABLE STRICT
+AS $$
+DECLARE
+    extra_bytes CONSTANT INTEGER := 4;
+    return_value INTEGER;
+BEGIN
+	return_value:=
+        CASE pg_catalog.LOWER(property_name)
+            WHEN 'charmaxlen' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN a.atttypmod > 0 THEN a.atttypmod - extra_bytes
+                    ELSE NULL
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
+            WHEN 'allowsnull' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN a.attnotnull THEN 0
+                    ELSE 1
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
+            WHEN 'iscomputed' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN a.attgenerated != '' THEN 1
+                    ELSE 0
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id and (a.attname = property COLLATE sys.database_default))
+            WHEN 'columnid' COLLATE sys.database_default THEN
+                (SELECT a.attnum FROM pg_catalog.pg_attribute a
+                 WHERE a.attrelid = object_id AND (a.attname = property COLLATE sys.database_default))
+            WHEN 'ordinal' COLLATE sys.database_default THEN
+                (SELECT b.count FROM (SELECT attname, row_number() OVER (ORDER BY a.attnum) AS count FROM pg_catalog.pg_attribute a
+                 WHERE a.attrelid = object_id AND attisdropped = false AND attnum > 0) AS b WHERE b.attname = property COLLATE sys.database_default)
+            WHEN 'isidentity' COLLATE sys.database_default THEN (SELECT
+                CASE
+                    WHEN char_length(a.attidentity) > 0 THEN 1
+                    ELSE 0
+                END FROM pg_catalog.pg_attribute a WHERE a.attrelid = object_id and (a.attname = property COLLATE sys.database_default))
+            ELSE
+                NULL
+        END;
+    RETURN return_value::INTEGER;
+EXCEPTION 
+	WHEN others THEN
+ 		RETURN NULL;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION sys.columnproperty(object_id OID, property NAME, property_name TEXT) TO PUBLIC;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);


### PR DESCRIPTION
### Description

In sys.columnproperty, the query for ordinal was incorrect. We put the order by clause outside `row_number() OVER()` clause which means the row_number() was called before ordering the result leading to random output.

As a fix move ORDER BY clause to inside OVER()

Additional an example to show that `row_number() OVER()` clause is executed before outside `ORDER BY`.
```
babelfish_db=# select a, row_number() over() from (select unnest(ARRAY[99, 1]) as a) order by a;
 a  | row_number 
----+------------
  1 |          2
 99 |          1
(2 rows)

babelfish_db=# select a, row_number() over(order by a) from (select unnest(ARRAY[99, 1]) as a);
 a  | row_number 
----+------------
  1 |          1
 99 |          2
(2 rows)
```

### Issues Resolved

[BABEL-5495]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).