### PR TITLE
Fix upgrade script to resolve MVU issue from 15.11

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.2.0--4.3.0.sql
@@ -6719,7 +6719,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.columns_internal AS
 			CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 			CAST(
 				COALESCE(
-					(SELECT string_agg(
+					(SELECT pg_catalog.string_agg(
 						CASE
 						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23 /* prefix length */)
 						ELSE NULL
@@ -6730,7 +6730,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.columns_internal AS
 
 			CAST(
 				COALESCE(
-					(SELECT string_agg(
+					(SELECT pg_catalog.string_agg(
 						CASE
 						WHEN option LIKE 'bbf_original_name=%' THEN substring(option, 19 /* prefix length */)
 						ELSE NULL
@@ -6836,7 +6836,7 @@ CREATE OR REPLACE VIEW information_schema_tsql.tables AS
 		   CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 		   CAST(
 				COALESCE(
-					(SELECT string_agg(
+					(SELECT pg_catalog.string_agg(
 						CASE
 						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23)
 						ELSE NULL


### PR DESCRIPTION
### Description
- Fix MVU issue from 15.11 by fixing upgrade script `babelfishpg_tsql--4.2.0--4.3.0.sql` to prepend `PG_CATALOG` schema on string_agg function call


### Issues Resolved
BABEL-5595

Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).