### PR TITLE
SELECT INTO does not keep nullability or identity (#3499)

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -48,6 +48,7 @@
 #include "nodes/pg_list.h"
 #include "parser/analyze.h"
 #include "parser/parser.h"
+#include "parser/parsetree.h"
 #include "parser/parse_clause.h"
 #include "parser/parse_expr.h"
 #include "parser/parse_relation.h"
@@ -6777,15 +6778,51 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 	{
 		Query *q = (Query *)n;
 		bool seen_identity = false;
+		bool ordinality_changed = false;
 		AttrNumber current_resno = 0;
 		Index identity_ressortgroupref = 0;
 		List *modifiedTargetList = NIL;
+
+		bool persist_identity = true;
+
+		/*
+		 * In T-SQL, identity property of column in destination
+		 * table is not persisted if the SELECT ... INTO statement
+		 * does not contain a single base relation
+		 */
+		if (q->jointree && q->jointree->fromlist != NIL)
+		{
+			if (list_length(q->jointree->fromlist) > 1)
+				persist_identity = false;
+			else
+			{
+				Node *n_from = (Node *) linitial(q->jointree->fromlist);
+
+				if (!IsA(n_from, RangeTblRef))
+					persist_identity = false;
+				else
+				{
+					RangeTblRef		*rtr = (RangeTblRef *) n_from;
+					RangeTblEntry	*rte = rt_fetch(rtr->rtindex, q->rtable);
+
+					/* Do not persist identity if not an ordinary relation */
+					if (rte->rtekind != RTE_RELATION)
+						persist_identity = false;
+				}
+			}
+		}
+
+		altstmt = makeNode(AlterTableStmt);
+		altstmt->relation = into->rel;
+		altstmt->objtype = OBJECT_TABLE;
+		altstmt->cmds = NIL;
 
 		foreach (elements, q->targetList)
 		{
 			TargetEntry *tle = (TargetEntry *)lfirst(elements);
 			if(tle->resname != NULL && !tle->resjunk)
 				tle->resname = downcase_identifier(tle->resname, strlen(tle->resname), false, false);
+
 			if (tle->expr && IsA(tle->expr, FuncExpr) && strcasecmp(get_func_name(((FuncExpr *)(tle->expr))->funcid), "identity_into_bigint") == 0)
 			{
 				FuncExpr *funcexpr;
@@ -6839,18 +6876,15 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				}
 
 				seen_identity = true;
+				ordinality_changed = true;
 				identity_ressortgroupref = tle->ressortgroupref; /** Save this Index to modify sortClause and distinctClause*/
 
 				/** Add alter table add identity node after Select Into statement */
-				altstmt = makeNode(AlterTableStmt);
-				altstmt->relation = into->rel;
-				altstmt->objtype = OBJECT_TABLE;
-				altstmt->cmds = NIL;
-
 				constraint = makeNode(Constraint);
 				constraint->contype = CONSTR_IDENTITY;
 				constraint->generated_when = ATTRIBUTE_IDENTITY_ALWAYS;
 				constraint->options = seqoptions;
+				constraint->location = -1;
 
 				def = makeNode(ColumnDef);
 				def->colname = tle->resname;
@@ -6865,6 +6899,61 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				lcmd->def = (Node *)def;
 				altstmt->cmds = lappend(altstmt->cmds, lcmd);
 			}
+			else if (tle->expr && IsA(tle->expr, Var) && OidIsValid(tle->resorigtbl))
+			{
+				HeapTuple	attrtup = SearchSysCacheAttNum(tle->resorigtbl, tle->resorigcol);
+
+				if (HeapTupleIsValid(attrtup))
+				{
+					AlterTableCmd *lcmd;
+					Form_pg_attribute attrStruct = (Form_pg_attribute) GETSTRUCT(attrtup);
+
+					if (attrStruct->attnotnull)
+					{
+						/*
+						 * Add ALTER TABLE ... ALTER COLUMN ... SET NOT NULL
+						 * after SELECT INTO statement
+						 */
+						lcmd = makeNode(AlterTableCmd);
+						lcmd->subtype = AT_SetNotNull;
+						lcmd->name = tle->resname;
+						altstmt->cmds = lappend(altstmt->cmds, lcmd);
+					}
+
+					if (attrStruct->attidentity && persist_identity)
+					{
+						Constraint *constraint;
+
+						if (seen_identity)
+							ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
+									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
+
+						seen_identity = true;
+
+						constraint = makeNode(Constraint);
+						constraint->contype = CONSTR_IDENTITY;
+						constraint->generated_when = attrStruct->attidentity;
+						constraint->options = sequence_options(get_table_identity(tle->resorigtbl));
+						constraint->location = -1;
+
+						/*
+						 * Add ALTER TABLE ... ALTER COLUMN ... after SELECT INTO
+						 * statement where the column is made an IDENTITY column
+						 */
+						lcmd = makeNode(AlterTableCmd);
+						lcmd->subtype = AT_AddIdentity;
+						lcmd->name = tle->resname;
+						lcmd->def = (Node *) constraint;
+						altstmt->cmds = lappend(altstmt->cmds, lcmd);
+					}
+
+					current_resno += 1;
+					tle->resno = current_resno;
+					modifiedTargetList = lappend(modifiedTargetList, tle);
+
+					ReleaseSysCache(attrtup);
+				}
+			}
 			else
 			{
 				current_resno += 1;
@@ -6874,7 +6963,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 		}
 		q->targetList = modifiedTargetList;
 
-		if (seen_identity)
+		if (ordinality_changed)
 		{
 			if (q->sortClause)
 			{
@@ -6899,7 +6988,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 	}
 
 	result = lappend(result, stmt);
-	if (altstmt)
+	if (altstmt && list_length(altstmt->cmds) > 0)
 		result = lappend(result, altstmt);
 
 	return result;

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2332,6 +2332,7 @@ extern void pltsql_nextval_identity(Oid seqid, int64 val);
 extern void pltsql_resetcache_identity(void);
 extern int64 pltsql_setval_identity(Oid seqid, int64 val, int64 last_val);
 extern int64 last_scope_identity_value(void);
+extern Oid	get_table_identity(Oid tableOid);
 
 /*
  * Functions in linked_servers.c

--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -55,7 +55,7 @@ static HTAB *seqhashtabidentity = NULL;
 
 static SeqTableIdentityData *last_used_seq_identity = NULL;
 
-static Oid	get_table_identity(Oid tableOid);
+Oid	get_table_identity(Oid tableOid);
 
 static ScopeIdentityStack *last_used_scope_seq_identity = NULL;
 static int	PltsqlScopeIdentityNestLevel = 0;
@@ -217,7 +217,7 @@ get_identity_current(PG_FUNCTION_ARGS)
 /*
  * Get the table's identity sequence OID.
  */
-static Oid
+Oid
 get_table_identity(Oid tableOid)
 {
 	Relation	rel;

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -1,0 +1,420 @@
+create database db_select_into
+go
+
+use db_select_into
+go
+
+create schema sch_select_into
+go
+
+create table t1_select_into ([Col1] INT IDENTITY(1, 1), [Col2] [NVarchar](20) NOT NULL)
+go
+
+insert into t1_select_into([Col2]) values ('First')
+go
+~~ROW COUNT: 1~~
+
+
+set identity_insert t1_select_into on
+go
+
+insert into t1_select_into([Col1], [Col2]) values (1, 'First_dup')
+go
+~~ROW COUNT: 1~~
+
+
+set identity_insert t1_select_into off
+go
+
+create view v1_select_into as select * from t1_select_into
+go
+
+create table sch_select_into.t1_select_into ([Col3] TINYINT IDENTITY(2, 2), [Col4] numeric(4,3) NOT NULL)
+go
+
+insert into sch_select_into.t1_select_into([Col4]) values (2.222)
+go
+~~ROW COUNT: 1~~
+
+
+use master
+go
+
+create schema sch_select_into_master
+go
+
+create table sch_select_into_master.t1_select_into_master ([Col5] SMALLINT IDENTITY(3, 3), [Col6] [Nvarchar](20) NOT NULL)
+go
+
+insert into sch_select_into_master.t1_select_into_master([Col6]) values ('Third')
+go
+~~ROW COUNT: 1~~
+
+
+create table t1_select_into_master ([Col7] float NOT NULL, [Col8] BIGINT IDENTITY(4, 4))
+go
+
+insert into t1_select_into_master([Col7]) values (4.4)
+go
+~~ROW COUNT: 1~~
+
+
+create table t1_select_into_master_dec ([Col9] DECIMAL(10,0) IDENTITY(5, 5) PRIMARY KEY, [Col10] real NOT NULL)
+go
+
+insert into t1_select_into_master_dec([Col10]) values (5.567)
+go
+~~ROW COUNT: 1~~
+
+
+use db_select_into
+go
+
+select * into dest_table_1 from t1_select_into order by [Col1]
+go
+
+select * into dest_table_2 from sch_select_into.t1_select_into group by [Col3], [Col4]
+go
+
+select * into dest_table_3 from master.sch_select_into_master.t1_select_into_master
+go
+
+select * into dest_table_4 from master..t1_select_into_master
+go
+
+select * into dest_table_5 from master.dbo.t1_select_into_master_dec
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'ignore';
+go
+
+-- Should throw error because there are 2 identity columns
+select identity(int, 1, 1) as identity_col, * into dest_table_error from t1_select_into
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attempting to add multiple identity columns to table "dest_table_error" using the SELECT INTO statement.)~~
+
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'strict';
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_1 ([Col2]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col2" of relation "dest_table_1" violates not-null constraint)~~
+
+
+insert into dest_table_1 ([Col2]) values ('Second')
+go
+~~ROW COUNT: 1~~
+
+
+-- Identity column should be populated by default
+select * from dest_table_1 order by [Col1]
+go
+~~START~~
+int#!#nvarchar
+1#!#First
+1#!#First_dup
+2#!#Second
+~~END~~
+
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_2 ([Col4]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col4" of relation "dest_table_2" violates not-null constraint)~~
+
+
+insert into dest_table_2 ([Col4]) values (3.333)
+go
+~~ROW COUNT: 1~~
+
+
+-- Identity column should be populated by default
+select * from dest_table_2 order by [Col3]
+go
+~~START~~
+smallint#!#numeric
+2#!#2.222
+4#!#3.333
+~~END~~
+
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_3 ([Col6]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col6" of relation "dest_table_3" violates not-null constraint)~~
+
+
+insert into dest_table_3 ([Col6]) values ('Fourth')
+go
+~~ROW COUNT: 1~~
+
+
+-- Identity column should be populated by default
+select * from dest_table_3 order by [Col5]
+go
+~~START~~
+smallint#!#nvarchar
+3#!#Third
+6#!#Fourth
+~~END~~
+
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_4 ([Col7]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col7" of relation "dest_table_4" violates not-null constraint)~~
+
+
+insert into dest_table_4 ([Col7]) values (5.5)
+go
+~~ROW COUNT: 1~~
+
+
+-- Identity column should be populated by default
+select * from dest_table_4 order by [Col8]
+go
+~~START~~
+float#!#bigint
+4.4#!#4
+5.5#!#8
+~~END~~
+
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_5 ([Col10]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col10" of relation "dest_table_5" violates not-null constraint)~~
+
+
+insert into dest_table_5 ([Col10]) values (6.789)
+go
+~~ROW COUNT: 1~~
+
+
+-- Identity column should be populated by default
+select * from dest_table_5 order by [Col9]
+go
+~~START~~
+bigint#!#real
+5#!#5.567
+10#!#6.789
+~~END~~
+
+
+-- FROM clause contains joins from multiple tables
+-- Should not fail as identity should not be persisted but nullability should
+select *
+into dest_table_join
+from dest_table_1 t1
+inner join dest_table_2 t2
+on t1.[Col1] * 2 = t2.[Col3]
+go
+
+select * from dest_table_join order by [Col1], [Col2]
+go
+~~START~~
+int#!#nvarchar#!#smallint#!#numeric
+1#!#First#!#2#!#2.222
+1#!#First_dup#!#2#!#2.222
+2#!#Second#!#4#!#3.333
+~~END~~
+
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_join ([Col2]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col1" of relation "dest_table_join" violates not-null constraint)~~
+
+
+-- Should fail. Violate NOT NULL constraint on other column
+insert into dest_table_join ([Col2]) values ('Join')
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col1" of relation "dest_table_join" violates not-null constraint)~~
+
+
+insert into dest_table_join ([Col1], [Col2], [Col3], [Col4]) values (99, 'Join', 88, 9.867)
+go
+~~ROW COUNT: 1~~
+
+
+select * from dest_table_join order by [Col1], [Col2]
+go
+~~START~~
+int#!#nvarchar#!#smallint#!#numeric
+1#!#First#!#2#!#2.222
+1#!#First_dup#!#2#!#2.222
+2#!#Second#!#4#!#3.333
+99#!#Join#!#88#!#9.867
+~~END~~
+
+
+-- FROM clause contains subquery
+select *
+into dest_table_union
+from
+(
+    select * from dest_table_1
+    union all
+    select * from dest_table_3
+) as combined_tables
+go
+
+select * from dest_table_union order by [Col1]
+go
+~~START~~
+int#!#nvarchar
+1#!#First
+1#!#First_dup
+2#!#Second
+3#!#Third
+6#!#Fourth
+~~END~~
+
+
+-- Ideally should fail as it violates NOT NULL constraint
+-- Currently NOT NULL constraint won't get carried over
+-- to destination table in case of subquery
+insert into dest_table_union ([Col2]) values (NULL)
+go
+~~ROW COUNT: 1~~
+
+
+insert into dest_table_union ([Col2]) values ('Union')
+go
+~~ROW COUNT: 1~~
+
+
+select * from dest_table_union order by [Col1]
+go
+~~START~~
+int#!#nvarchar
+<NULL>#!#<NULL>
+<NULL>#!#Union
+1#!#First_dup
+1#!#First
+2#!#Second
+3#!#Third
+6#!#Fourth
+~~END~~
+
+
+select *
+into dest_table_sub_join
+from
+(
+    select * from dest_table_1 t1
+    inner join dest_table_2 t2
+    on t1.[Col1] * 2 = t2.[Col3]
+) as combined_tables
+go
+
+select * from dest_table_sub_join order by [Col1], [Col2]
+go
+~~START~~
+int#!#nvarchar#!#smallint#!#numeric
+1#!#First#!#2#!#2.222
+1#!#First_dup#!#2#!#2.222
+2#!#Second#!#4#!#3.333
+~~END~~
+
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_sub_join ([Col1]) values (NULL)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col1" of relation "dest_table_sub_join" violates not-null constraint)~~
+
+
+-- Should fail. Violate NOT NULL constraint on other column
+insert into dest_table_sub_join ([Col1]) values (200)
+go
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "col2" of relation "dest_table_sub_join" violates not-null constraint)~~
+
+
+insert into dest_table_sub_join ([Col1], [Col2], [Col3], [Col4]) values (209, 'Sub-Join', 78, 8.567)
+go
+~~ROW COUNT: 1~~
+
+
+select * from dest_table_sub_join order by [Col1], [Col2]
+go
+~~START~~
+int#!#nvarchar#!#smallint#!#numeric
+1#!#First#!#2#!#2.222
+1#!#First_dup#!#2#!#2.222
+2#!#Second#!#4#!#3.333
+209#!#Sub-Join#!#78#!#8.567
+~~END~~
+
+
+select * into dest_table_view from v1_select_into
+go
+
+select * from dest_table_view order by [Col1], [Col2]
+go
+~~START~~
+int#!#nvarchar
+1#!#First
+1#!#First_dup
+~~END~~
+
+
+drop table dest_table_1
+drop table dest_table_2
+drop table dest_table_3
+drop table dest_table_4
+drop table dest_table_5
+drop table dest_table_join
+drop table dest_table_union
+drop table dest_table_sub_join
+drop view v1_select_into
+drop table dest_table_view
+go
+
+drop table t1_select_into
+go
+
+drop table sch_select_into.t1_select_into
+go
+
+drop schema sch_select_into
+go
+
+use master
+go
+
+drop database db_select_into
+go
+
+drop table t1_select_into_master
+go
+
+drop table t1_select_into_master_dec
+go
+
+drop table sch_select_into_master.t1_select_into_master
+go
+
+drop schema sch_select_into_master
+go

--- a/test/JDBC/input/select_into-identity-notnull.sql
+++ b/test/JDBC/input/select_into-identity-notnull.sql
@@ -1,0 +1,263 @@
+create database db_select_into
+go
+
+use db_select_into
+go
+
+create schema sch_select_into
+go
+
+create table t1_select_into ([Col1] INT IDENTITY(1, 1), [Col2] [NVarchar](20) NOT NULL)
+go
+
+insert into t1_select_into([Col2]) values ('First')
+go
+
+set identity_insert t1_select_into on
+go
+
+insert into t1_select_into([Col1], [Col2]) values (1, 'First_dup')
+go
+
+set identity_insert t1_select_into off
+go
+
+create view v1_select_into as select * from t1_select_into
+go
+
+create table sch_select_into.t1_select_into ([Col3] TINYINT IDENTITY(2, 2), [Col4] numeric(4,3) NOT NULL)
+go
+
+insert into sch_select_into.t1_select_into([Col4]) values (2.222)
+go
+
+use master
+go
+
+create schema sch_select_into_master
+go
+
+create table sch_select_into_master.t1_select_into_master ([Col5] SMALLINT IDENTITY(3, 3), [Col6] [Nvarchar](20) NOT NULL)
+go
+
+insert into sch_select_into_master.t1_select_into_master([Col6]) values ('Third')
+go
+
+create table t1_select_into_master ([Col7] float NOT NULL, [Col8] BIGINT IDENTITY(4, 4))
+go
+
+insert into t1_select_into_master([Col7]) values (4.4)
+go
+
+create table t1_select_into_master_dec ([Col9] DECIMAL(10,0) IDENTITY(5, 5) PRIMARY KEY, [Col10] real NOT NULL)
+go
+
+insert into t1_select_into_master_dec([Col10]) values (5.567)
+go
+
+use db_select_into
+go
+
+select * into dest_table_1 from t1_select_into order by [Col1]
+go
+
+select * into dest_table_2 from sch_select_into.t1_select_into group by [Col3], [Col4]
+go
+
+select * into dest_table_3 from master.sch_select_into_master.t1_select_into_master
+go
+
+select * into dest_table_4 from master..t1_select_into_master
+go
+
+select * into dest_table_5 from master.dbo.t1_select_into_master_dec
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'ignore';
+go
+
+-- Should throw error because there are 2 identity columns
+select identity(int, 1, 1) as identity_col, * into dest_table_error from t1_select_into
+go
+
+exec sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'strict';
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_1 ([Col2]) values (NULL)
+go
+
+insert into dest_table_1 ([Col2]) values ('Second')
+go
+
+-- Identity column should be populated by default
+select * from dest_table_1 order by [Col1]
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_2 ([Col4]) values (NULL)
+go
+
+insert into dest_table_2 ([Col4]) values (3.333)
+go
+
+-- Identity column should be populated by default
+select * from dest_table_2 order by [Col3]
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_3 ([Col6]) values (NULL)
+go
+
+insert into dest_table_3 ([Col6]) values ('Fourth')
+go
+
+-- Identity column should be populated by default
+select * from dest_table_3 order by [Col5]
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_4 ([Col7]) values (NULL)
+go
+
+insert into dest_table_4 ([Col7]) values (5.5)
+go
+
+-- Identity column should be populated by default
+select * from dest_table_4 order by [Col8]
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_5 ([Col10]) values (NULL)
+go
+
+insert into dest_table_5 ([Col10]) values (6.789)
+go
+
+-- Identity column should be populated by default
+select * from dest_table_5 order by [Col9]
+go
+
+-- FROM clause contains joins from multiple tables
+-- Should not fail as identity should not be persisted but nullability should
+select *
+into dest_table_join
+from dest_table_1 t1
+inner join dest_table_2 t2
+on t1.[Col1] * 2 = t2.[Col3]
+go
+
+select * from dest_table_join order by [Col1], [Col2]
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_join ([Col2]) values (NULL)
+go
+
+-- Should fail. Violate NOT NULL constraint on other column
+insert into dest_table_join ([Col2]) values ('Join')
+go
+
+insert into dest_table_join ([Col1], [Col2], [Col3], [Col4]) values (99, 'Join', 88, 9.867)
+go
+
+select * from dest_table_join order by [Col1], [Col2]
+go
+
+-- FROM clause contains subquery
+select *
+into dest_table_union
+from
+(
+    select * from dest_table_1
+    union all
+    select * from dest_table_3
+) as combined_tables
+go
+
+select * from dest_table_union order by [Col1]
+go
+
+-- Ideally should fail as it violates NOT NULL constraint
+-- Currently NOT NULL constraint won't get carried over
+-- to destination table in case of subquery
+insert into dest_table_union ([Col2]) values (NULL)
+go
+
+insert into dest_table_union ([Col2]) values ('Union')
+go
+
+select * from dest_table_union order by [Col1]
+go
+
+select *
+into dest_table_sub_join
+from
+(
+    select * from dest_table_1 t1
+    inner join dest_table_2 t2
+    on t1.[Col1] * 2 = t2.[Col3]
+) as combined_tables
+go
+
+select * from dest_table_sub_join order by [Col1], [Col2]
+go
+
+-- Should fail. Violate NOT NULL constraint
+insert into dest_table_sub_join ([Col1]) values (NULL)
+go
+
+-- Should fail. Violate NOT NULL constraint on other column
+insert into dest_table_sub_join ([Col1]) values (200)
+go
+
+insert into dest_table_sub_join ([Col1], [Col2], [Col3], [Col4]) values (209, 'Sub-Join', 78, 8.567)
+go
+
+select * from dest_table_sub_join order by [Col1], [Col2]
+go
+
+select * into dest_table_view from v1_select_into
+go
+
+select * from dest_table_view order by [Col1], [Col2]
+go
+
+drop table dest_table_1
+drop table dest_table_2
+drop table dest_table_3
+drop table dest_table_4
+drop table dest_table_5
+drop table dest_table_join
+drop table dest_table_union
+drop table dest_table_sub_join
+drop view v1_select_into
+drop table dest_table_view
+go
+
+drop table t1_select_into
+go
+
+drop table sch_select_into.t1_select_into
+go
+
+drop schema sch_select_into
+go
+
+use master
+go
+
+drop database db_select_into
+go
+
+drop table t1_select_into_master
+go
+
+drop table t1_select_into_master_dec
+go
+
+drop table sch_select_into_master.t1_select_into_master
+go
+
+drop schema sch_select_into_master
+go


### PR DESCRIPTION
### Description

Previously, if the source table contains an identity column or a not nullable column, then the destination table where these columns are SELECTed INTO did not keep their identity or nullability property.

In this commit, if the columns in the INTO clause, have the identity or not nullable property attributed with them, we will implicitly create an ALTER TABLE statement that would do the following:

 1. IDENTITY: ALTER TABLE dest_rel ADD COLUMN col. Where col is an IDENTITY column with the same properties as the source column.
 2. NOT NULL: ALTER TABLE dest_rel ALTER COLUMN col SET NOT NULL

Task: BABEL-5485
Signed-off-by: Sharu Goel <goelshar@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).