### PR TITLE
Display unmapped schema names in error messages

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -223,6 +223,7 @@ static PlannedStmt *pltsql_planner_hook(Query *parse, const char *query_string, 
 static Oid set_param_collation(Param *param);
 static Oid default_collation_for_builtin_type(Type typ, bool handle_text);
 static char* pltsql_get_object_identity_event_trigger(ObjectAddress *addr);
+static const char *remove_db_name_in_schema(const char *schema_name, const char *object_type);
 
 /***************************************************
  * 			Temp Table Related Declarations + Hooks
@@ -250,6 +251,7 @@ static pre_transform_setop_sort_clause_hook_type prev_pre_transform_setop_sort_c
 static pre_transform_target_entry_hook_type prev_pre_transform_target_entry_hook = NULL;
 static tle_name_comparison_hook_type prev_tle_name_comparison_hook = NULL;
 static get_trigger_object_address_hook_type prev_get_trigger_object_address_hook = NULL;
+static remove_db_name_in_schema_hook_type prev_remove_db_name_in_schema_hook = NULL;
 static resolve_target_list_unknowns_hook_type prev_resolve_target_list_unknowns_hook = NULL;
 static find_attr_by_name_from_column_def_list_hook_type prev_find_attr_by_name_from_column_def_list_hook = NULL;
 static find_attr_by_name_from_relation_hook_type prev_find_attr_by_name_from_relation_hook = NULL;
@@ -351,6 +353,9 @@ InstallExtendedHooks(void)
 
 	prev_get_trigger_object_address_hook = get_trigger_object_address_hook;
 	get_trigger_object_address_hook = get_trigger_object_address;
+
+	prev_remove_db_name_in_schema_hook = remove_db_name_in_schema_hook;
+	remove_db_name_in_schema_hook = remove_db_name_in_schema;
 
 	prev_resolve_target_list_unknowns_hook = resolve_target_list_unknowns_hook;
 	resolve_target_list_unknowns_hook = resolve_target_list_unknowns;
@@ -543,6 +548,7 @@ UninstallExtendedHooks(void)
 	pre_transform_target_entry_hook = prev_pre_transform_target_entry_hook;
 	tle_name_comparison_hook = prev_tle_name_comparison_hook;
 	get_trigger_object_address_hook = prev_get_trigger_object_address_hook;
+	remove_db_name_in_schema_hook = prev_remove_db_name_in_schema_hook;
 	resolve_target_list_unknowns_hook = prev_resolve_target_list_unknowns_hook;
 	find_attr_by_name_from_column_def_list_hook = prev_find_attr_by_name_from_column_def_list_hook;
 	find_attr_by_name_from_relation_hook = prev_find_attr_by_name_from_relation_hook;
@@ -5971,4 +5977,58 @@ allow_storing_init_privs(Oid objoid, Oid classoid, int objsubid)
 			return true;
 	}
 	return true;
+}
+
+/*
+ * remove_db_name_in_schema - remove the db name and underscore at the beginning
+ * 	of the given string. It is used to unmap schema name in error messages.
+ *
+ * 	@param object_name - char *
+ *  @param object_type - char *, can be 'sch' or 'func'
+ * 	@return - unmapped schema name char *
+ */
+static const char *
+remove_db_name_in_schema(const char *object_name, const char *object_type)
+{
+	char		*cur_db_name;
+	char		**splited_object_name;
+	char		*schema_name = NULL;
+	char		*mutable_name;
+    size_t		db_name_len;
+    size_t		prefix_len = 0;
+	size_t		schema_name_len;
+
+	mutable_name = pstrdup(object_name);
+	splited_object_name = split_object_name(mutable_name);
+
+	if (strcmp(object_type, "sch") == 0) {
+		/* If input is 'sch_name' format, consider when there is only one part in splited_object_name */
+		/* If there are two parts or more, then it’s a cross-db object name (db.sch_name) so we don’t need to deal with it */
+		if (strlen(splited_object_name[2]) == 0 && strlen(splited_object_name[1]) == 0)
+			schema_name = splited_object_name[3];
+	} else if (strcmp(object_type, "func") == 0) {
+		/* If input is 'func_name' format, consider when there is two parts in splited_object_name, like db1_sch.db1_func */
+		if (strlen(splited_object_name[2]) > 0 && strlen(splited_object_name[1]) == 0)
+			schema_name = splited_object_name[2];
+	}
+
+	if (schema_name)
+	{
+		cur_db_name = get_cur_db_name();
+		db_name_len = strlen(cur_db_name);
+		schema_name_len = strlen(schema_name);
+
+		if (schema_name_len > db_name_len && strncmp(schema_name, cur_db_name, db_name_len) == 0 && schema_name[db_name_len] == '_') {
+			/* Return the part after the prefix */
+			prefix_len = db_name_len + 1;
+		} 
+		pfree(cur_db_name);
+	} 
+	
+	pfree(mutable_name);
+	for (int k = 0; k < 4; k++)
+        pfree(splited_object_name[k]);
+	pfree(splited_object_name);
+
+	return (const char *)pstrdup(object_name + prefix_len);
 }

--- a/test/JDBC/expected/102_1.out
+++ b/test/JDBC/expected/102_1.out
@@ -129,7 +129,7 @@ GO
 
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 
 DROP TABLE t102__2;
@@ -344,7 +344,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -413,7 +413,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;

--- a/test/JDBC/expected/102_2.out
+++ b/test/JDBC/expected/102_2.out
@@ -133,7 +133,7 @@ GO
 
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 
 DROP TABLE t102__2;
@@ -352,7 +352,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -422,7 +422,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;

--- a/test/JDBC/expected/102_3.out
+++ b/test/JDBC/expected/102_3.out
@@ -133,7 +133,7 @@ GO
 
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 
 DROP TABLE t102__2;
@@ -352,7 +352,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -422,7 +422,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;

--- a/test/JDBC/expected/102_6.out
+++ b/test/JDBC/expected/102_6.out
@@ -129,7 +129,7 @@ GO
 
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 
 DROP TABLE t102__2;
@@ -344,7 +344,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -413,7 +413,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;

--- a/test/JDBC/expected/129_1.out
+++ b/test/JDBC/expected/129_1.out
@@ -111,7 +111,7 @@ GO
 
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 
 DROP TABLE t129 
@@ -306,7 +306,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -370,7 +370,7 @@ exec error_mapping.ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_error_mapping.errorhandling1() does not exist)~~
+~~ERROR (Message: procedure error_mapping.errorhandling1() does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;

--- a/test/JDBC/expected/2760_1.out
+++ b/test/JDBC/expected/2760_1.out
@@ -116,7 +116,7 @@ exec ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_n0nexistantschema" does not exist)~~
+~~ERROR (Message: schema "n0nexistantschema" does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -165,7 +165,7 @@ exec ErrorHandling2;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_n0nexistantschema" does not exist)~~
+~~ERROR (Message: schema "n0nexistantschema" does not exist)~~
 
 declare @err int = @@error; if (@err > 0 and @@trancount > 0) select cast('BATCH ONLY TERMINATING' as text) else if @err > 0 select cast('BATCH TERMINATING\ txn rolledback' as text);
 if @@trancount > 0 rollback transaction;
@@ -213,7 +213,7 @@ int
 
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_n0nexistantschema" does not exist)~~
+~~ERROR (Message: schema "n0nexistantschema" does not exist)~~
 
 GO
 

--- a/test/JDBC/expected/BABEL-1454.out
+++ b/test/JDBC/expected/BABEL-1454.out
@@ -208,7 +208,7 @@ GRANT ALL ON db1.dummy_schema TO PUBLIC;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "db1_db1" does not exist)~~
+~~ERROR (Message: schema "db1" does not exist)~~
 
 
 GRANT ALL ON babel1454.dummy_type TO PUBLIC;
@@ -247,7 +247,7 @@ DROP SCHEMA dummy_schema;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "db1_dummy_schema" does not exist)~~
+~~ERROR (Message: schema "dummy_schema" does not exist)~~
 
 
 -- Trigger
@@ -376,14 +376,14 @@ EXEC dummy.foo
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "db1_dummy" does not exist)~~
+~~ERROR (Message: schema "dummy" does not exist)~~
 
 
 EXEC db1.dummy.foo
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "db1_dummy" does not exist)~~
+~~ERROR (Message: schema "dummy" does not exist)~~
 
 
 --- Cleanup

--- a/test/JDBC/expected/BABEL-1712.out
+++ b/test/JDBC/expected/BABEL-1712.out
@@ -40,7 +40,7 @@ SELECT * FROM dbo.t1; -- error expected, querying master.dbo.t1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.t1" does not exist)~~
+~~ERROR (Message: relation "dbo.t1" does not exist)~~
 
 -- search path
 USE db1;

--- a/test/JDBC/expected/BABEL-1771.out
+++ b/test/JDBC/expected/BABEL-1771.out
@@ -38,7 +38,7 @@ SELECT * FROM .fake_schema.t
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_fake_schema.t" does not exist)~~
+~~ERROR (Message: relation "fake_schema.t" does not exist)~~
 
 
 EXEC test.bar
@@ -61,7 +61,7 @@ EXEC master..bar
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: procedure master_dbo.bar() does not exist)~~
+~~ERROR (Message: procedure dbo.bar() does not exist)~~
 
 
 EXEC ..bar

--- a/test/JDBC/expected/BABEL-2496.out
+++ b/test/JDBC/expected/BABEL-2496.out
@@ -8,7 +8,7 @@ drop schema non_exist_schema;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_non_exist_schema" does not exist)~~
+~~ERROR (Message: schema "non_exist_schema" does not exist)~~
 
 
 
@@ -20,7 +20,7 @@ drop schema s2496;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_s2496" does not exist)~~
+~~ERROR (Message: schema "s2496" does not exist)~~
 
 
 drop schema if exists s2496;
@@ -30,5 +30,5 @@ drop schema s2496;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_s2496" does not exist)~~
+~~ERROR (Message: schema "s2496" does not exist)~~
 

--- a/test/JDBC/expected/BABEL-2844.out
+++ b/test/JDBC/expected/BABEL-2844.out
@@ -555,7 +555,7 @@ SELECT dbo.WOSQL_BuildRevenueDetailOLUQuery()
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: function master_dbo.wosql_buildrevenuedetailoluquery() does not exist)~~
+~~ERROR (Message: function dbo.wosql_buildrevenuedetailoluquery() does not exist)~~
 
 
 SET BABELFISH_SHOWPLAN_ALL OFF;

--- a/test/JDBC/expected/BABEL-2961-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-2961-vu-cleanup.out
@@ -1,0 +1,36 @@
+IF OBJECT_ID('dbo.SomeNonExistentTable', 'U') IS NOT NULL
+    DROP TABLE dbo.SomeNonExistentTable
+GO
+
+
+IF OBJECT_ID('dbo.NonExistentTableView', 'V') IS NOT NULL
+    DROP VIEW dbo.NonExistentTableView
+GO
+
+IF OBJECT_ID('dbo.NonExistentTableFunc', 'IF') IS NOT NULL
+    DROP FUNCTION dbo.NonExistentTableFunc
+GO
+
+IF OBJECT_ID('dbo.CallNonExistentProc', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.CallNonExistentProc
+GO
+
+IF OBJECT_ID('dbo.TestTable', 'U') IS NOT NULL
+    DROP TABLE dbo.TestTable
+GO
+
+IF OBJECT_ID('dbo.NonExistentTable', 'U') IS NOT NULL
+    DROP TABLE dbo.NonExistentTable
+GO
+
+IF OBJECT_ID('dbo.DropNonExistentUser', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.DropNonExistentUser
+GO
+
+IF OBJECT_ID('dbo.NonExistentProc', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.NonExistentProc
+GO
+
+IF OBJECT_ID('nonexistent_schema.TestFunc', 'FN') IS NOT NULL
+    DROP FUNCTION nonexistent_schema.TestFunc
+GO

--- a/test/JDBC/expected/BABEL-2961-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-2961-vu-prepare.out
@@ -1,0 +1,54 @@
+-- Create a view that attempts to select from a non-existent table
+CREATE VIEW dbo.NonExistentTableView AS
+SELECT * FROM dbo.SomeNonExistentTable
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.somenonexistenttable" does not exist)~~
+
+
+
+-- Create a function that attempts to select from a non-existent table
+CREATE FUNCTION dbo.NonExistentTableFunc()
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM dbo.SomeNonExistentTable
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.somenonexistenttable" does not exist)~~
+
+
+-- Create a procedure that attempts to execute a non-existent procedure
+CREATE PROCEDURE dbo.CallNonExistentProc
+AS
+BEGIN
+    EXEC dbo.NonExistentProc
+END
+GO
+
+
+-- Create a function that attempts to use a non-existent schema
+CREATE FUNCTION nonexistent_schema.TestFunc()
+RETURNS INT
+AS
+BEGIN
+    RETURN 1
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "nonexistent_schema" does not exist)~~
+
+
+
+-- Create a procedure that attempts to drop a non-existent user
+CREATE PROCEDURE dbo.DropNonExistentUser
+AS
+BEGIN
+    DROP USER NonExistentUser
+END
+GO

--- a/test/JDBC/expected/BABEL-2961-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2961-vu-verify.out
@@ -1,0 +1,104 @@
+CREATE TABLE schema_2961.t(a int)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "schema_2961" does not exist)~~
+
+
+EXEC dbo.myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: procedure dbo.myproc() does not exist)~~
+
+
+SELECT * FROM dbo.t14
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.t14" does not exist)~~
+
+
+DROP USER smith
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'smith', because it does not exist or you do not have permission.)~~
+
+
+EXEC dbo.CallNonExistentProc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: procedure dbo.nonexistentproc() does not exist)~~
+
+
+EXEC dbo.DropNonExistentUser
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'nonexistentuser', because it does not exist or you do not have permission.)~~
+
+
+-- Attempt multiple operations within a single transaction
+BEGIN TRANSACTION
+    CREATE TABLE dbo.TestTable (ID INT)
+    INSERT INTO dbo.TestTable VALUES (1)
+    SELECT * FROM dbo.NonExistentTable
+COMMIT
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.nonexistenttable" does not exist)~~
+
+
+-- Verify if the transaction rolled back correctly
+SELECT * FROM dbo.TestTable
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.testtable" does not exist)~~
+
+
+CREATE DATABASE TestDB2961
+GO
+
+USE TestDB2961
+GO
+
+CREATE TABLE schema_2961.t(a int)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "schema_2961" does not exist)~~
+
+
+EXEC dbo.myproc
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: procedure dbo.myproc() does not exist)~~
+
+
+SELECT * FROM dbo.t14
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "dbo.t14" does not exist)~~
+
+
+DROP USER smith
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot drop the user 'smith', because it does not exist or you do not have permission.)~~
+
+
+USE master
+GO
+
+DROP DATABASE TestDB2961
+GO
+

--- a/test/JDBC/expected/BABEL-3000.out
+++ b/test/JDBC/expected/BABEL-3000.out
@@ -100,7 +100,7 @@ go
 bit#!#int#!#varchar#!#bit#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#varchar#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#smallint#!#smallint#!#smallint#!#int#!#int#!#int#!#tinyint
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_sc_result_set.nums" does not exist)~~
+~~ERROR (Message: relation "sc_result_set.nums" does not exist)~~
 
 
 create table sc_result_set.nums(a int, b smallint, c bigint, d float, e real, f numeric(5,3))

--- a/test/JDBC/expected/BABEL-3101.out
+++ b/test/JDBC/expected/BABEL-3101.out
@@ -63,7 +63,7 @@ GO
 tinyint
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: function master_dbo.isoweek("varchar") does not exist)~~
+~~ERROR (Message: function dbo.isoweek("varchar") does not exist)~~
 
 
 CREATE FUNCTION table_3101_2()

--- a/test/JDBC/expected/BABEL-3201-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3201-vu-verify.out
@@ -346,7 +346,7 @@ DBCC CHECKIDENT('fake_schema.babel_3201_t1', NORESEED);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_fake_schema" does not exist)~~
+~~ERROR (Message: schema "fake_schema" does not exist)~~
 
 
 -- Table undefined

--- a/test/JDBC/expected/BABEL-CREATE-TABLE.out
+++ b/test/JDBC/expected/BABEL-CREATE-TABLE.out
@@ -103,7 +103,7 @@ CREATE TABLE [Dummy].[Babel4433Table5](
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_dummy" does not exist)~~
+~~ERROR (Message: schema "dummy" does not exist)~~
 
 
 

--- a/test/JDBC/expected/BABEL-guest.out
+++ b/test/JDBC/expected/BABEL-guest.out
@@ -89,7 +89,7 @@ SELECT * FROM dbo.babel_2571_table2
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "babel_2571_db1_dbo.babel_2571_table2" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_2571_table2" does not exist)~~
 
 
 -- This should not
@@ -198,7 +198,7 @@ SELECT * FROM dbo.babel_2571_table2
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "babel_2571_db1_dbo.babel_2571_table2" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_2571_table2" does not exist)~~
 
 
 -- This should not

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -401,7 +401,7 @@ grant select on schema::non_existing_schema to guest; -- should fail
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "babel_4344_d1_non_existing_schema" does not exist)~~
+~~ERROR (Message: schema "non_existing_schema" does not exist)~~
 
 -- grant statement via a procedure
 create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
@@ -1519,7 +1519,7 @@ grant select on schema::non_existing_schema to guest; -- should fail
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "babel_4344_d1_non_existing_schema" does not exist)~~
+~~ERROR (Message: schema "non_existing_schema" does not exist)~~
 
 -- grant statement via a procedure
 create procedure grant_perm_proc as begin exec('grant select on schema::[] to guest') end;
@@ -6119,14 +6119,14 @@ GRANT SELECT on doesnt_exist.tbl TO public;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_doesnt_exist" does not exist)~~
+~~ERROR (Message: schema "doesnt_exist" does not exist)~~
 
 
 grant execute on xyz.babel_4344_p to public;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_xyz" does not exist)~~
+~~ERROR (Message: schema "xyz" does not exist)~~
 
 
 -- tsql

--- a/test/JDBC/expected/catalogs_dbo_sys_schema-upgrade-vu-verify.out
+++ b/test/JDBC/expected/catalogs_dbo_sys_schema-upgrade-vu-verify.out
@@ -2585,7 +2585,7 @@ select count(*) from master.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 select count(*) from tempdb.myschema.sysobjects
 go
@@ -5093,7 +5093,7 @@ select count(*) from tempdb.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "tempdb_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 select count(*) from myschematest_mydb.myschema.sysobjects
 go
@@ -7719,6 +7719,6 @@ select count(*) from myschematest_mydb.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "myschematest_mydb_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 

--- a/test/JDBC/expected/catalogs_dbo_sys_schema-vu-verify.out
+++ b/test/JDBC/expected/catalogs_dbo_sys_schema-vu-verify.out
@@ -2582,7 +2582,7 @@ select count(*) from master.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 select count(*) from tempdb.myschema.sysobjects
 go
@@ -5090,7 +5090,7 @@ select count(*) from tempdb.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "tempdb_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 select count(*) from myschematest_mydb.myschema.sysobjects
 go
@@ -7716,7 +7716,7 @@ select count(*) from myschematest_mydb.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "myschematest_mydb_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 
 

--- a/test/JDBC/expected/datepart-vu-verify.out
+++ b/test/JDBC/expected/datepart-vu-verify.out
@@ -69,7 +69,7 @@ GO
 tinyint
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: function master_dbo.isoweek("varchar") does not exist)~~
+~~ERROR (Message: function dbo.isoweek("varchar") does not exist)~~
 
 
 EXECUTE date_part_vu_prepare_proc '07-18-2022'

--- a/test/JDBC/expected/db_collation/BABEL-3000.out
+++ b/test/JDBC/expected/db_collation/BABEL-3000.out
@@ -100,7 +100,7 @@ go
 bit#!#int#!#varchar#!#bit#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#varchar#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#smallint#!#smallint#!#smallint#!#int#!#int#!#int#!#tinyint
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_sc_result_set.nums" does not exist)~~
+~~ERROR (Message: relation "sc_result_set.nums" does not exist)~~
 
 
 create table sc_result_set.nums(a int, b smallint, c bigint, d float, e real, f numeric(5,3))

--- a/test/JDBC/expected/exec_sp_in_udf-vu-verify.out
+++ b/test/JDBC/expected/exec_sp_in_udf-vu-verify.out
@@ -181,7 +181,7 @@ exec dbo.f_tvf_exec_sp_in_udf
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: master_dbo.f_tvf_exec_sp_in_udf() is not a procedure)~~
+~~ERROR (Message: dbo.f_tvf_exec_sp_in_udf() is not a procedure)~~
 
 create function f7_exec_sp_in_udf() 
 returns int
@@ -196,7 +196,7 @@ go
 int
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: master_dbo.f_tvf_exec_sp_in_udf() is not a procedure)~~
+~~ERROR (Message: dbo.f_tvf_exec_sp_in_udf() is not a procedure)~~
 
 
 -- inline TVF should not be callable with EXEC, but Babelfish currently allows this

--- a/test/JDBC/expected/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/four-part-names-vu-verify.out
@@ -97,7 +97,7 @@ SELECT * FROM bbf_fpn_server.master.invalid_schema.fpn_table
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
 
 
 -- Invalid object name (Should throw error)
@@ -105,7 +105,7 @@ SELECT * FROM bbf_fpn_server.master.dbo.invalid_fpn_table
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
 
 
 -- four part object is a procedure (Should throw error)

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-3000.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-3000.out
@@ -100,7 +100,7 @@ go
 bit#!#int#!#varchar#!#bit#!#int#!#nvarchar#!#smallint#!#tinyint#!#tinyint#!#varchar#!#int#!#varchar#!#varchar#!#varchar#!#nvarchar#!#int#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#bit#!#bit#!#bit#!#bit#!#bit#!#smallint#!#smallint#!#smallint#!#int#!#int#!#int#!#tinyint
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_sc_result_set.nums" does not exist)~~
+~~ERROR (Message: relation "sc_result_set.nums" does not exist)~~
 
 
 create table sc_result_set.nums(a int, b smallint, c bigint, d float, e real, f numeric(5,3))

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/trim-before-15_11-or-16_7-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/trim-before-15_11-or-16_7-vu-verify.out
@@ -1276,7 +1276,7 @@ SELECT TRIM(b FROM a) FROM dbo.babel_4489_trim_psql_t15
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.babel_4489_trim_psql_t15" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_4489_trim_psql_t15" does not exist)~~
 
 
 -- other different datatypes

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/trim-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/trim-vu-verify.out
@@ -1299,7 +1299,7 @@ SELECT TRIM(b FROM a) FROM dbo.babel_4489_trim_psql_t15
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.babel_4489_trim_psql_t15" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_4489_trim_psql_t15" does not exist)~~
 
 
 -- other different datatypes

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/trim-before-15_11-or-16_7-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/trim-before-15_11-or-16_7-vu-verify.out
@@ -1276,7 +1276,7 @@ SELECT TRIM(b FROM a) FROM dbo.babel_4489_trim_psql_t15
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.babel_4489_trim_psql_t15" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_4489_trim_psql_t15" does not exist)~~
 
 
 -- other different datatypes

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/trim-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/trim-vu-verify.out
@@ -1299,7 +1299,7 @@ SELECT TRIM(b FROM a) FROM dbo.babel_4489_trim_psql_t15
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.babel_4489_trim_psql_t15" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_4489_trim_psql_t15" does not exist)~~
 
 
 -- other different datatypes

--- a/test/JDBC/expected/parallel_query/BABEL-2844.out
+++ b/test/JDBC/expected/parallel_query/BABEL-2844.out
@@ -572,7 +572,7 @@ SELECT dbo.WOSQL_BuildRevenueDetailOLUQuery()
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: function master_dbo.wosql_buildrevenuedetailoluquery() does not exist)~~
+~~ERROR (Message: function dbo.wosql_buildrevenuedetailoluquery() does not exist)~~
 
 
 SET BABELFISH_SHOWPLAN_ALL OFF;

--- a/test/JDBC/expected/single_db/BABEL-1712.out
+++ b/test/JDBC/expected/single_db/BABEL-1712.out
@@ -40,7 +40,7 @@ SELECT * FROM dbo.t1; -- error expected, querying master.dbo.t1
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.t1" does not exist)~~
+~~ERROR (Message: relation "dbo.t1" does not exist)~~
 
 -- search path
 USE db1;

--- a/test/JDBC/expected/single_db/BABEL-3201-vu-verify.out
+++ b/test/JDBC/expected/single_db/BABEL-3201-vu-verify.out
@@ -346,7 +346,7 @@ DBCC CHECKIDENT('fake_schema.babel_3201_t1', NORESEED);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_fake_schema" does not exist)~~
+~~ERROR (Message: schema "fake_schema" does not exist)~~
 
 
 -- Table undefined

--- a/test/JDBC/expected/single_db/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/single_db/GRANT_SCHEMA.out
@@ -6119,14 +6119,14 @@ GRANT SELECT on doesnt_exist.tbl TO public;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_doesnt_exist" does not exist)~~
+~~ERROR (Message: schema "doesnt_exist" does not exist)~~
 
 
 grant execute on xyz.babel_4344_p to public;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_xyz" does not exist)~~
+~~ERROR (Message: schema "xyz" does not exist)~~
 
 
 -- tsql

--- a/test/JDBC/expected/single_db/catalogs_dbo_sys_schema-vu-verify.out
+++ b/test/JDBC/expected/single_db/catalogs_dbo_sys_schema-vu-verify.out
@@ -2582,7 +2582,7 @@ select count(*) from master.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 select count(*) from tempdb.myschema.sysobjects
 go
@@ -5090,7 +5090,7 @@ select count(*) from tempdb.myschema.sysobjects
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "tempdb_myschema.sysobjects" does not exist)~~
+~~ERROR (Message: relation "myschema.sysobjects" does not exist)~~
 
 select count(*) from myschematest_mydb.myschema.sysobjects
 go

--- a/test/JDBC/expected/single_db/four-part-names-vu-verify.out
+++ b/test/JDBC/expected/single_db/four-part-names-vu-verify.out
@@ -97,7 +97,7 @@ SELECT * FROM bbf_fpn_server.master.invalid_schema.fpn_table
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "invalid_schema.fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
 
 
 -- Invalid object name (Should throw error)
@@ -105,7 +105,7 @@ SELECT * FROM bbf_fpn_server.master.dbo.invalid_fpn_table
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "master_dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
+~~ERROR (Message: TDS client library error: Msg #: 33557097, Msg state: 1, Msg: relation "dbo.invalid_fpn_table" does not exist, Server: BABELFISH, Process: , Line: 1, Level: 16)~~
 
 
 -- four part object is a procedure (Should throw error)

--- a/test/JDBC/expected/table_variable_xact_errors.out
+++ b/test/JDBC/expected/table_variable_xact_errors.out
@@ -245,7 +245,7 @@ GO
 varchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_control.datarow" does not exist)~~
+~~ERROR (Message: relation "control.datarow" does not exist)~~
 
 
 DROP FUNCTION [Control].[csf_script_delete_row]

--- a/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
+++ b/test/JDBC/expected/table_variable_xact_errors_isolation_snapshot.out
@@ -247,7 +247,7 @@ GO
 varchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_control.datarow" does not exist)~~
+~~ERROR (Message: relation "control.datarow" does not exist)~~
 
 
 DROP FUNCTION [Control].[csf_script_delete_row]

--- a/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
+++ b/test/JDBC/expected/table_variable_xact_errors_xact_abort_on.out
@@ -233,7 +233,7 @@ GO
 varchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_control.datarow" does not exist)~~
+~~ERROR (Message: relation "control.datarow" does not exist)~~
 
 
 DROP FUNCTION [Control].[csf_script_delete_row]

--- a/test/JDBC/expected/trim-before-15_11-or-16_7-vu-verify.out
+++ b/test/JDBC/expected/trim-before-15_11-or-16_7-vu-verify.out
@@ -1276,7 +1276,7 @@ SELECT TRIM(b FROM a) FROM dbo.babel_4489_trim_psql_t15
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.babel_4489_trim_psql_t15" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_4489_trim_psql_t15" does not exist)~~
 
 
 -- other different datatypes

--- a/test/JDBC/expected/trim-vu-verify.out
+++ b/test/JDBC/expected/trim-vu-verify.out
@@ -1299,7 +1299,7 @@ SELECT TRIM(b FROM a) FROM dbo.babel_4489_trim_psql_t15
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "master_dbo.babel_4489_trim_psql_t15" does not exist)~~
+~~ERROR (Message: relation "dbo.babel_4489_trim_psql_t15" does not exist)~~
 
 
 -- other different datatypes

--- a/test/JDBC/expected/xml_exist-before-16_5-vu-verify.out
+++ b/test/JDBC/expected/xml_exist-before-16_5-vu-verify.out
@@ -422,7 +422,7 @@ SELECT @xml.EXIST('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
@@ -430,7 +430,7 @@ SELECT @xml.Exist('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
@@ -438,7 +438,7 @@ SELECT @xml.ExIsT('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
@@ -446,7 +446,7 @@ SELECT @xml.eXiSt('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 -- Acceptable argument types

--- a/test/JDBC/expected/xml_exist-vu-verify.out
+++ b/test/JDBC/expected/xml_exist-vu-verify.out
@@ -422,7 +422,7 @@ SELECT @xml.EXIST('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
@@ -430,7 +430,7 @@ SELECT @xml.Exist('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
@@ -438,7 +438,7 @@ SELECT @xml.ExIsT('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
@@ -446,7 +446,7 @@ SELECT @xml.eXiSt('/artists/artist/@name')
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_@xml" does not exist)~~
+~~ERROR (Message: schema "@xml" does not exist)~~
 
 
 -- Acceptable argument types

--- a/test/JDBC/input/BABEL-2961-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-2961-vu-cleanup.sql
@@ -1,0 +1,36 @@
+IF OBJECT_ID('dbo.SomeNonExistentTable', 'U') IS NOT NULL
+    DROP TABLE dbo.SomeNonExistentTable
+GO
+
+
+IF OBJECT_ID('dbo.NonExistentTableView', 'V') IS NOT NULL
+    DROP VIEW dbo.NonExistentTableView
+GO
+
+IF OBJECT_ID('dbo.NonExistentTableFunc', 'IF') IS NOT NULL
+    DROP FUNCTION dbo.NonExistentTableFunc
+GO
+
+IF OBJECT_ID('dbo.CallNonExistentProc', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.CallNonExistentProc
+GO
+
+IF OBJECT_ID('dbo.TestTable', 'U') IS NOT NULL
+    DROP TABLE dbo.TestTable
+GO
+
+IF OBJECT_ID('dbo.NonExistentTable', 'U') IS NOT NULL
+    DROP TABLE dbo.NonExistentTable
+GO
+
+IF OBJECT_ID('dbo.DropNonExistentUser', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.DropNonExistentUser
+GO
+
+IF OBJECT_ID('dbo.NonExistentProc', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.NonExistentProc
+GO
+
+IF OBJECT_ID('nonexistent_schema.TestFunc', 'FN') IS NOT NULL
+    DROP FUNCTION nonexistent_schema.TestFunc
+GO

--- a/test/JDBC/input/BABEL-2961-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-2961-vu-prepare.sql
@@ -1,0 +1,42 @@
+-- Create a view that attempts to select from a non-existent table
+CREATE VIEW dbo.NonExistentTableView AS
+SELECT * FROM dbo.SomeNonExistentTable
+GO
+
+
+-- Create a function that attempts to select from a non-existent table
+CREATE FUNCTION dbo.NonExistentTableFunc()
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM dbo.SomeNonExistentTable
+)
+GO
+
+-- Create a procedure that attempts to execute a non-existent procedure
+CREATE PROCEDURE dbo.CallNonExistentProc
+AS
+BEGIN
+    EXEC dbo.NonExistentProc
+END
+GO
+
+
+-- Create a function that attempts to use a non-existent schema
+CREATE FUNCTION nonexistent_schema.TestFunc()
+RETURNS INT
+AS
+BEGIN
+    RETURN 1
+END
+GO
+
+
+-- Create a procedure that attempts to drop a non-existent user
+CREATE PROCEDURE dbo.DropNonExistentUser
+AS
+BEGIN
+    DROP USER NonExistentUser
+END
+GO

--- a/test/JDBC/input/BABEL-2961-vu-verify.sql
+++ b/test/JDBC/input/BABEL-2961-vu-verify.sql
@@ -1,0 +1,54 @@
+CREATE TABLE schema_2961.t(a int)
+GO
+
+EXEC dbo.myproc
+GO
+
+SELECT * FROM dbo.t14
+GO
+
+DROP USER smith
+GO
+
+EXEC dbo.CallNonExistentProc
+GO
+
+EXEC dbo.DropNonExistentUser
+GO
+
+-- Attempt multiple operations within a single transaction
+BEGIN TRANSACTION
+    CREATE TABLE dbo.TestTable (ID INT)
+    INSERT INTO dbo.TestTable VALUES (1)
+    SELECT * FROM dbo.NonExistentTable
+COMMIT
+GO
+
+-- Verify if the transaction rolled back correctly
+SELECT * FROM dbo.TestTable
+GO
+
+CREATE DATABASE TestDB2961
+GO
+
+USE TestDB2961
+GO
+
+CREATE TABLE schema_2961.t(a int)
+GO
+
+EXEC dbo.myproc
+GO
+
+SELECT * FROM dbo.t14
+GO
+
+DROP USER smith
+GO
+
+USE master
+GO
+
+DROP DATABASE TestDB2961
+GO
+

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -591,4 +591,4 @@ BABEL-2736
 datareader_datawriter
 db_owner
 smalldatetime_date_cmp
-
+BABEL-2961


### PR DESCRIPTION
### Description

Previously, Babelfish displays the mapped schema names in error messages. This commit implements a hook function remove_db_name_in_schema and adds test cases. Original unmapped name will be displayed with this commit.

### Issues Resolved

[BABEL-2961](https://jira.rds.a2z.com/browse/BABEL-2961)

### Test Scenarios Covered ###
* **Use case based -** :white_check_mark:


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).