### PR TITLE
Handle entries in babelfish_schema_permissions where multiple objects have the same name

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -3817,7 +3817,8 @@ update_privileges_of_object(const char *schema_name,
 bool
 privilege_exists_in_bbf_schema_permissions(const char *schema_name,
 							const char *object_name,
-							const char *grantee)
+							const char *grantee,
+							const char *object_type)
 {
 	Relation	bbf_schema_rel;
 	HeapTuple	tuple_bbf_schema;
@@ -3831,7 +3832,7 @@ privilege_exists_in_bbf_schema_permissions(const char *schema_name,
 
 	if (grantee != NULL)
 	{
-		ScanKeyData	scanKey[4];
+		ScanKeyData	scanKey[5];
 		/* Immediately return false, if grantee is PUBLIC. */
 		if (strcmp(grantee, PUBLIC_ROLE_NAME) == 0)
 			return false;
@@ -3863,13 +3864,20 @@ privilege_exists_in_bbf_schema_permissions(const char *schema_name,
 					tsql_get_database_or_server_collation_oid_internal(false),
 					F_TEXTEQ,
 					CStringGetTextDatum(grantee));
+		ScanKeyEntryInitialize(&scanKey[4], 0,
+					Anum_bbf_schema_perms_object_type,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_database_or_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(object_type));
 		scan = systable_beginscan(bbf_schema_rel,
 					get_bbf_schema_perms_idx_oid(),
-					true, NULL, 4, scanKey);
+					true, NULL, 5, scanKey);
 	}
 	else
 	{
-		ScanKeyData	scanKey[3];
+		ScanKeyData	scanKey[4];
 		bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
 										AccessShareLock);
 		ScanKeyInit(&scanKey[0],
@@ -3890,10 +3898,17 @@ privilege_exists_in_bbf_schema_permissions(const char *schema_name,
 					tsql_get_database_or_server_collation_oid_internal(false),
 					F_TEXTEQ,
 					CStringGetTextDatum(object_name));
+		ScanKeyEntryInitialize(&scanKey[3], 0,
+					Anum_bbf_schema_perms_object_type,
+					BTEqualStrategyNumber,
+					InvalidOid,
+					tsql_get_database_or_server_collation_oid_internal(false),
+					F_TEXTEQ,
+					CStringGetTextDatum(object_type));
 
 		scan = systable_beginscan(bbf_schema_rel,
 					get_bbf_schema_perms_idx_oid(),
-					true, NULL, 3, scanKey);
+					true, NULL, 4, scanKey);
 	}
 
 	tuple_bbf_schema = systable_getnext(scan);
@@ -4056,7 +4071,7 @@ add_or_update_object_in_bbf_schema(const char *schema_name,
 				bool is_grant,
 				const char *func_args)
 {
-	if (!privilege_exists_in_bbf_schema_permissions(schema_name, object_name, grantee))
+	if (!privilege_exists_in_bbf_schema_permissions(schema_name, object_name, grantee, object_type))
 		add_entry_to_bbf_schema_perms(schema_name, object_name, new_permission, grantee, object_type, func_args);
 	else
 		update_privileges_of_object(schema_name, object_name, new_permission, grantee, object_type, is_grant);

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -369,7 +369,7 @@ typedef struct FormData_bbf_schema_perms
 typedef FormData_bbf_schema_perms *Form_bbf_schema_perms;
 
 extern void add_entry_to_bbf_schema_perms(const char *schema_name, const char *object_name, int permission, const char *grantee, const char *object_type, const char *func_args);
-extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee);
+extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
 extern void update_privileges_of_object(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant);
 extern void remove_entry_from_bbf_schema_perms(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
 extern void add_or_update_object_in_bbf_schema(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant, const char *func_args);

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -4035,7 +4035,7 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 		else
 		{
 			/* For REVOKE statement, update privileges in the catalog. */
-			if (privilege_exists_in_bbf_schema_permissions(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rolname))
+			if (privilege_exists_in_bbf_schema_permissions(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rolname, OBJ_SCHEMA))
 			{
 				/* If any object in the schema has the OBJECT level permission. Then, internally grant that permission back. */
 				for (i = 0; i < NUMBER_OF_PERMISSIONS; i++)

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4584,7 +4584,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								 * 2. If permission on object exists, update the privilege in the catalog and revoke permission.
 								 */
 								update_privileges_of_object(logical_schema, obj, ALL_PERMISSIONS_ON_RELATION, rol_spec->rolename, OBJ_RELATION, false);
-								if (privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+								if (privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
 									return;
 							}
 						}
@@ -4622,7 +4622,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									/*
 									 * If permission on schema exists, don't revoke any permission from the object.
 									 */
-									if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+									if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
 										exec_pg_command = true;
 
 									update_privileges_of_object(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, false);
@@ -4692,7 +4692,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								 * 2. If permission on object exists, update the privilege in the catalog and revoke permission.
 								 */
 								update_privileges_of_object(logicalschema, funcname, ALL_PERMISSIONS_ON_FUNCTION, rol_spec->rolename, obj_type, false);
-								if (privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+								if (privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
 									return;
 							}
 						}
@@ -4730,7 +4730,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								/*
 								 * If permission on schema exists, don't revoke any permission from the object.
 								 */
-								if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename))
+								if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
 									exec_pg_command = true;
 								/* Update the privilege in the catalog. */
 								update_privileges_of_object(logicalschema, funcname, privilege, rol_spec->rolename, obj_type, false);

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -6628,3 +6628,39 @@ go
 
 drop database babel_5172_db
 go
+
+-- check the catalog entry when the table name and proc name are same.
+create proc GRANT_SCHEMA_t1 as select 1;
+go
+grant execute on GRANT_SCHEMA_t1 to guest;
+go
+create table GRANT_SCHEMA_t1(a int);
+go
+grant select on GRANT_SCHEMA_t1 to guest;
+go
+
+-- psql
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+dbo#!#grant_schema_t1#!#128#!#master_guest#!#<NULL>
+dbo#!#grant_schema_t1#!#2#!#master_guest#!#<NULL>
+~~END~~
+
+
+-- tsql
+drop table GRANT_SCHEMA_t1;
+go
+drop proc GRANT_SCHEMA_t1;
+go
+
+-- psql
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+~~END~~
+

--- a/test/JDBC/expected/single_db/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/single_db/GRANT_SCHEMA.out
@@ -6628,3 +6628,39 @@ go
 
 drop database babel_5172_db
 go
+
+-- check the catalog entry when the table name and proc name are same.
+create proc GRANT_SCHEMA_t1 as select 1;
+go
+grant execute on GRANT_SCHEMA_t1 to guest;
+go
+create table GRANT_SCHEMA_t1(a int);
+go
+grant select on GRANT_SCHEMA_t1 to guest;
+go
+
+-- psql
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+dbo#!#grant_schema_t1#!#128#!#master_guest#!#<NULL>
+dbo#!#grant_schema_t1#!#2#!#master_guest#!#<NULL>
+~~END~~
+
+
+-- tsql
+drop table GRANT_SCHEMA_t1;
+go
+drop proc GRANT_SCHEMA_t1;
+go
+
+-- psql
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
+go
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
+~~END~~
+

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -3647,3 +3647,29 @@ go
 
 drop database babel_5172_db
 go
+
+-- check the catalog entry when the table name and proc name are same.
+create proc GRANT_SCHEMA_t1 as select 1;
+go
+grant execute on GRANT_SCHEMA_t1 to guest;
+go
+create table GRANT_SCHEMA_t1(a int);
+go
+grant select on GRANT_SCHEMA_t1 to guest;
+go
+
+-- psql
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
+go
+
+-- tsql
+drop table GRANT_SCHEMA_t1;
+go
+drop proc GRANT_SCHEMA_t1;
+go
+
+-- psql
+select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
+where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
+go


### PR DESCRIPTION
### Description

Handle entries in babelfish_schema_permissions where multiple objects have the same name. Earlier, the entry in `babelfish_schema_permissions` was getting overridden if there are table and procedure with the same name.


### Issues Resolved

Task: BABEL-5644
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -** Added


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).