### PR TITLE
Fix sys.dm_exec_sessions having rows for backends which are already terminated

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -155,7 +155,7 @@ typedef struct LocalTdsStatus
 } LocalTdsStatus;
 
 static TdsStatus *TdsStatusArray = NULL;
-static TdsStatus *MyTdsStatusEntry;
+static TdsStatus *MyTdsStatusEntry = NULL;
 static LocalTdsStatus *localTdsStatusTable = NULL;
 
 uint32_t	MyTdsClientVersion = 0;
@@ -446,8 +446,16 @@ tds_stats_shmem_shutdown(int code, Datum arg)
 		return;
 
 	/* Safety check ... shouldn't get here unless shmem is set up. */
-	if (TdsStatusArray == NULL)
+	if (TdsStatusArray == NULL || MyTdsStatusEntry == NULL)
 		return;
+
+	PGSTAT_BEGIN_WRITE_ACTIVITY(MyTdsStatusEntry);
+
+	MyTdsStatusEntry->st_procpid = 0;	/* mark invalid */
+
+	PGSTAT_END_WRITE_ACTIVITY(MyTdsStatusEntry);
+
+	MyTdsStatusEntry = NULL;
 
 	return;
 }

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -198,7 +198,7 @@ sys-datefirst
 sys-dm_exec_connections
 sys-dm_exec_connections-dep
 sys-dm_exec_sessions
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-dm_hadr_cluster
 sys-dm_hadr_database_replica_states
 sys-dm_os_host_info

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -194,7 +194,7 @@ sys-datefirst
 sys-dm_exec_connections
 sys-dm_exec_connections-dep
 sys-dm_exec_sessions
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-dm_hadr_cluster
 sys-dm_hadr_database_replica_states
 sys-dm_os_host_info

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -60,7 +60,7 @@ column_domain_usage
 constraint_column_usage
 select-strip-parens-before-15_5
 sp_describe_first_result_set
-#sys-host_name-before-15_8-or-16_4 TODO:BABEL-5414
+sys-host_name-before-15_8-or-16_4
 SYSTEM_USER
 indexproperty
 sys-all_parameters
@@ -240,7 +240,7 @@ sys-index_columns-dep
 sys-sp_databases-dep
 sys-syscolumns-dep
 sys-dm_exec_connections-dep
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-table_types-before-dep
 sys-all_sql_modules-dep_before_16_5
 sys-sql_modules-dep_before_16_5

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -60,7 +60,7 @@ column_domain_usage
 constraint_column_usage
 select-strip-parens-before-15_5
 sp_describe_first_result_set
-#sys-host_name-before-15_8-or-16_4 TODO:BABEL-5414
+sys-host_name-before-15_8-or-16_4
 SYSTEM_USER
 indexproperty
 sys-all_parameters
@@ -240,7 +240,7 @@ sys-index_columns-dep
 sys-sp_databases-dep
 sys-syscolumns-dep
 sys-dm_exec_connections-dep
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-table_types-before-dep
 sys-all_sql_modules-dep_before_16_5
 sys-sql_modules-dep_before_16_5

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -208,7 +208,7 @@ sys-datefirst
 sys-dm_exec_connections
 sys-dm_exec_connections-dep
 sys-dm_exec_sessions
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-dm_hadr_cluster
 sys-dm_hadr_database_replica_states
 sys-dm_os_host_info

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -214,7 +214,7 @@ sys-datefirst
 sys-dm_exec_connections
 sys-dm_exec_connections-dep
 sys-dm_exec_sessions
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-dm_hadr_cluster
 sys-dm_hadr_database_replica_states
 sys-dm_os_host_info
@@ -236,7 +236,7 @@ sys-fulltext_stoplists
 sys-hash_indexes
 sys-has_perms_by_name
 sys-has_perms_by_name-dep
-#sys-host_name-before-15_8-or-16_4 TODO:BABEL-5414
+sys-host_name-before-15_8-or-16_4
 sys-identity_columns
 sys-identity_columns-dep
 sys-index_columns

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -247,7 +247,7 @@ sys-default_constraints-dep
 sys-dm_exec_connections
 sys-dm_exec_connections-dep
 sys-dm_exec_sessions
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-dm_hadr_cluster
 sys-dm_hadr_database_replica_states
 sys-dm_os_host_info
@@ -269,7 +269,7 @@ sys-fulltext_stoplists
 sys-hash_indexes
 sys-has_perms_by_name
 sys-has_perms_by_name-dep
-#sys-host_name-before-15_8-or-16_4 TODO:BABEL-5414
+sys-host_name-before-15_8-or-16_4
 sys-identity_columns
 sys-identity_columns-dep
 sys-index_columns

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -270,7 +270,7 @@ sys-default_constraints-dep
 sys-dm_exec_connections
 sys-dm_exec_connections-dep
 sys-dm_exec_sessions
-#sys-dm_exec_sessions-dep TODO:BABEL-5414
+sys-dm_exec_sessions-dep
 sys-dm_hadr_cluster
 sys-dm_hadr_database_replica_states
 sys-dm_os_host_info
@@ -292,7 +292,7 @@ sys-fulltext_stoplists
 sys-hash_indexes
 sys-has_perms_by_name
 sys-has_perms_by_name-dep
-#sys-host_name-before-15_8-or-16_4 TODO:BABEL-5414
+sys-host_name-before-15_8-or-16_4
 sys-identity_columns
 sys-identity_columns-dep
 sys-index_columns


### PR DESCRIPTION
### Description

We initialize and keep a local status array which has the entries
for all TDS connections but we did not reset these entries during
connection abort or shmem exit of the backend, which means
future read of this local status array will see these entries as valid.

As a fix, mark the status entry as invalid during proc/shmem exit

### Cherry Picked From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3329

### Issues Resolved

[BABEL-5414]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).