### PR TITLE
[OSS-ONLY] Configure postgres without readline in github actions and fix engine clone step

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -35,7 +35,7 @@ runs:
           else
             ENGINE_BRANCH=${{inputs.engine_branch}}
           fi            
-          REPOSITORY_OWNER=$HEAD_OWNER
+          REPOSITORY_OWNER=${{ github.event.pull_request.head.repo.owner.login }}
         else
           if [[ ${{inputs.engine_branch}} == "latest" ]]; then
             ENGINE_BRANCH=$GITHUB_REF_NAME
@@ -86,13 +86,13 @@ runs:
         cd ..
         cd postgresql_modified_for_babelfish
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
-          ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
+          ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --without-readline --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
         elif [[ ${{inputs.code_coverage}} == "yes" ]]; then
-          ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-coverage --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8  --without-readline --enable-coverage --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         elif [[ ${{inputs.release_mode}} == "yes" ]]; then
-            ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 CFLAGS="-ggdb -O2" --with-libxml --with-uuid=ossp --with-icu
+            ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 CFLAGS="-ggdb -O2" --without-readline --with-libxml --with-uuid=ossp --with-icu
         else
-            ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+            ./configure CC='ccache gcc' --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3.8 --without-readline --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         fi
         make -j 4
         make install


### PR DESCRIPTION
### Description

Configure postgres engine without readline in github actions test
and fix engine clone script which as failing because $HEAD_OWNER
does not return correct value of user who created the PR so use 
${{ github.event.pull_request.head.repo.owner.login }} instead

#### Engine Change https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/520
#### Extensios Change https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3430

### Issues Resolved

[No JIRA]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).