### PR TITLE
Fix 'AT TIME ZONE' issue near DST change time with DATETIME2 datatype conversion

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1170,9 +1170,7 @@ DECLARE
     tz_offset PG_CATALOG.TEXT;
     tz_name PG_CATALOG.TEXT;
     lower_tzn PG_CATALOG.TEXT;
-    prev_res PG_CATALOG.TEXT;
     result PG_CATALOG.TEXT;
-    is_dstt bool;
     tz_diff PG_CATALOG.TEXT;
     input_expr_tx PG_CATALOG.TEXT;
     input_expr_tmz TIMESTAMPTZ;
@@ -1193,31 +1191,25 @@ BEGIN
     END IF;
 
     IF pg_typeof(input_expr) IN ('sys.smalldatetime'::regtype, 'sys.datetime'::regtype, 'sys.datetime2'::regtype) THEN
-        input_expr_tx := input_expr::TEXT;
-        input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
-
-        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
-        if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
-            tz_diff := PG_CATALOG.concat('+',tz_diff);
-        END IF;
-        tz_offset := PG_CATALOG.left(tz_diff,6);
-        input_expr_tx := PG_CATALOG.concat(input_expr_tx,tz_offset);
-        return cast(input_expr_tx as sys.datetimeoffset);
+        input_expr_tx := input_expr::TEXT || ' ' || tz_name;
     ELSIF  pg_typeof(input_expr) = 'sys.DATETIMEOFFSET'::regtype THEN
         input_expr_tx := input_expr::TEXT;
-        input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
-        result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
-        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
-        if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
-            tz_diff := PG_CATALOG.concat('+',tz_diff);
-        END IF;
-        tz_offset := PG_CATALOG.left(tz_diff,6);
-        result := PG_CATALOG.concat(result,tz_offset);
-        return cast(result as sys.datetimeoffset);
     ELSE
         RAISE USING MESSAGE := 'Argument data type varchar is invalid for argument 1 of AT TIME ZONE function.'; 
     END IF;
-       
+
+    input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
+    result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
+    tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
+
+    if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
+        tz_diff := PG_CATALOG.concat('+',tz_diff);
+    END IF;
+
+    tz_offset := PG_CATALOG.left(tz_diff,6);
+    result := PG_CATALOG.concat(result,tz_offset);
+
+    return cast(result as sys.datetimeoffset);
 END;
 $BODY$
 LANGUAGE 'plpgsql' STABLE;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -2660,9 +2660,7 @@ DECLARE
     tz_offset PG_CATALOG.TEXT;
     tz_name PG_CATALOG.TEXT;
     lower_tzn PG_CATALOG.TEXT;
-    prev_res PG_CATALOG.TEXT;
     result PG_CATALOG.TEXT;
-    is_dstt bool;
     tz_diff PG_CATALOG.TEXT;
     input_expr_tx PG_CATALOG.TEXT;
     input_expr_tmz TIMESTAMPTZ;
@@ -2683,31 +2681,25 @@ BEGIN
     END IF;
 
     IF pg_typeof(input_expr) IN ('sys.smalldatetime'::regtype, 'sys.datetime'::regtype, 'sys.datetime2'::regtype) THEN
-        input_expr_tx := input_expr::TEXT;
-        input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
-
-        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
-        if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
-            tz_diff := PG_CATALOG.concat('+',tz_diff);
-        END IF;
-        tz_offset := PG_CATALOG.left(tz_diff,6);
-        input_expr_tx := PG_CATALOG.concat(input_expr_tx,tz_offset);
-        return cast(input_expr_tx as sys.datetimeoffset);
+        input_expr_tx := input_expr::TEXT || ' ' || tz_name;
     ELSIF  pg_typeof(input_expr) = 'sys.DATETIMEOFFSET'::regtype THEN
         input_expr_tx := input_expr::TEXT;
-        input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
-        result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
-        tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
-        if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
-            tz_diff := PG_CATALOG.concat('+',tz_diff);
-        END IF;
-        tz_offset := PG_CATALOG.left(tz_diff,6);
-        result := PG_CATALOG.concat(result,tz_offset);
-        return cast(result as sys.datetimeoffset);
     ELSE
         RAISE USING MESSAGE := 'Argument data type varchar is invalid for argument 1 of AT TIME ZONE function.'; 
     END IF;
-       
+
+    input_expr_tmz := input_expr_tx :: TIMESTAMPTZ;
+    result := (SELECT input_expr_tmz  AT TIME ZONE tz_name)::TEXT;
+    tz_diff := (SELECT input_expr_tmz AT TIME ZONE tz_name - input_expr_tmz AT TIME ZONE 'UTC')::TEXT;
+
+    if PG_CATALOG.LEFT(tz_diff,1) <> '-' THEN
+        tz_diff := PG_CATALOG.concat('+',tz_diff);
+    END IF;
+
+    tz_offset := PG_CATALOG.left(tz_diff,6);
+    result := PG_CATALOG.concat(result,tz_offset);
+
+    return cast(result as sys.datetimeoffset);     
 END;
 $BODY$
 LANGUAGE 'plpgsql' STABLE;

--- a/test/JDBC/expected/ATTIMEZONE-dep-vu-verify.out
+++ b/test/JDBC/expected/ATTIMEZONE-dep-vu-verify.out
@@ -77,6 +77,311 @@ datetimeoffset
 ~~END~~
 
 
+SELECT CONVERT(DATETIME2(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 00:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 04:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 05:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 04:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 00:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 02:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 01:01:00.0000000 -08:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T02:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 03:01:00.0000000 -07:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 03:01:00.0000000 -07:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T02:00:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 02:00:00.0000000 -08:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 03:01:00.0000000 -08:00
+~~END~~
+
+
+-- PG handles overlap ambiguity by prefering standard time over DST.
+SELECT CONVERT(DATETIME2(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 02:00:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 01:01:00.0000000 -08:00
+~~END~~
+
+
 select set_config('timezone', 'Asia/Kolkata', false);
 GO
 ~~START~~
@@ -114,6 +419,624 @@ GO
 ~~START~~
 datetimeoffset
 9999-12-31 16:59:59.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 00:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 04:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 05:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 04:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 00:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 02:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 01:01:00.0000000 -08:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T02:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 03:01:00.0000000 -07:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 03:01:00.0000000 -07:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T02:00:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 02:00:00.0000000 -08:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 03:01:00.0000000 -08:00
+~~END~~
+
+
+-- PG handles overlap ambiguity by prefering standard time over DST.
+SELECT CONVERT(DATETIME2(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 02:00:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 01:01:00.0000000 -08:00
+~~END~~
+
+
+select set_config('timezone', 'America/Los_Angeles', false);
+GO
+~~START~~
+text
+America/Los_Angeles
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 00:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 04:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 05:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 04:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 00:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 01:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-03-27 03:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 02:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 00:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 01:01:00.0000000 +02:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 03:01:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 01:01:00.0000000 -08:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T02:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 03:01:00.0000000 -07:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-03-10 03:01:00.0000000 -07:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T02:00:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 02:00:00.0000000 -08:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 03:01:00.0000000 -08:00
+~~END~~
+
+
+-- PG handles overlap ambiguity by prefering standard time over DST.
+SELECT CONVERT(DATETIME2(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(smalldatetime, '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(datetime, '2022-10-30 02:00:00') AT TIME ZONE 'Central European Standard Time';
+GO
+~~START~~
+datetimeoffset
+2022-10-30 02:00:00.0000000 +01:00
+~~END~~
+
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+~~START~~
+datetimeoffset
+2024-11-03 01:01:00.0000000 -08:00
 ~~END~~
 
 

--- a/test/JDBC/input/ATTIMEZONE-dep-vu-verify.sql
+++ b/test/JDBC/input/ATTIMEZONE-dep-vu-verify.sql
@@ -28,6 +28,121 @@ GO
 Select convert(datetimeoffset,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
 GO
 
+SELECT CONVERT(DATETIME2(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 02:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T02:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T02:00:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+-- PG handles overlap ambiguity by prefering standard time over DST.
+SELECT CONVERT(DATETIME2(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 02:00:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
 select set_config('timezone', 'Asia/Kolkata', false);
 GO
 
@@ -41,6 +156,239 @@ Select convert(datetimeoffset,'2002-01-01 02:01:00.000 +00:00') AT TIME ZONE 'ea
 GO
 
 Select convert(datetimeoffset,'9999-12-31 15:59:59.000 +00:00') AT TIME ZONE 'Central Europe Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 02:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T02:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T02:00:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+-- PG handles overlap ambiguity by prefering standard time over DST.
+SELECT CONVERT(DATETIME2(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 02:00:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+select set_config('timezone', 'America/Los_Angeles', false);
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetimeoffset(0), '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T02:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-03-27T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T00:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T01:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T03:01:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 02:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 00:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 01:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 03:01:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T01:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T02:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-03-10T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T02:00:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T03:01:00', 126) AT TIME ZONE 'pacific standard time';
+GO
+
+-- PG handles overlap ambiguity by prefering standard time over DST.
+SELECT CONVERT(DATETIME2(0), '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(smalldatetime, '2022-10-30T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(datetime, '2022-10-30 02:00:00') AT TIME ZONE 'Central European Standard Time';
+GO
+
+SELECT CONVERT(DATETIME2(0), '2024-11-03T01:01:00', 126) AT TIME ZONE 'pacific standard time';
 GO
 
 select set_config('timezone', 'UTC', false);


### PR DESCRIPTION
## Description

### 1. Issues
- Convert function when converting to datetime2, datetime, smalldatettime with given timezone using AT TIME ZONE gives wrong output near DST change time.

### 2. Changes made to fix the issues
- Fix timestamp value to consider it in the given timezone instead of UTC for datetime2, datetime, smalldatettime datatypes. This fixes the issue and also makes it independent of local timezone setting.
```
# Input
1> SELECT CONVERT(DATETIME2(0), '2022-03-27T02:00:00', 126) AT TIME ZONE 'Central European Standard Time';
2> GO
```
```
# previous output (wrong output)               

---------------------------------------------
          2022-03-27 02:00:00.0000000 +02:00
```
```
# current output (correct output)

---------------------------------------------
          2022-03-27 03:00:00.0000000 +02:00                                                                                                                                                                                                                                           
```

```
# previous output (wrong output)
1> SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00') AT TIME ZONE 'Central European Standard Time';
2> GO
timezone 
---------------------------------------------
           2022-03-27 01:01:00.0000000 +02:00

(1 rows affected)
```
```
# current output (correct output)
1> SELECT CONVERT(DATETIME2(0), '2022-03-27T01:01:00') AT TIME ZONE 'Central European Standard Time';
2> GO
timezone 
---------------------------------------------
           2022-03-27 01:01:00.0000000 +01:00

(1 rows affected)
```
- Added Test Cases for this issue

Task: BABEL-5513
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)



### Test Scenarios Covered ###
* **Use case based -**  YES


* **Boundary conditions -**  YES


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -** 


* **Major version upgrade tests -** 


* **Performance tests -**


* **Tooling impact -**

* **Memory tests -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).