### PR TITLE
Improve performance of sys.sp_column_privileges by removing an unutilized check

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1370,6 +1370,7 @@ FROM sys.sp_column_privileges_internal()
 WHERE GRANTEE NOT IN ('db_datareader', 'db_datawriter');
 GRANT SELECT ON sys.sp_column_privileges_view TO PUBLIC;
 
+-- TODO: BABEL-5523
 CREATE OR REPLACE PROCEDURE sys.sp_column_privileges(
     "@table_name" sys.sysname,
     "@table_owner" sys.sysname = '',

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1354,7 +1354,7 @@ BEGIN
         JOIN information_schema.column_privileges t5 ON t1.relname = t5.table_name AND t2.nspname = t5.table_schema
         JOIN pg_attribute t6 ON t6.attrelid = t1.oid AND t6.attname = t5.column_name;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;
 
 CREATE OR REPLACE VIEW sys.sp_column_privileges_view AS
 SELECT
@@ -1450,7 +1450,7 @@ BEGIN
         JOIN information_schema.table_privileges t4 ON t1.relname = t4.table_name
     WHERE t4.privilege_type = 'DELETE';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;
 
 CREATE OR REPLACE VIEW sys.sp_table_privileges_view AS
 -- Will use sp_column_priivleges_view to get information from SELECT, INSERT and REFERENCES (only need permission from 1 column in table)

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -1385,46 +1385,21 @@ BEGIN
  	
 	IF (COALESCE(@table_owner, '') = '')
 	BEGIN
-		
-		IF EXISTS ( 
-			SELECT * FROM sys.sp_column_privileges_view 
-			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name) and pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_qualifier)
-			)
-		BEGIN 
-			SELECT 
-			TABLE_QUALIFIER,
-			TABLE_OWNER,
-			TABLE_NAME,
-			COLUMN_NAME,
-			GRANTOR,
-			GRANTEE,
-			PRIVILEGE,
-			IS_GRANTABLE
-			FROM sys.sp_column_privileges_view
-			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
-				AND (pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_owner))
-				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
-				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
-			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
-		END
-		ELSE
-		BEGIN
-			SELECT 
-			TABLE_QUALIFIER,
-			TABLE_OWNER,
-			TABLE_NAME,
-			COLUMN_NAME,
-			GRANTOR,
-			GRANTEE,
-			PRIVILEGE,
-			IS_GRANTABLE
-			FROM sys.sp_column_privileges_view
-			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
-				AND (pg_catalog.lower('dbo')= pg_catalog.lower(table_owner))
-				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
-				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
-			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
-		END
+		SELECT
+		TABLE_QUALIFIER,
+		TABLE_OWNER,
+		TABLE_NAME,
+		COLUMN_NAME,
+		GRANTOR,
+		GRANTEE,
+		PRIVILEGE,
+		IS_GRANTABLE
+		FROM sys.sp_column_privileges_view
+		WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+			AND (pg_catalog.lower('dbo')= pg_catalog.lower(table_owner))
+			AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+			AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
+		ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
 	END
 	ELSE
 	BEGIN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -802,46 +802,21 @@ BEGIN
  	
 	IF (COALESCE(@table_owner, '') = '')
 	BEGIN
-		
-		IF EXISTS ( 
-			SELECT * FROM sys.sp_column_privileges_view 
-			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name) and pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_qualifier)
-			)
-		BEGIN 
-			SELECT 
-			TABLE_QUALIFIER,
-			TABLE_OWNER,
-			TABLE_NAME,
-			COLUMN_NAME,
-			GRANTOR,
-			GRANTEE,
-			PRIVILEGE,
-			IS_GRANTABLE
-			FROM sys.sp_column_privileges_view
-			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
-				AND (pg_catalog.lower(SCHEMA_NAME()) = pg_catalog.lower(table_owner))
-				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
-				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
-			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
-		END
-		ELSE
-		BEGIN
-			SELECT 
-			TABLE_QUALIFIER,
-			TABLE_OWNER,
-			TABLE_NAME,
-			COLUMN_NAME,
-			GRANTOR,
-			GRANTEE,
-			PRIVILEGE,
-			IS_GRANTABLE
-			FROM sys.sp_column_privileges_view
-			WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
-				AND (pg_catalog.lower('dbo')= pg_catalog.lower(table_owner))
-				AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
-				AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
-			ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
-		END
+        SELECT
+        TABLE_QUALIFIER,
+        TABLE_OWNER,
+        TABLE_NAME,
+        COLUMN_NAME,
+        GRANTOR,
+        GRANTEE,
+        PRIVILEGE,
+        IS_GRANTABLE
+        FROM sys.sp_column_privileges_view
+        WHERE pg_catalog.lower(@table_name) = pg_catalog.lower(table_name)
+            AND (pg_catalog.lower('dbo')= pg_catalog.lower(table_owner))
+            AND ((SELECT COALESCE(@table_qualifier,'')) = '' OR pg_catalog.lower(table_qualifier) = pg_catalog.lower(@table_qualifier))
+            AND ((SELECT COALESCE(@column_name,'')) = '' OR pg_catalog.lower(column_name) LIKE pg_catalog.lower(@column_name))
+        ORDER BY table_qualifier, table_owner, table_name, column_name, privilege, grantee;
 	END
 	ELSE
 	BEGIN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -772,7 +772,7 @@ BEGIN
         JOIN information_schema.column_privileges t5 ON t1.relname = t5.table_name AND t2.nspname = t5.table_schema
         JOIN pg_attribute t6 ON t6.attrelid = t1.oid AND t6.attname = t5.column_name;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;
 
 CREATE OR REPLACE VIEW sys.sp_column_privileges_view AS
 SELECT
@@ -867,7 +867,7 @@ BEGIN
         JOIN information_schema.table_privileges t4 ON t1.relname = t4.table_name
     WHERE t4.privilege_type = 'DELETE';
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE PARALLEL SAFE;
 
 CREATE OR REPLACE VIEW sys.sp_table_privileges_view AS
 -- Will use sp_column_priivleges_view to get information from SELECT, INSERT and REFERENCES (only need permission from 1 column in table)


### PR DESCRIPTION
### Description

Improve performance of sys.sp_column_privileges by removing an unutilized check. 

### Issues Resolved

Task: BABEL-5353
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###

Performance Testing
20 login, 50 databases, each with 10 tables in dbo and 10 schema with 10 tables each making it 5.5k tables 
Each database has 20 users in each database making it 500+ users
Each database has 10 new roles.

```
1> select count(*) from sp_column_privileges_view
2> go

 4748 rows (1469 ms)


1> select * from sp_table_privileges_view
2> go

585 rows (1630 ms)
```


| query | Execution time before [with func](ms) | Execution time after [with func, current change](ms)| Execution time before [with join](ms)|Execution time before [without join, it returns incorrect value]|
|-------| -------| ------| ------| ------|
|EXEC sp_column_privileges @table_name = 'db1_table3' | 2903 | 1453| 1927| 1338|
|EXEC sp_column_privileges @table_name = 'db1_table3', @table_qualifier = 'db1', @COLUMN_NAME='column1' |  2900 | 1442| 1812| 1290|
|CREATE PROCEDURE usp_GetColumnPrivileges @TableName NVARCHAR(128) AS begin EXEC sys.sp_column_privileges @table_name = @TableName; end ; usp_GetColumnPrivileges @TableName = 'db1_table3'; | 2893 | 1454| 1860| 1339|
|EXEC sp_table_privileges @table_name = 'db1_table3' | 1590 | 1590| 1473 | 1435|


* **Use case based -**
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests -**



