### PR TITLE
[TEST] [OSS-ONLY] Implementing hashcode and mode based caching in 4X

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -24,11 +24,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout Modified PostgreSQL
+    - name: Checkout Modified PostgreSQL for Babelfish
       run: |
         cd ..
         rm -rf postgresql_modified_for_babelfish
-        
+
         if [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
           if [[ ${{inputs.engine_branch}} == "latest" ]]; then
             ENGINE_BRANCH=$GITHUB_HEAD_REF
@@ -45,6 +45,7 @@ runs:
           REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER
         fi
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
+        cd postgresql_modified_for_babelfish
         rm -rf ~/.ccache
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
           echo "CRESTORE_KEY=$(git rev-parse --short HEAD)-tapTest" >> $GITHUB_ENV

--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -58,15 +58,15 @@ runs:
       shell: bash
 
     - uses: actions/cache/restore@v4
-    id: restore-ccache
-    if: ${{ github.event_name == 'pull_request' }} || ${{ inputs.code_coverage == 'yes' }}
-    with:
-      path: 
-        ~/.ccache
-      key: 
-        random-random
-      restore-keys: 
-        ccache-${{ env.CRESTORE_KEY }}
+      id: restore-ccache
+      if: ${{ github.event_name == 'pull_request' }} || ${{ inputs.code_coverage == 'yes' }}
+      with:
+        path: 
+          ~/.ccache
+        key: 
+          random-random
+        restore-keys: 
+          ccache-${{ env.CRESTORE_KEY }}
 
     - name: Save cache if cache hit fails in pull requests
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout, Build, and Install the Modified PostgreSQL Instance and Run Tests
+    - name: Checkout Modified PostgreSQL
       run: |
         cd ..
         rm -rf postgresql_modified_for_babelfish
@@ -44,10 +44,46 @@ runs:
           fi
           REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER
         fi
-
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
+        rm -rf ~/.ccache
+        if [[ ${{inputs.tap_tests}} == "yes" ]]; then
+          echo "CRESTORE_KEY=$(git rev-parse --short HEAD)-tapTest" >> $GITHUB_ENV
+        elif [[ ${{inputs.code_coverage}} == "yes" ]]; then
+          echo "CRESTORE_KEY=$(git rev-parse --short HEAD)-coverage" >> $GITHUB_ENV
+        elif [[ ${{inputs.release_mode}} == "yes" ]]; then
+          echo "CRESTORE_KEY=$(git rev-parse --short HEAD)-release" >> $GITHUB_ENV
+        else
+          echo "CRESTORE_KEY=$(git rev-parse --short HEAD)-default" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - uses: actions/cache/restore@v4
+    id: restore-ccache
+    if: ${{ github.event_name == 'pull_request' }} || ${{ inputs.code_coverage == 'yes' }}
+    with:
+      path: 
+        ~/.ccache
+      key: 
+        random-random
+      restore-keys: 
+        ccache-${{ env.CRESTORE_KEY }}
+
+    - name: Save cache if cache hit fails in pull requests
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        if [[ '${{ steps.restore-ccache.outputs.cache-matched-key }}' == '' ]]; then
+          echo "SAVE_CCACHE=1" >> $GITHUB_ENV
+        elif [[ ${{ 'steps.restore-ccache.outputs.cache-matched-key' }} != '' ]]; then
+          echo "SAVE_CCACHE=" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Build and Install the Modified PostgreSQL Instance and Run Tests
+      run: |
+        echo "${{env.SAVE_CCACHE}}"
+        echo "${{ steps.restore-ccache.outputs.cache-matched-key }}"
+        cd ..
         cd postgresql_modified_for_babelfish
-        git rev-parse HEAD
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
           ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
         elif [[ ${{inputs.code_coverage}} == "yes" ]]; then

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -328,7 +328,7 @@ runs:
       shell: bash
 
     - name: Save cache
-      if: always()
+      if: always() && steps.run-pg_dump-restore.outcome == 'success'
       uses: ./.github/composite-actions/save-cacche
 
     - name: Run Verify Tests

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -329,7 +329,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-cacche
+      uses: ./.github/composite-actions/save-cacche
 
     - name: Run Verify Tests
       if: always() && steps.run-pg_dump-restore.outcome == 'success' && inputs.is_final_ver == 'true'

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -329,7 +329,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-cache
+      uses: ./github/composite-actions/save-cacche
 
     - name: Run Verify Tests
       if: always() && steps.run-pg_dump-restore.outcome == 'success' && inputs.is_final_ver == 'true'

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -327,6 +327,10 @@ runs:
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash
 
+    - name: Save cache
+      if: always()
+      uses: ./github/composite-actions/save-cache
+
     - name: Run Verify Tests
       if: always() && steps.run-pg_dump-restore.outcome == 'success' && inputs.is_final_ver == 'true'
       uses: ./.github/composite-actions/run-verify-tests

--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -15,14 +15,4 @@ runs:
         sudo /usr/sbin/update-ccache-symlinks
         echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
         source ~/.bashrc && echo $PATH
-        echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
       shell: bash
-
-    - name: Restore ccache
-      id: cache-compiler
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: ccache-${{ runner.os }}-${{ env.NOW }}
-        restore-keys: |
-          ccache-${{ runner.os }}

--- a/.github/composite-actions/major-version-upgrade-util/action.yml
+++ b/.github/composite-actions/major-version-upgrade-util/action.yml
@@ -1,4 +1,4 @@
-name: 'Major Version Upgrade Utility'
+name: 'Minor Version Upgrade Utility'
 inputs:
   engine_branch: 
     description: "Engine Branch"
@@ -9,14 +9,8 @@ inputs:
   is_final_ver:
     description: "Is this the final version"
     required: true
-  pg_old_dir: 
-    description: "Previous version was installed in this directory"
-    required: true
-  pg_new_dir:
+  install_dir:
     description: "Install new version in this directory"
-    required: true
-  migration_mode:
-    description: "Database migration mode for Babelfish"
     required: true
   server_collation_name:
     description: "Server collation name"
@@ -29,32 +23,86 @@ inputs:
 
 runs:
   using: "composite"
-  steps:
-    - name: Setup latest version
-      id: setup-new-version
+  steps:    
+    - name: Build and run tests for Postgres engine using ${{ inputs.engine_branch }}
+      id: build-modified-postgres-new
       if: always()
-      uses: ./.github/composite-actions/setup-new-version
+      uses: ./.github/composite-actions/build-modified-postgres
       with:
         engine_branch: ${{ inputs.engine_branch }}
-        extension_branch: ${{ inputs.extension_branch }}
-        pg_new_dir: ${{ inputs.pg_new_dir }}
-        antlr_version: ${{ inputs.antlr_version }}
+        install_dir: ${{ inputs.install_dir }}
 
-    - name: Run pg_upgrade
-      id: run-pg_upgrade
-      if: always() && steps.setup-new-version.outcome == 'success'
-      uses: ./.github/composite-actions/run-pg-upgrade
-      with: 
-        migration_mode: ${{ inputs.migration_mode }}
-        pg_old_dir: ${{ inputs.pg_old_dir }}
-        pg_new_dir: ${{ inputs.pg_new_dir }}
-        server_collation_name: ${{ inputs.server_collation_name }}
-
-    - name: Run Verify Tests
-      if: always() && steps.run-pg_upgrade.outcome == 'success' && inputs.is_final_ver == 'true'
-      uses: ./.github/composite-actions/run-verify-tests
+    - name: Compile new ANTLR
+      id: compile-new-antlr
+      if: always() && steps.build-modified-postgres-new.outcome == 'success'
+      uses: ./.github/composite-actions/compile-antlr
       with:
-        is_final_ver: ${{ inputs.is_final_ver }}
-        pg_new_dir: ${{ inputs.pg_new_dir }}
-        migration_mode: ${{ inputs.migration_mode }}
-        server_collation_name: ${{ inputs.server_collation_name }}
+        version: ${{ inputs.antlr_version }}
+        install_dir: ${{inputs.install_dir}}
+
+    - name: Set env variables and build extensions using ${{ inputs.extension_branch }}
+      id: build-extensions-newer
+      if: always() && steps.compile-new-antlr.outcome == 'success'
+      uses: ./.github/composite-actions/build-extensions
+      with: 
+        install_dir: ${{ inputs.install_dir }}
+        extension_branch: ${{ inputs.extension_branch }}
+
+    - name: Save cache
+      if: always() && steps.build-extensions-newer.outcome == 'success'
+      uses: ./.github/composite-actions/save-ccache
+
+    # Not created and used composite action update-extensions here since, in the previous step it has 
+    # checked out a branch/tag which may not have the updated update-extension composite action
+    - name: Update extensions
+      if: always() && steps.build-extensions-newer.outcome == 'success'
+      run: |
+        ulimit -c unlimited
+        cd ~
+        ~/${{ inputs.install_dir }}/bin/pg_ctl -c -D ~/${{ inputs.install_dir }}/data/ -l logfile restart
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
+        sudo ~/${{ inputs.install_dir }}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "\dx"
+        sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
+      shell: bash
+
+    - uses: actions/checkout@v2
+  
+    - name: Change migration mode to multi-db
+      id: change-migration-mode
+      if: always() && inputs.is_final_ver == 'true'
+      run: |
+        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.migration_mode = 'multi-db';"
+        sudo ~/${{ inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d babelfish_db -U runner -c "SELECT pg_reload_conf();"
+      shell: bash
+
+    - name: Run JDBC Verify Tests
+      id: jdbc-verify-tests
+      if: always() && steps.change-migration-mode.outcome == 'success' && inputs.is_final_ver == 'true'
+      env:
+        base_dir: ${{ matrix.upgrade-path.path[0] }}
+        tar_dir: ${{ matrix.upgrade-path.last_version }}
+      run: |
+        cd test/JDBC/
+        export isUpgradeTestMode=true
+        if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
+          export serverCollationName=${{ inputs.server_collation_name }}
+        fi
+        base_dir=${{ matrix.upgrade-path.path[0] }}
+        tar_dir=${{ matrix.upgrade-path.last_version }}
+        if [[ "$base_dir" == *"latest"* ]]; then
+          base_dir="latest"
+        fi
+        if [[ "$tar_dir" == *"latest"* ]]; then
+          tar_dir="latest"
+        fi
+        export inputFilesPath=upgrade/$tar_dir/verification_cleanup/$base_dir
+        mvn -B -ntp test
+        export inputFilesPath=input
+        for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" upgrade/$base_dir/schedule); do
+          sed -i "s/\b$filename[ ]*\b$/$filename-vu-verify\\n$filename-vu-cleanup/g" upgrade/$base_dir/schedule
+        done
+        export scheduleFile=upgrade/$base_dir/schedule
+        mvn -B -ntp test
+      shell: bash      

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-ccache
+      uses: ./.github/composite-actions/save-ccache
     
     # Not created and used composite action update-extensions here since, in the previous step it has 
     # checked out a branch/tag which may not have the updated update-extension composite action

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -48,6 +48,10 @@ runs:
         install_dir: ${{ inputs.install_dir }}
         extension_branch: ${{ inputs.extension_branch }}
 
+    - name: Save cache
+      if: always()
+      uses: ./github/composite-actions/save-cache
+    
     # Not created and used composite action update-extensions here since, in the previous step it has 
     # checked out a branch/tag which may not have the updated update-extension composite action
     - name: Update extensions

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -49,9 +49,9 @@ runs:
         extension_branch: ${{ inputs.extension_branch }}
 
     - name: Save cache
-      if: always() && steps.build-extensions-newer.outcome == 'success'
+      if: always() && steps.build-extensions-newer == 'success'
       uses: ./.github/composite-actions/save-ccache
-    
+
     # Not created and used composite action update-extensions here since, in the previous step it has 
     # checked out a branch/tag which may not have the updated update-extension composite action
     - name: Update extensions

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-cache
+      uses: ./github/composite-actions/save-ccache
     
     # Not created and used composite action update-extensions here since, in the previous step it has 
     # checked out a branch/tag which may not have the updated update-extension composite action

--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -49,7 +49,7 @@ runs:
         extension_branch: ${{ inputs.extension_branch }}
 
     - name: Save cache
-      if: always()
+      if: always() && steps.build-extensions-newer.outcome == 'success'
       uses: ./.github/composite-actions/save-ccache
     
     # Not created and used composite action update-extensions here since, in the previous step it has 

--- a/.github/composite-actions/save-ccache/action.yml
+++ b/.github/composite-actions/save-ccache/action.yml
@@ -1,0 +1,39 @@
+name: 'Save ccache on push'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup new cache key
+      if: always()
+      run: |
+        echo "CCACHE_KEY=${{env.CRESTORE_KEY}}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        echo "Event : ${{ github.event_name }}"
+        echo "Save ccache : ${{ env.SAVE_CCACHE }}"
+        if [[ ${{ github.event_name != 'pull_request' || env.SAVE_CCACHE == 1 }} == true ]]; then
+          echo "Cache to be Saved"
+          echo "SAVE_CACHE_HERE=1" >> $GITHUB_ENV
+        else
+          echo "Cache shouldn't be Saved"
+          echo "SAVE_CACHE_HERE=0" >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Save ccache
+      uses: actions/cache/save@v4
+      if: env.SAVE_CACHE_HERE == 1
+      with:
+        path: 
+          ~/.ccache
+        key: 
+          ccache-${{ env.CCACHE_KEY }}
+
+    - name: Clean ccache directory and unset env variables
+      if: always()
+      shell: bash
+      run: |
+        rm -rf ~/.ccache
+        echo "CCACHE_KEY=" >> $GITHUB_ENV
+        echo "SAVE_CCACHE=" >> $GITHUB_ENV
+        echo "SAVE_CACHE_HERE=" >> $GITHUB_ENV
+        echo "CRESTORE_KEY=" >> $GITHUB_ENV

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -223,7 +223,7 @@ runs:
     - uses: actions/checkout@v2
 
     - name: Save cache
-      if: always()
+      if: always()&& steps.jdbc-upgrade-tests.outcome == 'success'
       uses: ./.github/composite-actions/save-ccache
     
     - name: Install Python

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -224,7 +224,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-cache
+      uses: ./github/composite-actions/save-ccache
     
     - name: Install Python
       id: install-python

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -222,6 +222,10 @@ runs:
 
     - uses: actions/checkout@v2
 
+    - name: Save cache
+      if: always()
+      uses: ./github/composite-actions/save-cache
+    
     - name: Install Python
       id: install-python
       if: ${{ matrix.upgrade-path.path[0] == 'source_latest' && steps.jdbc-upgrade-tests.outcome == 'success' }}

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -224,7 +224,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-ccache
+      uses: ./.github/composite-actions/save-ccache
     
     - name: Install Python
       id: install-python

--- a/.github/composite-actions/setup-new-version/action.yml
+++ b/.github/composite-actions/setup-new-version/action.yml
@@ -65,7 +65,7 @@ runs:
         install_dir: ${{ inputs.pg_new_dir }}
 
     - name: Save cache
-      if: always()
+      if: always() && steps.build-postgis-extension.outcome == 'success'
       uses: ./.github/composite-actions/save-ccache
       
     - name: Setup new data directory

--- a/.github/composite-actions/setup-new-version/action.yml
+++ b/.github/composite-actions/setup-new-version/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-cache
+      uses: ./github/composite-actions/save-ccache
       
     - name: Setup new data directory
       id: setup-new-datadir

--- a/.github/composite-actions/setup-new-version/action.yml
+++ b/.github/composite-actions/setup-new-version/action.yml
@@ -64,6 +64,10 @@ runs:
       with:
         install_dir: ${{ inputs.pg_new_dir }}
 
+    - name: Save cache
+      if: always()
+      uses: ./github/composite-actions/save-cache
+      
     - name: Setup new data directory
       id: setup-new-datadir
       if: always() && steps.build-postgis-extension.outcome == 'success'

--- a/.github/composite-actions/setup-new-version/action.yml
+++ b/.github/composite-actions/setup-new-version/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Save cache
       if: always()
-      uses: ./github/composite-actions/save-ccache
+      uses: ./.github/composite-actions/save-ccache
       
     - name: Setup new data directory
       id: setup-new-datadir

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -43,7 +43,7 @@ jobs:
       
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-cache
+        uses: ./github/composite-actions/save-ccache
 
       - name: Run Dotnet Tests
         id: run-dotnet-tests

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -43,7 +43,7 @@ jobs:
       
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-ccache
+        uses: ./.github/composite-actions/save-ccache
 
       - name: Run Dotnet Tests
         id: run-dotnet-tests

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/composite-actions/install-extensions
       
       - name: Save cache
-        if: always()
+        if: always()&& steps.install-extensions.outcome == 'success'
         uses: ./.github/composite-actions/save-ccache
 
       - name: Run Dotnet Tests

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -41,6 +41,10 @@ jobs:
         if: always() && steps.build-postgis-extension.outcome == 'success'
         uses: ./.github/composite-actions/install-extensions
       
+      - name: Save cache
+        if: always()
+        uses: ./github/composite-actions/save-cache
+
       - name: Run Dotnet Tests
         id: run-dotnet-tests
         if: always() && steps.install-extensions.outcome == 'success'

--- a/.github/workflows/jdbc-tests-single-db-mode.yml
+++ b/.github/workflows/jdbc-tests-single-db-mode.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-ccache
+        uses: ./.github/composite-actions/save-ccache
 
       # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
       - name: Rename Test Summary Files

--- a/.github/workflows/jdbc-tests-single-db-mode.yml
+++ b/.github/workflows/jdbc-tests-single-db-mode.yml
@@ -102,6 +102,10 @@ jobs:
             ~/psql/data/logfile
             ~/psql/data_5433/logfile
 
+      - name: Save cache
+        if: always()
+        uses: ./github/composite-actions/save-cache
+
       # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
       - name: Rename Test Summary Files
         id: test-file-rename

--- a/.github/workflows/jdbc-tests-single-db-mode.yml
+++ b/.github/workflows/jdbc-tests-single-db-mode.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-cache
+        uses: ./github/composite-actions/save-ccache
 
       # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
       - name: Rename Test Summary Files

--- a/.github/workflows/jdbc-tests-single-db-mode.yml
+++ b/.github/workflows/jdbc-tests-single-db-mode.yml
@@ -103,7 +103,7 @@ jobs:
             ~/psql/data_5433/logfile
 
       - name: Save cache
-        if: always()
+        if: always() && steps.replication.outcome == 'success'
         uses: ./.github/composite-actions/save-ccache
 
       # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Save cache
-        if: always()
+        if: always()&& steps.install-extensions-old.outcome == 'success'
         uses: ./.github/composite-actions/save-ccache
 
       - name: Build Modified Postgres using latest version
@@ -171,7 +171,7 @@ jobs:
           install_dir: ${{env.NEW_INSTALL_DIR}}
       
       - name: Save cache
-        if: always()
+        if: always()&& steps.build-postgis-extension.outcome == 'success'
         uses: ./.github/composite-actions/save-ccache
         
       - name: Setup new data directory

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -125,7 +125,7 @@ jobs:
       
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-ccache
+        uses: ./.github/composite-actions/save-ccache
 
       - name: Build Modified Postgres using latest version
         id: build-modified-postgres-new
@@ -172,7 +172,7 @@ jobs:
       
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-ccache
+        uses: ./.github/composite-actions/save-ccache
         
       - name: Setup new data directory
         id: setup-new-datadir

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -125,7 +125,7 @@ jobs:
       
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-cache
+        uses: ./github/composite-actions/save-ccache
 
       - name: Build Modified Postgres using latest version
         id: build-modified-postgres-new
@@ -172,7 +172,7 @@ jobs:
       
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-cache
+        uses: ./github/composite-actions/save-ccache
         
       - name: Setup new data directory
         id: setup-new-datadir

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -19,19 +19,12 @@ jobs:
         uses: ./.github/composite-actions/install-dependencies
 
       - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_FROM}}
+        uses: ./.github/composite-actions/build-modified-postgres
         id: build-modified-postgres-old
         if: always() && steps.install-dependencies.outcome == 'success'
-        run: |
-          cd ..
-          git clone --branch ${{env.ENGINE_BRANCH_FROM}} https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
-          cd postgresql_modified_for_babelfish
-          ./configure --prefix=$HOME/${{env.OLD_INSTALL_DIR}} --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
-          make clean
-          make -j 4 2>error.txt
-          make install
-          make check
-          cd contrib && make && sudo make install
-        shell: bash
+        with:
+          engine_branch: ${{env.ENGINE_BRANCH_FROM}}
+          install_dir: ${{env.OLD_INSTALL_DIR}}
       
       - name: Compile ANTLR
         id: compile-antlr
@@ -129,6 +122,10 @@ jobs:
         shell: bash
 
       - uses: actions/checkout@v2
+      
+      - name: Save cache
+        if: always()
+        uses: ./github/composite-actions/save-cache
 
       - name: Build Modified Postgres using latest version
         id: build-modified-postgres-new
@@ -172,7 +169,11 @@ jobs:
         uses: ./.github/composite-actions/build-postgis-extension
         with:
           install_dir: ${{env.NEW_INSTALL_DIR}}
-
+      
+      - name: Save cache
+        if: always()
+        uses: ./github/composite-actions/save-cache
+        
       - name: Setup new data directory
         id: setup-new-datadir
         if: always() && steps.build-postgis-extension.outcome == 'success'

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Save cache
-        if: always()
+        if: always() && steps.install-extensions-older.outcome == 'success'
         uses: ./.github/composite-actions/save-ccache
 
       - name: Build and run tests for Postgres engine using latest engine

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -106,12 +106,16 @@ jobs:
           sudo make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config install
         shell: bash
 
-      - uses: actions/checkout@v2
-
       - name: Install extensions
         id: install-extensions-older
         if: always() && steps.build-tds_fdw-extension.outcome == 'success'
         uses: ./.github/composite-actions/install-extensions
+
+      - uses: actions/checkout@v2
+
+      - name: Save cache
+        if: always()
+        uses: ./github/composite-actions/save-cache
 
       - name: Build and run tests for Postgres engine using latest engine
         id: build-modified-postgres-newer

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-cache
+        uses: ./github/composite-actions/save-ccache
 
       - name: Build and run tests for Postgres engine using latest engine
         id: build-modified-postgres-newer

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Save cache
         if: always()
-        uses: ./github/composite-actions/save-ccache
+        uses: ./.github/composite-actions/save-ccache
 
       - name: Build and run tests for Postgres engine using latest engine
         id: build-modified-postgres-newer

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -106,16 +106,16 @@ jobs:
           sudo make USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config install
         shell: bash
 
+      - uses: actions/checkout@v2
+      
+      - name: Save cache
+        if: always() && steps.build-tds_fdw-extension.outcome == 'success'
+        uses: ./.github/composite-actions/save-ccache
+
       - name: Install extensions
         id: install-extensions-older
         if: always() && steps.build-tds_fdw-extension.outcome == 'success'
         uses: ./.github/composite-actions/install-extensions
-
-      - uses: actions/checkout@v2
-
-      - name: Save cache
-        if: always() && steps.install-extensions-older.outcome == 'success'
-        uses: ./.github/composite-actions/save-ccache
 
       - name: Build and run tests for Postgres engine using latest engine
         id: build-modified-postgres-newer

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -99,6 +99,10 @@ jobs:
           extension_branch: ${{env.EXTENSION_BRANCH_OLD}}
 
       - uses: actions/checkout@v2
+      
+      - name: Save cache
+        if: always() && steps.build-extensions-old.outcome == 'success'
+        uses: ./.github/composite-actions/save-ccache
 
       - name: Build Modified Postgres using latest version
         id: build-modified-postgres-new
@@ -128,6 +132,10 @@ jobs:
         uses: ./.github/composite-actions/build-postgis-extension
         with:
           install_dir: ${{env.NEW_INSTALL_DIR}}
+      
+      - name: Save cache
+        if: always() && steps.build-postgis-extension.outcome == 'success'
+        uses: ./.github/composite-actions/save-ccache
 
       - name: Run TAP Tests
         id: tap


### PR DESCRIPTION
Description
This commit implements a more efficient method of caching compilations. Cache now restored will now be guaranteed to compatible with the version and build configuration of compilations.

We will now save 5-8 mins in version upgrade and dump restore tests.

Key changes:

Implemented new format for cache keys which includes github hashcode of corresponding engine branch and build mode to better identify the cache stored in a key.
New format "ccache-engineHashcode-buildMode-extensionHashcode".
Cache restoration handled by build-modified-postgres.yml and saving by save-ccache.yml composite actions.
Removed timeStamp based caching.
Task: [BABEL-5564](https://jira.rds.a2z.com/browse/BABEL-5564)
Signed-off-by: Siddharth Sengar [sensid@amazon.com](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/sensid@amazon.com)

Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request,
I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).