### PR TITLE
Reduce log level of some internal log statements

### DIFF
--- a/.github/scripts/scan-warnings.sh
+++ b/.github/scripts/scan-warnings.sh
@@ -49,8 +49,8 @@ if [[ "$SNAPSHOT_ACTIVE_COUNT" -ne 44 ]]; then
     ERROR_FOUND=true
 fi
 
-if [[ "$LEAK_COUNT" -ne 380 ]]; then
-    echo "Error: Expected 380 leak warnings, but found $LEAK_COUNT"
+if [[ "$LEAK_COUNT" -ne 324 ]]; then
+    echo "Error: Expected 324 leak warnings, but found $LEAK_COUNT"
     ERROR_FOUND=true
 fi
 

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -489,12 +489,12 @@ get_remove_accents_internal_oid()
 #ifdef USE_ICU
 	if (U_ICU_VERSION_MAJOR_NUM == pltsql_remove_accent_map_icu_major_version && U_ICU_VERSION_MINOR_NUM == pltsql_remove_accent_map_icu_min_version)
 	{
-		elog(LOG, "Using cached mappings to remove accents");
+		elog(DEBUG1, "Using cached mappings to remove accents");
 		remove_accents_internal_oid = LookupFuncName(list_make2(makeString("sys"), makeString("remove_accents_internal_using_cache")), -1, funcargtypes, true);
 		return;
 	}
 #endif
-	elog(LOG, "Using ICU function to remove accents");
+	elog(DEBUG1, "Using ICU function to remove accents");
 	remove_accents_internal_oid = LookupFuncName(list_make2(makeString("sys"), makeString("remove_accents_internal")), -1, funcargtypes, true);
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5359,7 +5359,7 @@ terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 			 SPI_depth, current_spi_stack_depth);
 	
 	if (current_spi_stack_depth > SPI_depth)
-		elog(WARNING, "SPI connection leak found, expected count:%d, current count:%d",
+		elog(LOG, "SPI connection leak found, expected count:%d, current count:%d",
 			 SPI_depth, current_spi_stack_depth);
 		
 	while (current_spi_stack_depth-- >= SPI_depth)


### PR DESCRIPTION
### Description

Reduce log level of "SPI connection leak found, expected count:%d, current count:%d" to LOG since this is expected when a pltsql routine calls a non pltsql routine and it hits an error. In an error case non pltsql routines do not cleanup their SPI connections.

Also reduce the log level inside remove_accents_internal because for every new session we will try to cache the oid for the remove accent function and end up logging the whole first query in the server log, so reduce it to DEBUG.


### Issues Resolved

[BABEL-5549]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).