### PR TITLE
[OSS-ONLY] Restrict grant to/from any babelfish created role via PG port

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -35,7 +35,6 @@
 #include "utils/fmgroids.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
-#include "utils/lsyscache.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
 
@@ -934,11 +933,11 @@ check_babelfish_droprole_restrictions(char *role)
 static bool
 is_bbf_admin_of_role(Oid roleid, Oid bbf_role_admin)
 {
-	CatCList   *memlist;
-	int			i;
+	CatCList	*memlist;
+	int		i;
 	bool		is_bbf_admin_of_role = true;
 
-	/* Find roles that roleid is directly a member of */
+	/* Find roles that are direct membes of roleid */
 	memlist = SearchSysCacheList1(AUTHMEMROLEMEM,
                                   ObjectIdGetDatum(roleid));
 	for (i = 0; i < memlist->n_members; i++)
@@ -968,7 +967,7 @@ is_bbf_admin_of_role(Oid roleid, Oid bbf_role_admin)
  * 	Since role related DDLs could be executed in any PG databases,
  * 	This function check the underlying assumption:
  * 	1. Given role is the bbf_role_admin.
- * 	2. If bbf_role_admin is admin of the given role.
+ * 	2. If bbf_role_admin is only admin of the given role.
  */
 static bool
 is_babelfish_role(const char *role)

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -928,14 +928,14 @@ check_babelfish_droprole_restrictions(char *role)
 }
 
 /*
- * Checks if bbf_role_admin is the direct admin of a role.
+ * Checks if admin_of is member of the given roleid and its immediate admin.
  */
 static bool
-is_bbf_admin_of_role(Oid roleid, Oid bbf_role_admin)
+member_and_immediate_admin_of_role(Oid admin_of, Oid roleid)
 {
 	CatCList	*memlist;
 	int		i;
-	bool		is_bbf_admin_of_role = true;
+	bool		member_and_immediate_admin_of_role = false;
 
 	/* Find roles that are direct membes of roleid */
 	memlist = SearchSysCacheList1(AUTHMEMROLEMEM,
@@ -945,15 +945,15 @@ is_bbf_admin_of_role(Oid roleid, Oid bbf_role_admin)
 		HeapTuple	tup = &memlist->members[i]->tuple;
 		Form_pg_auth_members form = (Form_pg_auth_members) GETSTRUCT(tup);
 
-		/* If role is member of a login other than bbf_role_admin WITH ADMIN OPTION. */
-		if (form->member != bbf_role_admin && form->admin_option)
+		/* If admin_of is the direct member of roleid WITH ADMIN OPTION. */
+		if (form->member == admin_of && form->admin_option)
 		{
-			is_bbf_admin_of_role = false;
+			member_and_immediate_admin_of_role = true;
 			break;
 		}
 	}
 	ReleaseSysCacheList(memlist);
-	return is_bbf_admin_of_role;
+	return member_and_immediate_admin_of_role;
 }
 
 /*
@@ -967,7 +967,7 @@ is_bbf_admin_of_role(Oid roleid, Oid bbf_role_admin)
  * 	Since role related DDLs could be executed in any PG databases,
  * 	This function check the underlying assumption:
  * 	1. Given role is the bbf_role_admin.
- * 	2. If bbf_role_admin is only admin of the given role.
+ * 	2. If bbf_role_admin is member of the given role and its immediate admin.
  */
 static bool
 is_babelfish_role(const char *role)
@@ -982,7 +982,7 @@ is_babelfish_role(const char *role)
 		return false;
 
 	if ((pg_strcasecmp(role, BABELFISH_ROLE_ADMIN) == 0) ||
-			(is_bbf_admin_of_role(role_oid, bbf_admin_oid) && is_admin_of_role(bbf_admin_oid, role_oid)))
+			member_and_immediate_admin_of_role(bbf_admin_oid, role_oid))
 		return true;
 
 	return false;

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -20,6 +20,7 @@
 #include "access/htup_details.h"
 #include "access/table.h"
 #include "catalog/pg_authid.h"
+#include "catalog/pg_auth_members.h"
 #include "catalog/pg_db_role_setting.h"
 #include "catalog/pg_database.h"
 #include "commands/dbcommands.h"
@@ -29,10 +30,12 @@
 #include "parser/parser.h"
 #include "parser/parse_node.h"
 #include "utils/acl.h"
+#include "utils/catcache.h"
 #include "utils/elog.h"
 #include "utils/fmgroids.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
+#include "utils/lsyscache.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
 
@@ -926,6 +929,35 @@ check_babelfish_droprole_restrictions(char *role)
 }
 
 /*
+ * Checks if bbf_role_admin is the direct admin of a role.
+ */
+static bool
+is_bbf_admin_of_role(Oid roleid, Oid bbf_role_admin)
+{
+	CatCList   *memlist;
+	int			i;
+	bool		is_bbf_admin_of_role = true;
+
+	/* Find roles that roleid is directly a member of */
+	memlist = SearchSysCacheList1(AUTHMEMROLEMEM,
+                                  ObjectIdGetDatum(roleid));
+	for (i = 0; i < memlist->n_members; i++)
+	{
+		HeapTuple	tup = &memlist->members[i]->tuple;
+		Form_pg_auth_members form = (Form_pg_auth_members) GETSTRUCT(tup);
+
+		/* If role is member of a login other than bbf_role_admin WITH ADMIN OPTION. */
+		if (form->member != bbf_role_admin && form->admin_option)
+		{
+			is_bbf_admin_of_role = false;
+			break;
+		}
+	}
+	ReleaseSysCacheList(memlist);
+	return is_bbf_admin_of_role;
+}
+
+/*
  * is_babelfish_role
  *
  * Helper function to check if a given role is babelfish user or role or login
@@ -934,46 +966,24 @@ check_babelfish_droprole_restrictions(char *role)
  * 	Direct evidence of babelfish membership is stored in babelfish catalog,
  * 	that is only accessible in babelfish_db.
  * 	Since role related DDLs could be executed in any PG databases,
- * 	This function check the underlying assumption on the membership chain instead
- * 	sysadmin <-- dbo* <--- db_owner* <--- users/roles
- *
- * actual dbo and db_owner name varies across different babelfish logical databases
+ * 	This function check the underlying assumption:
+ * 	1. Given role is the bbf_role_admin.
+ * 	2. If bbf_role_admin is admin of the given role.
  */
 static bool
 is_babelfish_role(const char *role)
 {
-	Oid			sysadmin_oid;
 	Oid			role_oid;
-	Oid			bbf_master_guest_oid;
-	Oid			bbf_tempdb_guest_oid;
-	Oid			bbf_msdb_guest_oid;
-	Oid			securityadmin;
-	Oid			dbcreator;
+	Oid			bbf_admin_oid;
 
-	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
-	securityadmin = get_role_oid(BABELFISH_SECURITYADMIN, true);  /* missing OK */
-	dbcreator = get_role_oid(BABELFISH_DBCREATOR, true);  /* missing OK */
+	bbf_admin_oid = get_role_oid(BABELFISH_ROLE_ADMIN, true); /* missing OK */
 
-	if (!OidIsValid(sysadmin_oid) || !OidIsValid(role_oid) 
-			|| !OidIsValid(securityadmin) || !OidIsValid(dbcreator))
+	if (!OidIsValid(role_oid) || !OidIsValid(bbf_admin_oid))
 		return false;
 
-	if (is_member_of_role(sysadmin_oid, role_oid) ||
-		is_member_of_role(securityadmin, role_oid) ||
-		is_member_of_role(dbcreator, role_oid) ||
-		pg_strcasecmp(role, BABELFISH_ROLE_ADMIN) == 0) /* check if it is bbf_role_admin */
-		return true;
-
-	bbf_master_guest_oid = get_role_oid("master_guest", true);
-	bbf_tempdb_guest_oid = get_role_oid("tempdb_guest", true);
-	bbf_msdb_guest_oid = get_role_oid("msdb_guest", true);
-	if (OidIsValid(bbf_master_guest_oid)
-		&& OidIsValid(bbf_tempdb_guest_oid)
-		&& OidIsValid(bbf_msdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_master_guest_oid)
-		&& is_member_of_role(role_oid, bbf_tempdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_msdb_guest_oid))
+	if ((pg_strcasecmp(role, BABELFISH_ROLE_ADMIN) == 0) ||
+			(is_bbf_admin_of_role(role_oid, bbf_admin_oid) && is_admin_of_role(bbf_admin_oid, role_oid)))
 		return true;
 
 	return false;
@@ -1242,7 +1252,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 			continue;
 
 		roleid = get_role_oid(rolename, false);
-		if (OidIsValid(roleid) && IS_DEFAULT_BBF_SERVER_ROLE(rolename))
+		if (OidIsValid(roleid) && is_babelfish_role(rolename))
 			check_babelfish_alterrole_restictions(false);
 	}
 
@@ -1254,7 +1264,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 		Oid			roleid;
 
 		roleid = get_rolespec_oid(rolespec, false);
-		if (OidIsValid(roleid) && IS_DEFAULT_BBF_SERVER_ROLE(rolespec->rolename))
+		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
 			check_babelfish_alterrole_restictions(false);
 	}
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -928,14 +928,14 @@ check_babelfish_droprole_restrictions(char *role)
 }
 
 /*
- * Checks if admin_of is member of the given roleid and its immediate admin.
+ * Checks if admin_of is member of the given roleid and its direct admin.
  */
 static bool
-member_and_immediate_admin_of_role(Oid admin_of, Oid roleid)
+member_and_direct_admin_of_role(Oid admin_of, Oid roleid)
 {
 	CatCList	*memlist;
 	int		i;
-	bool		member_and_immediate_admin_of_role = false;
+	bool		member_and_direct_admin_of_role = false;
 
 	/* Find roles that are direct membes of roleid */
 	memlist = SearchSysCacheList1(AUTHMEMROLEMEM,
@@ -948,12 +948,12 @@ member_and_immediate_admin_of_role(Oid admin_of, Oid roleid)
 		/* If admin_of is the direct member of roleid WITH ADMIN OPTION. */
 		if (form->member == admin_of && form->admin_option)
 		{
-			member_and_immediate_admin_of_role = true;
+			member_and_direct_admin_of_role = true;
 			break;
 		}
 	}
 	ReleaseSysCacheList(memlist);
-	return member_and_immediate_admin_of_role;
+	return member_and_direct_admin_of_role;
 }
 
 /*
@@ -967,7 +967,7 @@ member_and_immediate_admin_of_role(Oid admin_of, Oid roleid)
  * 	Since role related DDLs could be executed in any PG databases,
  * 	This function check the underlying assumption:
  * 	1. Given role is the bbf_role_admin.
- * 	2. If bbf_role_admin is member of the given role and its immediate admin.
+ * 	2. If bbf_role_admin is member of the given role and its direct admin.
  */
 static bool
 is_babelfish_role(const char *role)
@@ -982,7 +982,7 @@ is_babelfish_role(const char *role)
 		return false;
 
 	if ((pg_strcasecmp(role, BABELFISH_ROLE_ADMIN) == 0) ||
-			member_and_immediate_admin_of_role(bbf_admin_oid, role_oid))
+			member_and_direct_admin_of_role(bbf_admin_oid, role_oid))
 		return true;
 
 	return false;

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -259,12 +259,6 @@ extern ProcessUtility_hook_type next_ProcessUtility;
 #define BABELFISH_SECURITYADMIN "securityadmin"
 #define BABELFISH_DBCREATOR "dbcreator"
 
-#define IS_DEFAULT_BBF_SERVER_ROLE(rolename) \
-	((strlen(rolename) == 13 && strncmp(rolename, BABELFISH_SECURITYADMIN, 13) == 0) || \
-	(strlen(rolename) == 14 && strncmp(rolename, BABELFISH_ROLE_ADMIN, 14) == 0) || \
-	(strlen(rolename) == 9 && strncmp(rolename, BABELFISH_DBCREATOR, 9) == 0) || \
-	(strlen(rolename) == 8 && strncmp(rolename, BABELFISH_SYSADMIN, 8) == 0))
-
 /* Functions in backend/tds/tdscomm.c */
 extern void TdsSetMessageType(uint8_t msgType);
 extern void TdsCommInit(uint32_t bufferSize,

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -1344,8 +1344,7 @@ GRANT db_securityadmin_restrictions_login TO master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "db_securityadmin_restrictions_login"
-  Detail: Only roles with the ADMIN option on role "db_securityadmin_restrictions_login" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1356,8 +1355,7 @@ REVOKE master_dbo FROM master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_dbo"
-  Detail: Only roles with the ADMIN option on role "master_dbo" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1418,8 +1416,7 @@ GRANT master_db_securityadmin TO db_securityadmin_restrictions_login;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "master_db_securityadmin"
-  Detail: Only roles with the ADMIN option on role "master_db_securityadmin" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1427,8 +1424,7 @@ GRANT db_securityadmin_restrictions_login TO master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "db_securityadmin_restrictions_login"
-  Detail: Only roles with the ADMIN option on role "db_securityadmin_restrictions_login" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1436,8 +1432,7 @@ REVOKE master_db_securityadmin FROM master_dbo;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_db_securityadmin"
-  Detail: Only roles with the ADMIN option on role "master_db_securityadmin" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1445,8 +1440,7 @@ REVOKE master_dbo FROM master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_dbo"
-  Detail: Only roles with the ADMIN option on role "master_dbo" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 


### PR DESCRIPTION
### Description

Restrict grant to/from any babelfish created role via PG port
All server and database roles including fixed server roles and database roles have 'bbf_role_admin' as its admin. Added a check to identify if 'bbf_role_admin' is the direct admin of the role to avoid granting any Babelfish role  to another Babelfish roles including fixed db and server roles. 


### Issues Resolved

Task: BABEL-5505
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests -**


