### PR TITLE
Sessions terminated using kill command still leave behind entries in dm_exec_sessions

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tds.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tds.c
@@ -441,19 +441,17 @@ tds_status_shmem_startup(void)
 static void
 tds_stats_shmem_shutdown(int code, Datum arg)
 {
-	/* Don't try to save the outlines during a crash. */
-	if (code)
-		return;
+	volatile TdsStatus *myTdsStatusEntry = MyTdsStatusEntry;
 
 	/* Safety check ... shouldn't get here unless shmem is set up. */
 	if (TdsStatusArray == NULL || MyTdsStatusEntry == NULL)
 		return;
 
-	PGSTAT_BEGIN_WRITE_ACTIVITY(MyTdsStatusEntry);
+	PGSTAT_BEGIN_WRITE_ACTIVITY(myTdsStatusEntry);
 
-	MyTdsStatusEntry->st_procpid = 0;	/* mark invalid */
+	myTdsStatusEntry->st_procpid = 0;	/* mark invalid */
 
-	PGSTAT_END_WRITE_ACTIVITY(MyTdsStatusEntry);
+	PGSTAT_END_WRITE_ACTIVITY(myTdsStatusEntry);
 
 	MyTdsStatusEntry = NULL;
 

--- a/test/JDBC/expected/kill-vu-verify.out
+++ b/test/JDBC/expected/kill-vu-verify.out
@@ -3,6 +3,8 @@ create table tab_kill_spid(spid int)
 go
 create login victim_user_tds with password = '12345678';
 go
+select count(*) as count into #kill_temp_table from sys.dm_exec_sessions
+go
 
 -- tsql user=victim_user_tds password=12345678
 select 1
@@ -761,5 +763,16 @@ GO
 ~~START~~
 int
 0
+~~END~~
+
+
+IF ((SELECT COUNT(*) FROM sys.dm_exec_sessions) = (SELECT count FROM #kill_temp_table))	
+	SELECT 'SUCESS';
+ELSE
+	SELECT 'FAILURE expected count ==> ', (SELECT count FROM #kill_temp_table), ' actual count ==> ', count(*) from sys.dm_exec_sessions b;
+GO
+~~START~~
+varchar
+SUCESS
 ~~END~~
 

--- a/test/JDBC/expected/single_db/kill-vu-verify.out
+++ b/test/JDBC/expected/single_db/kill-vu-verify.out
@@ -3,6 +3,8 @@ create table tab_kill_spid(spid int)
 go
 create login victim_user_tds with password = '12345678';
 go
+select count(*) as count into #kill_temp_table from sys.dm_exec_sessions
+go
 
 -- tsql user=victim_user_tds password=12345678
 select 1
@@ -861,5 +863,16 @@ GO
 ~~START~~
 int
 0
+~~END~~
+
+
+IF ((SELECT COUNT(*) FROM sys.dm_exec_sessions) = (SELECT count FROM #kill_temp_table))	
+	SELECT 'SUCESS';
+ELSE
+	SELECT 'FAILURE expected count ==> ', (SELECT count FROM #kill_temp_table), ' actual count ==> ', count(*) from sys.dm_exec_sessions b;
+GO
+~~START~~
+varchar
+SUCESS
 ~~END~~
 

--- a/test/JDBC/input/kill-vu-verify.mix
+++ b/test/JDBC/input/kill-vu-verify.mix
@@ -4,6 +4,8 @@ create table tab_kill_spid(spid int)
 go
 create login victim_user_tds with password = '12345678';
 go
+select count(*) as count into #kill_temp_table from sys.dm_exec_sessions
+go
 
 -- tsql user=victim_user_tds password=12345678
 select 1
@@ -403,4 +405,10 @@ SELECT count(*) from sys.dm_exec_sessions where login_name = 'test_kill'
 GO
 
 SELECT COUNT(*) from pg_stat_activity where usename = 'test_kill'
+GO
+
+IF ((SELECT COUNT(*) FROM sys.dm_exec_sessions) = (SELECT count FROM #kill_temp_table))	
+	SELECT 'SUCESS';
+ELSE
+	SELECT 'FAILURE expected count ==> ', (SELECT count FROM #kill_temp_table), ' actual count ==> ', count(*) from sys.dm_exec_sessions b;
 GO


### PR DESCRIPTION
### Description

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3329 was not enough to fix abandoned rows in sys.dm_exec_sessions. Sessions terminated using kill command still leave behind an entry in sys.dm_exec_sessions.

Root cause was not executing the shmem exit hook when session terminated because of SIGTERM.

As a fix make `tds_stats_shmem_shutdown` completely similar to `pgstat_beshutdown_hook`.

### Cherry Picked From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3350

### Issues Resolved

[BABEL-5414]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).