### PR TITLE
Fix crash due to null current memory context after error in open json with

### DIFF
--- a/contrib/babelfishpg_tsql/src/json_funcs.c
+++ b/contrib/babelfishpg_tsql/src/json_funcs.c
@@ -306,6 +306,7 @@ tsql_openjson_with_internal(PG_FUNCTION_ARGS)
 
 		funcctx = SRF_FIRSTCALL_INIT();
 		prev_sql_dialect = sql_dialect;
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 		PG_TRY();
 		{
 			Jsonb	   *sub_jb;
@@ -317,7 +318,6 @@ tsql_openjson_with_internal(PG_FUNCTION_ARGS)
 			 * processing
 			 */
 			sql_dialect = SQL_DIALECT_TSQL;
-			oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 			/*
 			 * Get information about return type. Used to build return message
@@ -377,9 +377,10 @@ tsql_openjson_with_internal(PG_FUNCTION_ARGS)
 		PG_FINALLY();
 		{
 			sql_dialect = prev_sql_dialect;
-			MemoryContextSwitchTo(oldcontext);
 		}
 		PG_END_TRY();
+
+		MemoryContextSwitchTo(oldcontext);
 	}
 
 	funcctx = SRF_PERCALL_SETUP();

--- a/test/JDBC/expected/BABEL-OPENJSON.out
+++ b/test/JDBC/expected/BABEL-OPENJSON.out
@@ -316,3 +316,22 @@ int#!#nvarchar#!#nvarchar#!#int#!#datetime2
 5#!#Jane#!#Smith#!#<NULL>#!#2005-11-04 12:00:00.0000000
 ~~END~~
 
+
+-- BABEL-5020
+CREATE PROC babel_5020_p
+AS
+SELECT * INTO babel_5020_t FROM openjson(N'{"a":1}', 'strict $.a') with (a nvarchar(20))
+GO
+
+EXEC babel_5020_p
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Value referenced by JSON path is not an array or object and cannot be opened with OPENJSON.)~~
+
+
+DROP PROC babel_5020_p
+GO
+
+DROP TABLE IF EXISTS babel_5020_t
+GO

--- a/test/JDBC/input/BABEL-OPENJSON.sql
+++ b/test/JDBC/input/BABEL-OPENJSON.sql
@@ -139,3 +139,18 @@ SELECT *
 FROM OPENJSON(@json)
   WITH ( id INT 'strict $.id', firstName NVARCHAR(50) '$.info.name', lastName NVARCHAR(50) '$.info.surname', age INT, dateOfBirth DATETIME2 '$.dob' );
 go
+
+-- BABEL-5020
+CREATE PROC babel_5020_p
+AS
+SELECT * INTO babel_5020_t FROM openjson(N'{"a":1}', 'strict $.a') with (a nvarchar(20))
+GO
+
+EXEC babel_5020_p
+GO
+
+DROP PROC babel_5020_p
+GO
+
+DROP TABLE IF EXISTS babel_5020_t
+GO


### PR DESCRIPTION
### Description

Any variable we set in try, may not be visible to catch block.
Fix such a case where we set oldcontext variable in try block
the use it in catch block, which leads to setting current 
memory context as NULL.

### Cherry Picked from

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3339

### Issues Resolved

[BABEL-5020]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).