### PR TITLE
Add graceful handling in some hooks when temp name space is deleted by concurrent postgres sessions

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -5712,7 +5712,7 @@ handle_grantstmt_for_dbsecadmin(ObjectType objType, Oid objId, Oid ownerId,
 	 * 3. Grantor is same as owner OR Grantor already has all the required privileges.
 	 *    This means already the best grantor has been selected using select_best_grantor().
 	 */
-	if (!MyProcPort->is_tds_conn ||
+	if (!IS_TDS_CONN() ||
 		sql_dialect != SQL_DIALECT_TSQL ||
 		*grantorId == ownerId ||
 		*grantOptions == ACL_GRANT_OPTION_FOR(privileges))
@@ -5750,7 +5750,7 @@ handle_grantstmt_for_dbsecadmin(ObjectType objType, Oid objId, Oid ownerId,
 		schema_oid = get_object_namespace(&address);
 	}
 
-	if (OidIsValid(schema_oid))
+	if (OidIsValid(schema_oid) && !isTempOrTempToastNamespace(schema_oid))
 	{
 		/*
 		 * Don't allow if object's schema is not from current database OR
@@ -5795,13 +5795,19 @@ pltsql_get_object_owner(Oid namespaceId, Oid ownerId)
 
 	Assert(OidIsValid(namespaceId));
 
-	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
+	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN() || isTempOrTempToastNamespace(namespaceId))
 		return ownerId;
 
 	if (!OidIsValid(ownerId))
 		ownerId = GetUserId();
 
 	tuple = SearchSysCache1(NAMESPACEOID, ObjectIdGetDatum(namespaceId));
+
+	if (!HeapTupleIsValid(tuple))
+		ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_SCHEMA),
+					 errmsg("schema with OID %u does not exist", namespaceId)));
+
 	nsptup = (Form_pg_namespace) GETSTRUCT(tuple);
 
 	logical_schema_name = get_logical_schema_name(NameStr(nsptup->nspname), true);
@@ -5856,10 +5862,14 @@ is_bbf_db_ddladmin_operation(Oid namespaceId)
 
 	Assert(OidIsValid(namespaceId));
 
-	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
+	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN() || isTempOrTempToastNamespace(namespaceId))
 		return false;
 
 	nspname = get_namespace_name(namespaceId);
+
+	if (nspname == NULL)
+		return false;
+
 	schema_db_id = get_dbid_from_physical_schema_name(nspname, true);
 	db_ddladmin = get_db_ddladmin_oid(get_current_pltsql_db_name(), false);
 

--- a/test/JDBC/input/ddl/temp-tables.mix
+++ b/test/JDBC/input/ddl/temp-tables.mix
@@ -7,6 +7,7 @@ GO
 
 -- Basic temp table create/insert/select using tsql dialect
 
+-- tsql
 CREATE TABLE #local_tempt(col int);
 GO
 
@@ -281,8 +282,68 @@ go
 drop table #tt_1637
 go
 
--- cleanup
+-- BABEL-5569
+CREATE LOGIN babel_5569_l1 WITH PASSWORD = '12345678'
+GO
+CREATE USER babel_5569_l1
+GO
+ALTER ROLE db_ddladmin ADD MEMBER babel_5569_l1
+GO
+CREATE TABLE babel_5569_table(a INT)
+GO
+GRANT SELECT ON babel_5569_table TO babel_5569_l1
+GO
 
+-- tsql user=babel_5569_l1 password=12345678
+CREATE TABLE #babel_5569_temp_table (a INT)
+GO
+
+-- psql
+CREATE OR REPLACE FUNCTION drop_orphaned_temp_schemas() RETURNS void AS $$
+DECLARE
+    schema_record RECORD;
+    v_state text;
+    v_msg text;
+    v_detail text;
+    v_hint text;
+    v_context text;
+BEGIN
+    FOR schema_record IN 
+        SELECT nspname 
+        FROM pg_namespace 
+        WHERE nspname LIKE 'pg_temp%' 
+           OR nspname LIKE 'pg_toast_temp%'
+    LOOP
+        BEGIN
+            EXECUTE 'DROP SCHEMA IF EXISTS ' || quote_ident(schema_record.nspname) || ' CASCADE';
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE EXCEPTION 'Permission denied: must be owner of schema';
+        END;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+GO
+SET ROLE sysadmin;
+GO
+SELECT drop_orphaned_temp_schemas();
+GO
+RESET ROLE;
+GO
+SELECT drop_orphaned_temp_schemas();
+GO
+DROP FUNCTION drop_orphaned_temp_schemas();
+GO
+
+-- tsql user=babel_5569_l1 password=12345678
+SELECT * INTO #babel_5569_temp_table2 FROM babel_5569_table
+GO
+-- terminate-tsql-conn user=babel_5569_l1 password=12345678
+-- terminate-tsql-conn
+-- terminate-psql-conn
+
+-- cleanup
+-- tsql
 DROP PROCEDURE temp_table_sp;
 GO
 DROP PROCEDURE babel903;
@@ -302,4 +363,10 @@ GO
 DROP PROCEDURE sp_babel1637
 GO
 DROP TABLE tt_test_t1;
+GO
+DROP TABLE babel_5569_table;
+GO
+DROP USER babel_5569_l1
+GO
+DROP LOGIN babel_5569_l1
 GO

--- a/test/JDBC/sql_expected/temp-tables.out
+++ b/test/JDBC/sql_expected/temp-tables.out
@@ -3,6 +3,7 @@ GO
 
 
 
+-- tsql
 --
 -- Tests for T-SQL style temp tables
 --
@@ -409,7 +410,78 @@ int
 drop table #tt_1637
 go
 
+-- BABEL-5569
+CREATE LOGIN babel_5569_l1 WITH PASSWORD = '12345678'
+GO
+CREATE USER babel_5569_l1
+GO
+ALTER ROLE db_ddladmin ADD MEMBER babel_5569_l1
+GO
+CREATE TABLE babel_5569_table(a INT)
+GO
+GRANT SELECT ON babel_5569_table TO babel_5569_l1
+GO
 
+-- tsql user=babel_5569_l1 password=12345678
+CREATE TABLE #babel_5569_temp_table (a INT)
+GO
+
+-- psql
+CREATE OR REPLACE FUNCTION drop_orphaned_temp_schemas() RETURNS void AS $$
+DECLARE
+    schema_record RECORD;
+    v_state text;
+    v_msg text;
+    v_detail text;
+    v_hint text;
+    v_context text;
+BEGIN
+    FOR schema_record IN 
+        SELECT nspname 
+        FROM pg_namespace 
+        WHERE nspname LIKE 'pg_temp%' 
+           OR nspname LIKE 'pg_toast_temp%'
+    LOOP
+        BEGIN
+            EXECUTE 'DROP SCHEMA IF EXISTS ' || quote_ident(schema_record.nspname) || ' CASCADE';
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE EXCEPTION 'Permission denied: must be owner of schema';
+        END;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+GO
+SET ROLE sysadmin;
+GO
+SELECT drop_orphaned_temp_schemas();
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Permission denied: must be owner of schema
+  Where: PL/pgSQL function drop_orphaned_temp_schemas() line 20 at RAISE
+    Server SQLState: P0001)~~
+
+RESET ROLE;
+GO
+SELECT drop_orphaned_temp_schemas();
+GO
+~~START~~
+void
+
+~~END~~
+
+DROP FUNCTION drop_orphaned_temp_schemas();
+GO
+
+-- tsql user=babel_5569_l1 password=12345678
+SELECT * INTO #babel_5569_temp_table2 FROM babel_5569_table
+GO
+-- terminate-tsql-conn user=babel_5569_l1 password=12345678
+-- terminate-tsql-conn
+-- terminate-psql-conn
+
+-- tsql
 -- cleanup
 DROP PROCEDURE temp_table_sp;
 GO
@@ -430,4 +502,10 @@ GO
 DROP PROCEDURE sp_babel1637
 GO
 DROP TABLE tt_test_t1;
+GO
+DROP TABLE babel_5569_table;
+GO
+DROP USER babel_5569_l1
+GO
+DROP LOGIN babel_5569_l1
 GO


### PR DESCRIPTION
### Description

A couple of hooks introduced as part of supporting fixed database level roles assumed that the namespace for an object will always exists, but an exception to this is temp namespace which can be deleted by a concurrent postgres sessions.

As a fix completely skip the hook logic if we are processing a temp namespace and add safety null checks.

### Cherry Picked From

https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3420

### Issues Resolved

[BABEL-5569]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).