### PR TITLE
Update principal_id column in database_principals for fixed db roles

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -448,7 +448,18 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
-CAST(Base.oid AS INT) AS principal_id,
+-- PG reserves these oid > 16383 AND oid < 16400 for PG specific internal roles.
+-- Any change here in the oid should be reflected in sys.database_role_members view as well.
+CAST(
+  CASE Ext.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
+    ELSE Base.oid
+  END AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
 CAST(
   CASE
@@ -479,7 +490,12 @@ WHERE Ext.database_name = DB_NAME()
 UNION ALL
 SELECT
 CAST(name AS SYS.SYSNAME) AS name,
-CAST(-1 AS INT) AS principal_id,
+CAST(
+  CASE name
+    WHEN 'public' THEN 0
+    WHEN 'INFORMATION_SCHEMA' THEN 3
+    WHEN 'sys' THEN 4
+  END AS INT) AS principal_id,
 CAST(type AS CHAR(1)) as type,
 CAST(
   CASE
@@ -607,8 +623,26 @@ GRANT SELECT ON sys.sysusers TO PUBLIC;
 -- DATABASE_ROLE_MEMBERS
 CREATE OR REPLACE VIEW sys.database_role_members AS
 SELECT
-CAST(Auth1.oid AS INT) AS role_principal_id,
-CAST(Auth2.oid AS INT) AS member_principal_id
+CAST(
+  CASE Ext1.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
+    ELSE Auth1.oid
+  END AS INT) AS role_principal_id,
+CAST(
+  CASE Ext2.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
+    ELSE Auth2.oid
+  END AS INT) AS member_principal_id
 FROM pg_catalog.pg_auth_members AS Authmbr
 INNER JOIN pg_catalog.pg_roles AS Auth1 ON Auth1.oid = Authmbr.roleid
 INNER JOIN pg_catalog.pg_roles AS Auth2 ON Auth2.oid = Authmbr.member

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.4.0--5.0.0.sql
@@ -543,7 +543,18 @@ AS 'babelfishpg_tsql', 'bbf_is_role_member' LANGUAGE C;
 CREATE OR REPLACE VIEW sys.database_principals AS
 SELECT
 CAST(Ext.orig_username AS SYS.SYSNAME) AS name,
-CAST(Base.oid AS INT) AS principal_id,
+-- PG reserves these oid > 16383 AND oid < 16400 for PG specific internal roles.
+-- Any change here in the oid should be reflected in sys.database_role_members view as well.
+CAST(
+  CASE Ext.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
+    ELSE Base.oid
+  END AS INT) AS principal_id,
 CAST(Ext.type AS CHAR(1)) as type,
 CAST(
   CASE
@@ -574,7 +585,12 @@ WHERE Ext.database_name = DB_NAME()
 UNION ALL
 SELECT
 CAST(name AS SYS.SYSNAME) AS name,
-CAST(-1 AS INT) AS principal_id,
+CAST(
+  CASE name
+    WHEN 'public' THEN 0
+    WHEN 'INFORMATION_SCHEMA' THEN 3
+    WHEN 'sys' THEN 4
+  END AS INT) AS principal_id,
 CAST(type AS CHAR(1)) as type,
 CAST(
   CASE
@@ -598,6 +614,41 @@ CAST(0 AS SYS.BIT) AS allow_encrypted_value_modifications
 FROM (VALUES ('public', 'R'), ('sys', 'S'), ('INFORMATION_SCHEMA', 'S')) as dummy_principals(name, type);
 
 GRANT SELECT ON sys.database_principals TO PUBLIC;
+
+-- DATABASE_ROLE_MEMBERS
+CREATE OR REPLACE VIEW sys.database_role_members AS
+SELECT
+CAST(
+  CASE Ext1.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
+    ELSE Auth1.oid
+  END AS INT) AS role_principal_id,
+CAST(
+  CASE Ext2.orig_username
+    WHEN 'db_owner' THEN 16384
+    WHEN 'db_accessadmin' THEN 16385
+    WHEN 'db_securityadmin' THEN 16386
+    WHEN 'db_ddladmin' THEN 16387
+    WHEN 'db_datareader' THEN 16390
+    WHEN 'db_datawriter' THEN 16391
+    ELSE Auth2.oid
+  END AS INT) AS member_principal_id
+FROM pg_catalog.pg_auth_members AS Authmbr
+INNER JOIN pg_catalog.pg_roles AS Auth1 ON Auth1.oid = Authmbr.roleid
+INNER JOIN pg_catalog.pg_roles AS Auth2 ON Auth2.oid = Authmbr.member
+INNER JOIN sys.babelfish_authid_user_ext AS Ext1 ON Auth1.rolname = Ext1.rolname
+INNER JOIN sys.babelfish_authid_user_ext AS Ext2 ON Auth2.rolname = Ext2.rolname
+WHERE Ext1.database_name = DB_NAME() 
+AND Ext2.database_name = DB_NAME()
+AND Ext1.type = 'R'
+AND Ext2.orig_username != 'db_owner';
+
+GRANT SELECT ON sys.database_role_members TO PUBLIC;
 
 CREATE OR REPLACE PROCEDURE sys.sp_helpdbfixedrole("@rolename" sys.SYSNAME = NULL) AS
 $$

--- a/test/JDBC/expected/db_securityadmin-vu-prepare.out
+++ b/test/JDBC/expected/db_securityadmin-vu-prepare.out
@@ -38,17 +38,6 @@ GO
 CREATE FUNCTION babel_5135_schema1.babel_5135_tvf1() RETURNS TABLE AS RETURN (SELECT a, b FROM babel_5135_schema1.babel_5135_t1);
 GO
 
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
-GO
-
 CREATE PROCEDURE babel_5135_roleop_proc1 AS BEGIN CREATE ROLE babel_5135_role2; ALTER ROLE babel_5135_role2 WITH NAME = babel_5135_role3; DROP ROLE babel_5135_role3; END
 GO
 CREATE PROCEDURE babel_5135_roleop_proc2 AS BEGIN ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_u1; END
@@ -94,15 +83,4 @@ USE babel_5135_db1;
 GO
 
 create user babel_5135_u1 for login babel_5135_l1;
-GO
-
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
 GO

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -20,6 +20,31 @@ GO
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_r1;
 GO
 
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
+GO
+~~START~~
+varchar
+db_accessadmin
+db_datareader
+db_datawriter
+db_ddladmin
+db_owner
+db_securityadmin
+~~END~~
+
+
 EXEC sp_addrolemember 'db_securityadmin', 'babel_5135_u1';
 GO
 
@@ -57,6 +82,31 @@ varchar#!#varchar
 -- CASE 1.3 Test inside database with truncated name
 USE babel_5135_db1;
 GO
+
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
+GO
+~~START~~
+varchar
+db_accessadmin
+db_datareader
+db_datawriter
+db_ddladmin
+db_owner
+db_securityadmin
+~~END~~
+
 
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_u1;
 GO

--- a/test/JDBC/input/ownership/db_securityadmin-vu-prepare.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-prepare.mix
@@ -38,17 +38,6 @@ GO
 CREATE FUNCTION babel_5135_schema1.babel_5135_tvf1() RETURNS TABLE AS RETURN (SELECT a, b FROM babel_5135_schema1.babel_5135_t1);
 GO
 
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
-GO
-
 CREATE PROCEDURE babel_5135_roleop_proc1 AS BEGIN CREATE ROLE babel_5135_role2; ALTER ROLE babel_5135_role2 WITH NAME = babel_5135_role3; DROP ROLE babel_5135_role3; END
 GO
 CREATE PROCEDURE babel_5135_roleop_proc2 AS BEGIN ALTER ROLE babel_5135_r1 ADD MEMBER babel_5135_u1; END
@@ -94,15 +83,4 @@ USE babel_5135_db1;
 GO
 
 create user babel_5135_u1 for login babel_5135_l1;
-GO
-
-CREATE VIEW babel_5135_show_role_mem AS
-SELECT 
-roles.name AS RolePrincipalName
-, members.name AS MemberPrincipalName
-FROM sys.database_role_members AS db_role_mems
-INNER JOIN sys.database_principals AS roles
-    ON db_role_mems.role_principal_id = roles.principal_id
-INNER JOIN sys.database_principals AS members 
-    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
 GO

--- a/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
+++ b/test/JDBC/input/ownership/db_securityadmin-vu-verify.mix
@@ -20,6 +20,21 @@ GO
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_r1;
 GO
 
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
+GO
+
 EXEC sp_addrolemember 'db_securityadmin', 'babel_5135_u1';
 GO
 
@@ -46,6 +61,21 @@ GO
 
 -- CASE 1.3 Test inside database with truncated name
 USE babel_5135_db1;
+GO
+
+CREATE VIEW babel_5135_show_role_mem AS
+SELECT 
+roles.name AS RolePrincipalName
+, members.name AS MemberPrincipalName
+FROM sys.database_role_members AS db_role_mems
+INNER JOIN sys.database_principals AS roles
+    ON db_role_mems.role_principal_id = roles.principal_id
+INNER JOIN sys.database_principals AS members 
+    ON db_role_mems.member_principal_id = members.principal_id order by MemberPrincipalName;
+GO
+
+-- Should only show fixed database roles
+SELECT name from sys.database_principals WHERE principal_id > 16383 AND principal_id < 16400 ORDER BY name;
 GO
 
 ALTER ROLE db_securityadmin ADD MEMBER babel_5135_u1;

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -976,6 +976,7 @@ View sys.change_tracking_tables
 View sys.database_files
 View sys.database_filestream_options
 View sys.database_recovery_status
+View sys.database_role_members
 View sys.dm_hadr_cluster
 View sys.dm_hadr_database_replica_states
 View sys.dm_os_host_info


### PR DESCRIPTION
### Description

Babelfish should script only user created database roles, not the fixed roles like db_datareader, db_securityadmin etc.
T-SQL reserves the oid from 16383 to 16400 for fixed database roles. Updated the principal_id in the views database_principals and database_role_members

### Issues Resolved

Task: BABEL-5528

Signed-off-by: Shalini Lohia lshalini@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



