### PR TITLE
Update migration tests to remove set_config calls

### DIFF
--- a/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
+++ b/test/JDBC/expected/babelfish_migration_mode-vu-verify.out
@@ -96,22 +96,6 @@ GO
 ~~ROW COUNT: 1~~
 
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
-
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
 ~~START~~
@@ -164,6 +148,7 @@ GO
 ~~ERROR (Message: Database 'babelfish_migration_mode_db1' already exists. Choose a different database name.)~~
 
 
+-- should fail in single-db
 CREATE DATABASE babelfish_migration_mode_db2
 GO
 
@@ -247,53 +232,9 @@ int
 USE master
 GO
 
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
-~~START~~
-text
-single-db
-~~END~~
-
-
-SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-~~START~~
-text
-single-db
-~~END~~
-
-
--- should fail
+-- should fail in single-db
 USE babelfish_migration_mode_db2
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: role "dbo" does not exist)~~
-
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'multi-db', false)
-GO
-~~START~~
-text
-multi-db
-~~END~~
-
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
@@ -303,7 +244,7 @@ multi-db
 ~~END~~
 
 
--- should success
+-- should success in multi-db
 USE babelfish_migration_mode_db2
 GO
 
@@ -323,30 +264,6 @@ GO
 
 DROP DATABASE babelfish_migration_mode_db2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.migration_mode', 'single-db', false)
-GO
-~~START~~
-text
-single-db
-~~END~~
-
-
-SELECT current_setting('babelfishpg_tsql.migration_mode')
-GO
-~~START~~
-text
-single-db
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
@@ -379,25 +296,6 @@ varchar#!#int
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
-
-SELECT set_config('role', 'jdbc_user', false)
-GO
-~~START~~
-text
-jdbc_user
-~~END~~
-
-
--- Reset migration mode to default
-DECLARE @mig_mode VARCHAR(10)
-SET @mig_mode = (SELECT mig_mode FROM babelfish_migration_mode_tbl WHERE id_num = 1)
-SELECT CASE WHEN (SELECT set_config('babelfishpg_tsql.migration_mode', @mig_mode, false)) IS NOT NULL THEN 1 ELSE 0 END
-GO
-~~START~~
-int
-1
-~~END~~
-
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases

--- a/test/JDBC/expected/babelfish_migration_mode.out
+++ b/test/JDBC/expected/babelfish_migration_mode.out
@@ -1,60 +1,153 @@
--- tsql
+CREATE TABLE babelfish_migration_mode_tbl (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+
+CREATE TABLE babelfish_migration_mode_catalog_status (catalog_name VARCHAR(50), num INT)
+GO
+
+CREATE TABLE babelfish_migration_mode_catalog_status2 (catalog_name VARCHAR(50), num INT)
+GO
+
+CREATE PROC babelfish_migration_mode_compare AS
+BEGIN
+SELECT * FROM babelfish_migration_mode_catalog_status
+EXCEPT
+SELECT * FROM babelfish_migration_mode_catalog_status2
+END
+GO
+
 -- Test initial databases
 SELECT COUNT(*) FROM pg_roles where rolname = 'sysadmin';
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 SELECT COUNT(*) FROM pg_roles where rolname = 'master_dbo';
 SELECT COUNT(*) FROM pg_roles where rolname = 'master_db_owner';
 SELECT COUNT(*) FROM pg_namespace where nspname = 'master_dbo';
 GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
 
 SELECT COUNT(*) FROM pg_roles where rolname = 'tempdb_dbo';
 SELECT COUNT(*) FROM pg_roles where rolname = 'tempdb_db_owner';
 SELECT COUNT(*) FROM pg_namespace where nspname = 'tempdb_dbo';
 GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
 
 SELECT COUNT(*) FROM pg_roles where rolname = 'msdb_dbo';
 SELECT COUNT(*) FROM pg_roles where rolname = 'msdb_db_owner';
 SELECT COUNT(*) FROM pg_namespace where nspname = 'msdb_dbo';
 GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
 
 -- Store default migration mode in table
 INSERT INTO babelfish_migration_mode_tbl SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
+~~ROW COUNT: 1~~
+
 
 -- Store current catalog snapshot in table
 INSERT INTO babelfish_migration_mode_catalog_status 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status
 SELECT 'sys.babelfish_namespace_ext', COUNT(*) FROM sys.babelfish_namespace_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status
 SELECT 'sys.babelfish_authid_login_ext', COUNT(*) FROM sys.babelfish_authid_login_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status
 SELECT 'sys.babelfish_authid_user_ext', COUNT(*) FROM sys.babelfish_authid_user_ext
 GO
+~~ROW COUNT: 1~~
+
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
+~~START~~
+text
+single-db
+~~END~~
+
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_namespace_ext', COUNT(*) FROM sys.babelfish_namespace_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_authid_login_ext', COUNT(*) FROM sys.babelfish_authid_login_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_authid_user_ext', COUNT(*) FROM sys.babelfish_authid_user_ext
 GO
+~~ROW COUNT: 1~~
+
 
 -- Check catalog status
 EXEC babelfish_migration_mode_compare
 GO
+~~START~~
+varchar#!#int
+~~END~~
+
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
@@ -66,41 +159,98 @@ GO
 -- should fail
 CREATE DATABASE babelfish_migration_mode_db1
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Database 'babelfish_migration_mode_db1' already exists. Choose a different database name.)~~
+
 
 -- should fail in single-db
 CREATE DATABASE babelfish_migration_mode_db2
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Only one user database allowed under single-db mode. User database "babelfish_migration_mode_db1" already exists)~~
+
 
 SELECT name FROM sys.sysdatabases 
 WHERE name LIKE 'babelfish_migration_mode%'
 ORDER BY name
 GO
+~~START~~
+text
+babelfish_migration_mode_db1
+~~END~~
+
 
 SELECT COUNT(*) FROM pg_roles WHERE rolname = 'babelfish_migration_mode_db1_dbo'
 GO
+~~START~~
+int
+0
+~~END~~
+
 SELECT COUNT(*) FROM pg_roles WHERE rolname = 'babelfish_migration_mode_db1_db_owner'
 GO
+~~START~~
+int
+0
+~~END~~
+
 SELECT COUNT(*) FROM pg_namespace WHERE nspname = 'babelfish_migration_mode_db1_dbo'
 GO
+~~START~~
+int
+0
+~~END~~
+
 
 SELECT COUNT(*) FROM pg_roles WHERE rolname = 'babelfish_migration_mode_db2_dbo'
 GO
+~~START~~
+int
+0
+~~END~~
+
 SELECT COUNT(*) FROM pg_roles WHERE rolname = 'babelfish_migration_mode_db2_db_owner'
 GO
+~~START~~
+int
+0
+~~END~~
+
 SELECT COUNT(*) FROM pg_namespace WHERE nspname = 'babelfish_migration_mode_db2_dbo'
 GO
+~~START~~
+int
+0
+~~END~~
+
 
 USE babelfish_migration_mode_db1
 GO
 
 SELECT 1
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 USE babelfish_migration_mode_db2
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "babelfish_migration_mode_db2" does not exist)~~
+
 
 SELECT 1
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 USE master
 GO
@@ -108,16 +258,34 @@ GO
 -- should fail in single-db
 USE babelfish_migration_mode_db2
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "babelfish_migration_mode_db2" does not exist)~~
+
 
 SELECT current_setting('babelfishpg_tsql.migration_mode')
 GO
+~~START~~
+text
+single-db
+~~END~~
+
 
 -- should success in multi-db
 USE babelfish_migration_mode_db2
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "babelfish_migration_mode_db2" does not exist)~~
+
 
 SELECT 1
 GO
+~~START~~
+int
+1
+~~END~~
+
 
 USE master
 GO
@@ -127,23 +295,47 @@ GO
 
 DROP DATABASE babelfish_migration_mode_db2
 GO
+~~ERROR (Code: 911)~~
+
+~~ERROR (Message: database "babelfish_migration_mode_db2" does not exist)~~
+
+
+SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+~~START~~
+text
+single-db
+~~END~~
+
 
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_namespace_ext', COUNT(*) FROM sys.babelfish_namespace_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_authid_login_ext', COUNT(*) FROM sys.babelfish_authid_login_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_authid_user_ext', COUNT(*) FROM sys.babelfish_authid_user_ext
 GO
+~~ROW COUNT: 1~~
+
 
 -- Check catalog status
 EXEC babelfish_migration_mode_compare
 GO
+~~START~~
+varchar#!#int
+~~END~~
+
 
 TRUNCATE TABLE babelfish_migration_mode_catalog_status2
 GO
@@ -151,16 +343,40 @@ GO
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_namespace_ext', COUNT(*) FROM sys.babelfish_namespace_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_authid_login_ext', COUNT(*) FROM sys.babelfish_authid_login_ext
 GO
+~~ROW COUNT: 1~~
+
 INSERT INTO babelfish_migration_mode_catalog_status2
 SELECT 'sys.babelfish_authid_user_ext', COUNT(*) FROM sys.babelfish_authid_user_ext
 GO
+~~ROW COUNT: 1~~
+
 
 -- Check catalog status
 EXEC babelfish_migration_mode_compare
+GO
+~~START~~
+varchar#!#int
+~~END~~
+
+
+DROP PROC babelfish_migration_mode_compare
+GO
+
+DROP TABLE babelfish_migration_mode_tbl
+GO
+
+DROP TABLE babelfish_migration_mode_catalog_status
+GO
+
+DROP TABLE babelfish_migration_mode_catalog_status2
 GO

--- a/test/JDBC/input/ownership/babelfish_migration_mode.sql
+++ b/test/JDBC/input/ownership/babelfish_migration_mode.sql
@@ -1,4 +1,20 @@
--- tsql
+CREATE TABLE babelfish_migration_mode_tbl (id_num INT IDENTITY(1,1), mig_mode VARCHAR(10))
+GO
+
+CREATE TABLE babelfish_migration_mode_catalog_status (catalog_name VARCHAR(50), num INT)
+GO
+
+CREATE TABLE babelfish_migration_mode_catalog_status2 (catalog_name VARCHAR(50), num INT)
+GO
+
+CREATE PROC babelfish_migration_mode_compare AS
+BEGIN
+SELECT * FROM babelfish_migration_mode_catalog_status
+EXCEPT
+SELECT * FROM babelfish_migration_mode_catalog_status2
+END
+GO
+
 -- Test initial databases
 SELECT COUNT(*) FROM pg_roles where rolname = 'sysadmin';
 GO
@@ -128,6 +144,9 @@ GO
 DROP DATABASE babelfish_migration_mode_db2
 GO
 
+SELECT current_setting('babelfishpg_tsql.migration_mode')
+GO
+
 INSERT INTO babelfish_migration_mode_catalog_status2 
 SELECT 'sys.babelfish_sysdatabases', COUNT(*) FROM sys.babelfish_sysdatabases
 GO
@@ -163,4 +182,16 @@ GO
 
 -- Check catalog status
 EXEC babelfish_migration_mode_compare
+GO
+
+DROP PROC babelfish_migration_mode_compare
+GO
+
+DROP TABLE babelfish_migration_mode_tbl
+GO
+
+DROP TABLE babelfish_migration_mode_catalog_status
+GO
+
+DROP TABLE babelfish_migration_mode_catalog_status2
 GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -11,9 +11,6 @@
 all
 
 ignore#!#BABEL-4279
-ignore#!#babelfish_migration_mode-vu-prepare
-ignore#!#babelfish_migration_mode-vu-verify
-ignore#!#babelfish_migration_mode-vu-cleanup
 ignore#!#test_search_path
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
@@ -136,6 +133,9 @@ ignore#!#case_insensitive_collation-before-13-5-vu-cleanup
 ignore#!#jira-BABEL-3504-upgrade-vu-prepare
 ignore#!#jira-BABEL-3504-upgrade-vu-verify
 ignore#!#jira-BABEL-3504-upgrade-vu-cleanup
+ignore#!#babelfish_migration_mode-vu-prepare
+ignore#!#babelfish_migration_mode-vu-verify
+ignore#!#babelfish_migration_mode-vu-cleanup
 
 ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-prepare
 ignore#!#AVG-Aggregate-Dep-before-15-2-or-14-7-vu-verify

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -124,6 +124,7 @@ BABEL-ROLE
 babelfish_sysdatabases
 babelfish_namespace_ext
 babelfish_authid_login_ext
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 babel_char

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -185,6 +185,7 @@ BABEL-ROLE
 babelfish_sysdatabases
 babelfish_namespace_ext
 babelfish_authid_login_ext
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 BABEL-EXTENDEDPROPERTY

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -215,6 +215,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -214,6 +214,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -214,6 +214,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -211,6 +211,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -173,6 +173,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -171,6 +171,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 collation_tests_arabic
 collation_tests_greek

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -215,6 +215,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-14_5
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -152,6 +152,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 select-strip-parens-before-14-10
 BABEL-3147-before-16_3-or-15_7-or-14_12

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -163,6 +163,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -172,6 +172,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -172,6 +172,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -173,6 +173,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147-before-16_3-or-15_7-or-14_12
 collation_tests_arabic

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -174,6 +174,7 @@ babelfish_namespace_ext
 babelfish_authid_login_ext
 babelfish_authid_user_ext
 babelfish_inconsistent_metadata
+babelfish_migration_mode
 schema_resolution_func
 BABEL-3147
 collation_tests_arabic


### PR DESCRIPTION
### Description

Previous commit #3096 has restricted the configurations including role and migration mode, which makes babelfish_migration_mode tests no longer runnable.

To address it, this commit separate the tests into single-db (general test) and multi-db (during upgrade) versions to ensure test coverage.

Note that this commit is only for 2X branch due to the JDBC framework difference between 2X and 3X+. Tests in 3X and later branches are already fixed.


### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).