### PR TITLE
Fix parallel query execution for TSQL statements post community commit 7f07ff583ea8d55bb32853de40c3a9b69644c80f

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1089,7 +1089,6 @@ ProcessLoginFlags(LoginRequest loginInfo)
 	{
 		char	   *textSize = psprintf("%d", (loginInfo->tdsVersion <= TDS_VERSION_7_2) ?
 										TEXT_SIZE_2GB : TEXT_SIZE_INFINITE);
-		char	   *rowCount = psprintf("%d", INT_MAX);
 
 		set_config_option("babelfishpg_tsql.ansi_defaults",
 						  "ON",
@@ -1125,7 +1124,7 @@ ProcessLoginFlags(LoginRequest loginInfo)
 						  0,
 						  false);
 		set_config_option("babelfishpg_tsql.rowcount",
-						  rowCount,
+						  0,
 						  PGC_USERSET,
 						  PGC_S_OVERRIDE,
 						  GUC_ACTION_SET,

--- a/test/JDBC/expected/parallel_query/BABEL-2843.out
+++ b/test/JDBC/expected/parallel_query/BABEL-2843.out
@@ -35,7 +35,7 @@ text
 Query Text: select 1
 Gather  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Result  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
 ~~END~~
@@ -51,8 +51,8 @@ text
 Query Text: select * from babel_2843_t1 where b1 = 1
 Gather  (cost=0.00..19.11 rows=11 width=8) (actual rows=0 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..19.11 rows=4 width=8) (actual rows=0 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..19.11 rows=4 width=8) (actual rows=0 loops=4)
         Filter: (b1 = 1)
 ~~END~~
 
@@ -78,7 +78,7 @@ int#!#int
 
 ~~START~~
 xml
-<explain xmlns="http://www.postgresql.org/2009/explain"><newline>  <Query-Text>select * from babel_2843_t1 where b1 = 1</Query-Text><newline>  <Plan><newline>    <Node-Type>Gather</Node-Type><newline>    <Parallel-Aware>false</Parallel-Aware><newline>    <Async-Capable>false</Async-Capable><newline>    <Startup-Cost>0.00</Startup-Cost><newline>    <Total-Cost>19.11</Total-Cost><newline>    <Plan-Rows>11</Plan-Rows><newline>    <Plan-Width>8</Plan-Width><newline>    <Actual-Rows>0</Actual-Rows><newline>    <Actual-Loops>1</Actual-Loops><newline>    <Workers-Planned>3</Workers-Planned><newline>    <Workers-Launched>0</Workers-Launched><newline>    <Single-Copy>false</Single-Copy><newline>    <Plans><newline>      <Plan><newline>        <Node-Type>Seq Scan</Node-Type><newline>        <Parent-Relationship>Outer</Parent-Relationship><newline>        <Parallel-Aware>true</Parallel-Aware><newline>        <Async-Capable>false</Async-Capable><newline>        <Relation-Name>babel_2843_t1</Relation-Name><newline>        <Alias>babel_2843_t1</Alias><newline>        <Startup-Cost>0.00</Startup-Cost><newline>        <Total-Cost>19.11</Total-Cost><newline>        <Plan-Rows>4</Plan-Rows><newline>        <Plan-Width>8</Plan-Width><newline>        <Actual-Rows>0</Actual-Rows><newline>        <Actual-Loops>1</Actual-Loops><newline>        <Filter>(b1 = 1)</Filter><newline>        <Rows-Removed-by-Filter>0</Rows-Removed-by-Filter><newline>      </Plan><newline>    </Plans><newline>  </Plan><newline>  <Triggers><newline>  </Triggers><newline></explain>
+<explain xmlns="http://www.postgresql.org/2009/explain"><newline>  <Query-Text>select * from babel_2843_t1 where b1 = 1</Query-Text><newline>  <Plan><newline>    <Node-Type>Gather</Node-Type><newline>    <Parallel-Aware>false</Parallel-Aware><newline>    <Async-Capable>false</Async-Capable><newline>    <Startup-Cost>0.00</Startup-Cost><newline>    <Total-Cost>19.11</Total-Cost><newline>    <Plan-Rows>11</Plan-Rows><newline>    <Plan-Width>8</Plan-Width><newline>    <Actual-Rows>0</Actual-Rows><newline>    <Actual-Loops>1</Actual-Loops><newline>    <Workers-Planned>3</Workers-Planned><newline>    <Workers-Launched>3</Workers-Launched><newline>    <Single-Copy>false</Single-Copy><newline>    <Plans><newline>      <Plan><newline>        <Node-Type>Seq Scan</Node-Type><newline>        <Parent-Relationship>Outer</Parent-Relationship><newline>        <Parallel-Aware>true</Parallel-Aware><newline>        <Async-Capable>false</Async-Capable><newline>        <Relation-Name>babel_2843_t1</Relation-Name><newline>        <Alias>babel_2843_t1</Alias><newline>        <Startup-Cost>0.00</Startup-Cost><newline>        <Total-Cost>19.11</Total-Cost><newline>        <Plan-Rows>4</Plan-Rows><newline>        <Plan-Width>8</Plan-Width><newline>        <Actual-Rows>0</Actual-Rows><newline>        <Actual-Loops>4</Actual-Loops><newline>        <Filter>(b1 = 1)</Filter><newline>        <Rows-Removed-by-Filter>0</Rows-Removed-by-Filter><newline>        <Workers><newline>        </Workers><newline>      </Plan><newline>    </Plans><newline>  </Plan><newline>  <Triggers><newline>  </Triggers><newline></explain>
 ~~END~~
 
 
@@ -103,7 +103,7 @@ int#!#int
 
 ~~START~~
 text
-{<newline>  "Query Text": "select * from babel_2843_t1 where b1 = 1",<newline>  "Plan": {<newline>    "Node Type": "Gather",<newline>    "Parallel Aware": false,<newline>    "Async Capable": false,<newline>    "Startup Cost": 0.00,<newline>    "Total Cost": 19.11,<newline>    "Plan Rows": 11,<newline>    "Plan Width": 8,<newline>    "Actual Rows": 0,<newline>    "Actual Loops": 1,<newline>    "Workers Planned": 3,<newline>    "Workers Launched": 0,<newline>    "Single Copy": false,<newline>    "Plans": [<newline>      {<newline>        "Node Type": "Seq Scan",<newline>        "Parent Relationship": "Outer",<newline>        "Parallel Aware": true,<newline>        "Async Capable": false,<newline>        "Relation Name": "babel_2843_t1",<newline>        "Alias": "babel_2843_t1",<newline>        "Startup Cost": 0.00,<newline>        "Total Cost": 19.11,<newline>        "Plan Rows": 4,<newline>        "Plan Width": 8,<newline>        "Actual Rows": 0,<newline>        "Actual Loops": 1,<newline>        "Filter": "(b1 = 1)",<newline>        "Rows Removed by Filter": 0<newline>      }<newline>    ]<newline>  },<newline>  "Triggers": [<newline>  ]<newline>}
+{<newline>  "Query Text": "select * from babel_2843_t1 where b1 = 1",<newline>  "Plan": {<newline>    "Node Type": "Gather",<newline>    "Parallel Aware": false,<newline>    "Async Capable": false,<newline>    "Startup Cost": 0.00,<newline>    "Total Cost": 19.11,<newline>    "Plan Rows": 11,<newline>    "Plan Width": 8,<newline>    "Actual Rows": 0,<newline>    "Actual Loops": 1,<newline>    "Workers Planned": 3,<newline>    "Workers Launched": 3,<newline>    "Single Copy": false,<newline>    "Plans": [<newline>      {<newline>        "Node Type": "Seq Scan",<newline>        "Parent Relationship": "Outer",<newline>        "Parallel Aware": true,<newline>        "Async Capable": false,<newline>        "Relation Name": "babel_2843_t1",<newline>        "Alias": "babel_2843_t1",<newline>        "Startup Cost": 0.00,<newline>        "Total Cost": 19.11,<newline>        "Plan Rows": 4,<newline>        "Plan Width": 8,<newline>        "Actual Rows": 0,<newline>        "Actual Loops": 4,<newline>        "Filter": "(b1 = 1)",<newline>        "Rows Removed by Filter": 0,<newline>        "Workers": [<newline>        ]<newline>      }<newline>    ]<newline>  },<newline>  "Triggers": [<newline>  ]<newline>}
 ~~END~~
 
 
@@ -128,7 +128,7 @@ int#!#int
 
 ~~START~~
 text
-Query Text: "select * from babel_2843_t1 where b1 = 1"<newline>Plan: <newline>  Node Type: "Gather"<newline>  Parallel Aware: false<newline>  Async Capable: false<newline>  Startup Cost: 0.00<newline>  Total Cost: 19.11<newline>  Plan Rows: 11<newline>  Plan Width: 8<newline>  Actual Rows: 0<newline>  Actual Loops: 1<newline>  Workers Planned: 3<newline>  Workers Launched: 0<newline>  Single Copy: false<newline>  Plans: <newline>    - Node Type: "Seq Scan"<newline>      Parent Relationship: "Outer"<newline>      Parallel Aware: true<newline>      Async Capable: false<newline>      Relation Name: "babel_2843_t1"<newline>      Alias: "babel_2843_t1"<newline>      Startup Cost: 0.00<newline>      Total Cost: 19.11<newline>      Plan Rows: 4<newline>      Plan Width: 8<newline>      Actual Rows: 0<newline>      Actual Loops: 1<newline>      Filter: "(b1 = 1)"<newline>      Rows Removed by Filter: 0<newline>Triggers: 
+Query Text: "select * from babel_2843_t1 where b1 = 1"<newline>Plan: <newline>  Node Type: "Gather"<newline>  Parallel Aware: false<newline>  Async Capable: false<newline>  Startup Cost: 0.00<newline>  Total Cost: 19.11<newline>  Plan Rows: 11<newline>  Plan Width: 8<newline>  Actual Rows: 0<newline>  Actual Loops: 1<newline>  Workers Planned: 3<newline>  Workers Launched: 3<newline>  Single Copy: false<newline>  Plans: <newline>    - Node Type: "Seq Scan"<newline>      Parent Relationship: "Outer"<newline>      Parallel Aware: true<newline>      Async Capable: false<newline>      Relation Name: "babel_2843_t1"<newline>      Alias: "babel_2843_t1"<newline>      Startup Cost: 0.00<newline>      Total Cost: 19.11<newline>      Plan Rows: 4<newline>      Plan Width: 8<newline>      Actual Rows: 0<newline>      Actual Loops: 4<newline>      Filter: "(b1 = 1)"<newline>      Rows Removed by Filter: 0<newline>      Workers: <newline>Triggers: 
 ~~END~~
 
 
@@ -193,8 +193,8 @@ text
 Query Text: select * from babel_2843_t1
 Gather  (cost=0.00..17.29 rows=2260 width=8) (actual rows=2 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..17.29 rows=729 width=8) (actual rows=2 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..17.29 rows=729 width=8) (actual rows=0 loops=4)
 ~~END~~
 
 ~~START~~
@@ -207,8 +207,8 @@ text
 Query Text: select * from babel_2843_t2
 Gather  (cost=0.00..17.29 rows=2260 width=8) (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on babel_2843_t2  (cost=0.00..17.29 rows=729 width=8) (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on babel_2843_t2  (cost=0.00..17.29 rows=729 width=8) (actual rows=0 loops=4)
 ~~END~~
 
 
@@ -239,10 +239,10 @@ text
 Query Text: select * from babel_2843_t1 where a1 = "@param"
 Gather  (cost=0.00..19.11 rows=11 width=8) (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..19.11 rows=4 width=8) (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..19.11 rows=4 width=8) (actual rows=0 loops=4)
         Filter: (a1 = 1)
-        Rows Removed by Filter: 2
+        Rows Removed by Filter: 0
 ~~END~~
 
 drop procedure babel_2843_proc;
@@ -362,7 +362,7 @@ text
 Query Text: select 1
 Gather  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Result  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
 ~~END~~
@@ -388,10 +388,10 @@ text
 Query Text: select * from babel_2843_t1 where a1 = "@param"
 Gather  (cost=0.00..19.11 rows=11 width=8) (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..19.11 rows=4 width=8) (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on babel_2843_t1  (cost=0.00..19.11 rows=4 width=8) (actual rows=0 loops=4)
         Filter: (a1 = 2)
-        Rows Removed by Filter: 2
+        Rows Removed by Filter: 0
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/BABEL-3248.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3248.out
@@ -84,7 +84,7 @@ text
 Query Text: select 1
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Result (actual rows=1 loops=1)
 ~~END~~

--- a/test/JDBC/expected/parallel_query/BABEL_3571.out
+++ b/test/JDBC/expected/parallel_query/BABEL_3571.out
@@ -221,7 +221,7 @@ text
 Query Text: SELECT * FROM babel_3571_1 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_1_id1_key on babel_3571_1 (actual rows=5 loops=1)
 ~~END~~
@@ -242,7 +242,7 @@ text
 Query Text: SELECT * FROM babel_3571_2 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_2_id1_id2_key on babel_3571_2 (actual rows=5 loops=1)
 ~~END~~
@@ -263,7 +263,7 @@ text
 Query Text: SELECT * FROM babel_3571_3 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_3_unique_idxbabel_35df79da2a42216884edca5a4a798829ce on babel_3571_3 (actual rows=5 loops=1)
 ~~END~~
@@ -481,7 +481,7 @@ text
 Query Text: SELECT * FROM babel_3571_1 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_1_id1_key on babel_3571_1 (actual rows=5 loops=1)
 ~~END~~
@@ -502,7 +502,7 @@ text
 Query Text: SELECT * FROM babel_3571_2 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_2_id1_id2_key on babel_3571_2 (actual rows=5 loops=1)
 ~~END~~
@@ -524,7 +524,7 @@ text
 Query Text: SELECT * FROM babel_3571_3 ORDER BY id1
 Gather (actual rows=6 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan Backward using babel_3571_3_unique_idx on babel_3571_3 (actual rows=6 loops=1)
 ~~END~~
@@ -790,7 +790,7 @@ text
 Query Text: SELECT * FROM babel_3571_1 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_1_id1_key on babel_3571_1 (actual rows=5 loops=1)
 ~~END~~
@@ -811,7 +811,7 @@ text
 Query Text: SELECT * FROM babel_3571_2 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_2_id1_key on babel_3571_2 (actual rows=5 loops=1)
 ~~END~~
@@ -832,7 +832,7 @@ text
 Query Text: SELECT * FROM babel_3571_3 ORDER BY id1
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_3571_3_unique_idxbabel_35df79da2a42216884edca5a4a798829ce on babel_3571_3 (actual rows=5 loops=1)
 ~~END~~

--- a/test/JDBC/expected/parallel_query/BABEL_4940.out
+++ b/test/JDBC/expected/parallel_query/BABEL_4940.out
@@ -117,7 +117,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
@@ -144,7 +144,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t1 ORDER BY id DESC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan Backward using babel_4940_t1_pkey on babel_4940_t1 (actual rows=10 loops=1)
@@ -171,7 +171,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
@@ -198,7 +198,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t2 ORDER BY id DESC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan Backward using babel_4940_t2_pkey on babel_4940_t2 (actual rows=10 loops=1)
@@ -225,7 +225,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id, id1
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
@@ -252,7 +252,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t3 ORDER BY id DESC, id1 DESC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan Backward using babel_4940_t3_pkey on babel_4940_t3 (actual rows=10 loops=1)
@@ -279,7 +279,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
@@ -306,7 +306,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t4 ORDER BY id DESC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan Backward using babel_4940_t4_pkey on babel_4940_t4 (actual rows=10 loops=1)
@@ -333,7 +333,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan using c on babel_4940_t5 (actual rows=10 loops=1)
@@ -360,7 +360,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t5 ORDER BY id DESC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan Backward using c on babel_4940_t5 (actual rows=10 loops=1)
@@ -387,7 +387,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id, id1 DESC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan using c1 on babel_4940_t6 (actual rows=10 loops=1)
@@ -414,7 +414,7 @@ text
 Query Text: SELECT TOP 10 * FROM babel_4940_t6 ORDER BY id DESC, id1 ASC
 Gather (actual rows=10 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=10 loops=1)
         ->  Index Scan Backward using c1 on babel_4940_t6 (actual rows=10 loops=1)

--- a/test/JDBC/expected/parallel_query/TestHalfvecDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestHalfvecDatatype.out
@@ -966,7 +966,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -985,7 +985,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <-> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -1007,7 +1007,7 @@ text
 Query Text: SELECT COUNT(*) FROM halfvec_table
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
@@ -1028,7 +1028,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=0 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -1091,7 +1091,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <#> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <#> '[3,3,3]'::halfvec)
@@ -1110,7 +1110,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <#> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -1175,7 +1175,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <=> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
         Order By: (val <=> '[3,3,3]'::halfvec)
@@ -1194,7 +1194,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> CAST('[0,0,0]' AS halfvec) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -1214,7 +1214,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -1280,7 +1280,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <+> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <+> '[3,3,3]'::halfvec)
@@ -1299,7 +1299,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <+> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -1365,7 +1365,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -1384,7 +1384,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <-> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -1406,7 +1406,7 @@ text
 Query Text: SELECT COUNT(*) FROM halfvec_table
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
@@ -1427,7 +1427,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=0 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -1495,11 +1495,11 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <#> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Sort (actual rows=5 loops=1)
         Sort Key: ((val <#> '[3,3,3]'::halfvec))
-        Sort Method: quicksort  Memory: 25kB
+        Worker 0:  Sort Method: quicksort  Memory: 25kB
         ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
 ~~END~~
 
@@ -1516,12 +1516,12 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <#> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Sort (actual rows=5 loops=1)
               Sort Key: ((halfvec_table.val <#> (InitPlan 1).col1))
-              Sort Method: quicksort  Memory: 25kB
+              Worker 0:  Sort Method: quicksort  Memory: 25kB
               InitPlan 1
                 ->  Result (actual rows=1 loops=1)
               ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
@@ -1583,7 +1583,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <=> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
         Order By: (val <=> '[3,3,3]'::halfvec)
@@ -1602,7 +1602,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> CAST('[0,0,0]' AS halfvec) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -1622,7 +1622,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -2786,7 +2786,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -2805,7 +2805,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <-> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -2827,7 +2827,7 @@ text
 Query Text: SELECT COUNT(*) FROM halfvec_table
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
@@ -2848,7 +2848,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=0 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -2911,7 +2911,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <#> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <#> '[3,3,3]'::halfvec)
@@ -2930,7 +2930,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <#> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -2995,7 +2995,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <=> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
         Order By: (val <=> '[3,3,3]'::halfvec)
@@ -3014,7 +3014,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> CAST('[0,0,0]' AS halfvec) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -3034,7 +3034,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -3100,7 +3100,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <+> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <+> '[3,3,3]'::halfvec)
@@ -3119,7 +3119,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <+> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -3185,7 +3185,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -3204,7 +3204,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <-> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=4 loops=1)
@@ -3226,7 +3226,7 @@ text
 Query Text: SELECT COUNT(*) FROM halfvec_table
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
@@ -3247,7 +3247,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <-> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=0 loops=1)
         Order By: (val <-> '[3,3,3]'::halfvec)
@@ -3315,11 +3315,11 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <#> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=5 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Sort (actual rows=5 loops=1)
         Sort Key: ((val <#> '[3,3,3]'::halfvec))
-        Sort Method: quicksort  Memory: 25kB
+        Worker 0:  Sort Method: quicksort  Memory: 25kB
         ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
 ~~END~~
 
@@ -3336,12 +3336,12 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <#> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Sort (actual rows=5 loops=1)
               Sort Key: ((halfvec_table.val <#> (InitPlan 1).col1))
-              Sort Method: quicksort  Memory: 25kB
+              Worker 0:  Sort Method: quicksort  Memory: 25kB
               InitPlan 1
                 ->  Result (actual rows=1 loops=1)
               ->  Seq Scan on halfvec_table (actual rows=5 loops=1)
@@ -3403,7 +3403,7 @@ text
 Query Text: SELECT * FROM halfvec_table ORDER BY val <=> CAST('[3,3,3]' AS halfvec) NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
         Order By: (val <=> '[3,3,3]'::halfvec)
@@ -3422,7 +3422,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> CAST('[0,0,0]' AS halfvec) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)
@@ -3442,7 +3442,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM halfvec_table ORDER BY val <=> (SELECT CAST(NULL as halfvec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxhalfvec_table7f9bec28bc8902d45d905788d7aa59a1 on halfvec_table (actual rows=3 loops=1)

--- a/test/JDBC/expected/parallel_query/TestSparsevecDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestSparsevecDatatype.out
@@ -1049,7 +1049,7 @@ text
 Query Text: SELECT * FROM sparsevec_table ORDER BY val <-> CAST('{1:3,2:3,3:3}/3' AS sparsevec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=4 loops=1)
         Order By: (val <-> '{1:3,2:3,3:3}/3'::sparsevec)
@@ -1068,7 +1068,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM sparsevec_table ORDER BY val <-> (SELECT CAST(NULL as sparsevec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=4 loops=1)
@@ -1090,7 +1090,7 @@ text
 Query Text: SELECT COUNT(*) FROM sparsevec_table
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Seq Scan on sparsevec_table (actual rows=5 loops=1)
@@ -1111,7 +1111,7 @@ text
 Query Text: SELECT * FROM sparsevec_table ORDER BY val <-> CAST('{1:3,2:3,3:3}/3' AS sparsevec) NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=0 loops=1)
         Order By: (val <-> '{1:3,2:3,3:3}/3'::sparsevec)
@@ -1174,7 +1174,7 @@ text
 Query Text: SELECT * FROM sparsevec_table ORDER BY val <#> CAST('{1:3,2:3,3:3}/3' AS sparsevec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=4 loops=1)
         Order By: (val <#> '{1:3,2:3,3:3}/3'::sparsevec)
@@ -1193,7 +1193,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM sparsevec_table ORDER BY val <#> (SELECT CAST(NULL as sparsevec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=4 loops=1)
@@ -1258,7 +1258,7 @@ text
 Query Text: SELECT * FROM sparsevec_table ORDER BY val <=> CAST('{1:3,2:3,3:3}/3' AS sparsevec) NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=3 loops=1)
         Order By: (val <=> '{1:3,2:3,3:3}/3'::sparsevec)
@@ -1277,7 +1277,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM sparsevec_table ORDER BY val <=> CAST('{}/3' AS sparsevec) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=3 loops=1)
@@ -1297,7 +1297,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM sparsevec_table ORDER BY val <=> (SELECT CAST(NULL as sparsevec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=3 loops=1)
@@ -1363,7 +1363,7 @@ text
 Query Text: SELECT * FROM sparsevec_table ORDER BY val <+> CAST('{1:3,2:3,3:3}/3' AS sparsevec) NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=4 loops=1)
         Order By: (val <+> '{1:3,2:3,3:3}/3'::sparsevec)
@@ -1382,7 +1382,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM sparsevec_table ORDER BY val <+> (SELECT CAST(NULL as sparsevec)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxsparsevec_table7f9bec28bc8902d45d905788d7aa59a1 on sparsevec_table (actual rows=4 loops=1)

--- a/test/JDBC/expected/parallel_query/TestVectorDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestVectorDatatype.out
@@ -401,7 +401,7 @@ text
 Query Text: SELECT * FROM vector_table WHERE val = '[1,2,3]'
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=1 loops=1)
         Index Cond: (val = '[1,2,3]'::vector)
@@ -421,7 +421,7 @@ text
 Query Text: SELECT TOP 1 * FROM vector_table ORDER BY val
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=1 loops=1)
         ->  Index Only Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=1 loops=1)
@@ -478,7 +478,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <=> '[3,3,3]' NULLS LAST
 Gather (actual rows=2 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=2 loops=1)
         Order By: (val <=> '[3,3,3]'::vector)
@@ -497,7 +497,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=2 loops=1)
@@ -516,7 +516,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=2 loops=1)
@@ -576,7 +576,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <#> '[3,3,3]' NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
         Order By: (val <#> '[3,3,3]'::vector)
@@ -595,7 +595,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -614,7 +614,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -674,7 +674,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <-> '[3,3,3]' NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
         Order By: (val <-> '[3,3,3]'::vector)
@@ -693,7 +693,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -712,7 +712,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -845,7 +845,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <=> '[3,3,3]' NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
         Order By: (val <=> '[3,3,3]'::vector)
@@ -864,7 +864,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -884,7 +884,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -950,7 +950,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <#> '[3,3,3]' NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idx2vector_table8408d573e4ed8cfc5bc30f15b5393f14 on vector_table (actual rows=4 loops=1)
         Order By: (val <#> '[3,3,3]'::vector)
@@ -969,7 +969,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idx2vector_table8408d573e4ed8cfc5bc30f15b5393f14 on vector_table (actual rows=4 loops=1)
@@ -989,7 +989,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idx2vector_table8408d573e4ed8cfc5bc30f15b5393f14 on vector_table (actual rows=4 loops=1)
@@ -1055,7 +1055,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <-> '[3,3,3]' NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=4 loops=1)
         Order By: (val <-> '[3,3,3]'::vector)
@@ -1074,7 +1074,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=4 loops=1)
@@ -1094,7 +1094,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=4 loops=1)
@@ -1375,7 +1375,7 @@ text
 Query Text: SELECT * FROM vector_table1 ORDER BY val <=> '[3,3,3]' NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table17f9bec28bc8902d45d905788d7aa59a1 on vector_table1 (actual rows=0 loops=1)
         Order By: (val <=> '[3,3,3]'::vector)
@@ -1394,7 +1394,7 @@ text
 Query Text: SELECT t1.*, t2.* FROM vector_table1 as t1 JOIN vector_table2 as t2 ON t1.a = t2.a ORDER BY t1.val <=> '[0,0,0]' NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Nested Loop (actual rows=0 loops=1)
         Join Filter: (t1.a = t2.a)
@@ -1417,15 +1417,19 @@ text
 Query Text: SELECT t1.* FROM vector_table1 as t1 JOIN vector_table2 as t2 ON t1.a = t2.a ORDER BY t1.val <=> '[0,0,0]', t2.val <=> '[1,1,1]'
 Gather Merge (actual rows=0 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Sort (actual rows=0 loops=1)
+  Workers Launched: 3
+  ->  Sort (actual rows=0 loops=4)
         Sort Key: ((t1.val <=> '[0,0,0]'::vector)) NULLS FIRST, ((t2.val <=> '[1,1,1]'::vector)) NULLS FIRST
         Sort Method: quicksort  Memory: 25kB
-        ->  Parallel Hash Join (actual rows=0 loops=1)
+        Worker 0:  Sort Method: quicksort  Memory: 25kB
+        Worker 1:  Sort Method: quicksort  Memory: 25kB
+        Worker 2:  Sort Method: quicksort  Memory: 25kB
+        ->  Parallel Hash Join (actual rows=0 loops=4)
               Hash Cond: (t1.a = t2.a)
-              ->  Parallel Seq Scan on vector_table1 t1 (actual rows=0 loops=1)
-              ->  Parallel Hash (never executed)
-                    ->  Parallel Seq Scan on vector_table2 t2 (never executed)
+              ->  Parallel Seq Scan on vector_table1 t1 (never executed)
+              ->  Parallel Hash (actual rows=0 loops=4)
+                    Buckets: 2048  Batches: 1  Memory Usage: 0kB
+                    ->  Parallel Seq Scan on vector_table2 t2 (actual rows=0 loops=1)
 ~~END~~
 
 
@@ -1440,7 +1444,7 @@ text
 Query Text: SELECT t1.* FROM vector_table1 as t1 JOIN table3 as t2 ON t1.a = t2.a ORDER BY val <=> '[0,0,0]' NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Nested Loop (actual rows=0 loops=1)
         Join Filter: (t1.a = t2.a)
@@ -1462,16 +1466,16 @@ text
 Query Text: SELECT t1.* FROM vector_table1 as t1 JOIN table3 as t2 ON t1.a = t2.a ORDER BY val <=> '[0,0,0]', t2.a
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Sort (actual rows=0 loops=1)
         Sort Key: ((t1.val <=> '[0,0,0]'::vector)) NULLS FIRST, t1.a NULLS FIRST
-        Sort Method: quicksort  Memory: 25kB
+        Worker 0:  Sort Method: quicksort  Memory: 25kB
         ->  Merge Join (actual rows=0 loops=1)
               Merge Cond: (t1.a = t2.a)
               ->  Sort (actual rows=0 loops=1)
                     Sort Key: t1.a
-                    Sort Method: quicksort  Memory: 25kB
+                    Worker 0:  Sort Method: quicksort  Memory: 25kB
                     ->  Seq Scan on vector_table1 t1 (actual rows=0 loops=1)
               ->  Sort (never executed)
                     Sort Key: t2.a
@@ -2068,7 +2072,7 @@ text
 Query Text: SELECT * FROM vector_table WHERE val = '[1,2,3]'
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=1 loops=1)
         Index Cond: (val = '[1,2,3]'::vector)
@@ -2088,7 +2092,7 @@ text
 Query Text: SELECT TOP 1 * FROM vector_table ORDER BY val
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Limit (actual rows=1 loops=1)
         ->  Index Only Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=1 loops=1)
@@ -2145,7 +2149,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <=> '[3,3,3]' NULLS LAST
 Gather (actual rows=2 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=2 loops=1)
         Order By: (val <=> '[3,3,3]'::vector)
@@ -2164,7 +2168,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=2 loops=1)
@@ -2183,7 +2187,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=2 loops=1)
@@ -2243,7 +2247,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <#> '[3,3,3]' NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
         Order By: (val <#> '[3,3,3]'::vector)
@@ -2262,7 +2266,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -2281,7 +2285,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -2341,7 +2345,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <-> '[3,3,3]' NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
         Order By: (val <-> '[3,3,3]'::vector)
@@ -2360,7 +2364,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -2379,7 +2383,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -2512,7 +2516,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <=> '[3,3,3]' NULLS LAST
 Gather (actual rows=3 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
         Order By: (val <=> '[3,3,3]'::vector)
@@ -2531,7 +2535,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -2551,7 +2555,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <=> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=3 loops=1)
@@ -2617,7 +2621,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <#> '[3,3,3]' NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idx2vector_table8408d573e4ed8cfc5bc30f15b5393f14 on vector_table (actual rows=4 loops=1)
         Order By: (val <#> '[3,3,3]'::vector)
@@ -2636,7 +2640,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idx2vector_table8408d573e4ed8cfc5bc30f15b5393f14 on vector_table (actual rows=4 loops=1)
@@ -2656,7 +2660,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <#> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idx2vector_table8408d573e4ed8cfc5bc30f15b5393f14 on vector_table (actual rows=4 loops=1)
@@ -2722,7 +2726,7 @@ text
 Query Text: SELECT * FROM vector_table ORDER BY val <-> '[3,3,3]' NULLS LAST
 Gather (actual rows=4 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=4 loops=1)
         Order By: (val <-> '[3,3,3]'::vector)
@@ -2741,7 +2745,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> '[0,0,0]' NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=4 loops=1)
@@ -2761,7 +2765,7 @@ text
 Query Text: SELECT COUNT(*) FROM (SELECT * FROM vector_table ORDER BY val <-> (SELECT CAST(NULL as vector)) NULLS LAST) t2
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Aggregate (actual rows=1 loops=1)
         ->  Index Scan using idxvector_table7f9bec28bc8902d45d905788d7aa59a1 on vector_table (actual rows=4 loops=1)
@@ -3042,7 +3046,7 @@ text
 Query Text: SELECT * FROM vector_table1 ORDER BY val <=> '[3,3,3]' NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using idxvector_table17f9bec28bc8902d45d905788d7aa59a1 on vector_table1 (actual rows=0 loops=1)
         Order By: (val <=> '[3,3,3]'::vector)
@@ -3061,7 +3065,7 @@ text
 Query Text: SELECT t1.*, t2.* FROM vector_table1 as t1 JOIN vector_table2 as t2 ON t1.a = t2.a ORDER BY t1.val <=> '[0,0,0]' NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Nested Loop (actual rows=0 loops=1)
         Join Filter: (t1.a = t2.a)
@@ -3084,15 +3088,19 @@ text
 Query Text: SELECT t1.* FROM vector_table1 as t1 JOIN vector_table2 as t2 ON t1.a = t2.a ORDER BY t1.val <=> '[0,0,0]', t2.val <=> '[1,1,1]'
 Gather Merge (actual rows=0 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Sort (actual rows=0 loops=1)
+  Workers Launched: 3
+  ->  Sort (actual rows=0 loops=4)
         Sort Key: ((t1.val <=> '[0,0,0]'::vector)) NULLS FIRST, ((t2.val <=> '[1,1,1]'::vector)) NULLS FIRST
         Sort Method: quicksort  Memory: 25kB
-        ->  Parallel Hash Join (actual rows=0 loops=1)
+        Worker 0:  Sort Method: quicksort  Memory: 25kB
+        Worker 1:  Sort Method: quicksort  Memory: 25kB
+        Worker 2:  Sort Method: quicksort  Memory: 25kB
+        ->  Parallel Hash Join (actual rows=0 loops=4)
               Hash Cond: (t1.a = t2.a)
-              ->  Parallel Seq Scan on vector_table1 t1 (actual rows=0 loops=1)
-              ->  Parallel Hash (never executed)
-                    ->  Parallel Seq Scan on vector_table2 t2 (never executed)
+              ->  Parallel Seq Scan on vector_table1 t1 (never executed)
+              ->  Parallel Hash (actual rows=0 loops=4)
+                    Buckets: 2048  Batches: 1  Memory Usage: 0kB
+                    ->  Parallel Seq Scan on vector_table2 t2 (actual rows=0 loops=1)
 ~~END~~
 
 
@@ -3107,7 +3115,7 @@ text
 Query Text: SELECT t1.* FROM vector_table1 as t1 JOIN table3 as t2 ON t1.a = t2.a ORDER BY val <=> '[0,0,0]' NULLS LAST
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Nested Loop (actual rows=0 loops=1)
         Join Filter: (t1.a = t2.a)
@@ -3129,16 +3137,16 @@ text
 Query Text: SELECT t1.* FROM vector_table1 as t1 JOIN table3 as t2 ON t1.a = t2.a ORDER BY val <=> '[0,0,0]', t2.a
 Gather (actual rows=0 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Sort (actual rows=0 loops=1)
         Sort Key: ((t1.val <=> '[0,0,0]'::vector)) NULLS FIRST, t1.a NULLS FIRST
-        Sort Method: quicksort  Memory: 25kB
+        Worker 0:  Sort Method: quicksort  Memory: 25kB
         ->  Merge Join (actual rows=0 loops=1)
               Merge Cond: (t1.a = t2.a)
               ->  Sort (actual rows=0 loops=1)
                     Sort Key: t1.a
-                    Sort Method: quicksort  Memory: 25kB
+                    Worker 0:  Sort Method: quicksort  Memory: 25kB
                     ->  Seq Scan on vector_table1 t1 (actual rows=0 loops=1)
               ->  Sort (never executed)
                     Sort Key: t2.a

--- a/test/JDBC/expected/parallel_query/babel_collection.out
+++ b/test/JDBC/expected/parallel_query/babel_collection.out
@@ -192,7 +192,7 @@ Gather  (cost=11.40..24.02 rows=3 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.278 ms
 ~~END~~
 
 
@@ -210,7 +210,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.096 ms
+Babelfish T-SQL Batch Parsing Time: 0.161 ms
 ~~END~~
 
 
@@ -228,7 +228,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.114 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -246,7 +246,7 @@ Gather  (cost=11.40..24.02 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.092 ms
+Babelfish T-SQL Batch Parsing Time: 0.129 ms
 ~~END~~
 
 
@@ -264,7 +264,7 @@ Gather  (cost=11.41..24.03 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.089 ms
+Babelfish T-SQL Batch Parsing Time: 0.129 ms
 ~~END~~
 
 
@@ -283,7 +283,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.094 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -300,7 +300,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.097 ms
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -317,7 +317,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.146 ms
 ~~END~~
 
 
@@ -336,7 +336,7 @@ Gather  (cost=11.56..24.18 rows=647 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.100 ms
+Babelfish T-SQL Batch Parsing Time: 1.103 ms
 ~~END~~
 
 
@@ -354,7 +354,7 @@ Gather  (cost=11.56..25.23 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.091 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -372,7 +372,7 @@ Gather  (cost=11.55..25.22 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.131 ms
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
 ~~END~~
 
 
@@ -392,7 +392,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -410,7 +410,7 @@ Gather  (cost=11.40..25.07 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.092 ms
+Babelfish T-SQL Batch Parsing Time: 0.131 ms
 ~~END~~
 
 
@@ -490,8 +490,8 @@ select * from p1 union all select * from p2;
 GO
 ~~START~~
 nvarchar
-äƀCd
 äbĆD
+äƀCd
 ~~END~~
 
 -- test case expression
@@ -545,7 +545,7 @@ Gather  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.086 ms
+Babelfish T-SQL Batch Parsing Time: 0.186 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -589,7 +589,7 @@ Gather  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.183 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -616,7 +616,7 @@ Gather  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.151 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -646,7 +646,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.089 ms
+Babelfish T-SQL Batch Parsing Time: 0.153 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -675,7 +675,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.089 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/parallel_query/cast_eliminate-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/cast_eliminate-vu-verify.out
@@ -340,13 +340,12 @@ text
 Query Text: SELECT * FROM cast_eliminate WHERE (CAST(CAST(ROID AS BIGINT) AS BIGINT) = 3 OR CAST(CAST(ROID AS INT) AS BIGINT) = 2147483647) AND CAST(CAST(s_int AS INT) AS BIGINT) != 32767
 Gather (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Bitmap Heap Scan on cast_eliminate (actual rows=1 loops=1)
         Recheck Cond: ((roid = 3) OR (roid = 2147483647))
         Filter: (((s_int)::integer)::bigint <> 32767)
         Rows Removed by Filter: 1
-        Heap Blocks: exact=1
         ->  BitmapOr (actual rows=0 loops=1)
               ->  Bitmap Index Scan on cast_eliminate_pkey (actual rows=1 loops=1)
                     Index Cond: (roid = 3)
@@ -367,10 +366,10 @@ text
 Query Text: SELECT * FROM cast_eliminate WHERE CAST(CAST(s_int AS INT) AS BIGINT) >= 2394 AND CAST(CAST(ROID AS BIGINT) AS SMALLINT) >= 3
 Gather (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on cast_eliminate (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
         Filter: ((s_int >= 2394) AND (((roid)::bigint)::smallint >= 3))
-        Rows Removed by Filter: 4
+        Rows Removed by Filter: 1
 ~~END~~
 
 
@@ -386,10 +385,10 @@ text
 Query Text: SELECT * FROM cast_eliminate WHERE -32768 = CAST(s_int AS INT)
 Gather (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on cast_eliminate (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
         Filter: ('-32768'::integer = s_int)
-        Rows Removed by Filter: 4
+        Rows Removed by Filter: 1
 ~~END~~
 
 
@@ -405,10 +404,10 @@ text
 Query Text: SELECT * FROM cast_eliminate WHERE -32768 = CAST(CAST(s_int AS INT) AS BIGINT)
 Gather (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on cast_eliminate (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
         Filter: ('-32768'::integer = s_int)
-        Rows Removed by Filter: 4
+        Rows Removed by Filter: 1
 ~~END~~
 
 
@@ -428,8 +427,8 @@ text
 Query Text: SELECT * FROM cast_eliminate WHERE -32768 < CAST(CAST(s_int AS INT) AS BIGINT) OR CAST(ROID AS BIGINT) = -2147483648
 Gather (actual rows=5 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on cast_eliminate (actual rows=5 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=1 loops=4)
         Filter: (('-32768'::integer < s_int) OR (roid = '-2147483648'::integer))
 ~~END~~
 
@@ -445,10 +444,10 @@ text
 Query Text: SELECT * FROM cast_eliminate WHERE -9223372036854775808 = CAST(s_int AS BIGINT)
 Gather (actual rows=0 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on cast_eliminate (actual rows=0 loops=4)
         Filter: ('-9223372036854775808'::bigint = s_int)
-        Rows Removed by Filter: 5
+        Rows Removed by Filter: 1
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/charindex_replace_patindex-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/charindex_replace_patindex-vu-verify.out
@@ -170,7 +170,7 @@ text
 Query Text: SELECT * FROM babel_5144_t1 WHERE [replaced] = sys.replace('abc?è?ÈdedEDEabcd', 'de', '##')
 Gather (actual rows=2 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_5144_idx1babel_5144_t145234637e3ecc830cb4dde1fe866640f on babel_5144_t1 (actual rows=2 loops=1)
         Index Cond: ((replaced)::"varchar" = 'abc?è?È######abcd'::"varchar")
@@ -221,7 +221,7 @@ text
 Query Text: SELECT * FROM babel_5144_t3 WHERE [replaced] = sys.replace('abc?è?ÈdedEDEabcd', 'de', '##')
 Gather (actual rows=2 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Index Scan using babel_5144_idx3babel_5144_t313c3a4389779eae0c4b18abc08f95caa on babel_5144_t3 (actual rows=2 loops=1)
         Index Cond: ((replaced)::"varchar" = 'abc?è?È######abcd'::"varchar")

--- a/test/JDBC/expected/parallel_query/test_dynamic_local_vars.out
+++ b/test/JDBC/expected/parallel_query/test_dynamic_local_vars.out
@@ -1351,7 +1351,7 @@ text
 Query Text: select "@i", "@j"
 Gather  (cost=0.00..0.01 rows=1 width=8) (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Result  (cost=0.00..0.01 rows=1 width=8) (actual rows=1 loops=1)
 ~~END~~
@@ -1379,7 +1379,7 @@ text
 Query Text: select "@i"
 Gather  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
   Workers Planned: 1
-  Workers Launched: 0
+  Workers Launched: 1
   Single Copy: true
   ->  Result  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
 ~~END~~
@@ -1536,8 +1536,8 @@ text
 Query Text: select * from local_var_tst where id = "@a"
 Gather  (cost=0.00..20.28 rows=13 width=4) (actual rows=1 loops=1)
   Workers Planned: 3
-  Workers Launched: 0
-  ->  Parallel Seq Scan on local_var_tst  (cost=0.00..20.28 rows=4 width=4) (actual rows=1 loops=1)
+  Workers Launched: 3
+  ->  Parallel Seq Scan on local_var_tst  (cost=0.00..20.28 rows=4 width=4) (actual rows=0 loops=4)
         Filter: (id = 1)
 ~~END~~
 

--- a/test/JDBC/expected/rowcount-vu-verify.out
+++ b/test/JDBC/expected/rowcount-vu-verify.out
@@ -124,7 +124,7 @@ select setting from pg_settings where name = 'babelfishpg_tsql.rowcount';
 go
 ~~START~~
 text
-2147483647
+0
 ~~END~~
 
 
@@ -218,7 +218,7 @@ select setting from pg_settings where name = 'babelfishpg_tsql.rowcount';
 go
 ~~START~~
 text
-2147483647
+0
 ~~END~~
 
 


### PR DESCRIPTION
### Description

Community [commit](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/7f07ff583ea8d55bb32853de40c3a9b69644c80f) simplified executor code to decide whether to use parallel query. Based on the new condition executor will never pick parallel operation if numberTuples != 0 is non zero, which happens when we put a limit on number of tuples that can be returned by executor.

In babelfish we were always initializing the rowcount as INT_MAX and the setting numberTuples = rowcount, which means babelfish select query will never be able to use parallelism even though it could.

The correct default value for row count should always have been zero meaning no LIMIT.

Even with this patch, queries will not use parallel query when row count is set to a non zero value by user.

A very simple example with & without this patch
```
SELECT * INTO t FROM generate_series(1,10000000)
GO
SELECT COUNT(*) FROM t
GO

-- With patch
SELECT COUNT(*) FROM t
Clock Time (ms.): total       526  avg   526.0 (1.9 xacts per sec.)

-- Without patch
SELECT COUNT(*) FROM t
Clock Time (ms.): total      1427  avg   1427.0 (0.7 xacts per sec.)
```


### Issues Resolved

[BABEL-5606]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).