### PR TITLE
Set current db_id along with db_name for parallel workers

### DIFF
--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -57,6 +57,7 @@ void
 set_cur_db_name_for_parallel_worker(const char* logical_db_name)
 {
 	int len;
+	int16 db_id;
 
 	if (logical_db_name == NULL)
 		ereport(ERROR,
@@ -67,13 +68,15 @@ set_cur_db_name_for_parallel_worker(const char* logical_db_name)
 
 	Assert(len <= MAX_BBF_NAMEDATALEND);
 
-	if(!DbidIsValid(get_db_id(logical_db_name)))
+	db_id = get_db_id(logical_db_name);
+	if(!DbidIsValid(db_id))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_DATABASE),
 				 errmsg("database \"%s\" does not exist", logical_db_name)));
 	
 	strncpy(current_db_name, logical_db_name, MAX_BBF_NAMEDATALEND);
 	current_db_name[len] = '\0';
+	current_db_id = db_id;
 }
 
 


### PR DESCRIPTION
### Description

This commit addresses the issue of empty result sets in queries joining with sys.db_id() or sys.db_name() in Enforced Parallel Query mode by setting the current_db_id in addition to current_db_name for parallel workers.

Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)

### Issues Resolved
Task: BABEL-5504


### Root cause 
While we were communicating the logical database name to parallel workers and setting the current_db_name using logical database name (Ref: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2262), we failed to set current_db_id. This omission affected functions like sys.db_id() and sys.db_name(), resulting in empty result sets for queries involving these functions in parallel execution contexts.




### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).