### PR TITLE
Fix branch name for upgrade in singledb mode

### DIFF
--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -7,8 +7,8 @@ jobs:
       env:
       OLD_INSTALL_DIR: psql_source
       NEW_INSTALL_DIR: psql_target
-      ENGINE_BRANCH_FROM: BABEL_2_13_STABLE__PG_14_16
-      EXTENSION_BRANCH_FROM: BABEL_2_13_STABLE
+      ENGINE_BRANCH_FROM: BABEL_2_12_STABLE__PG_14_16
+      EXTENSION_BRANCH_FROM: BABEL_2_12_STABLE
 
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION


### Description

This commit fixes the default branch name for upgrade scenario in single db mode.

### Issues Resolved

Task: NO-JIRA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).