### PR TITLE
Override max length of 0 for char parameter types in an RPC (#3515)

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -40,6 +40,8 @@
  */
 #define INT32_STRLEN	12
 
+#define VARCHAR_MAX_LEN	0x1F40 /* 8000 */
+
 /* For checking the invalid length parameters */
 #define CheckForInvalidLength(temp) \
 do \
@@ -1182,6 +1184,15 @@ GetSetColMetadataForCharType(ParameterToken temp, StringInfo message, uint8_t td
 		return STATUS_ERROR;
 
 	memcpy(&tempLen, &message->data[offset], sizeof(tempLen));
+
+	/*
+	 * Technically maxLen can be 0 but since typmod of
+	 * 0 is not supported in PG, we will translate it
+	 * to max supported typmod of char based datatypes.
+	 */
+	if (tempLen == 0)
+		tempLen = VARCHAR_MAX_LEN;
+
 	temp->maxLen = tempLen;
 	offset += sizeof(tempLen);
 	memcpy(&collation, &message->data[offset], sizeof(collation));


### PR DESCRIPTION
### Description

In a TDS remote procedure call (RPC), the max length of char based datatypes can be 0 - 8000. The typmod of the base PG type that we map the RPC parameter to is directly related to the max length of the parameter type specified in the RPC. For char/varchar typmod = maxLen and for nchar/nvarchar typmod = maxLen / 2. Thus, if maxLen = 0, we will translate it to typmod of 0 which is invalid for char based types in PG.

To fix this, if the max length of the RPC parameter on the wire is 0, we will override the max length to the maximum permissible length of PG char types i.e. 8000.

Task: BABEL-5639
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).