### PR TITLE
[OSS-ONLY] Drop and recreate babelfish database before running dotnet tests in scheduled github actions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -68,7 +68,7 @@ jobs:
         uses: ./.github/composite-actions/run-jdbc-tests 
 
       - name: Drop and re-create Babelfish database
-        id: re-install-extensions
+        id: re-install-extensions-1
         if: always() && steps.install-extensions.outcome == 'success'
         run: |
           sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
@@ -77,7 +77,7 @@ jobs:
       
       - name: Run Dotnet Tests
         id: install-and-run-dotnet
-        if: always() && steps.install-extensions.outcome == 'success'
+        if: always() && steps.re-install-extensions-1.outcome == 'success'
         uses: ./.github/composite-actions/install-and-run-dotnet
       
       - name: Run ODBC Tests
@@ -86,7 +86,7 @@ jobs:
         uses: ./.github/composite-actions/install-and-run-odbc
 
       - name: Drop and re-create Babelfish database
-        id: re-install-extensions
+        id: re-install-extensions-2
         if: always() && steps.install-extensions.outcome == 'success'
         run: |
           sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
@@ -95,7 +95,7 @@ jobs:
       
       - name: Run Python Tests
         id: install-and-run-python
-        if: always() && steps.re-install-extensions.outcome == 'success'
+        if: always() && steps.re-install-extensions-2.outcome == 'success'
         uses: ./.github/composite-actions/install-and-run-python
 
       - name: Generate code coverage HTML report

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,7 +1,7 @@
 name: Code Coverage
-on: [push, pull_request]
-  # schedule:
-  #   - cron: '0 0 * * *'  # runs every midnight
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs every midnight
   
 jobs:
   run-code-coverage-tests:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,7 +1,7 @@
 name: Code Coverage
-on:
-  schedule:
-    - cron: '0 0 * * *'  # runs every midnight
+on: [push, pull_request]
+  # schedule:
+  #   - cron: '0 0 * * *'  # runs every midnight
   
 jobs:
   run-code-coverage-tests:
@@ -66,6 +66,14 @@ jobs:
         if: always() && steps.install-extensions.outcome == 'success'
         timeout-minutes: 60
         uses: ./.github/composite-actions/run-jdbc-tests 
+
+      - name: Drop and re-create Babelfish database
+        id: re-install-extensions
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql
+          sqlcmd -S localhost -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
       
       - name: Run Dotnet Tests
         id: install-and-run-dotnet

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,7 +1,7 @@
 name: JDBC Tests With PG AUDIT Enable
-on: [push, pull_request]
-  # schedule:
-  #   - cron: '0 0 * * *'  # runs every midnight
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs every midnight
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Run Dotnet Tests
         id: run-dotnet-tests
-        if: always() && steps.install-extensions.outcome == 'success'
+        if: always() && steps.re-install-extensions.outcome == 'success'
         uses: ./.github/composite-actions/install-and-run-dotnet
 
       - name: Start secondary server

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,7 +1,7 @@
 name: JDBC Tests With PG AUDIT Enable
-on:
-  schedule:
-    - cron: '0 0 * * *'  # runs every midnight
+on: [push, pull_request]
+  # schedule:
+  #   - cron: '0 0 * * *'  # runs every midnight
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
@@ -128,6 +128,15 @@ jobs:
         if: always() && steps.install-extensions.outcome == 'success'
         timeout-minutes: 60
         uses: ./.github/composite-actions/run-jdbc-tests
+
+      - name: Drop and re-create Babelfish database with pgaudit installed
+        id: re-install-extensions
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
+          sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql
+          sudo PGPASSWORD=12345678 ~/${{ env.INSTALL_DIR }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "CREATE EXTENSION pgaudit;"
+          sqlcmd -S localhost -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
 
       - name: Run Dotnet Tests
         id: run-dotnet-tests


### PR DESCRIPTION
### Description

Drop and recreate babelfish database before running dotnet tests in scheduled github actions.
We need to do this since JDBC tests leaves behind uncleaned objects which causes dotnet tests to fail.

### Issues Resolved

[NO JIRA]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).