### PR TITLE
Fix sys.dm_exec_sessions having rows for backends which are already terminated

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -155,7 +155,7 @@ typedef struct LocalTdsStatus
 } LocalTdsStatus;
 
 static TdsStatus *TdsStatusArray = NULL;
-static TdsStatus *MyTdsStatusEntry;
+static TdsStatus *MyTdsStatusEntry = NULL;
 static LocalTdsStatus *localTdsStatusTable = NULL;
 
 uint32_t	MyTdsClientVersion = 0;
@@ -446,8 +446,16 @@ tds_stats_shmem_shutdown(int code, Datum arg)
 		return;
 
 	/* Safety check ... shouldn't get here unless shmem is set up. */
-	if (TdsStatusArray == NULL)
+	if (TdsStatusArray == NULL || MyTdsStatusEntry == NULL)
 		return;
+
+	PGSTAT_BEGIN_WRITE_ACTIVITY(MyTdsStatusEntry);
+
+	MyTdsStatusEntry->st_procpid = 0;	/* mark invalid */
+
+	PGSTAT_END_WRITE_ACTIVITY(MyTdsStatusEntry);
+
+	MyTdsStatusEntry = NULL;
 
 	return;
 }


### PR DESCRIPTION
### Description

We initialize and keep a local status array which has the entries
for all TDS connections but we did not reset these entries during
connection abort or shmem exit of the backend, which means
future read of this local status array will see these entries as valid.

As a fix, mark the status entry as invalid during proc/shmem exit

### Cherry Picked From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3329

### Issues Resolved

[BABEL-5414]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).