### PR TITLE
Fix for cache reference leak warning

### DIFF
--- a/.github/composite-actions/install-extensions/action.yml
+++ b/.github/composite-actions/install-extensions/action.yml
@@ -65,9 +65,9 @@ runs:
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           sudo echo "babelfishpg_tsql.server_collation_name = '${{ inputs.server_collation_name }}'" >> postgresql.conf
         fi
-        ~/${{inputs.install_dir}}/bin/pg_ctl -c -D ~/${{inputs.install_dir}}/$DATADIR/ -l logfile start
+        ~/${{inputs.install_dir}}/bin/pg_ctl -c -D ~/${{inputs.install_dir}}/$DATADIR/ -l ~/${{inputs.install_dir}}/$DATADIR/logfile start
         cd ~/work/babelfish_extensions/babelfish_extensions/
         sudo ~/${{inputs.install_dir}}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -p ${{inputs.psql_port}} -v user="jdbc_user" -v db="babelfish_db" -v migration_mode=${{inputs.migration_mode}} -v tsql_port=${{inputs.tsql_port}} -v parallel_query_mode=${{inputs.parallel_query_mode}} -f .github/scripts/create_extension.sql
-        ~/${{inputs.install_dir}}/bin/pg_ctl -c -D ~/${{inputs.install_dir}}/$DATADIR/ -l logfile restart
+        ~/${{inputs.install_dir}}/bin/pg_ctl -c -D ~/${{inputs.install_dir}}/$DATADIR/ -l ~/${{inputs.install_dir}}/$DATADIR/logfile restart
         sqlcmd -S localhost,${{inputs.tsql_port}} -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
       shell: bash

--- a/.github/scripts/scan-warnings.sh
+++ b/.github/scripts/scan-warnings.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/bash
+LOG_FILE=~/psql/data/logfile
+# File to store the current warnings
+CURRENT_WARNINGS="actual-leak-warnings.out"
+
+# Function to extract and classify warnings
+extract_and_classify_warnings() {
+    grep "WARNING:" "$LOG_FILE" | 
+    awk -F"WARNING: " '{print $2}' | 
+    sort | 
+    while read -r line; do
+        case "$line" in
+            *"snapshot"*"still active"*)
+                echo "SNAPSHOT_ACTIVE_WARNING: $line"
+                ;;
+            *"leak"*)
+                echo "LEAK_WARNING: $line"
+                ;;
+            *"role"*"has not been granted membership"*|*"permission denied"*|*"transaction left non-empty SPI stack"*|*"cast will be ignored because the source data type is a domain"*|*"Query parsing failed using SLL parser mode but succeeded with LL mode"*|*"Using the TDS Foreign data wrapper (tds_fdw) as provider"*|*"Ignoring @provstr argument value"*|*"Product version setting by babelfishpg_tds.product_version GUC will have no effect on @@VERSION"*|*"no privileges could be revoked for"*|*"could not convert locale name"*|*"you don't own a lock of type"*|*"precision reduced to maximum allowed"*|*"WITH TIME ZONE precision reduced to maximum allowed"*|*"no privileges were granted for"*|*"parameter cannot be null"*|*"babelfishpg_tds.product_version cannot be set"*|*"could not convert locale name"*|*"This function has been deprecated and will no longer drop all users."*|*"cannot add relations to publication:"*|*"NUMERIC or DECIMAL type is cast to BIGINT"*)
+                # These warnings are expected and will be ignored
+                ;;
+            *)
+                echo "OTHER_WARNING: $line"
+                ;;
+        esac
+    done
+}
+
+# Extract and classify warnings
+extract_and_classify_warnings > "$CURRENT_WARNINGS"
+ERROR_FOUND=false
+# Check for other warning
+OTHER_WARNING_COUNT=$(grep -c "OTHER_WARNING:" "$CURRENT_WARNINGS" || echo 0)
+
+if [[ "$OTHER_WARNING_COUNT" -ge 1 ]]; then
+    echo "Error: $OTHER_WARNING_COUNT unexpected warning type(s) detected."
+    grep "OTHER_WARNING:" "$CURRENT_WARNINGS"
+    ERROR_FOUND=true
+fi
+# Count warnings
+SNAPSHOT_ACTIVE_COUNT=$(grep -c "SNAPSHOT_ACTIVE_WARNING:" "$CURRENT_WARNINGS")
+LEAK_COUNT=$(grep -c "LEAK_WARNING:" "$CURRENT_WARNINGS")
+
+if [[ "$SNAPSHOT_ACTIVE_COUNT" -ne 44 ]]; then
+    echo "Error: Expected 44 'snapshot ... still active' warnings, but found $SNAPSHOT_ACTIVE_COUNT"
+    ERROR_FOUND=true
+fi
+
+if [[ "$LEAK_COUNT" -ne 380 ]]; then
+    echo "Error: Expected 380 leak warnings, but found $LEAK_COUNT"
+    ERROR_FOUND=true
+fi
+
+if [[ "$ERROR_FOUND" = true ]]; then
+    echo "Unexpected warning counts detected. Please investigate."
+    echo "Snapshot 'still active' warnings: $SNAPSHOT_ACTIVE_COUNT"
+    echo "Leak warnings: $LEAK_COUNT"
+    exit 1
+fi
+echo "Warning counts are as expected:"
+echo "Snapshot 'still active' warnings: $SNAPSHOT_ACTIVE_COUNT"
+echo "Leak warnings: $LEAK_COUNT"

--- a/.github/scripts/scan-warnings.sh
+++ b/.github/scripts/scan-warnings.sh
@@ -13,6 +13,9 @@ extract_and_classify_warnings() {
             *"snapshot"*"still active"*)
                 echo "SNAPSHOT_ACTIVE_WARNING: $line"
                 ;;
+            *"resource was not closed"*)
+                echo "LEAK_WARNING: $line"
+                ;;                
             *"leak"*)
                 echo "LEAK_WARNING: $line"
                 ;;

--- a/.github/workflows/jdbc-tests.yml
+++ b/.github/workflows/jdbc-tests.yml
@@ -100,6 +100,20 @@ jobs:
             ~/psql/data/logfile
             ~/psql/data_5433/logfile
 
+      - name: Check for unexpected warnings
+        if: always()
+        id: check-warnings
+        run: |
+            bash ./.github/scripts/scan-warnings.sh
+
+      - name: Upload Unexpected Warning
+        if: always() && steps.check-warnings.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unexpected_warnings.log
+          path: |
+            actual-leak-warnings.out
+
       # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
       - name: Rename Test Summary Files
         id: test-file-rename

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2545,6 +2545,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					bool 				with_recompile = false;
 					Node                *tbltypStmt = NULL;
 					ListCell            *parameter;
+					HeapTuple 			proctup;
 
 					cfs = makeNode(CreateFunctionStmt);
 					cfs->returnType = NULL;
@@ -2626,13 +2627,22 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						originalFunc.objectId = oldoid;
 						originalFunc.classId = ProcedureRelationId;
 						originalFunc.objectSubId = 0;
-						if(get_bbf_function_tuple_from_proctuple(SearchSysCache1(PROCOID, ObjectIdGetDatum(oldoid))) == NULL)
+						proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(oldoid));
+						if (!HeapTupleIsValid(proctup))
+						{
+							ereport(ERROR,
+									(errcode(ERRCODE_UNDEFINED_OBJECT),
+										errmsg("cache lookup failed for procedure %u", oldoid)));
+						}
+						if (get_bbf_function_tuple_from_proctuple(proctup) == NULL)
 						{
 							/* Detect PSQL functions and throw error */
 							ereport(ERROR,
-								(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
-									errmsg("No existing TSQL procedure found with the name for ALTER PROCEDURE")));
+									(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+										errmsg("No existing TSQL procedure found with the name for ALTER PROCEDURE")));
 						}
+						ReleaseSysCache(proctup);
+
 						if(!cfs->is_procedure)
 						{
 							/*

--- a/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
@@ -542,6 +542,7 @@ tsql_get_functiondef(PG_FUNCTION_ARGS)
 	if (has_tvp)
 	{
 		ReleaseSysCache(proctup);
+		PG_RETURN_NULL();
 	}
 
 	if (isfunction || proc->pronargs > 0)

--- a/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
@@ -526,7 +526,10 @@ tsql_get_functiondef(PG_FUNCTION_ARGS)
 	if (!isnull)
 		probin_c = TextDatumGetCString(tmp);
 	if (!probin_c || probin_c[0] != '{')
+	{
+		ReleaseSysCache(proctup);
 		PG_RETURN_NULL();
+	}
 
 	number_args = proc->pronargs;
 	if (isfunction)
@@ -537,7 +540,9 @@ tsql_get_functiondef(PG_FUNCTION_ARGS)
 	(void) tsql_print_function_arguments(&buf, proctup, false, true, &typmod_arr, &has_tvp);
 	/* TODO: In case of Table Valued Functions, return NULL. */
 	if (has_tvp)
-		PG_RETURN_NULL();
+	{
+		ReleaseSysCache(proctup);
+	}
 
 	if (isfunction || proc->pronargs > 0)
 		appendStringInfoString(&buf, ")");


### PR DESCRIPTION
### Description
Cherry-pick : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3161
Problem: Cache Reference Leaks
1. During the Alter function/procedure we are doing a sys-cache search without releasing it. 
2. During the routines-definition, in one case we were not releasing the syscache search.

Fix: 
 a. To do sys-cache search via tuple and releasing it after the sys-cache search.
 b. Also we are generating the logfile but the path that we were giving it github action workflow was not correct, updated 
  that too.
 c. Added a step in jdbc-test workflow which will compare the warnings in logfile with expected warnings

### Issues Resolved
[BABEL-5551]
Signed-off-by: Pranav Jain [pranavjc@amazon.com](mailto:pranavjc@amazon.com)
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).