### PR TITLE
Add null check for func args in tsql_get_expr

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
@@ -398,11 +398,16 @@ PG_FUNCTION_INFO_V1(tsql_get_expr);
 Datum
 tsql_get_expr(PG_FUNCTION_ARGS)
 {
-	text	   *expr = PG_GETARG_TEXT_PP(0);
-	Oid			relid = PG_GETARG_OID(1);
+	text	   *expr;
+	Oid			relid;
 	int			prettyFlags;
 	char	   *relname;
-
+	
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+	
+	expr = PG_GETARG_TEXT_PP(0);
+	relid = PG_GETARG_OID(1);
 	prettyFlags = PRETTYFLAG_INDENT;
 
 	if (OidIsValid(relid))

--- a/test/JDBC/expected/sys-computed_columns-vu-verify.out
+++ b/test/JDBC/expected/sys-computed_columns-vu-verify.out
@@ -56,3 +56,11 @@ text
 <NULL>
 ~~END~~
 
+
+Select sys.tsql_get_expr(null, null)
+GO
+~~START~~
+text
+<NULL>
+~~END~~
+

--- a/test/JDBC/input/views/sys-computed_columns-vu-verify.sql
+++ b/test/JDBC/input/views/sys-computed_columns-vu-verify.sql
@@ -21,3 +21,6 @@ GO
 
 Select sys.tsql_get_expr('abc',0)
 GO
+
+Select sys.tsql_get_expr(null, null)
+GO


### PR DESCRIPTION
### Description
The function [get_rule_expr](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_5_X_DEV/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c#L1205) inside of sys.tsql_get_expr crash when the param is null. Adding null check for the input parameters.


### Issues Resolved

BABEL-5460

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
Yes

* **Major version upgrade tests -**
Yes

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).