### PR TITLE
Only create CASTs if they do not already exist

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.0.0--5.1.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.0.0--5.1.0.sql
@@ -39,22 +39,37 @@ RETURNS sys.VARCHAR
 AS 'babelfishpg_common', 'fixeddecimal2varchar'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION sys.fixeddecimal2pgvarchar(sys.FIXEDDECIMAL, integer, BOOLEAN)
+RETURNS pg_catalog.VARCHAR
+AS 'babelfishpg_common', 'fixeddecimal2varchar'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION sys.fixeddecimal2bpchar(sys.FIXEDDECIMAL, integer, BOOLEAN)
 RETURNS sys.BPCHAR
 AS 'babelfishpg_common', 'fixeddecimal2bpchar'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE CAST (sys.FIXEDDECIMAL AS sys.VARCHAR)
-WITH FUNCTION sys.fixeddecimal2varchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    CREATE CAST (sys.FIXEDDECIMAL AS sys.VARCHAR)
+    WITH FUNCTION sys.fixeddecimal2varchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
 
-CREATE CAST (sys.FIXEDDECIMAL AS pg_catalog.VARCHAR)
-WITH FUNCTION sys.fixeddecimal2varchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
+    CREATE CAST (sys.FIXEDDECIMAL AS pg_catalog.VARCHAR)
+    WITH FUNCTION sys.fixeddecimal2pgvarchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
 
-CREATE CAST (sys.FIXEDDECIMAL AS sys.BPCHAR)
-WITH FUNCTION sys.fixeddecimal2bpchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
+    CREATE CAST (sys.FIXEDDECIMAL AS sys.BPCHAR)
+    WITH FUNCTION sys.fixeddecimal2bpchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
 
-CREATE CAST (sys.FIXEDDECIMAL AS pg_catalog.BPCHAR)
-WITH FUNCTION sys.fixeddecimal2bpchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
+    CREATE CAST (sys.FIXEDDECIMAL AS pg_catalog.BPCHAR)
+    WITH FUNCTION sys.fixeddecimal2bpchar(sys.FIXEDDECIMAL, integer, BOOLEAN) AS IMPLICIT;
+EXCEPTION WHEN duplicate_object THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);


### PR DESCRIPTION
### Description
Only create CASTs from money to (n)varchar/(n)char if they do not already exist
during upgrade otherwise upgrade would fail complaining that the CAST already
exists.

Task: BABEL-5478
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).