### PR TITLE
Update upload/download artifacts GitHub action version to v4

### DIFF
--- a/.github/composite-actions/upload-coredump/action.yml
+++ b/.github/composite-actions/upload-coredump/action.yml
@@ -14,7 +14,7 @@ runs:
 
 
     - name: Upload Coredumps
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: coredumps

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -119,28 +119,28 @@ jobs:
           lcov --list lcov.info
       - name: Upload Coverage Report for babelfishpg_tsql extension
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_tsql_${{github.ref_name}}
           path: contrib/babelfishpg_tsql/coverage/
 
       - name: Upload Coverage Report for babelfishpg_tds extension
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_tds_${{github.ref_name}}
           path: contrib/babelfishpg_tds/coverage/
 
       - name: Upload Coverage Report for babelfishpg_common extension
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_common_${{github.ref_name}}
           path: contrib/babelfishpg_common/coverage/
 
       - name: Upload Coverage Report for babelfishpg_money extension
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_money_${{github.ref_name}}
           path: contrib/babelfishpg_money/coverage/
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload CSV report with latest coverage numbers
         if: (github.event_name == 'schedule')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: csv_${{github.ref_name}}
           path: contrib/${{github.ref_name}}.csv

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload Coverage Report for Babelfish Extensions
         if: always() && steps.code-coverage-summary.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-babelfish-extensions-dotnet
           path: contrib/dotnet-lcov.info

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Coverage Report for Babelfish Extensions
         if: always() && steps.code-coverage-summary.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-babelfish-extensions-isolation
           path: contrib/isolation-lcov.info

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload Coverage Report for Babelfish Extensions
         if: always() && steps.code-coverage-summary.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-babelfish-extensions-jdbc
           path: contrib/jdbc-lcov.info

--- a/.github/workflows/odbc-tests.yml
+++ b/.github/workflows/odbc-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload Coverage Report for Babelfish Extensions
         if: always() && steps.code-coverage-summary.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-babelfish-extensions-odbc
           path: contrib/odbc-lcov.info

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -37,31 +37,31 @@ jobs:
       run: |
         sudo apt-get install lcov
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download-jdbc-coverage
       with:
         name:  coverage-babelfish-extensions-jdbc
         path: contrib/
     
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download-dotnet-coverage
       with:
         name: coverage-babelfish-extensions-dotnet
         path: contrib/
     
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download-odbc-coverage
       with:
         name: coverage-babelfish-extensions-odbc
         path: contrib/
     
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download-python-coverage
       with:
         name: coverage-babelfish-extensions-python
         path: contrib/
         
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download-isolation-coverage
       with:
         name: coverage-babelfish-extensions-isolation

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload Coverage Report for Babelfish Extensions
         if: always() && steps.code-coverage-summary.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-babelfish-extensions-python
           path: contrib/python-lcov.info


### PR DESCRIPTION
### Description

Bumping up the version of GitHub action upload/download

### Issues Resolved

[No JIRA]

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).