### PR TITLE
Enhancements for db_securityadmin fixed role

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -5723,6 +5723,7 @@ handle_grantstmt_for_dbsecadmin(ObjectType objType, Oid objId, Oid ownerId,
 		case OBJECT_TABLE:
 		case OBJECT_COLUMN:
 		case OBJECT_VIEW:
+		case OBJECT_SEQUENCE:
 			classid = RelationRelationId;
 			break;
 		case OBJECT_FUNCTION:

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2051,16 +2051,21 @@ check_alter_role_stmt(GrantRoleStmt *stmt)
 		return;
 
 	/*
+	 * Members of db_securityadmin role can ALTER ANY ROLE
+	 */
+	if (get_db_principal_kind(granted, db_name) == BBF_ROLE &&
+		has_privs_of_role(GetUserId(), get_db_securityadmin_oid(db_name, false)))
+	{
+		return;
+	}
+
+	/*
 	 * Disallow ALTER ROLE if
 	 * 1. Current login doesn't have permission on the granted role
 	 * OR
-	 * 2. Granted role is not a fixed db role or current user is a member of db_securityadmin
-	 * OR
-	 * 3. The current user is trying to add/drop itself from the granted role
+	 * 2. The current user is trying to add/drop itself from the granted role
 	 */
-	if ((!has_privs_of_role(GetSessionUserId(), granted) &&
-		 !(get_db_principal_kind(granted, db_name) == BBF_ROLE &&
-		   has_privs_of_role(GetUserId(), get_db_securityadmin_oid(get_current_pltsql_db_name(), false)))) ||
+	if (!has_privs_of_role(GetSessionUserId(), granted) ||
 		grantee == GetUserId())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/test/JDBC/expected/BABEL-ROLE-MEMBER.out
+++ b/test/JDBC/expected/BABEL-ROLE-MEMBER.out
@@ -1343,6 +1343,76 @@ GO
 ~~ERROR (Message: The role has members. It must be empty before it can be dropped.)~~
 
 
+-- tsql
+-- Test system defined database role memberships
+-- Following should return 1
+select is_rolemember('db_ddladmin', 'db_ddladmin')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('db_securityadmin', 'db_securityadmin')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('db_accessadmin', 'db_accessadmin')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('db_datareader', 'db_datareader')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('db_datawriter', 'db_datawriter')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('db_owner', 'db_owner')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('db_owner', 'dbo')
+GO
+~~START~~
+int
+1
+~~END~~
+
+select is_rolemember('dbo', 'dbo')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- This should return NULL
+select is_rolemember('dbo', 'db_owner')
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+
 -- Clean up
 DROP USER test_user1
 GO

--- a/test/JDBC/expected/db_securityadmin-vu-cleanup.out
+++ b/test/JDBC/expected/db_securityadmin-vu-cleanup.out
@@ -23,6 +23,8 @@ DROP FUNCTION babel_5135_schema1.babel_5135_f1();
 GO
 DROP FUNCTION babel_5135_schema1.babel_5135_tvf1();
 GO
+DROP SEQUENCE babel_5135_schema1.babel_5135_seq1;
+GO
 DROP PROCEDURE babel_5135_roleop_proc1;
 GO
 DROP PROCEDURE babel_5135_roleop_proc2;

--- a/test/JDBC/expected/db_securityadmin-vu-prepare.out
+++ b/test/JDBC/expected/db_securityadmin-vu-prepare.out
@@ -38,6 +38,9 @@ GO
 CREATE FUNCTION babel_5135_schema1.babel_5135_tvf1() RETURNS TABLE AS RETURN (SELECT a, b FROM babel_5135_schema1.babel_5135_t1);
 GO
 
+CREATE SEQUENCE babel_5135_schema1.babel_5135_seq1 START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 999999 CYCLE;
+GO
+
 CREATE VIEW babel_5135_show_role_mem AS
 SELECT 
 roles.name AS RolePrincipalName
@@ -63,6 +66,7 @@ GRANT SELECT ON babel_5135_schema1.babel_5135_v1 TO babel_5135_u1;
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_p1 TO babel_5135_u1;
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_f1 TO babel_5135_u1;
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
 END
 GO
 CREATE PROCEDURE babel_5135_revokeop_proc1 AS BEGIN
@@ -71,6 +75,7 @@ REVOKE SELECT ON babel_5135_schema1.babel_5135_v1 FROM babel_5135_u1;
 REVOKE EXECUTE ON babel_5135_schema1.babel_5135_p1 FROM babel_5135_u1;
 REVOKE EXECUTE ON babel_5135_schema1.babel_5135_f1 FROM babel_5135_u1;
 REVOKE EXECUTE ON babel_5135_schema1.babel_5135_tvf1 FROM babel_5135_u1;
+REVOKE UPDATE ON babel_5135_schema1.babel_5135_seq1 FROM babel_5135_u1;
 END
 GO
 

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -129,7 +129,9 @@ GO
 -- tsql
 -- CASE 3 - Able to manage database roles
 	-- CASE 3.1 - CREATE/ALTER/DROP ROLE
-	-- CASE 3.2 - ADD/DROP the membership of user-defined database roles should be allowed
+	-- CASE 3.2.a - ADD/DROP the membership of user-defined database roles should be allowed
+	-- CASE 3.2.b - ADD/DROP the membership of user-defined database roles to/from current_user
+	-- CASE 3.2.c - It should be able to ALTER the membership of database role which is member of db_owner
 	-- CASE 3.3 - ADD/DROP the membership of system-defined database roles should be blocked
 	-- CASE 3.4 - CREATE/ALTER/DROP USER should not be Allowed
 -- role created by another user, to test alter/drop on it
@@ -157,12 +159,48 @@ GO
 EXEC babel_5135_roleop_proc1;
 GO
 
--- CASE 3.2 - ADD/DROP the membership of user-defined database roles
+-- CASE 3.2.a - ADD/DROP the membership of user-defined database roles
 ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_u1;
 GO
 
 ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_u1;
 GO
+
+-- CASE 3.2.b - ADD/DROP the membership of user-defined database roles to/from current_user
+SELECT current_user;
+GO
+~~START~~
+varchar
+babel_5135_dbsecadmin_u1
+~~END~~
+
+
+ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+-- CASE 3.2.c - It should be able to ALTER the membership of database role which is member of db_owner
+ALTER ROLE db_owner ADD MEMBER babel_5135_r1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Adding database roles to db_owner is not currently supported in Babelfish)~~
+
+
+ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+ALTER ROLE db_owner DROP MEMBER babel_5135_r1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Dropping database roles from db_owner is not currently supported in Babelfish)~~
+
 
 -- alter role add member inside procedure
 -- execution should be succeeded with no error
@@ -187,6 +225,20 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Cannot alter the role 'db_owner', because it does not exist or you do not have permission.)~~
+
+
+ALTER ROLE babel_5135_r1 DROP MEMBER dbo;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbo')~~
+
+
+ALTER ROLE babel_5135_r1 ADD MEMBER dbo;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the special principal 'dbo')~~
 
 
 -- CASE 3.4 -- CREATE/ALTER/DROP USER should fail
@@ -345,6 +397,13 @@ GO
 ~~ERROR (Message: permission denied for function babel_5135_tvf1)~~
 
 
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
+
+
 -- tsql user=babel_5135_l1 password=12345678
 SELECT current_user;
 GO
@@ -390,6 +449,15 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for function babel_5135_tvf1)~~
+
+
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
 
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
@@ -453,6 +521,15 @@ GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: permission denied for function babel_5135_tvf1)~~
+
+
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
 
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
@@ -517,6 +594,14 @@ int#!#int
 ~~END~~
 
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 -- Testing revokes inside procedure
 EXEC babel_5135_revokeop_proc1;
@@ -568,6 +653,14 @@ GO
 
 ~~ERROR (Message: permission denied for function babel_5135_tvf1)~~
 
+
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
 
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
@@ -631,6 +724,15 @@ int#!#int
 ~~END~~
 
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
+
+
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 REVOKE SELECT, INSERT, UPDATE, DELETE, EXECUTE ON SCHEMA::babel_5135_schema1 FROM babel_5135_u1;
 GO
@@ -682,6 +784,15 @@ GO
 ~~ERROR (Message: permission denied for function babel_5135_tvf1)~~
 
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
+
+
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 -- CASE 5.2 - Validate members of db_securityadmin can not actually access given objects 
 SELECT current_user;
@@ -730,6 +841,15 @@ GO
 ~~ERROR (Message: permission denied for function babel_5135_tvf1)~~
 
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for sequence babel_5135_seq1)~~
+
+
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 -- CASE 5.3 - Validate that after GRANT/REVOKE, objectowner/dbo can execute REVOKE/GRANT respectively
 -- execute GRANT via db_securityadmin member and REVOKE it with object owner
@@ -746,6 +866,9 @@ GRANT EXECUTE ON babel_5135_schema1.babel_5135_f1 TO babel_5135_u1;
 GO
 
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
+GO
+
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
 GO
 
 -- tsql
@@ -778,6 +901,9 @@ GRANT EXECUTE ON babel_5135_schema1.babel_5135_f1 TO babel_5135_u1;
 GO
 
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
+GO
+
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
 GO
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -182,6 +182,7 @@ ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_dbsecadmin_u1;
 GO
 
 -- CASE 3.2.c - It should be able to ALTER the membership of database role which is member of db_owner
+-- Currently it is not supported to add database role to db_owner
 ALTER ROLE db_owner ADD MEMBER babel_5135_r1;
 GO
 ~~ERROR (Code: 33557097)~~

--- a/test/JDBC/input/BABEL-ROLE-MEMBER.mix
+++ b/test/JDBC/input/BABEL-ROLE-MEMBER.mix
@@ -623,6 +623,31 @@ GO
 DROP ROLE test_role3
 GO
 
+-- Test system defined database role memberships
+-- tsql
+-- Following should return 1
+select is_rolemember('db_ddladmin', 'db_ddladmin')
+GO
+select is_rolemember('db_securityadmin', 'db_securityadmin')
+GO
+select is_rolemember('db_accessadmin', 'db_accessadmin')
+GO
+select is_rolemember('db_datareader', 'db_datareader')
+GO
+select is_rolemember('db_datawriter', 'db_datawriter')
+GO
+select is_rolemember('db_owner', 'db_owner')
+GO
+select is_rolemember('db_owner', 'dbo')
+GO
+select is_rolemember('dbo', 'dbo')
+GO
+
+-- This should return NULL
+select is_rolemember('dbo', 'db_owner')
+GO
+
+
 -- Clean up
 DROP USER test_user1
 GO

--- a/test/JDBC/input/ownership/db_securityadmin-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-cleanup.mix
@@ -23,6 +23,8 @@ DROP FUNCTION babel_5135_schema1.babel_5135_f1();
 GO
 DROP FUNCTION babel_5135_schema1.babel_5135_tvf1();
 GO
+DROP SEQUENCE babel_5135_schema1.babel_5135_seq1;
+GO
 DROP PROCEDURE babel_5135_roleop_proc1;
 GO
 DROP PROCEDURE babel_5135_roleop_proc2;

--- a/test/JDBC/input/ownership/db_securityadmin-vu-prepare.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-prepare.mix
@@ -38,6 +38,9 @@ GO
 CREATE FUNCTION babel_5135_schema1.babel_5135_tvf1() RETURNS TABLE AS RETURN (SELECT a, b FROM babel_5135_schema1.babel_5135_t1);
 GO
 
+CREATE SEQUENCE babel_5135_schema1.babel_5135_seq1 START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 999999 CYCLE;
+GO
+
 CREATE VIEW babel_5135_show_role_mem AS
 SELECT 
 roles.name AS RolePrincipalName
@@ -63,6 +66,7 @@ GRANT SELECT ON babel_5135_schema1.babel_5135_v1 TO babel_5135_u1;
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_p1 TO babel_5135_u1;
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_f1 TO babel_5135_u1;
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
 END
 GO
 CREATE PROCEDURE babel_5135_revokeop_proc1 AS BEGIN
@@ -71,6 +75,7 @@ REVOKE SELECT ON babel_5135_schema1.babel_5135_v1 FROM babel_5135_u1;
 REVOKE EXECUTE ON babel_5135_schema1.babel_5135_p1 FROM babel_5135_u1;
 REVOKE EXECUTE ON babel_5135_schema1.babel_5135_f1 FROM babel_5135_u1;
 REVOKE EXECUTE ON babel_5135_schema1.babel_5135_tvf1 FROM babel_5135_u1;
+REVOKE UPDATE ON babel_5135_schema1.babel_5135_seq1 FROM babel_5135_u1;
 END
 GO
 

--- a/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
@@ -141,6 +141,7 @@ ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_dbsecadmin_u1;
 GO
 
 -- CASE 3.2.c - It should be able to ALTER the membership of database role which is member of db_owner
+-- Currently it is not supported to add database role to db_owner
 ALTER ROLE db_owner ADD MEMBER babel_5135_r1;
 GO
 

--- a/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
@@ -92,7 +92,9 @@ GO
 
 -- CASE 3 - Able to manage database roles
 	-- CASE 3.1 - CREATE/ALTER/DROP ROLE
-	-- CASE 3.2 - ADD/DROP the membership of user-defined database roles should be allowed
+	-- CASE 3.2.a - ADD/DROP the membership of user-defined database roles should be allowed
+	-- CASE 3.2.b - ADD/DROP the membership of user-defined database roles to/from current_user
+	-- CASE 3.2.c - It should be able to ALTER the membership of database role which is member of db_owner
 	-- CASE 3.3 - ADD/DROP the membership of system-defined database roles should be blocked
 	-- CASE 3.4 - CREATE/ALTER/DROP USER should not be Allowed
 -- role created by another user, to test alter/drop on it
@@ -121,11 +123,34 @@ GO
 EXEC babel_5135_roleop_proc1;
 GO
 
--- CASE 3.2 - ADD/DROP the membership of user-defined database roles
+-- CASE 3.2.a - ADD/DROP the membership of user-defined database roles
 ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_u1;
 GO
 
 ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_u1;
+GO
+
+-- CASE 3.2.b - ADD/DROP the membership of user-defined database roles to/from current_user
+SELECT current_user;
+GO
+
+ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+-- CASE 3.2.c - It should be able to ALTER the membership of database role which is member of db_owner
+ALTER ROLE db_owner ADD MEMBER babel_5135_r1;
+GO
+
+ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+ALTER ROLE babel_5135_r1 DROP MEMBER babel_5135_dbsecadmin_u1;
+GO
+
+ALTER ROLE db_owner DROP MEMBER babel_5135_r1;
 GO
 
 -- alter role add member inside procedure
@@ -143,6 +168,12 @@ ALTER ROLE db_accessadmin ADD MEMBER babel_5135_u1;
 GO
 
 ALTER ROLE db_owner ADD MEMBER babel_5135_u1;
+GO
+
+ALTER ROLE babel_5135_r1 DROP MEMBER dbo;
+GO
+
+ALTER ROLE babel_5135_r1 ADD MEMBER dbo;
 GO
 
 -- CASE 3.4 -- CREATE/ALTER/DROP USER should fail
@@ -236,6 +267,9 @@ GO
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
 GO
 
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
+GO
+
 -- tsql user=babel_5135_l1 password=12345678
 SELECT current_user;
 GO
@@ -256,6 +290,9 @@ SELECT babel_5135_schema1.babel_5135_f1();
 GO
 
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
+GO
+
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
 GO
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
@@ -296,6 +333,9 @@ GO
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
 GO
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+
 -- Testing GRANT inside procedure
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 EXEC babel_5135_grantop_proc1;
@@ -321,6 +361,9 @@ SELECT babel_5135_schema1.babel_5135_f1();
 GO
 
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
+GO
+
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
 GO
 
 -- Testing revokes inside procedure
@@ -350,6 +393,8 @@ GO
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
 GO
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON SCHEMA::babel_5135_schema1 TO babel_5135_u1;
@@ -375,6 +420,9 @@ SELECT babel_5135_schema1.babel_5135_f1();
 GO
 
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
+GO
+
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
 GO
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
@@ -403,6 +451,9 @@ GO
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
 GO
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+
 -- CASE 5.2 - Validate members of db_securityadmin can not actually access given objects 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
 SELECT current_user;
@@ -426,6 +477,9 @@ GO
 SELECT * FROM babel_5135_schema1.babel_5135_tvf1();
 GO
 
+SELECT NEXT VALUE FOR babel_5135_schema1.babel_5135_seq1;
+GO
+
 -- CASE 5.3 - Validate that after GRANT/REVOKE, objectowner/dbo can execute REVOKE/GRANT respectively
 -- execute GRANT via db_securityadmin member and REVOKE it with object owner
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678
@@ -442,6 +496,9 @@ GRANT EXECUTE ON babel_5135_schema1.babel_5135_f1 TO babel_5135_u1;
 GO
 
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
+GO
+
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
 GO
 
 -- tsql
@@ -474,6 +531,9 @@ GRANT EXECUTE ON babel_5135_schema1.babel_5135_f1 TO babel_5135_u1;
 GO
 
 GRANT EXECUTE ON babel_5135_schema1.babel_5135_tvf1 TO babel_5135_u1;
+GO
+
+GRANT UPDATE ON babel_5135_schema1.babel_5135_seq1 TO babel_5135_u1;
 GO
 
 -- tsql user=babel_5135_dbsecadmin_l1 password=12345678


### PR DESCRIPTION
### Description

Allow UPDATE on sequence and allow add/dropping current user(which is member of db_securityadmin) from user-defined database roles. Added some more tests.

### Issues Resolved
BABEL-5135

### Test Scenarios Covered ###
* **Use case based -**
Added

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).