### PR TITLE
Update migration tests to remove set_config calls

### DIFF
--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -96,22 +96,6 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 ~~START~~
@@ -164,6 +148,7 @@ GO
 ~~ERROR (Message: Database 'babelfish_migration_mode_db1' already exists. Choose a different database name.)~~
 
 
+-- should fail in single-db
 CREATE DATABASE babelfish_migration_mode_db2
 GO
 
@@ -247,53 +232,9 @@ int
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
-~~START~~
-text
-single-db
-~~END~~
-
-
-SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-~~START~~
-text
-single-db
-~~END~~
-
-
--- should fail
+-- should fail in single-db
 USE babelfish_migration_mode_db2
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "dbo" does not exist)~~
-
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
@@ -303,7 +244,7 @@ multi-db
 ~~END~~
 
 
--- should success
+-- should success in multi-db
 USE babelfish_migration_mode_db2
 GO
 
@@ -323,30 +264,6 @@ GO
 
 DROP DATABASE babelfish_migration_mode_db2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
-~~START~~
-text
-single-db
-~~END~~
-
-
-SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-~~START~~
-text
-single-db
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
@@ -379,25 +296,6 @@ varchar#!#int
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases

--- a/test/JDBC/input/ownership/babelfish_migration_mode.sql
+++ b/test/JDBC/input/ownership/babelfish_migration_mode.sql
@@ -1,4 +1,20 @@
--- tsql
+CREATE TABLE babelfish_migration_mode_tbl (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+
+CREATE TABLE babelfish_migration_mode_catalog_status (catalog_name VARCHAR(50), num INT)
+GO
+
+CREATE TABLE babelfish_migration_mode_catalog_status2 (catalog_name VARCHAR(50), num INT)
+GO
+
+CREATE PROC babelfish_migration_mode_compare AS
+BEGIN
+SELECT * FROM babelfish_migration_mode_catalog_status
+EXCEPT
+SELECT * FROM babelfish_migration_mode_catalog_status2
+END
+GO
+
 -- Test initial databases
 SELECT COUNT(*) FROM pg_roles where rolname = 'sysadmin';
 GO
@@ -128,6 +144,9 @@ GO
 DROP DATABASE babelfish_migration_mode_db2
 GO
 
+SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO
@@ -163,4 +182,16 @@ GO
 
 -- Check catalog status
 EXEC babelfish_migration_mode_compare
+GO
+
+DROP PROC babelfish_migration_mode_compare
+GO
+
+DROP TABLE babelfish_migration_mode_tbl
+GO
+
+DROP TABLE babelfish_migration_mode_catalog_status
+GO
+
+DROP TABLE babelfish_migration_mode_catalog_status2
 GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -11,9 +11,6 @@
 all
 
 ignore#!#BABEL-4279
-ignore#!#babelfish_migration_mode-vu-prepare
-ignore#!#babelfish_migration_mode-vu-verify
-ignore#!#babelfish_migration_mode-vu-cleanup
 ignore#!#test_search_path
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
@@ -136,6 +133,9 @@ ignore#!#case_insensitive_collation-before-13-5-vu-cleanup
 ignore#!#jira-BABEL-3504-upgrade-vu-prepare
 ignore#!#jira-BABEL-3504-upgrade-vu-verify
 ignore#!#jira-BABEL-3504-upgrade-vu-cleanup
+ignore#!#babelfish_migration_mode-vu-prepare
+ignore#!#babelfish_migration_mode-vu-verify
+ignore#!#babelfish_migration_mode-vu-cleanup
 
 ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-prepare
 ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-verify


### PR DESCRIPTION


### Description
Previous commit #3096  has restricted the configurations including role and migration mode, which makes babelfish_migration_mode tests no longer runnable.

To address it, this commit separate the tests into single-db (general test) and multi-db (during upgrade) versions to ensure test coverage.

Note that this commit is only for 2X branch due to the JDBC framework difference between 2X and 3X+. Tests in 3X and later branches are already fixed.

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).