### PR TITLE
Fix a corner case '=' not properly rewritten to AS (#3405)

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2936,17 +2936,38 @@ public:
 		clear_rewritten_query_fragment();
 	}
 
-	PLtsql_expr *rewrite_if_condition(TSqlParser::Search_conditionContext *ctx)
+	PLtsql_expr *rewrite_if_condition(TSqlParser::Search_conditionContext *ctx, PLtsql_expr *expr)
 	{
-		PLtsql_expr *expr = makeTsqlExpr(ctx, false);
-		PLtsql_expr_query_mutator mutator(expr, ctx);
-		add_rewritten_query_fragment_to_mutator(&mutator);
-		mutator.run();
+		if (!expr)
+			expr = makeTsqlExpr(ctx, false);
+		if (statementMutator)
+		{
+			add_rewritten_query_fragment_to_mutator(statementMutator.get());
+			statementMutator->run();
+			statementMutator = nullptr;
+		}
+		else
+		{
+			PLtsql_expr_query_mutator mutator(expr, ctx);
+			add_rewritten_query_fragment_to_mutator(&mutator);
+			mutator.run();
+		}
 		clear_rewritten_query_fragment();
 
 		/* Now we can prepend SELECT to rewritten search_condition */
 		expr->query = strdup((std::string("SELECT ") + std::string(expr->query)).c_str());
 		return expr;
+	}
+
+	void enterSearch_condition(TSqlParser::Search_conditionContext *ctx) override
+	{
+		if (((TSqlParser::Cfl_statementContext *) ctx->parent->parent)->if_statement())
+		{
+			PLtsql_stmt_if *fragment = (PLtsql_stmt_if *) getPLtsql_fragment(ctx->parent->parent);
+			fragment->cond = makeTsqlExpr(ctx, false);
+			clear_rewritten_query_fragment();
+			statementMutator = std::make_unique<PLtsql_expr_query_mutator>(fragment->cond, ctx);
+		}
 	}
 
 	void exitSearch_condition(TSqlParser::Search_conditionContext *ctx) override
@@ -2956,14 +2977,13 @@ public:
 
 		if (((TSqlParser::Cfl_statementContext *) ctx->parent->parent)->if_statement())
 		{
-
 			PLtsql_stmt_if *fragment = (PLtsql_stmt_if *) getPLtsql_fragment(ctx->parent->parent);
-			fragment->cond = rewrite_if_condition(ctx);
+			fragment->cond = rewrite_if_condition(ctx, fragment->cond);
 		}
 		else if (((TSqlParser::Cfl_statementContext *) ctx->parent->parent)->while_statement())
 		{
 			PLtsql_stmt_while *fragment = (PLtsql_stmt_while *) getPLtsql_fragment(ctx->parent->parent);
-			fragment->cond = rewrite_if_condition(ctx);
+			fragment->cond = rewrite_if_condition(ctx, fragment->cond);
 		}
 	}
 };

--- a/test/JDBC/expected/BABEL-2514.out
+++ b/test/JDBC/expected/BABEL-2514.out
@@ -197,3 +197,14 @@ int#!#int
 
 drop view if exists babel_2514_complex_view;
 go
+
+IF EXISTS 
+(
+SELECT tblnam = a.name FROM sysobjects a where a.name = 'tablename'
+) select 'Exists'; ELSE select 'Not Exists';
+GO
+~~START~~
+varchar
+Not Exists
+~~END~~
+

--- a/test/JDBC/input/BABEL-2514.sql
+++ b/test/JDBC/input/BABEL-2514.sql
@@ -126,3 +126,9 @@ select * from babel_2514_complex_view order by b;
 go
 drop view if exists babel_2514_complex_view;
 go
+
+IF EXISTS 
+(
+SELECT tblnam = a.name FROM sysobjects a where a.name = 'tablename'
+) select 'Exists'; ELSE select 'Not Exists';
+GO


### PR DESCRIPTION
Previously we rewrite "SELECT COL=expr" to "SELECT expr as "COL"", but there's a corner case that for if condition, it didn't do the rewrite, because different parser path from if condition to dml statement.

This commit fix this issue by adding the mutator logic to if statement rewrite.

Task: BABEL-5320


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).