### PR TITLE
[OSS-ONLY] Restrict grant to/from any babelfish created role via PG port

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1242,7 +1242,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 			continue;
 
 		roleid = get_role_oid(rolename, false);
-		if (OidIsValid(roleid) && IS_DEFAULT_BBF_SERVER_ROLE(rolename))
+		if (OidIsValid(roleid) && is_babelfish_role(rolename))
 			check_babelfish_alterrole_restictions(false);
 	}
 
@@ -1254,7 +1254,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 		Oid			roleid;
 
 		roleid = get_rolespec_oid(rolespec, false);
-		if (OidIsValid(roleid) && IS_DEFAULT_BBF_SERVER_ROLE(rolespec->rolename))
+		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
 			check_babelfish_alterrole_restictions(false);
 	}
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -971,9 +971,9 @@ is_babelfish_role(const char *role)
 	if (OidIsValid(bbf_master_guest_oid)
 		&& OidIsValid(bbf_tempdb_guest_oid)
 		&& OidIsValid(bbf_msdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_master_guest_oid)
-		&& is_member_of_role(role_oid, bbf_tempdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_msdb_guest_oid))
+		&& (is_member_of_role(role_oid, bbf_master_guest_oid)
+		|| is_member_of_role(role_oid, bbf_tempdb_guest_oid)
+		|| is_member_of_role(role_oid, bbf_msdb_guest_oid)))
 		return true;
 
 	return false;

--- a/contrib/babelfishpg_tds/src/include/tds_int.h
+++ b/contrib/babelfishpg_tds/src/include/tds_int.h
@@ -259,12 +259,6 @@ extern ProcessUtility_hook_type next_ProcessUtility;
 #define BABELFISH_SECURITYADMIN "securityadmin"
 #define BABELFISH_DBCREATOR "dbcreator"
 
-#define IS_DEFAULT_BBF_SERVER_ROLE(rolename) \
-	((strlen(rolename) == 13 && strncmp(rolename, BABELFISH_SECURITYADMIN, 13) == 0) || \
-	(strlen(rolename) == 14 && strncmp(rolename, BABELFISH_ROLE_ADMIN, 14) == 0) || \
-	(strlen(rolename) == 9 && strncmp(rolename, BABELFISH_DBCREATOR, 9) == 0) || \
-	(strlen(rolename) == 8 && strncmp(rolename, BABELFISH_SYSADMIN, 8) == 0))
-
 /* Functions in backend/tds/tdscomm.c */
 extern void TdsSetMessageType(uint8_t msgType);
 extern void TdsCommInit(uint32_t bufferSize,

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -1344,8 +1344,7 @@ GRANT db_securityadmin_restrictions_login TO master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "db_securityadmin_restrictions_login"
-  Detail: Only roles with the ADMIN option on role "db_securityadmin_restrictions_login" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1356,8 +1355,7 @@ REVOKE master_dbo FROM master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_dbo"
-  Detail: Only roles with the ADMIN option on role "master_dbo" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1418,8 +1416,7 @@ GRANT master_db_securityadmin TO db_securityadmin_restrictions_login;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "master_db_securityadmin"
-  Detail: Only roles with the ADMIN option on role "master_db_securityadmin" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1427,8 +1424,7 @@ GRANT db_securityadmin_restrictions_login TO master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to grant role "db_securityadmin_restrictions_login"
-  Detail: Only roles with the ADMIN option on role "db_securityadmin_restrictions_login" may grant this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1436,8 +1432,7 @@ REVOKE master_db_securityadmin FROM master_dbo;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_db_securityadmin"
-  Detail: Only roles with the ADMIN option on role "master_db_securityadmin" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -1445,8 +1440,7 @@ REVOKE master_dbo FROM master_db_securityadmin;
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied to revoke role "master_dbo"
-  Detail: Only roles with the ADMIN option on role "master_dbo" may revoke this role.
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -126,6 +126,15 @@ go
 alter user permission_restrictions_psql_user1 with password '1234'
 go
 
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -45,6 +45,15 @@ go
     Server SQLState: 42501)~~
 
 
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
 -- Dropping a role by an underprivileged login should be restricted
 drop user permission_restrictions_psql_user;
 go

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -2,6 +2,12 @@
 create login permission_restrictions_tsql_login with password = '123';
 go
 
+create login permission_restrictions_tsql_login1 with password = '123';
+go
+
+create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -51,6 +57,47 @@ go
 ~~ERROR (Code: 0)~~
 
 ~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_db_datareader;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -135,6 +182,47 @@ go
     Server SQLState: 42501)~~
 
 
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_db_datareader;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go
@@ -187,6 +275,28 @@ void
 ~~END~~
 
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
 -- tsql
+drop user permission_restrictions_tsql_user1;
+go
+
+drop login permission_restrictions_tsql_login1;
+go
+
 drop login permission_restrictions_tsql_login
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -23,6 +23,10 @@ go
 alter user permission_restrictions_psql_user with password '123'
 go
 
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+
 -- Dropping a role by an underprivileged login should be restricted
 drop user permission_restrictions_psql_user;
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -2,6 +2,12 @@
 create login permission_restrictions_tsql_login with password = '123';
 go
 
+create login permission_restrictions_tsql_login1 with password = '123';
+go
+
+create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -25,6 +31,22 @@ go
 
 -- Grant on BBF role should not be allowed
 grant master_db_datareader to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_db_datareader;
+go
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+
+drop user master_permission_restrictions_tsql_user1;
 go
 
 -- Dropping a role by an underprivileged login should be restricted
@@ -69,6 +91,22 @@ go
 grant master_db_datareader to permission_restrictions_psql_user;
 go
 
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_db_datareader;
+go
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+
+drop user master_permission_restrictions_tsql_user1;
+go
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go
@@ -105,6 +143,19 @@ GO
 select pg_sleep(1);
 GO
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+select pg_sleep(1);
+GO
+
 -- tsql
+drop user permission_restrictions_tsql_user1;
+go
+
+drop login permission_restrictions_tsql_login1;
+go
+
 drop login permission_restrictions_tsql_login
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -65,6 +65,10 @@ go
 alter user permission_restrictions_psql_user1 with password '1234'
 go
 
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go


### PR DESCRIPTION
### Description

Restrict grant to/from any babelfish created role via PG port.
Earlier GRANT on role was only restricted for default Babelfish server roles, now it will be blocked for any babelfish created role via PG port.


### Issues Resolved

Task: BABEL-5505
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**
* **Performance tests -**
* **Tooling impact -**
* **Client tests -**


