### PR TITLE
Fix IDENTITY_INSERT to work cross-db (#3402)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -319,6 +319,19 @@ check_identity_insert(char** newval, void **extra, GucSource source)
 }
 
 static void
+throw_error_for_identity_insert(char *database, char *schema, char* object)
+{
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("Cannot find the object \"%s%s%s%s%s\" because it does not exist or you do not have permissions.",
+				database ? database : "",
+				database ? "." : "",
+				schema ? schema : "",
+				schema ? "." : "",
+				object)));
+}
+
+static void
 assign_identity_insert(const char *newval, void *extra)
 {
 	if (IsParallelWorker())
@@ -336,6 +349,10 @@ assign_identity_insert(const char *newval, void *extra)
 		char	   *id_insert_rel_name = NULL;
 		char	   *id_insert_schema_name = NULL;
 		char	   *cur_db_name;
+		char	   *catalog_name = NULL;
+		char	   *logical_schema_name = NULL;
+		char	   *curr_user_if_cross_db = NULL;
+		Oid			curr_user_id = InvalidOid;
 
 		cur_db_name = get_cur_db_name();
 
@@ -363,40 +380,61 @@ assign_identity_insert(const char *newval, void *extra)
 		option_flag = (char *) linitial(elemlist);
 		rel_name = (char *) lsecond(elemlist);
 
+		/* Use catalog name if provided */
+		if (list_length(elemlist) == 4)
+		{
+			catalog_name = (char *) lfourth(elemlist);
+
+			if(!DbidIsValid(get_db_id(catalog_name)))
+			{
+				/* Get schema name for error message */
+				logical_schema_name = (char *) lthird(elemlist);
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
+			}
+
+			cur_db_name = catalog_name;
+			curr_user_if_cross_db = get_user_for_database(cur_db_name);
+
+			/*
+			 * User in cross-db case can be NULL if login has no user
+			 * that it can use to connect to that database. We should
+			 * throw permission denied error in that case
+			 */
+			if (!curr_user_if_cross_db)
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
+		}
+
 		/* Check the user provided schema value */
 		if (list_length(elemlist) >= 3)
 		{
-			schema_name = (char *) lthird(elemlist);
+			logical_schema_name = (char *) lthird(elemlist);
 
 			if (cur_db_name)
 				schema_name = get_physical_schema_name(cur_db_name,
-													   schema_name);
+													   logical_schema_name);
+
+			/* If no schema name is provided, we should use default schema */
+			if (!schema_name)
+			{
+				char *user_name = NULL;
+
+				/* If catalog name is not NULL, it is cross-db */
+				if (catalog_name)
+					user_name = curr_user_if_cross_db;
+				else
+					user_name = GetUserNameFromId(GetUserId(), false);
+
+				schema_name = get_physical_schema_name(cur_db_name,
+								get_authid_user_ext_schema_name(cur_db_name, user_name));
+			}
 
 			schema_oid = LookupExplicitNamespace(schema_name, true);
 			if (!OidIsValid(schema_oid))
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_SCHEMA),
-						 errmsg("schema \"%s\" does not exist",
-								schema_name)));
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
 
 			rel_oid = get_relname_relid(rel_name, schema_oid);
 			if (!OidIsValid(rel_oid))
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_TABLE),
-						 errmsg("relation \"%s\" does not exist",
-								rel_name)));
-		}
-
-		/* Check the catalog name then ignore it */
-		if (list_length(elemlist) == 4)
-		{
-			char	   *catalog_name = (char *) lfourth(elemlist);
-
-			if (strcmp(catalog_name, get_database_name(MyDatabaseId)) != 0)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("cross-database references are not implemented: \"%s.%s.%s\"",
-								catalog_name, schema_name, rel_name)));
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
 		}
 
 		/* If schema is not provided, find it from the search path. */
@@ -408,14 +446,50 @@ assign_identity_insert(const char *newval, void *extra)
 			 */
 			rel_oid = RelnameGetRelid(rel_name);
 			if (!OidIsValid(rel_oid))
-				ereport(ERROR,
-						(errcode(ERRCODE_UNDEFINED_TABLE),
-						 errmsg("relation \"%s\" does not exist",
-								rel_name)));
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
 
 			schema_oid = get_rel_namespace(rel_oid);
 			schema_name = get_namespace_name(schema_oid);
 		}
+
+		/* If catalog name is not NULL, it is cross-db */
+		if (catalog_name)
+			curr_user_id = get_role_oid(curr_user_if_cross_db, false);
+		else
+			curr_user_id = GetUserId();
+
+		/* Check if the physical schema is actually associated with current logical database */
+		/* Ignore for temporary tables */
+		if (schema_name && !isTempNamespace(get_namespace_oid(schema_name, false)))
+		{
+			Datum		datum;
+			int16		db_id;
+			bool		isnull;
+			HeapTuple	tuple = SearchSysCache1(SYSNAMESPACENAME, CStringGetDatum(schema_name));
+
+			if (!HeapTupleIsValid(tuple))
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
+
+			datum = SysCacheGetAttr(SYSNAMESPACENAME, tuple, Anum_namespace_ext_dbid, &isnull);
+			db_id = DatumGetInt16(datum);
+
+			if (!DbidIsValid(db_id) || db_id != get_db_id(cur_db_name))
+				throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
+
+			ReleaseSysCache(tuple);
+		}
+
+		/*
+		 * For SET IDENTITY_INSERT, ALTER permission on relation is needed. In
+		 * Babelfish, current user has ALTER permission on relation if either:
+		 *
+		 * 1. User is owner of object
+		 * 2. User is member of db_ddladmin or db_owner database role
+		 */
+		if (!(object_ownercheck(RelationRelationId, rel_oid, curr_user_id) ||
+			has_privs_of_role(curr_user_id, get_db_ddladmin_oid(cur_db_name, false)) ||
+			has_privs_of_role(curr_user_id, get_db_owner_oid(cur_db_name, false))))
+			throw_error_for_identity_insert(catalog_name, logical_schema_name, rel_name);
 
 		/* Process assignment logic */
 		if (strcmp(option_flag, "on") == 0)

--- a/test/JDBC/expected/BABEL-IDENTITY.out
+++ b/test/JDBC/expected/BABEL-IDENTITY.out
@@ -137,19 +137,19 @@ SET IDENTITY_INSERT test_table2 ON;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: relation "test_table2" does not exist)~~
+~~ERROR (Message: Cannot find the object "test_table2" because it does not exist or you do not have permissions.)~~
 
 SET IDENTITY_INSERT fake_schema.test_table1 ON;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "master_fake_schema" does not exist)~~
+~~ERROR (Message: Cannot find the object "fake_schema.test_table1" because it does not exist or you do not have permissions.)~~
 
 SET IDENTITY_INSERT fake_db.dbo.test_table1 ON;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cross-database references are not implemented: "fake_db.master_dbo.test_table1")~~
+~~ERROR (Message: Cannot find the object "fake_db.dbo.test_table1" because it does not exist or you do not have permissions.)~~
 
 
 CREATE TABLE dbo.test_table2 (test_id INT IDENTITY(7,2), test_col1 INT);
@@ -763,7 +763,7 @@ Index Scan using test_id_index_pkey on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 14.214 ms
+Babelfish T-SQL Batch Parsing Time: 9.792 ms
 ~~END~~
 
 
@@ -778,7 +778,7 @@ Index Scan using test_id_index_pkey on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.005 ms
+Babelfish T-SQL Batch Parsing Time: 3.872 ms
 ~~END~~
 
 
@@ -793,7 +793,7 @@ Index Scan using test_id_index_pkey on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 11.694 ms
+Babelfish T-SQL Batch Parsing Time: 4.621 ms
 ~~END~~
 
 
@@ -808,7 +808,7 @@ Index Scan using test_id_index_pkey on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 67.645 ms
+Babelfish T-SQL Batch Parsing Time: 42.064 ms
 ~~END~~
 
 
@@ -825,7 +825,7 @@ Bitmap Heap Scan on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.888 ms
+Babelfish T-SQL Batch Parsing Time: 9.045 ms
 ~~END~~
 
 
@@ -840,7 +840,7 @@ Seq Scan on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 1.746 ms
+Babelfish T-SQL Batch Parsing Time: 2.038 ms
 ~~END~~
 
 
@@ -857,7 +857,7 @@ Bitmap Heap Scan on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.471 ms
+Babelfish T-SQL Batch Parsing Time: 9.868 ms
 ~~END~~
 
 
@@ -873,7 +873,7 @@ Index Scan using test_id_index_pkey on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.360 ms
+Babelfish T-SQL Batch Parsing Time: 0.577 ms
 ~~END~~
 
 
@@ -888,7 +888,7 @@ Seq Scan on test_id_index
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 2.401 ms
+Babelfish T-SQL Batch Parsing Time: 2.833 ms
 ~~END~~
 
 
@@ -903,7 +903,7 @@ Index Scan using test_id_index_tinyint_pkey on test_id_index_tinyint
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.229 ms
+Babelfish T-SQL Batch Parsing Time: 0.302 ms
 ~~END~~
 
 
@@ -918,7 +918,7 @@ Index Scan using test_id_index_smallint_pkey on test_id_index_smallint
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.178 ms
+Babelfish T-SQL Batch Parsing Time: 0.229 ms
 ~~END~~
 
 
@@ -933,7 +933,7 @@ Index Scan using test_id_index_bigint_pkey on test_id_index_bigint
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.175 ms
+Babelfish T-SQL Batch Parsing Time: 0.226 ms
 ~~END~~
 
 
@@ -948,7 +948,7 @@ Index Scan using test_id_index_numeric_pkey on test_id_index_numeric
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.175 ms
+Babelfish T-SQL Batch Parsing Time: 0.223 ms
 ~~END~~
 
 
@@ -974,7 +974,7 @@ Index Scan using test_numeric_index_no_id_pkey on test_numeric_index_no_id
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.169 ms
+Babelfish T-SQL Batch Parsing Time: 0.290 ms
 ~~END~~
 
 
@@ -1194,7 +1194,7 @@ Index Only Scan using babel_3384_test_pkey on babel_3384_test
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.187 ms
+Babelfish T-SQL Batch Parsing Time: 0.171 ms
 ~~END~~
 
 select id from babel_3384_test WHERE id = @@IDENTITY
@@ -1208,7 +1208,7 @@ Index Only Scan using babel_3384_test_pkey on babel_3384_test
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.159 ms
+Babelfish T-SQL Batch Parsing Time: 0.164 ms
 ~~END~~
 
 
@@ -1231,4 +1231,334 @@ int
 
 
 DROP TABLE babel_3384_test
+GO
+
+-- tsql
+CREATE DATABASE identity_insert_db
+GO
+
+USE identity_insert_db
+GO
+
+CREATE LOGIN identity_insert_l1 WITH PASSWORD = '123'
+GO
+
+CREATE USER identity_insert_u1 FOR LOGIN identity_insert_l1 WITH DEFAULT_SCHEMA = identity_insert_sch
+GO
+
+CREATE SCHEMA identity_insert_sch AUTHORIZATION identity_insert_u1
+GO
+
+CREATE TABLE identity_insert_t1 (a int identity, b int)
+GO
+
+-- Three part name: wrong catalog name. Should throw error
+SET IDENTITY_INSERT wrong_db.dbo.identity_insert_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "wrong_db.dbo.identity_insert_t1" because it does not exist or you do not have permissions.)~~
+
+
+-- Three part name: wrong schema name. Should throw error
+SET IDENTITY_INSERT identity_insert_db.wrong_sch.identity_insert_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "identity_insert_db.wrong_sch.identity_insert_t1" because it does not exist or you do not have permissions.)~~
+
+
+-- Three part name: wrong table name. Should throw error
+SET IDENTITY_INSERT identity_insert_db.dbo.wrong_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "identity_insert_db.dbo.wrong_t1" because it does not exist or you do not have permissions.)~~
+
+
+-- Three part name: omit database name. Should throw syntax error
+SET IDENTITY_INSERT .dbo.wrong_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near ".")~~
+
+
+-- Three part name: omit schema name. Should throw syntax error
+SET IDENTITY_INSERT identity_insert_db..wrong_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "..")~~
+
+
+-- Three part name: omit both database and schema name. Should throw syntax error
+SET IDENTITY_INSERT ..wrong_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "..")~~
+
+
+-- Should fail as IDENTITY_INSERT is OFF by default
+INSERT INTO identity_insert_t1 (a, b) VALUES (2, 102);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot insert a non-DEFAULT value into column "a")~~
+
+
+-- Three-part name: catalog name = current database
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+
+-- Should not fail
+INSERT INTO identity_insert_t1 (a, b) VALUES (3, 103);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM identity_insert_t1 ORDER BY a
+GO
+~~START~~
+int#!#int
+3#!#103
+~~END~~
+
+
+USE master
+GO
+
+-- Three-part name: catalog name != current database (cross-db)
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 OFF
+GO
+
+-- Should fail
+INSERT INTO identity_insert_db.dbo.identity_insert_t1 (a, b) VALUES (4, 104);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot insert a non-DEFAULT value into column "a")~~
+
+
+-- tsql user=identity_insert_l1 password=123
+USE master
+GO
+
+-- User does not have ALTER permission on table
+-- Three-part name: catalog name != current database (cross-db). Should throw error
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "identity_insert_db.dbo.identity_insert_t1" because it does not exist or you do not have permissions.)~~
+
+
+-- tsql
+-- Add user as member of db_owner
+USE identity_insert_db
+GO
+
+ALTER ROLE db_owner ADD MEMBER identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should now have permission
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 OFF
+GO
+
+-- Should fail
+INSERT INTO identity_insert_db.dbo.identity_insert_t1 (a, b) VALUES (5, 105);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot insert a non-DEFAULT value into column "a")~~
+
+
+-- tsql
+-- Drop from db_owner, give all supported GRANTs. Should still not have permission to set IDENTITY_INSERT
+USE identity_insert_db
+GO
+
+ALTER ROLE db_owner DROP MEMBER identity_insert_u1
+GO
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON OBJECT :: identity_insert_t1 TO identity_insert_u1
+GO
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA :: dbo TO identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should not have permission. Should give error
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "identity_insert_db.dbo.identity_insert_t1" because it does not exist or you do not have permissions.)~~
+
+
+-- tsql
+-- Revoke all the GRANTs. Add user as a member of db_ddladmin. Should now have permission to set IDENTITY_INSERT
+USE identity_insert_db
+GO
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON OBJECT :: identity_insert_t1 FROM identity_insert_u1
+GO
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON SCHEMA :: dbo FROM identity_insert_u1
+GO
+
+ALTER ROLE db_ddladmin ADD MEMBER identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should now have permission
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 OFF
+GO
+
+-- Should fail
+INSERT INTO identity_insert_db.dbo.identity_insert_t1 (a, b) VALUES (6, 106);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot insert a non-DEFAULT value into column "a")~~
+
+
+-- tsql
+-- Remove user as a member of db_ddladmin. Should not have permission to set IDENTITY_INSERT
+USE identity_insert_db
+GO
+
+ALTER ROLE db_ddladmin DROP MEMBER identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should not have permission. Should give error
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "identity_insert_db.dbo.identity_insert_t1" because it does not exist or you do not have permissions.)~~
+
+
+-- Create a table in schema where user is owner
+USE identity_insert_db
+GO
+
+CREATE TABLE identity_insert_sch.identity_insert_t2 (c int identity, d int)
+GO
+
+SELECT USER_NAME(), IS_MEMBER('db_owner'), IS_MEMBER('db_ddladmin')
+GO
+~~START~~
+nvarchar#!#int#!#int
+identity_insert_u1#!#0#!#0
+~~END~~
+
+
+USE master
+GO
+
+SELECT USER_NAME(), IS_MEMBER('db_owner'), IS_MEMBER('db_ddladmin')
+GO
+~~START~~
+nvarchar#!#int#!#int
+guest#!#0#!#0
+~~END~~
+
+
+-- Even though user is not member of db_owner, db_ddladmin roles, as owner of table it can set IDENTITY_INSERT
+-- Three part name
+SET IDENTITY_INSERT identity_insert_db.identity_insert_sch.identity_insert_t2 ON
+GO
+
+USE identity_insert_db
+GO
+
+-- Should not fail
+INSERT INTO identity_insert_t2 (c, d) VALUES (1, 101);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM identity_insert_t2
+GO
+~~START~~
+int#!#int
+1#!#101
+~~END~~
+
+
+DROP TABLE identity_insert_t2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'identity_insert_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+t
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE identity_insert_db
+GO
+
+DROP TABLE identity_insert_t1
+GO
+
+DROP SCHEMA identity_insert_sch
+GO
+
+DROP USER identity_insert_u1
+GO
+
+DROP LOGIN identity_insert_l1
+GO
+
+USE master
+GO
+
+DROP DATABASE identity_insert_db
+GO
+
+-- We should ensure physical schema found corresponds to appropriate logical database
+CREATE DATABASE master_ident_ins
+GO
+
+USE master_ident_ins
+GO
+
+CREATE TABLE ident_t1 (a int identity, b int)
+GO
+
+-- Should not fail because relation exists
+SET IDENTITY_INSERT master_ident_ins.dbo.ident_t1 ON
+GO
+
+-- Should fail because relation does not exist
+SET IDENTITY_INSERT master.ident_ins_dbo.ident_t1 ON
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the object "master.ident_ins_dbo.ident_t1" because it does not exist or you do not have permissions.)~~
+
+
+USE master
+GO
+
+DROP DATABASE master_ident_ins
 GO

--- a/test/JDBC/input/BABEL-IDENTITY.mix
+++ b/test/JDBC/input/BABEL-IDENTITY.mix
@@ -557,3 +557,243 @@ GO
 
 DROP TABLE babel_3384_test
 GO
+
+-- tsql
+CREATE DATABASE identity_insert_db
+GO
+
+USE identity_insert_db
+GO
+
+CREATE LOGIN identity_insert_l1 WITH PASSWORD = '123'
+GO
+
+CREATE USER identity_insert_u1 FOR LOGIN identity_insert_l1 WITH DEFAULT_SCHEMA = identity_insert_sch
+GO
+
+CREATE SCHEMA identity_insert_sch AUTHORIZATION identity_insert_u1
+GO
+
+CREATE TABLE identity_insert_t1 (a int identity, b int)
+GO
+
+-- Three part name: wrong catalog name. Should throw error
+SET IDENTITY_INSERT wrong_db.dbo.identity_insert_t1 ON
+GO
+
+-- Three part name: wrong schema name. Should throw error
+SET IDENTITY_INSERT identity_insert_db.wrong_sch.identity_insert_t1 ON
+GO
+
+-- Three part name: wrong table name. Should throw error
+SET IDENTITY_INSERT identity_insert_db.dbo.wrong_t1 ON
+GO
+
+-- Three part name: omit database name. Should throw syntax error
+SET IDENTITY_INSERT .dbo.wrong_t1 ON
+GO
+
+-- Three part name: omit schema name. Should throw syntax error
+SET IDENTITY_INSERT identity_insert_db..wrong_t1 ON
+GO
+
+-- Three part name: omit both database and schema name. Should throw syntax error
+SET IDENTITY_INSERT ..wrong_t1 ON
+GO
+
+-- Should fail as IDENTITY_INSERT is OFF by default
+INSERT INTO identity_insert_t1 (a, b) VALUES (2, 102);
+GO
+
+-- Three-part name: catalog name = current database
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+
+-- Should not fail
+INSERT INTO identity_insert_t1 (a, b) VALUES (3, 103);
+GO
+
+SELECT * FROM identity_insert_t1 ORDER BY a
+GO
+
+USE master
+GO
+
+-- Three-part name: catalog name != current database (cross-db)
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 OFF
+GO
+
+-- Should fail
+INSERT INTO identity_insert_db.dbo.identity_insert_t1 (a, b) VALUES (4, 104);
+GO
+
+-- tsql user=identity_insert_l1 password=123
+USE master
+GO
+
+-- User does not have ALTER permission on table
+-- Three-part name: catalog name != current database (cross-db). Should throw error
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+
+-- tsql
+-- Add user as member of db_owner
+USE identity_insert_db
+GO
+
+ALTER ROLE db_owner ADD MEMBER identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should now have permission
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 OFF
+GO
+
+-- Should fail
+INSERT INTO identity_insert_db.dbo.identity_insert_t1 (a, b) VALUES (5, 105);
+GO
+
+-- tsql
+-- Drop from db_owner, give all supported GRANTs. Should still not have permission to set IDENTITY_INSERT
+USE identity_insert_db
+GO
+
+ALTER ROLE db_owner DROP MEMBER identity_insert_u1
+GO
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON OBJECT :: identity_insert_t1 TO identity_insert_u1
+GO
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA :: dbo TO identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should not have permission. Should give error
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+
+-- tsql
+-- Revoke all the GRANTs. Add user as a member of db_ddladmin. Should now have permission to set IDENTITY_INSERT
+USE identity_insert_db
+GO
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON OBJECT :: identity_insert_t1 FROM identity_insert_u1
+GO
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON SCHEMA :: dbo FROM identity_insert_u1
+GO
+
+ALTER ROLE db_ddladmin ADD MEMBER identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should now have permission
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 OFF
+GO
+
+-- Should fail
+INSERT INTO identity_insert_db.dbo.identity_insert_t1 (a, b) VALUES (6, 106);
+GO
+
+-- tsql
+-- Remove user as a member of db_ddladmin. Should not have permission to set IDENTITY_INSERT
+USE identity_insert_db
+GO
+
+ALTER ROLE db_ddladmin DROP MEMBER identity_insert_u1
+GO
+
+-- tsql user=identity_insert_l1 password=123
+-- Should not have permission. Should give error
+SET IDENTITY_INSERT identity_insert_db.dbo.identity_insert_t1 ON
+GO
+
+-- Create a table in schema where user is owner
+USE identity_insert_db
+GO
+
+CREATE TABLE identity_insert_sch.identity_insert_t2 (c int identity, d int)
+GO
+
+SELECT USER_NAME(), IS_MEMBER('db_owner'), IS_MEMBER('db_ddladmin')
+GO
+
+USE master
+GO
+
+SELECT USER_NAME(), IS_MEMBER('db_owner'), IS_MEMBER('db_ddladmin')
+GO
+
+-- Even though user is not member of db_owner, db_ddladmin roles, as owner of table it can set IDENTITY_INSERT
+-- Three part name
+SET IDENTITY_INSERT identity_insert_db.identity_insert_sch.identity_insert_t2 ON
+GO
+
+USE identity_insert_db
+GO
+
+-- Should not fail
+INSERT INTO identity_insert_t2 (c, d) VALUES (1, 101);
+GO
+
+SELECT * FROM identity_insert_t2
+GO
+
+DROP TABLE identity_insert_t2
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'identity_insert_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+USE identity_insert_db
+GO
+
+DROP TABLE identity_insert_t1
+GO
+
+DROP SCHEMA identity_insert_sch
+GO
+
+DROP USER identity_insert_u1
+GO
+
+DROP LOGIN identity_insert_l1
+GO
+
+USE master
+GO
+
+DROP DATABASE identity_insert_db
+GO
+
+-- We should ensure physical schema found corresponds to appropriate logical database
+CREATE DATABASE master_ident_ins
+GO
+
+USE master_ident_ins
+GO
+
+CREATE TABLE ident_t1 (a int identity, b int)
+GO
+
+-- Should not fail because relation exists
+SET IDENTITY_INSERT master_ident_ins.dbo.ident_t1 ON
+GO
+
+-- Should fail because relation does not exist
+SET IDENTITY_INSERT master.ident_ins_dbo.ident_t1 ON
+GO
+
+USE master
+GO
+
+DROP DATABASE master_ident_ins
+GO


### PR DESCRIPTION
Previously, passing three part object names to SET IDENTITY_INSERT was throwing an error. In this commit, if the relation name is a three part name, we will parse the catalog name and set the IDENTITY_INSERT property for the relation in that catalog.

Also with this commit, we will check if current user has permission to SET IDENTITY_INSERT for the relation.

Task: BABEL-3212
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).