### PR TITLE
fix test file BABEL-5186

### DIFF
--- a/test/JDBC/expected/BABEL-5186-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-5186-vu-cleanup.out
@@ -1,3 +1,9 @@
+-- psql
+DROP PROCEDURE master_dbo.babel_5186_relation_err_pg_proc;
+DROP PROCEDURE master_dbo.babel_5186_column_err_pg_proc;
+GO
+
+-- tsql
 DROP PROCEDURE babel_5186_1_errProc3_41
 DROP PROCEDURE babel_5186_1_errProc3_4
 DROP PROCEDURE babel_5186_1_errProc3_31

--- a/test/JDBC/expected/BABEL-5186-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-5186-vu-prepare.out
@@ -1,3 +1,4 @@
+-- tsql
 CREATE PROCEDURE babel_5186_try_catch_relation_err_proc1
 AS
     SELECT * FROM non_existent_table;
@@ -806,4 +807,21 @@ INSERT INTO babel_5186_1_table_errTable VALUES (4);
 EXEC babel_5186_1_errProc3_4;
 INSERT INTO babel_5186_1_table_errTable VALUES (5);
 COMMIT TRAN;
+GO
+
+-- psql
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_relation_err_pg_proc()
+AS $$
+BEGIN
+	SELECT * FROM non_existent_table;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_column_err_pg_proc()
+AS $$
+BEGIN
+	SELECT non_existent_column FROM master_dbo.babel_5186_try_catch_table;
+END;
+$$ LANGUAGE plpgsql;
 GO

--- a/test/JDBC/expected/BABEL-5186-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5186-vu-verify.out
@@ -4271,23 +4271,6 @@ int
 IF @@trancount > 0 ROLLBACK TRAN;
 GO
 
--- psql
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_relation_err_pg_proc()
-AS $$
-BEGIN
-	SELECT * FROM non_existent_table;
-END;
-$$ LANGUAGE plpgsql;
-GO
-
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_column_err_pg_proc()
-AS $$
-BEGIN
-	SELECT * FROM non_existent_table;
-END;
-$$ LANGUAGE plpgsql;
-GO
-
 -- tsql
 -- Error: relation \"%s\" does not exist
 -- plpgsql procedure inside try-catch
@@ -4309,6 +4292,8 @@ Severity_16 Error State_1 Xact State_0 Error number_33557097 Error Line number_3
 ~~END~~
 
 
+-- Error: column \"%s\" does not exist
+-- plpgsql procedure inside try-catch
 BEGIN TRY
     EXEC dbo.babel_5186_column_err_pg_proc;
 END TRY
@@ -4323,6 +4308,6 @@ END CATCH;
 GO
 ~~START~~
 nvarchar
-Severity_16 Error State_1 Xact State_0 Error number_33557097 Error Line number_3 Error message_relation "non_existent_table" does not exist
+Severity_16 Error State_1 Xact State_0 Error number_33557097 Error Line number_3 Error message_column "non_existent_column" does not exist
 ~~END~~
 

--- a/test/JDBC/input/BABEL-5186-vu-cleanup.mix
+++ b/test/JDBC/input/BABEL-5186-vu-cleanup.mix
@@ -1,3 +1,9 @@
+-- psql
+DROP PROCEDURE master_dbo.babel_5186_relation_err_pg_proc;
+DROP PROCEDURE master_dbo.babel_5186_column_err_pg_proc;
+GO
+
+-- tsql
 DROP PROCEDURE babel_5186_1_errProc3_41
 DROP PROCEDURE babel_5186_1_errProc3_4
 DROP PROCEDURE babel_5186_1_errProc3_31

--- a/test/JDBC/input/BABEL-5186-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-5186-vu-prepare.mix
@@ -1,3 +1,4 @@
+-- tsql
 CREATE PROCEDURE babel_5186_try_catch_relation_err_proc1
 AS
     SELECT * FROM non_existent_table;
@@ -770,4 +771,21 @@ INSERT INTO babel_5186_1_table_errTable VALUES (4);
 EXEC babel_5186_1_errProc3_4;
 INSERT INTO babel_5186_1_table_errTable VALUES (5);
 COMMIT TRAN;
+GO
+
+-- psql
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_relation_err_pg_proc()
+AS $$
+BEGIN
+	SELECT * FROM non_existent_table;
+END;
+$$ LANGUAGE plpgsql;
+GO
+
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_column_err_pg_proc()
+AS $$
+BEGIN
+	SELECT non_existent_column FROM master_dbo.babel_5186_try_catch_table;
+END;
+$$ LANGUAGE plpgsql;
 GO

--- a/test/JDBC/input/BABEL-5186-vu-verify.mix
+++ b/test/JDBC/input/BABEL-5186-vu-verify.mix
@@ -2487,23 +2487,6 @@ GO
 IF @@trancount > 0 ROLLBACK TRAN;
 GO
 
--- psql
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_relation_err_pg_proc()
-AS $$
-BEGIN
-	SELECT * FROM non_existent_table;
-END;
-$$ LANGUAGE plpgsql;
-GO
-
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5186_column_err_pg_proc()
-AS $$
-BEGIN
-	SELECT * FROM non_existent_table;
-END;
-$$ LANGUAGE plpgsql;
-GO
-
 -- tsql
 -- Error: relation \"%s\" does not exist
 -- plpgsql procedure inside try-catch
@@ -2520,6 +2503,8 @@ BEGIN CATCH
 END CATCH;
 GO
 
+-- Error: column \"%s\" does not exist
+-- plpgsql procedure inside try-catch
 BEGIN TRY
     EXEC dbo.babel_5186_column_err_pg_proc;
 END TRY

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -569,7 +569,6 @@ smalldatetime_date_cmp
 dbcreator_role
 securityadmin_role
 datareader_datawriter
-BABEL-5186
 test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4


### PR DESCRIPTION
### Description

In test file `BABEL-5186-vu-verify` we had created two procedures `babel_5186_relation_err_pg_proc` and `babel_5186_column_err_pg_proc` which was not dropped, due to which we were seeing failures while scripting in dotnet tests in Code Coverage. To fix this moved the creation of procedures to `BABEL-5186-vu-prepare` and dropped these procedures in `BABEL-5186-vu-cleanup` 

Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3529

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).