### PR TITLE
Some fixes for db_owner role (#3355)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -2229,6 +2229,7 @@ BEGIN
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
 		AND Ext1.type != 'R'
+		AND ((Ext2.orig_username IS NULL AND Base2.oid IS NULL) OR Ext2.type = 'R') -- We should only show public if user has no members i.e. Base2.oid is NULL
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		ORDER BY UserName, RoleName;
 	END
@@ -2299,6 +2300,7 @@ BEGIN
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
 		AND Ext1.type != 'R'
+		AND ((Ext2.orig_username IS NULL AND Base2.oid IS NULL) OR Ext2.type = 'R') -- We should only show public if user has no members i.e. Base2.oid is NULL
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		AND (Ext1.orig_username = @name_in_db OR pg_catalog.lower(Ext1.orig_username) = pg_catalog.lower(@name_in_db))
 		ORDER BY UserName, RoleName;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -276,7 +276,7 @@ GRANT SELECT ON information_schema_tsql.key_column_usage TO PUBLIC;
 UPDATE sys.babelfish_authid_login_ext SET is_fixed_role = 1 WHERE rolname = 'sysadmin';
 
 -- At this point, there will be only one database fixed role which is db_owner.
-UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 1 WHERE orig_username = 'db_owner';
+UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 1, type = 'R' WHERE orig_username = 'db_owner';
 UPDATE sys.babelfish_authid_user_ext SET is_fixed_role = 0 WHERE orig_username != 'db_owner';
 
 CREATE OR REPLACE PROCEDURE sys.create_db_roles_during_upgrade()
@@ -661,6 +661,7 @@ BEGIN
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
 		AND Ext1.type != 'R'
+		AND ((Ext2.orig_username IS NULL AND Base2.oid IS NULL) OR Ext2.type = 'R') -- We should only show public if user has no members i.e. Base2.oid is NULL
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		ORDER BY UserName, RoleName;
 	END
@@ -731,6 +732,7 @@ BEGIN
 		LEFT OUTER JOIN pg_catalog.pg_roles AS Base4 ON Base4.rolname = Bsdb.owner
 		WHERE Ext1.database_name = DB_NAME()
 		AND Ext1.type != 'R'
+		AND ((Ext2.orig_username IS NULL AND Base2.oid IS NULL) OR Ext2.type = 'R') -- We should only show public if user has no members i.e. Base2.oid is NULL
 		AND Ext1.orig_username NOT IN ('db_owner', 'db_securityadmin', 'db_accessadmin', 'db_datareader', 'db_datawriter', 'db_ddladmin')
 		AND (Ext1.orig_username = @name_in_db OR pg_catalog.lower(Ext1.orig_username) = pg_catalog.lower(@name_in_db))
 		ORDER BY UserName, RoleName;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2737,8 +2737,35 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					bool		isrole = false;
 					bool		from_windows = false;
 					Oid 		save_userid;
+					Oid 		role_oid = InvalidOid;
 					int 		save_sec_context;
 					const char	*old_createrole_self_grant;
+
+					/* Throw error if there is a possibility of name clash with an internal role */
+					role_oid = get_role_oid(stmt->role, true);
+
+					if (OidIsValid(role_oid) &&
+						(is_admin_of_role(get_bbf_role_admin_oid(), role_oid)))
+					{
+						HeapTuple tuple_cache = SearchSysCache1(AUTHIDUSEREXTROLENAME, CStringGetDatum(stmt->role));
+
+						/*
+						 * If role:
+						 *  - Is a valid PG role
+						 *  - Does not exist in Babelfish catalogs
+						 *  - bbf_role_admin is admin of this role
+						 *
+						 * We can safely assume it is a role created internally by us
+						 */
+						if (!HeapTupleIsValid(tuple_cache) && !is_login_name(stmt->role))
+							ereport(ERROR,
+								(errcode(ERRCODE_DUPLICATE_OBJECT),
+								 errmsg("Cannot create database principal \"%s\" as there already exists "
+										"a Babelfish internal role with the same name", stmt->role)));
+
+						if (HeapTupleIsValid(tuple_cache))
+							ReleaseSysCache(tuple_cache);
+					}
 
 					/* Check if creating login or role. Expect islogin first */
 					if (stmt->options != NIL)
@@ -3801,6 +3828,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					else if (rolspec && strcmp(queryString, CREATE_FIXED_DB_ROLES) != 0)
 					{
 						const char *db_name = get_current_pltsql_db_name();
+						Oid db_owner_oid = InvalidOid;
 
 						owner_oid = get_rolespec_oid(rolspec, true);
 						/*
@@ -3818,7 +3846,10 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							alter_owner = true;
 						}
 
-						if (has_privs_of_role(owner_oid, get_db_owner_oid(db_name, false)) && owner_oid != get_dbo_oid(db_name, false))
+						db_owner_oid = get_db_owner_oid(db_name, false);
+
+						if (has_privs_of_role(owner_oid, db_owner_oid) &&
+							owner_oid != get_dbo_oid(db_name, false) && owner_oid != db_owner_oid)
 						{
 							const char* new_owner = get_obj_role(get_rolespec_name(rolspec));
 							create_schema->authrole = make_rolespec_node(new_owner);

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -2826,7 +2826,7 @@ get_obj_role(const char *rolname)
 	initStringInfo(&rolname_obj);
 
 	appendStringInfoString(&rolname_obj, rolname);
-	appendStringInfoString(&rolname_obj, "_obj");
+	appendStringInfoString(&rolname_obj, "_bbfobj");
 
 	truncate_tsql_identifier(rolname_obj.data);
 
@@ -2840,7 +2840,7 @@ static List
 *gen_alter_dbowner_add_subcmds(const char *rolname, const char* dbname)
 {
 	StringInfoData	query;
-	List		*stmt_list;
+	List		*stmt_list = NIL;
 	Node		*stmt;
 	int		expected_stmts = 7;
 	int		i = 0;
@@ -2852,9 +2852,20 @@ static List
 	ScanKeyData	skey;
 	Relation	rel;
 
+	/* If role is already member of db_owner role, do nothing */
+	if (has_privs_of_role(get_role_oid(rolname, false), get_db_owner_oid(dbname, false)))
+		return stmt_list;
+
 	initStringInfo(&query);
 
 	truncate_tsql_identifier(rolname_obj);
+
+	/* Throw relevant error if there will be a name clash */
+	if (get_role_oid(rolname_obj, true) != InvalidOid)
+		ereport(ERROR,
+				(errcode(ERRCODE_DUPLICATE_OBJECT),
+				 errmsg("Internal role \"%s\" could not be created because a "
+						"role already exists with the same name", rolname_obj)));
 
 	appendStringInfoString(&query, "CREATE ROLE dummy; ");
 	appendStringInfoString(&query, "GRANT dummy TO dummy; ");
@@ -2940,7 +2951,7 @@ static List
 *gen_alter_dbowner_drop_subcmds(const char *rolname, const char* dbname)
 {
 	StringInfoData query;
-	List		*stmt_list;
+	List		*stmt_list = NIL;
 	Node		*stmt;
 	int			expected_stmts = 7;
 	int			i = 0;
@@ -2951,6 +2962,10 @@ static List
 	SysScanDesc sscan;
 	ScanKeyData skey;
 	Relation	rel;
+
+	/* If role is already not a member of db_owner role, do nothing */
+	if (!has_privs_of_role(get_role_oid(rolname, false), get_db_owner_oid(dbname, false)))
+		return stmt_list;
 
 	initStringInfo(&query);
 
@@ -3098,6 +3113,7 @@ void
 change_object_owner_if_db_owner()
 {
 	Oid		dbo_id = InvalidOid;
+	Oid		db_owner_id = InvalidOid;
 	StringInfoData	query;
 	char		*rolname = NULL;
 	char 		*obj_rolname = NULL;
@@ -3113,9 +3129,11 @@ change_object_owner_if_db_owner()
 
 	cur_db_name = get_cur_db_name();
 	dbo_id = get_dbo_oid(cur_db_name, true);
+	db_owner_id = get_db_owner_oid(cur_db_name, true);
 
-	/* Don't change object owner if current user is dbo */
-	if (role_oid == dbo_id || dbo_id == InvalidOid)
+	/* Don't change object owner if database principal is dbo or db_owner */
+	if (role_oid == dbo_id || dbo_id == InvalidOid ||
+		role_oid == db_owner_id || db_owner_id == InvalidOid)
 		return;
 
 	rolname = GetUserNameFromId(role_oid, true);
@@ -3126,7 +3144,7 @@ change_object_owner_if_db_owner()
 	if (!user_exists_for_db(cur_db_name, rolname))
 		return;
 
-	if (!is_member_of_role(role_oid, get_db_owner_oid(cur_db_name, false)))
+	if (!is_member_of_role(role_oid, db_owner_id))
 		return;
 
 	obj_rolname = get_obj_role(rolname);
@@ -3176,7 +3194,7 @@ PG_FUNCTION_INFO_V1(bbf_is_role_member);
 /*
  * The bbf_is_role_memeber function will check if a user (u1) is member of a role (r1):
  * - If role is not a member of db_owner, we will check if u1 is member of r1 role
- * - If role is a member of db_owner, we will check if u1 is member of r1_obj role
+ * - If role is a member of db_owner, we will check if u1 is member of r1_bbfobj role
  */
 Datum
 bbf_is_role_member(PG_FUNCTION_ARGS)
@@ -3212,7 +3230,7 @@ bbf_is_role_member(PG_FUNCTION_ARGS)
 /*
  * This helper function will first check if user is member of
  * db_owner role. If it is, then we will attempt drop the linked
- * "_obj" role. If it is not, this function will do nothing.
+ * "_bbfobj" role. If it is not, this function will do nothing.
  */
 static void
 drop_db_owner_related_roles(Oid roleid, const char* rolname)

--- a/test/JDBC/expected/db_owner-vu-verify.out
+++ b/test/JDBC/expected/db_owner-vu-verify.out
@@ -4,7 +4,7 @@ SELECT r.rolname AS parent_role
 FROM pg_auth_members m
 JOIN pg_roles r ON (m.roleid = r.oid)
 JOIN pg_roles mr ON (m.member = mr.oid)
-WHERE mr.rolname = 'dbowner__main_db_dbowner__u1_obj'
+WHERE mr.rolname = 'dbowner__main_db_dbowner__u1_bbfobj'
 ORDER BY r.rolname;
 go
 ~~START~~
@@ -23,7 +23,7 @@ go
 name
 dbowner__main_db_db_owner
 dbowner__main_db_dbo
-dbowner__main_db_dbowner__u1_obj
+dbowner__main_db_dbowner__u1_bbfobj
 ~~END~~
 
 
@@ -43,7 +43,7 @@ dbowner__main_db_db_ddladmin
 dbowner__main_db_db_securityadmin
 dbowner__main_db_dbowner__r1
 dbowner__main_db_dbowner__r2
-dbowner__main_db_dbowner__u1_obj
+dbowner__main_db_dbowner__u1_bbfobj
 dbowner__main_db_dbowner__u2
 dbowner__main_db_guest
 ~~END~~
@@ -68,6 +68,28 @@ go
 alter login dbowner__l2 with password = '123'
 go
 alter login dbowner__temp with password = '123'
+go
+
+-- Testing for name clash
+create login dbowner__main_db_dbowner__u1_bbfobj with password = '123'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create database principal "dbowner__main_db_dbowner__u1_bbfobj" as there already exists a Babelfish internal role with the same name)~~
+
+use dbowner__main_db
+go
+create login dbowner__nameclash with password = '123'
+go
+create user dbowner__u1_bbfobj for login dbowner__nameclash
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot create database principal "dbowner__main_db_dbowner__u1_bbfobj" as there already exists a Babelfish internal role with the same name)~~
+
+drop login dbowner__nameclash
+go
+use master
 go
 
 -- Adding/Dropping non-existent user to db_owner should throw error
@@ -280,6 +302,8 @@ create schema dbowner__s3 authorization dbowner__u1
 go
 create schema dbowner__sch_u2 authorization dbowner__u2
 go
+create schema dbowner__sch_db_owner authorization db_owner
+go
 create type dbowner__s3.dbowner__typ3 from int
 go
 create table dbowner__s3.dbowner__t3 (a dbowner__s3.dbowner__typ3)
@@ -421,7 +445,7 @@ exec sp_rename 'dbowner__s3.dbowner__seq3', 'dbowner__seq3_renamed', 'object'
 go
 
 -- psql
--- Procedure/function owners should be dbowner__main_db_dbowner__u1_obj
+-- Procedure/function owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT proname,
        proowner::regrole
 FROM pg_proc
@@ -431,15 +455,15 @@ ORDER BY proname;
 GO
 ~~START~~
 name#!#regrole
-dbowner__f1_renamed#!#dbowner__main_db_dbowner__u1_obj
-dbowner__f3_renamed#!#dbowner__main_db_dbowner__u1_obj
-dbowner__p1_renamed#!#dbowner__main_db_dbowner__u1_obj
-dbowner__p3_renamed#!#dbowner__main_db_dbowner__u1_obj
-dbowner__trg1_renamed#!#dbowner__main_db_dbowner__u1_obj
+dbowner__f1_renamed#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__f3_renamed#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__p1_renamed#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__p3_renamed#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__trg1_renamed#!#dbowner__main_db_dbowner__u1_bbfobj
 ~~END~~
 
 
--- Table owners should be dbowner__main_db_dbowner__u1_obj
+-- Table owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT
     n.nspname AS schema,
     c.relname AS table,
@@ -461,14 +485,14 @@ ORDER BY n.nspname, c.relkind, c.relname;
 GO
 ~~START~~
 name#!#name#!#text#!#name
-dbowner__main_db_dbowner__s1#!#dbowner__seq1_renamed#!#sequence#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__idx1dbowner__t1051d92a6c0688536803636483cfc1e78#!#index#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__t11#!#table#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__t1_renamed#!#table#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__v1_renamed#!#view#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s3#!#dbowner__seq3_renamed#!#sequence#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s3#!#dbowner__t3_renamed#!#table#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s3#!#dbowner__v3_renamed#!#view#!#dbowner__main_db_dbowner__u1_obj
+dbowner__main_db_dbowner__s1#!#dbowner__seq1_renamed#!#sequence#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__idx1dbowner__t1051d92a6c0688536803636483cfc1e78#!#index#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__t11#!#table#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__t1_renamed#!#table#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__v1_renamed#!#view#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s3#!#dbowner__seq3_renamed#!#sequence#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s3#!#dbowner__t3_renamed#!#table#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s3#!#dbowner__v3_renamed#!#view#!#dbowner__main_db_dbowner__u1_bbfobj
 ~~END~~
 
 
@@ -650,11 +674,32 @@ use dbowner__main_db
 go
 alter role db_owner drop member dbowner__u1
 go
+alter role db_owner drop member dbowner__u1 -- adding again should not throw error
+go
 grant select on schema::dbowner__s0 to dbowner__u2
 go
 alter role db_owner add member dbowner__u1
 go
+alter role db_owner add member dbowner__u1 -- dropping again should not throw error
+go
 grant execute on schema::dbowner__s0 to dbowner__u2
+go
+
+-- Check sp_helpuser
+CREATE TABLE #db_owner_roles(userName sys.SYSNAME, roleName sys.SYSNAME, loginName sys.SYSNAME NULL, defdb sys.SYSNAME NULL, defschema sys.SYSNAME, userid INT, sid sys.VARBINARY(85));
+go
+INSERT INTO #db_owner_roles EXEC sp_helpuser 'dbowner__u1';
+go
+~~ROW COUNT: 1~~
+
+SELECT userName, roleName FROM #db_owner_roles;
+go
+~~START~~
+varchar#!#varchar
+dbowner__u1#!#db_owner
+~~END~~
+
+DROP TABLE #db_owner_roles;
 go
 
 -- tsql user=dbowner__l2 password=123
@@ -787,7 +832,24 @@ use dbowner__main_db
 go
 exec sp_droprolemember 'db_owner', 'dbowner__u1'
 go
+exec sp_droprolemember 'db_owner', 'dbowner__u1' -- dropping again should not throw error
+go
+
+-- Check name clash scenario
+create role dbowner__u1_bbfobj
+go
 exec sp_addrolemember 'db_owner', 'dbowner__u1'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Internal role "dbowner__main_db_dbowner__u1_bbfobj" could not be created because a role already exists with the same name)~~
+
+drop role dbowner__u1_bbfobj
+go
+
+exec sp_addrolemember 'db_owner', 'dbowner__u1' -- adding again should not throw error
+go
+exec sp_addrolemember 'db_owner', 'dbowner__u1' -- adding again should not throw error
 go
 alter user dbowner__u1 with login = dbowner__l1
 go
@@ -1003,7 +1065,7 @@ sys
 
 
 -- psql
--- Procedure/function owners should be dbowner__main_db_dbowner__u1_obj
+-- Procedure/function owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT proname,
        proowner::regrole
 FROM pg_proc
@@ -1013,15 +1075,15 @@ ORDER BY proname;
 GO
 ~~START~~
 name#!#regrole
-dbowner__f1#!#dbowner__main_db_dbowner__u1_obj
-dbowner__f3#!#dbowner__main_db_dbowner__u1_obj
-dbowner__p1#!#dbowner__main_db_dbowner__u1_obj
-dbowner__p3#!#dbowner__main_db_dbowner__u1_obj
-dbowner__trg1#!#dbowner__main_db_dbowner__u1_obj
+dbowner__f1#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__f3#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__p1#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__p3#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__trg1#!#dbowner__main_db_dbowner__u1_bbfobj
 ~~END~~
 
 
--- Table owners should be dbowner__main_db_dbowner__u1_obj
+-- Table owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT
     n.nspname AS schema,
     c.relname AS table,
@@ -1043,18 +1105,18 @@ ORDER BY n.nspname, c.relkind, c.relname;
 GO
 ~~START~~
 name#!#name#!#text#!#name
-dbowner__main_db_dbowner__s1#!#dbowner__seq1#!#sequence#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__idx1dbowner__t1051d92a6c0688536803636483cfc1e78#!#index#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__t1#!#table#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__t11#!#table#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s1#!#dbowner__v1#!#view#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s3#!#dbowner__seq3#!#sequence#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s3#!#dbowner__t3#!#table#!#dbowner__main_db_dbowner__u1_obj
-dbowner__main_db_dbowner__s3#!#dbowner__v3#!#view#!#dbowner__main_db_dbowner__u1_obj
+dbowner__main_db_dbowner__s1#!#dbowner__seq1#!#sequence#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__idx1dbowner__t1051d92a6c0688536803636483cfc1e78#!#index#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__t1#!#table#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__t11#!#table#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s1#!#dbowner__v1#!#view#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s3#!#dbowner__seq3#!#sequence#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s3#!#dbowner__t3#!#table#!#dbowner__main_db_dbowner__u1_bbfobj
+dbowner__main_db_dbowner__s3#!#dbowner__v3#!#view#!#dbowner__main_db_dbowner__u1_bbfobj
 ~~END~~
 
 
--- Schemas owner should be dbowner__main_db_dbowner__u1_obj except for dbowner__main_db_dbowner__sch_u2
+-- Schemas owner should be dbowner__main_db_dbowner__u1_bbfobj except for dbowner__main_db_dbowner__sch_u2 and dbowner__main_db_dbowner__sch_db_owner
 SELECT
     r.rolname AS schema_owner,
     ns.nspname
@@ -1065,13 +1127,14 @@ JOIN
 ON
     ns.nspowner = r.oid
 WHERE
-    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u2')
+    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u2', 'dbowner__main_db_dbowner__sch_db_owner')
 ORDER BY ns.nspname;
 GO
 ~~START~~
 name#!#name
-dbowner__main_db_dbowner__u1_obj#!#dbowner__main_db_dbowner__s1
-dbowner__main_db_dbowner__u1_obj#!#dbowner__main_db_dbowner__s3
+dbowner__main_db_dbowner__u1_bbfobj#!#dbowner__main_db_dbowner__s1
+dbowner__main_db_dbowner__u1_bbfobj#!#dbowner__main_db_dbowner__s3
+dbowner__main_db_db_owner#!#dbowner__main_db_dbowner__sch_db_owner
 dbowner__main_db_dbowner__u2#!#dbowner__main_db_dbowner__sch_u2
 ~~END~~
 
@@ -1231,7 +1294,7 @@ int
 create schema dbowner__sch_u1 authorization dbowner__u1
 go
 
--- Schema owners should be dbowner__main_db_dbowner__u1_obj
+-- Schema owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT
     r.rolname AS schema_owner,
     ns.nspname
@@ -1247,7 +1310,7 @@ ORDER BY ns.nspname;
 GO
 ~~START~~
 varchar#!#varchar
-dbowner__main_db_dbowner__u1_obj#!#dbowner__main_db_dbowner__sch_u1
+dbowner__main_db_dbowner__u1_bbfobj#!#dbowner__main_db_dbowner__sch_u1
 ~~END~~
 
 
@@ -1279,7 +1342,7 @@ go
 
 -- psql
 -- Before anything, let's check if internal role linking/delinking got reverted as expected
-SELECT rolname FROM pg_roles WHERE rolname = 'dbowner__main_db_dbowner__u1_obj'; -- "_obj" role should not exist
+SELECT rolname FROM pg_roles WHERE rolname = 'dbowner__main_db_dbowner__u1_bbfobj'; -- "_bbfobj" role should not exist
 go
 ~~START~~
 name
@@ -1609,13 +1672,14 @@ JOIN
 ON
     ns.nspowner = r.oid
 WHERE
-    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u1', 'dbowner__main_db_dbowner__sch_u2')
+    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u1', 'dbowner__main_db_dbowner__sch_u2', 'dbowner__main_db_dbowner__sch_db_owner')
 ORDER BY ns.nspname;
 GO
 ~~START~~
 name#!#name
 dbowner__main_db_dbowner__u1#!#dbowner__main_db_dbowner__s1
 dbowner__main_db_dbowner__u1#!#dbowner__main_db_dbowner__s3
+dbowner__main_db_db_owner#!#dbowner__main_db_dbowner__sch_db_owner
 dbowner__main_db_dbowner__u1#!#dbowner__main_db_dbowner__sch_u1
 dbowner__main_db_dbowner__u2#!#dbowner__main_db_dbowner__sch_u2
 ~~END~~
@@ -1759,6 +1823,8 @@ drop schema dbowner__sch_u1
 go
 drop schema dbowner__sch_u2
 go
+drop schema dbowner__sch_db_owner
+go
 drop user dbowner__u2
 go
 
@@ -1873,7 +1939,7 @@ void
 
 
 -- psql
--- Check if dropping user, also drops the linked "_obj" role
+-- Check if dropping user, also drops the linked "_bbfobj" role
 select rolname from pg_authid where rolname like 'dbowner__test_db_%' order by rolname;
 go
 ~~START~~
@@ -1886,9 +1952,9 @@ dbowner__test_db_db_owner
 dbowner__test_db_db_securityadmin
 dbowner__test_db_dbo
 dbowner__test_db_dbowner__test_db_dbowner__u1
-dbowner__test_db_dbowner__test_db_dbowner__u1_obj
+dbowner__test_db_dbowner__test_db_dbowner__u1_bbfobj
 dbowner__test_db_dbowner__test_db_dbowner__u2
-dbowner__test_db_dbowner__test_db_dbowner__u2_obj
+dbowner__test_db_dbowner__test_db_dbowner__u2_bbfobj
 dbowner__test_db_guest
 ~~END~~
 

--- a/test/JDBC/input/db_owner-vu-verify.mix
+++ b/test/JDBC/input/db_owner-vu-verify.mix
@@ -4,7 +4,7 @@ SELECT r.rolname AS parent_role
 FROM pg_auth_members m
 JOIN pg_roles r ON (m.roleid = r.oid)
 JOIN pg_roles mr ON (m.member = mr.oid)
-WHERE mr.rolname = 'dbowner__main_db_dbowner__u1_obj'
+WHERE mr.rolname = 'dbowner__main_db_dbowner__u1_bbfobj'
 ORDER BY r.rolname;
 go
 
@@ -38,6 +38,20 @@ go
 alter login dbowner__l2 with password = '123'
 go
 alter login dbowner__temp with password = '123'
+go
+
+-- Testing for name clash
+create login dbowner__main_db_dbowner__u1_bbfobj with password = '123'
+go
+use dbowner__main_db
+go
+create login dbowner__nameclash with password = '123'
+go
+create user dbowner__u1_bbfobj for login dbowner__nameclash
+go
+drop login dbowner__nameclash
+go
+use master
 go
 
 -- Adding/Dropping non-existent user to db_owner should throw error
@@ -109,6 +123,8 @@ go
 create schema dbowner__s3 authorization dbowner__u1
 go
 create schema dbowner__sch_u2 authorization dbowner__u2
+go
+create schema dbowner__sch_db_owner authorization db_owner
 go
 create type dbowner__s3.dbowner__typ3 from int
 go
@@ -236,7 +252,7 @@ exec sp_rename 'dbowner__s3.dbowner__seq3', 'dbowner__seq3_renamed', 'object'
 go
 
 -- psql
--- Procedure/function owners should be dbowner__main_db_dbowner__u1_obj
+-- Procedure/function owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT proname,
        proowner::regrole
 FROM pg_proc
@@ -245,7 +261,7 @@ OR pronamespace::regnamespace::text = 'dbowner__main_db_dbowner__s3'
 ORDER BY proname;
 GO
 
--- Table owners should be dbowner__main_db_dbowner__u1_obj
+-- Table owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT
     n.nspname AS schema,
     c.relname AS table,
@@ -415,11 +431,25 @@ use dbowner__main_db
 go
 alter role db_owner drop member dbowner__u1
 go
+alter role db_owner drop member dbowner__u1 -- adding again should not throw error
+go
 grant select on schema::dbowner__s0 to dbowner__u2
 go
 alter role db_owner add member dbowner__u1
 go
+alter role db_owner add member dbowner__u1 -- dropping again should not throw error
+go
 grant execute on schema::dbowner__s0 to dbowner__u2
+go
+
+-- Check sp_helpuser
+CREATE TABLE #db_owner_roles(userName sys.SYSNAME, roleName sys.SYSNAME, loginName sys.SYSNAME NULL, defdb sys.SYSNAME NULL, defschema sys.SYSNAME, userid INT, sid sys.VARBINARY(85));
+go
+INSERT INTO #db_owner_roles EXEC sp_helpuser 'dbowner__u1';
+go
+SELECT userName, roleName FROM #db_owner_roles;
+go
+DROP TABLE #db_owner_roles;
 go
 
 -- GRANT on dbowner__u2 should allow it to still access objects in schema
@@ -484,7 +514,20 @@ use dbowner__main_db
 go
 exec sp_droprolemember 'db_owner', 'dbowner__u1'
 go
+exec sp_droprolemember 'db_owner', 'dbowner__u1' -- dropping again should not throw error
+go
+
+-- Check name clash scenario
+create role dbowner__u1_bbfobj
+go
 exec sp_addrolemember 'db_owner', 'dbowner__u1'
+go
+drop role dbowner__u1_bbfobj
+go
+
+exec sp_addrolemember 'db_owner', 'dbowner__u1' -- adding again should not throw error
+go
+exec sp_addrolemember 'db_owner', 'dbowner__u1' -- adding again should not throw error
 go
 alter user dbowner__u1 with login = dbowner__l1
 go
@@ -553,7 +596,7 @@ select name from sys.database_principals order by name
 go
 
 -- psql
--- Procedure/function owners should be dbowner__main_db_dbowner__u1_obj
+-- Procedure/function owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT proname,
        proowner::regrole
 FROM pg_proc
@@ -562,7 +605,7 @@ OR pronamespace::regnamespace::text = 'dbowner__main_db_dbowner__s3'
 ORDER BY proname;
 GO
 
--- Table owners should be dbowner__main_db_dbowner__u1_obj
+-- Table owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT
     n.nspname AS schema,
     c.relname AS table,
@@ -583,7 +626,7 @@ AND c.relkind IN ('r', 'v', 'm', 'i', 'S', 's', 'f')
 ORDER BY n.nspname, c.relkind, c.relname;
 GO
 
--- Schemas owner should be dbowner__main_db_dbowner__u1_obj except for dbowner__main_db_dbowner__sch_u2
+-- Schemas owner should be dbowner__main_db_dbowner__u1_bbfobj except for dbowner__main_db_dbowner__sch_u2 and dbowner__main_db_dbowner__sch_db_owner
 SELECT
     r.rolname AS schema_owner,
     ns.nspname
@@ -594,7 +637,7 @@ JOIN
 ON
     ns.nspowner = r.oid
 WHERE
-    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u2')
+    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u2', 'dbowner__main_db_dbowner__sch_db_owner')
 ORDER BY ns.nspname;
 GO
 
@@ -644,7 +687,7 @@ go
 create schema dbowner__sch_u1 authorization dbowner__u1
 go
 
--- Schema owners should be dbowner__main_db_dbowner__u1_obj
+-- Schema owners should be dbowner__main_db_dbowner__u1_bbfobj
 SELECT
     r.rolname AS schema_owner,
     ns.nspname
@@ -668,7 +711,7 @@ go
 
 -- psql
 -- Before anything, let's check if internal role linking/delinking got reverted as expected
-SELECT rolname FROM pg_roles WHERE rolname = 'dbowner__main_db_dbowner__u1_obj'; -- "_obj" role should not exist
+SELECT rolname FROM pg_roles WHERE rolname = 'dbowner__main_db_dbowner__u1_bbfobj'; -- "_bbfobj" role should not exist
 go
 
 SELECT r.rolname AS parent_role
@@ -806,7 +849,7 @@ JOIN
 ON
     ns.nspowner = r.oid
 WHERE
-    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u1', 'dbowner__main_db_dbowner__sch_u2')
+    ns.nspname IN ('dbowner__main_db_dbowner__s1', 'dbowner__main_db_dbowner__s3', 'dbowner__main_db_dbowner__sch_u1', 'dbowner__main_db_dbowner__sch_u2', 'dbowner__main_db_dbowner__sch_db_owner')
 ORDER BY ns.nspname;
 GO
 
@@ -933,6 +976,8 @@ drop schema dbowner__sch_u1
 go
 drop schema dbowner__sch_u2
 go
+drop schema dbowner__sch_db_owner
+go
 drop user dbowner__u2
 go
 
@@ -1011,7 +1056,7 @@ SELECT pg_sleep(1);
 GO
 
 
--- Check if dropping user, also drops the linked "_obj" role
+-- Check if dropping user, also drops the linked "_bbfobj" role
 -- psql
 select rolname from pg_authid where rolname like 'dbowner__test_db_%' order by rolname;
 go


### PR DESCRIPTION
### Description

This commit addresses the following issues in the implementation of supporting adding of multiple users to db_owner role:
 - Name clash around internal db_owner role: We will now check if the internal role we are about to create already exists or not, if it does, we throw an error. Conversely, if a server/database principal exists with the same name as the internal role we are about to create, we will throw an appropriate error.
 - Extra rows for sp_helpuser: Added a check for RoleName column to only contain T-SQL roles.
 - Unable to make db_owner role schema owner: We will not change owner of schema if it's authorization lies with db_owner role.
 - Adding/dropping of valid users to db_owner role again should not throw error: During addition, if user is already member of db_owner, we will omit creating internal role. During drop, if user is not member of db_owner role, we will omit dropping the internal role.

Task: BABEL-4899, BABEL-5491, BABEL-5502
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).