### PR TITLE
Fix version-branch-template for v14.16, v15.11 and v16.7

### DIFF
--- a/.github/template/version-branch-template.yml
+++ b/.github/template/version-branch-template.yml
@@ -50,8 +50,8 @@
   engine_branch: BABEL_2_11_STABLE__PG_14_15
   extension_branch: BABEL_2_11_STABLE
 '14.16':
-  engine_branch: BABEL_2_X_DEV__PG_14_X
-  extension_branch: BABEL_2_X_DEV
+  engine_branch: BABEL_2_12_STABLE__PG_14_16
+  extension_branch: BABEL_2_12_STABLE
 '15.2':
   engine_branch: BABEL_3_1_STABLE__PG_15_2
   extension_branch: BABEL_3_1_STABLE
@@ -77,8 +77,8 @@
   engine_branch: BABEL_3_8_STABLE__PG_15_10
   extension_branch: BABEL_3_8_STABLE
 '15.11':
-  engine_branch: BABEL_3_X_DEV__PG_15_X
-  extension_branch: BABEL_3_X_DEV
+  engine_branch: BABEL_3_9_STABLE__PG_15_11
+  extension_branch: BABEL_3_9_STABLE
 '16.1':
   engine_branch: BABEL_4_0_STABLE__PG_16_1
   extension_branch: BABEL_4_0_STABLE
@@ -95,8 +95,8 @@
   engine_branch: BABEL_4_4_STABLE__PG_16_6
   extension_branch: BABEL_4_4_STABLE
 '16.7':
-  engine_branch: BABEL_4_X_DEV__PG_16_X
-  extension_branch: BABEL_4_X_DEV
+  engine_branch: BABEL_4_5_STABLE__PG_16_7
+  extension_branch: BABEL_4_5_STABLE
 '17.2':
   engine_branch: BABEL_5_0_STABLE__PG_17_2
   extension_branch: BABEL_5_0_STABLE

--- a/.github/workflows/major-version-upgrade.yml
+++ b/.github/workflows/major-version-upgrade.yml
@@ -6,8 +6,8 @@ jobs:
     env:
       OLD_INSTALL_DIR: psql_source
       NEW_INSTALL_DIR: psql_target
-      ENGINE_BRANCH_FROM: BABEL_2_X_DEV__PG_14_X
-      EXTENSION_BRANCH_FROM: BABEL_2_X_DEV
+      ENGINE_BRANCH_FROM: BABEL_2_12_STABLE__PG_14_16
+      EXTENSION_BRANCH_FROM: BABEL_2_12_STABLE
 
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -23,7 +23,7 @@ jobs:
           extension_branch: ${{ env.EXTENSION_BRANCH_FROM }}
           install_dir: ${{ env.OLD_INSTALL_DIR }}
           migration_mode: 'single-db'
-          antlr_version: 4.9.3
+          antlr_version: 4.13.2
 
       - name: Check Babelfish metadata inconsistency before Major Version Upgrade
         id: check-babelfish-inconsistency

--- a/.github/workflows/singledb-version-upgrade.yml
+++ b/.github/workflows/singledb-version-upgrade.yml
@@ -7,7 +7,7 @@ jobs:
       env:
       OLD_INSTALL_DIR: psql_source
       NEW_INSTALL_DIR: psql_target
-      ENGINE_BRANCH_FROM: BABEL_4_5_STABLE__PG_16_6
+      ENGINE_BRANCH_FROM: BABEL_4_5_STABLE__PG_16_7
       EXTENSION_BRANCH_FROM: BABEL_4_5_STABLE
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Description
1. Update branches for 14.16, 15.11 and 16.7 from dev to stable.
2. Update MVU source version from dev to stable.
3. Fix singledb-version-upgrade from 16.6 to 16.7

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).