### PR TITLE
[5x] Minor fix for babel_index_nulls_order_before_15_5 test

### DIFF
--- a/test/JDBC/expected/babel_index_nulls_order-before-15-5-vu-verify.out
+++ b/test/JDBC/expected/babel_index_nulls_order-before-15-5-vu-verify.out
@@ -131,7 +131,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 112.787 ms
+Babelfish T-SQL Batch Parsing Time: 111.217 ms
 ~~END~~
 
 SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_asc_idx_a)) WHERE a > 5 ORDER BY a ASC
@@ -148,7 +148,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 6.412 ms
+Babelfish T-SQL Batch Parsing Time: 5.817 ms
 ~~END~~
 
 SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_asc_idx_a)) WHERE a > 5 ORDER BY a
@@ -165,58 +165,58 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.489 ms
+Babelfish T-SQL Batch Parsing Time: 0.276 ms
 ~~END~~
 
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
 go
 ~~START~~
 text
-Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl bel_index_nulls_order_before_15ddb71b88216e14ad4d8372c9021114b4) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                             WHERE b <= 'sss' ORDER BY b DESC
+Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                               WHERE b <= 'sss' ORDER BY b DESC
 Limit
   ->  Sort
         Sort Key: b DESC NULLS LAST
-        ->  Index Only Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
+        ->  Index Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
               Index Cond: (b <= 'sss'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 5.479 ms
+Babelfish T-SQL Batch Parsing Time: 4.350 ms
 ~~END~~
 
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
 go
 ~~START~~
 text
-Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl bel_index_nulls_order_before_15ddb71b88216e14ad4d8372c9021114b4) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                             WHERE b > 'sss' ORDER BY b ASC
+Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                               WHERE b > 'sss' ORDER BY b ASC
 Limit
   ->  Sort
         Sort Key: b NULLS FIRST
-        ->  Index Only Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
+        ->  Index Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
               Index Cond: (b > 'sss'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 4.604 ms
+Babelfish T-SQL Batch Parsing Time: 4.366 ms
 ~~END~~
 
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
 go
 ~~START~~
 text
-Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl bel_index_nulls_order_before_15ddb71b88216e14ad4d8372c9021114b4) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                             WHERE b > 'sss' ORDER BY b
+Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                               WHERE b > 'sss' ORDER BY b
 Limit
   ->  Sort
         Sort Key: b NULLS FIRST
-        ->  Index Only Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
+        ->  Index Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
               Index Cond: (b > 'sss'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.208 ms
+Babelfish T-SQL Batch Parsing Time: 0.167 ms
 ~~END~~
 
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b DESC
@@ -233,7 +233,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 23.774 ms
+Babelfish T-SQL Batch Parsing Time: 19.769 ms
 ~~END~~
 
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b ASC
@@ -250,7 +250,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.267 ms
+Babelfish T-SQL Batch Parsing Time: 0.208 ms
 ~~END~~
 
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b
@@ -267,7 +267,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.205 ms
+Babelfish T-SQL Batch Parsing Time: 0.202 ms
 ~~END~~
 
 
@@ -393,7 +393,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.233 ms
+Babelfish T-SQL Batch Parsing Time: 0.172 ms
 ~~END~~
 
 SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_asc_idx_a)) WHERE a > 5 ORDER BY a ASC
@@ -408,7 +408,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.177 ms
+Babelfish T-SQL Batch Parsing Time: 0.167 ms
 ~~END~~
 
 SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_asc_idx_a)) WHERE a > 5 ORDER BY a
@@ -423,52 +423,52 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.163 ms
+Babelfish T-SQL Batch Parsing Time: 0.162 ms
 ~~END~~
 
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
 go
 ~~START~~
 text
-Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl bel_index_nulls_order_before_15ddb71b88216e14ad4d8372c9021114b4) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                             WHERE b <= 'sss' ORDER BY b DESC
+Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                               WHERE b <= 'sss' ORDER BY b DESC
 Limit
-  ->  Index Only Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
+  ->  Index Scan using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
         Index Cond: (b <= 'sss'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.174 ms
+Babelfish T-SQL Batch Parsing Time: 0.164 ms
 ~~END~~
 
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
 go
 ~~START~~
 text
-Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl bel_index_nulls_order_before_15ddb71b88216e14ad4d8372c9021114b4) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                             WHERE b > 'sss' ORDER BY b ASC
+Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                               WHERE b > 'sss' ORDER BY b ASC
 Limit
-  ->  Index Only Scan Backward using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
+  ->  Index Scan Backward using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
         Index Cond: (b > 'sss'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.180 ms
+Babelfish T-SQL Batch Parsing Time: 0.179 ms
 ~~END~~
 
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
 go
 ~~START~~
 text
-Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl bel_index_nulls_order_before_15ddb71b88216e14ad4d8372c9021114b4) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                             WHERE b > 'sss' ORDER BY b
+Query Text: SELECT/*+ indexscan(babel_index_nulls_order_before_15_5_tbl babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5) */ TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl                                                               WHERE b > 'sss' ORDER BY b
 Limit
-  ->  Index Only Scan Backward using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
+  ->  Index Scan Backward using babel_index_nulls_order_before_713975587e1cf6ee0c2fe82e930b89b5 on babel_index_nulls_order_before_15_5_tbl
         Index Cond: (b > 'sss'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.167 ms
+Babelfish T-SQL Batch Parsing Time: 0.159 ms
 ~~END~~
 
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b DESC
@@ -483,7 +483,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.216 ms
+Babelfish T-SQL Batch Parsing Time: 0.204 ms
 ~~END~~
 
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b ASC
@@ -498,7 +498,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.208 ms
+Babelfish T-SQL Batch Parsing Time: 0.203 ms
 ~~END~~
 
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b
@@ -513,7 +513,7 @@ Limit
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.205 ms
+Babelfish T-SQL Batch Parsing Time: 0.198 ms
 ~~END~~
 
 

--- a/test/JDBC/input/ddl/babel_index_nulls_order-before-15-5-vu-verify.sql
+++ b/test/JDBC/input/ddl/babel_index_nulls_order-before-15-5-vu-verify.sql
@@ -43,11 +43,11 @@ SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_i
 go
 SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_asc_idx_a)) WHERE a > 5 ORDER BY a
 go
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
 go
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
 go
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
 go
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b DESC
 go
@@ -112,11 +112,11 @@ SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_i
 go
 SELECT TOP 1 a FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_asc_idx_a)) WHERE a > 5 ORDER BY a
 go
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b <= 'sss' ORDER BY b DESC
 go
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b ASC
 go
-SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (bel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
+SELECT TOP 1 b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_desc_idx_b)) WHERE b > 'sss' ORDER BY b
 go
 SELECT TOP 1 a, b FROM babel_index_nulls_order_before_15_5_tbl WITH (INDEX (babel_index_nulls_order_before_15_5_default_idx_ab)) WHERE (a = 3 AND b <= 'sss') ORDER BY b DESC
 go


### PR DESCRIPTION
### Description

This commit fixes typo in babel_index_nulls_order_before_15_5 test.

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).