### PR TITLE
Update principal_id column in database_principals for fixed db roles

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -450,8 +450,6 @@ SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
 CAST(
   CASE Ext.orig_username
-    WHEN 'dbo' THEN 1
-    WHEN 'guest' THEN 2
     WHEN 'db_owner' THEN 16384
     WHEN 'db_accessadmin' THEN 16385
     WHEN 'db_securityadmin' THEN 16386
@@ -623,8 +621,26 @@ GRANT SELECT ON sys.sysusers TO PUBLIC;
 -- DATABASE_ROLE_MEMBERS
 CREATE OR REPLACE VIEW sys.database_role_members AS
 SELECT
-CAST(Auth1.oid AS INT) AS role_principal_id,
-CAST(Auth2.oid AS INT) AS member_principal_id
+CAST(
+  CASE Ext1.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16390
+    ELSE Auth1.oid
+  END AS INT) AS role_principal_id,
+CAST(
+  CASE Ext2.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16390
+    ELSE Auth2.oid
+  END AS INT) AS member_principal_id
 FROM pg_catalog.pg_auth_members AS Authmbr
 INNER JOIN pg_catalog.pg_roles AS Auth1 ON Auth1.oid = Authmbr.roleid
 INNER JOIN pg_catalog.pg_roles AS Auth2 ON Auth2.oid = Authmbr.member

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -448,6 +448,9 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
+-- PG reserves these oid > 16383 AND oid < 16400 for rds roles like rds_iam etc.
+-- We need to make sure that any user defined role doesn't get assigned oid > 16383 AND oid < 16400.
+-- Any change here in the oid should be reflected in sys.database_role_members view as well.
 CAST(
   CASE Ext.orig_username
     WHEN 'db_owner' THEN 16384

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -448,7 +448,18 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
-CAST(Base.oid AS INT) AS principal_id,
+CAST(
+  CASE Ext.orig_username
+    WHEN 'dbo' THEN 1
+    WHEN 'guest' THEN 2
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16390
+    ELSE Base.oid
+  END AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
 CAST(
   CASE
@@ -479,7 +490,12 @@ WHERE Ext.database_name = DB_NAME()
 UNION ALL
 SELECT
 CAST(name AS SYS.SYSNAME) AS name,
-CAST(-1 AS INT) AS principal_id,
+CAST(
+  CASE name
+    WHEN 'public' THEN 0
+    WHEN 'INFORMATION_SCHEMA' THEN 3
+    WHEN 'sys' THEN 4
+  END AS INT) AS principal_id,
 CAST(type AS CHAR(1)) as type,
 CAST(
   CASE

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -448,8 +448,7 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
--- PG reserves these oid > 16383 AND oid < 16400 for rds roles like rds_iam etc.
--- We need to make sure that any user defined role does not get assigned oid > 16383 AND oid < 16400.
+-- PG reserves these oid > 16383 AND oid < 16400 for PG specific internal roles.
 -- Any change here in the oid should be reflected in sys.database_role_members view as well.
 CAST(
   CASE Ext.orig_username
@@ -458,7 +457,7 @@ CAST(
     WHEN 'db_securityadmin' THEN 16386
     WHEN 'db_ddladmin' THEN 16387
     WHEN 'db_datareader' THEN 16390
-    WHEN 'db_datawriter' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
     ELSE Base.oid
   END AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
@@ -631,7 +630,7 @@ CAST(
     WHEN 'db_securityadmin' THEN 16386
     WHEN 'db_ddladmin' THEN 16387
     WHEN 'db_datareader' THEN 16390
-    WHEN 'db_datawriter' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
     ELSE Auth1.oid
   END AS INT) AS role_principal_id,
 CAST(
@@ -641,7 +640,7 @@ CAST(
     WHEN 'db_securityadmin' THEN 16386
     WHEN 'db_ddladmin' THEN 16387
     WHEN 'db_datareader' THEN 16390
-    WHEN 'db_datawriter' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
     ELSE Auth2.oid
   END AS INT) AS member_principal_id
 FROM pg_catalog.pg_auth_members AS Authmbr

--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -449,7 +449,7 @@ CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
 -- PG reserves these oid > 16383 AND oid < 16400 for rds roles like rds_iam etc.
--- We need to make sure that any user defined role doesn't get assigned oid > 16383 AND oid < 16400.
+-- We need to make sure that any user defined role does not get assigned oid > 16383 AND oid < 16400.
 -- Any change here in the oid should be reflected in sys.database_role_members view as well.
 CAST(
   CASE Ext.orig_username

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -213,6 +213,8 @@ CREATE OR REPLACE FUNCTION sys.bbf_is_role_member(member NAME, rolename NAME)
 RETURNS BOOLEAN
 AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 
+ALTER VIEW sys.database_principals RENAME TO database_principals_deprecated_4_5_0;
+
 -- DATABASE_PRINCIPALS
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
@@ -289,6 +291,9 @@ CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
 FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
 
 GRANT SELECT ON sys.database_principals TO PUBLIC;
+CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'database_principals_deprecated_4_5_0');
+
+ALTER VIEW sys.database_role_members RENAME TO database_role_members_deprecated_4_5_0;
 
 -- DATABASE_ROLE_MEMBERS
 CREATE OR REPLACE VIEW sys.database_role_members AS
@@ -324,6 +329,7 @@ AND Ext1.type = 'R'
 AND Ext2.orig_username != 'db_owner';
 
 GRANT SELECT ON sys.database_role_members TO PUBLIC;
+CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'database_role_members_deprecated_4_5_0');
 
 CREATE OR REPLACE PROCEDURE sys.sp_helpuser("@name_in_db" sys.SYSNAME = NULL) AS
 $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -289,6 +289,41 @@ FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dumm
 
 GRANT SELECT ON sys.database_principals TO PUBLIC;
 
+-- DATABASE_ROLE_MEMBERS
+CREATE OR REPLACE VIEW sys.database_role_members AS
+SELECT
+CAST(
+  CASE Ext1.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16390
+    ELSE Auth1.oid
+  END AS INT) AS role_principal_id,
+CAST(
+  CASE Ext2.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16390
+    ELSE Auth2.oid
+  END AS INT) AS member_principal_id
+FROM pg_catalog.pg_auth_members AS Authmbr
+INNER JOIN pg_catalog.pg_roles AS Auth1 ON Auth1.oid = Authmbr.roleid
+INNER JOIN pg_catalog.pg_roles AS Auth2 ON Auth2.oid = Authmbr.member
+INNER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Auth1.rolname = Ext1.rolname
+INNER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Auth2.rolname = Ext2.rolname
+WHERE Ext1.database_name = DB_NAME() 
+AND Ext2.database_name = DB_NAME()
+AND Ext1.type = 'R'
+AND Ext2.orig_username != 'db_owner';
+
+GRANT SELECT ON sys.database_role_members TO PUBLIC;
+
 CREATE OR REPLACE PROCEDURE sys.sp_helpuser("@name_in_db" sys.SYSNAME = NULL) AS
 $$
 BEGIN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -217,8 +217,7 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
--- PG reserves these oid > 16383 AND oid < 16400 for rds roles like rds_iam etc.
--- We need to make sure that any user defined role does not get assigned oid > 16383 AND oid < 16400.
+-- PG reserves these oid > 16383 AND oid < 16400 for PG specific internal roles.
 -- Any change here in the oid should be reflected in sys.database_role_members view as well.
 CAST(
   CASE Ext.orig_username
@@ -227,7 +226,7 @@ CAST(
     WHEN 'db_securityadmin' THEN 16386
     WHEN 'db_ddladmin' THEN 16387
     WHEN 'db_datareader' THEN 16390
-    WHEN 'db_datawriter' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
     ELSE Base.oid
   END AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
@@ -300,7 +299,7 @@ CAST(
     WHEN 'db_securityadmin' THEN 16386
     WHEN 'db_ddladmin' THEN 16387
     WHEN 'db_datareader' THEN 16390
-    WHEN 'db_datawriter' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
     ELSE Auth1.oid
   END AS INT) AS role_principal_id,
 CAST(
@@ -310,7 +309,7 @@ CAST(
     WHEN 'db_securityadmin' THEN 16386
     WHEN 'db_ddladmin' THEN 16387
     WHEN 'db_datareader' THEN 16390
-    WHEN 'db_datawriter' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
     ELSE Auth2.oid
   END AS INT) AS member_principal_id
 FROM pg_catalog.pg_auth_members AS Authmbr

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -213,14 +213,12 @@ CREATE OR REPLACE FUNCTION sys.bbf_is_role_member(member NAME, rolename NAME)
 RETURNS BOOLEAN
 AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 
-ALTER VIEW sys.database_principals RENAME TO database_principals_deprecated_4_5_0;
-
 -- DATABASE_PRINCIPALS
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
 -- PG reserves these oid > 16383 AND oid < 16400 for rds roles like rds_iam etc.
--- We need to make sure that any user defined role doesn't get assigned oid > 16383 AND oid < 16400.
+-- We need to make sure that any user defined role does not get assigned oid > 16383 AND oid < 16400.
 -- Any change here in the oid should be reflected in sys.database_role_members view as well.
 CAST(
   CASE Ext.orig_username
@@ -291,9 +289,6 @@ CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
 FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
 
 GRANT SELECT ON sys.database_principals TO PUBLIC;
-CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'database_principals_deprecated_4_5_0');
-
-ALTER VIEW sys.database_role_members RENAME TO database_role_members_deprecated_4_5_0;
 
 -- DATABASE_ROLE_MEMBERS
 CREATE OR REPLACE VIEW sys.database_role_members AS
@@ -329,7 +324,6 @@ AND Ext1.type = 'R'
 AND Ext2.orig_username != 'db_owner';
 
 GRANT SELECT ON sys.database_role_members TO PUBLIC;
-CALL sys.babelfish_drop_deprecated_object('view', 'sys', 'database_role_members_deprecated_4_5_0');
 
 CREATE OR REPLACE PROCEDURE sys.sp_helpuser("@name_in_db" sys.SYSNAME = NULL) AS
 $$

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -217,7 +217,18 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
-CAST(Base.oid AS INT) AS principal_id,
+CAST(
+  CASE Ext.orig_username
+    WHEN 'dbo' THEN 1
+    WHEN 'guest' THEN 2
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16390
+    ELSE Base.oid
+  END AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
 CAST(
   CASE
@@ -248,7 +259,12 @@ WHERE Ext.database_name = DB_NAME()
 UNION ALL
 SELECT
 CAST(name AS SYS.SYSNAME) AS name,
-CAST(-1 AS INT) AS principal_id,
+CAST(
+  CASE name
+    WHEN 'public' THEN 0
+    WHEN 'INFORMATION_SCHEMA' THEN 3
+    WHEN 'sys' THEN 4
+  END AS INT) AS principal_id,
 CAST(type AS CHAR(1)) as type,
 CAST(
   CASE

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--4.5.0.sql
@@ -217,10 +217,11 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
+-- PG reserves these oid > 16383 AND oid < 16400 for rds roles like rds_iam etc.
+-- We need to make sure that any user defined role doesn't get assigned oid > 16383 AND oid < 16400.
+-- Any change here in the oid should be reflected in sys.database_role_members view as well.
 CAST(
   CASE Ext.orig_username
-    WHEN 'dbo' THEN 1
-    WHEN 'guest' THEN 2
     WHEN 'db_owner' THEN 16384
     WHEN 'db_accessadmin' THEN 16385
     WHEN 'db_securityadmin' THEN 16386

--- a/test/JDBC/expected/db_securityadmin-vu-prepare.out
+++ b/test/JDBC/expected/db_securityadmin-vu-prepare.out
@@ -38,17 +38,6 @@ GO
 CREATE FUNCTION babel_5135_schema1.babel_5135_tvf1() RETURNS TABLE AS RETURN (SELECT a, b FROM babel_5135_schema1.babel_5135_t1);
 GO
 
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
-GO
-
 CREATE PROCEDURE babel_5135_roleop_proc1 AS BEGIN CREATE ROLE babel_5135_role2; ALTER ROLE babel_5135_role2 WITH NAME = babel_5135_role3; DROP ROLE babel_5135_role3; END
 GO
 CREATE PROCEDURE babel_5135_roleop_proc2 AS BEGIN ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_u1; END
@@ -94,15 +83,4 @@ USE babel_5135_db1;
 GO
 
 create user babel_5135_u1 for login babel_5135_l1;
-GO
-
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
 GO

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -20,6 +20,31 @@ GO
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_r1;
 GO
 
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
+GO
+~~START~~
+varchar
+db_accessadmin
+db_datareader
+db_datawriter
+db_ddladmin
+db_owner
+db_securityadmin
+~~END~~
+
+
 EXEC sp_addrolemember 'db_securityadmin', 'babel_5135_u1';
 GO
 
@@ -57,6 +82,31 @@ varchar#!#varchar
 -- CASE 1.3 Test inside database with truncated name
 USE babel_5135_db1;
 GO
+
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
+GO
+~~START~~
+varchar
+db_accessadmin
+db_datareader
+db_datawriter
+db_ddladmin
+db_owner
+db_securityadmin
+~~END~~
+
 
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_u1;
 GO

--- a/test/JDBC/input/ownership/db_securityadmin-vu-prepare.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-prepare.mix
@@ -38,17 +38,6 @@ GO
 CREATE FUNCTION babel_5135_schema1.babel_5135_tvf1() RETURNS TABLE AS RETURN (SELECT a, b FROM babel_5135_schema1.babel_5135_t1);
 GO
 
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
-GO
-
 CREATE PROCEDURE babel_5135_roleop_proc1 AS BEGIN CREATE ROLE babel_5135_role2; ALTER ROLE babel_5135_role2 WITH NAME = babel_5135_role3; DROP ROLE babel_5135_role3; END
 GO
 CREATE PROCEDURE babel_5135_roleop_proc2 AS BEGIN ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_u1; END
@@ -94,15 +83,4 @@ USE babel_5135_db1;
 GO
 
 create user babel_5135_u1 for login babel_5135_l1;
-GO
-
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
 GO

--- a/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
@@ -20,6 +20,21 @@ GO
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_r1;
 GO
 
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
+GO
+
 EXEC sp_addrolemember 'db_securityadmin', 'babel_5135_u1';
 GO
 
@@ -46,6 +61,21 @@ GO
 
 -- CASE 1.3 Test inside database with truncated name
 USE babel_5135_db1;
+GO
+
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
 GO
 
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_u1;

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -976,6 +976,7 @@ View sys.change_tracking_tables
 View sys.database_files
 View sys.database_filestream_options
 View sys.database_recovery_status
+View sys.database_role_members
 View sys.dm_hadr_cluster
 View sys.dm_hadr_database_replica_states
 View sys.dm_os_host_info


### PR DESCRIPTION
### Description

Babelfish should script only user created database roles, not the fixed roles like db_datareader, db_securityadmin etc. 
T-SQL reserves the oid from 16383 to 16400 for fixed database roles. Updated the principal_id in the views database_principals and database_role_members

### Issues Resolved

Task: BABEL-5528
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###

SSMS uses this query to script all the database roles while scripting a single database at once. 
```
exec sp_executesql N'SELECT
''Server[@Name='' + quotename(CAST(
        serverproperty(N''Servername'')
       AS sysname),'''''''') + '']'' + ''/Database[@Name='' + quotename(db_name(),'''''''') + '']'' + ''/Role[@Name='' + quotename(rl.name,'''''''') + '']'' AS [Urn],
rl.name AS [Name]
FROM
sys.database_principals AS rl
WHERE
(rl.type = ''R'')and(CAST(CASE WHEN rl.principal_id > 16383 AND rl.principal_id < 16400 THEN 1 ELSE 0 END AS bit)=0 and rl.name<>@_msparam_0)
ORDER BY
[Name] ASC',N'@_msparam_0 nvarchar(4000)',@_msparam_0=N'public' 
```

Before the change:
```
BBF:
----------
Name
--- ----
db_accessadmin
db_datareader
db_datawriter
db_ddladmin
db_owner
db_securityadmin
(6 rows affected)

```

After:
```
(0 rows affected)
```

* **Use case based -** Added


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



