### PR TITLE
Mark table_constraints_internal() function as parallel safe and set current_db_id for parallel workers

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -535,7 +535,7 @@ BEGIN
                OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES') );
 END;
 $$
-LANGUAGE plpgsql STABLE;
+LANGUAGE plpgsql STABLE PARALLEL SAFE;
 
 /*
  * TABLE_CONSTRAINTS view

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.8.0--3.9.0.sql
@@ -9567,7 +9567,7 @@ BEGIN
                OR has_any_column_privilege(r.oid, 'SELECT, INSERT, UPDATE, REFERENCES') );
 END;
 $$
-LANGUAGE plpgsql STABLE;
+LANGUAGE plpgsql STABLE PARALLEL SAFE;
 
 /*
  * TABLE_CONSTRAINTS view

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -57,6 +57,7 @@ void
 set_cur_db_name_for_parallel_worker(const char* logical_db_name)
 {
 	int len;
+	int16 db_id;
 
 	if (logical_db_name == NULL)
 		ereport(ERROR,
@@ -67,13 +68,15 @@ set_cur_db_name_for_parallel_worker(const char* logical_db_name)
 
 	Assert(len <= MAX_BBF_NAMEDATALEND);
 
-	if(!DbidIsValid(get_db_id(logical_db_name)))
+	db_id = get_db_id(logical_db_name);
+	if(!DbidIsValid(db_id))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_DATABASE),
 				 errmsg("database \"%s\" does not exist", logical_db_name)));
 	
 	strncpy(current_db_name, logical_db_name, MAX_BBF_NAMEDATALEND);
 	current_db_name[len] = '\0';
+	current_db_id = db_id;
 }
 
 


### PR DESCRIPTION
### Description
The INFORMATION_SCHEMA_TSQL.TABLE_CONSTRAINTS_INTERNAL() function was recently introduced 
but not marked as PARALLEL SAFE. This prevented the query optimizer from utilizing parallel 
plans in queries involving this function, leading to suboptimal performance for certain operations. 

By marking the function as PARALLEL SAFE, we enable the use of parallel query execution plans, 
which can significantly improve performance for large datasets.

This commit also addresses the issue of empty result sets in queries joining with sys.db_id() 
or sys.db_name() in Enforced Parallel Query mode by setting the current_db_id in addition to 
current_db_name for parallel workers.



Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)
### Issues Resolved
Task: BABEL-5427, BABEL-5504

### Root cause for parallel worker issue:
While we were communicating the logical database name to parallel workers and setting the current_db_name using logical database name (Ref: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2262), we failed to set current_db_id. This omission affected functions like sys.db_id() and sys.db_name(), resulting in empty result sets for queries involving these functions in parallel execution contexts.


### Performance Testing
Query:
```
SELECT 
    tc.TABLE_SCHEMA, 
    tc.TABLE_NAME, 
    kcu.COLUMN_NAME, 
    c.DATA_TYPE 
FROM 
    INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc 
JOIN 
    INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu 
    ON tc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA 
    AND tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME 
JOIN 
    INFORMATION_SCHEMA.COLUMNS c 
    ON kcu.TABLE_SCHEMA = c.TABLE_SCHEMA 
    AND kcu.TABLE_NAME = c.TABLE_NAME 
    AND kcu.COLUMN_NAME = c.COLUMN_NAME 
WHERE 
    tc.CONSTRAINT_TYPE = 'PRIMARY KEY';
```
Before :  50187 ms
After: 47285 ms



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).