### PR TITLE
[OSS-ONLY] Restrict grant to/from any babelfish created role via PG port

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1246,10 +1246,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 
 		roleid = get_role_oid(rolename, false);
 		if (OidIsValid(roleid) && is_babelfish_role(rolename))
-		{
-			pfree(rolename);
 			check_babelfish_alterrole_restictions(false);
-		}
 	}
 
 	/* Restrict grant to/from bbf created role */

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -949,11 +949,13 @@ is_babelfish_role(const char *role)
 	Oid			bbf_msdb_guest_oid;
 	Oid			securityadmin;
 	Oid			dbcreator;
+	Oid			bbf_admin_oid;
 
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
 	securityadmin = get_role_oid(BABELFISH_SECURITYADMIN, true);  /* missing OK */
 	dbcreator = get_role_oid(BABELFISH_DBCREATOR, true);  /* missing OK */
+	bbf_admin_oid = get_role_oid(BABELFISH_ROLE_ADMIN, true); /* missing OK */
 
 	if (!OidIsValid(sysadmin_oid) || !OidIsValid(role_oid) 
 			|| !OidIsValid(securityadmin) || !OidIsValid(dbcreator))
@@ -973,7 +975,8 @@ is_babelfish_role(const char *role)
 		&& OidIsValid(bbf_msdb_guest_oid)
 		&& is_member_of_role(role_oid, bbf_master_guest_oid)
 		&& is_member_of_role(role_oid, bbf_tempdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_msdb_guest_oid))
+		&& is_member_of_role(role_oid, bbf_msdb_guest_oid)
+		&& is_member_of_role(bbf_admin_oid, role_oid))
 		return true;
 
 	return false;
@@ -1231,7 +1234,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 	if (get_bbf_role_admin_oid() == GetUserId())
 		return true;
 
-	/* Restrict roles to added as a member of BBF default server roles */
+	/* Restrict roles to added as a member of BBF created roles */
 	foreach(item, grant_stmt->granted_roles)
 	{
 		AccessPriv *priv = (AccessPriv *) lfirst(item);
@@ -1242,11 +1245,14 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 			continue;
 
 		roleid = get_role_oid(rolename, false);
-		if (OidIsValid(roleid) && IS_DEFAULT_BBF_SERVER_ROLE(rolename))
+		if (OidIsValid(roleid) && is_babelfish_role(rolename))
+		{
+			pfree(rolename);
 			check_babelfish_alterrole_restictions(false);
+		}
 	}
 
-	/* Restrict grant to/from bbf_role_admin, securityadmin or dbcreator role */
+	/* Restrict grant to/from bbf created role */
 
 	foreach(item, grant_stmt->grantee_roles)
 	{
@@ -1254,7 +1260,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 		Oid			roleid;
 
 		roleid = get_rolespec_oid(rolespec, false);
-		if (OidIsValid(roleid) && IS_DEFAULT_BBF_SERVER_ROLE(rolespec->rolename))
+		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
 			check_babelfish_alterrole_restictions(false);
 	}
 

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -259,12 +259,6 @@ extern ProcessUtility_hook_type next_ProcessUtility;
 #define BABELFISH_SECURITYADMIN "securityadmin"
 #define BABELFISH_DBCREATOR "dbcreator"
 
-#define IS_DEFAULT_BBF_SERVER_ROLE(rolename) \
-	((strlen(rolename) == 13 && strncmp(rolename, BABELFISH_SECURITYADMIN, 13) == 0) || \
-	(strlen(rolename) == 14 && strncmp(rolename, BABELFISH_ROLE_ADMIN, 14) == 0) || \
-	(strlen(rolename) == 9 && strncmp(rolename, BABELFISH_DBCREATOR, 9) == 0) || \
-	(strlen(rolename) == 8 && strncmp(rolename, BABELFISH_SYSADMIN, 8) == 0))
-
 /* Functions in backend/tds/tdscomm.c */
 extern void TdsSetMessageType(uint8_t msgType);
 extern void TdsCommInit(uint32_t bufferSize,

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -1217,8 +1217,7 @@ GRANT db_securityadmin_restrictions_login TO master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "db_securityadmin_restrictions_login"
-  Detail: Only roles with the ADMIN option on role "db_securityadmin_restrictions_login" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1229,8 +1228,7 @@ REVOKE master_dbo FROM master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_dbo"
-  Detail: Only roles with the ADMIN option on role "master_dbo" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1291,8 +1289,7 @@ GRANT master_db_securityadmin TO db_securityadmin_restrictions_login;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "master_db_securityadmin"
-  Detail: Only roles with the ADMIN option on role "master_db_securityadmin" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1300,8 +1297,7 @@ GRANT db_securityadmin_restrictions_login TO master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "db_securityadmin_restrictions_login"
-  Detail: Only roles with the ADMIN option on role "db_securityadmin_restrictions_login" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1309,8 +1305,7 @@ REVOKE master_db_securityadmin FROM master_dbo;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_db_securityadmin"
-  Detail: Only roles with the ADMIN option on role "master_db_securityadmin" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1318,8 +1313,7 @@ REVOKE master_dbo FROM master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_dbo"
-  Detail: Only roles with the ADMIN option on role "master_dbo" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 


### PR DESCRIPTION
### Description

Restrict grant to/from any babelfish created role via PG port
All server and database roles including fixed server roles and database roles have 'bbf_role_admin' as its member. Added a check to identify if 'bbf_role_admin' is a member of any role in addition to the existing checks to avoid granting any Babelfish db/server role  to another Babelfish db/server roles including fixed db and server roles.


### Issues Resolved

Task: BABEL-5505
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests -**


