### PR TITLE
Add null check for func args in tsql_get_expr

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
@@ -399,11 +399,16 @@ PG_FUNCTION_INFO_V1(tsql_get_expr);
 Datum
 tsql_get_expr(PG_FUNCTION_ARGS)
 {
-	text	   *expr = PG_GETARG_TEXT_PP(0);
-	Oid			relid = PG_GETARG_OID(1);
+	text	   *expr;
+	Oid			relid;
 	int			prettyFlags;
 	char	   *relname;
-
+	
+	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+	
+	expr = PG_GETARG_TEXT_PP(0);
+	relid = PG_GETARG_OID(1);
 	prettyFlags = PRETTYFLAG_INDENT;
 
 	if (OidIsValid(relid))

--- a/test/JDBC/expected/sys-computed_columns-vu-verify.out
+++ b/test/JDBC/expected/sys-computed_columns-vu-verify.out
@@ -56,3 +56,11 @@ text
 <NULL>
 ~~END~~
 
+
+Select sys.tsql_get_expr(null, null)
+GO
+~~START~~
+text
+<NULL>
+~~END~~
+

--- a/test/JDBC/expected/sys-configurations-vu-prepare.out
+++ b/test/JDBC/expected/sys-configurations-vu-prepare.out
@@ -2,11 +2,11 @@ USE master;
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v1 AS
-SELECT * FROM sys.configurations
+SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p1 AS
-SELECT * FROM sys.configurations
+SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f1()

--- a/test/JDBC/expected/sys-configurations-vu-verify.out
+++ b/test/JDBC/expected/sys-configurations-vu-verify.out
@@ -4,32 +4,32 @@ GO
 SELECT * FROM sys_configurations_vu_prepare_v1
 GO
 ~~START~~
-int#!#nvarchar#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
-103#!#user connections#!#100#!#1#!#262143#!#100#!#Sets the maximum number of concurrent connections.#!#0#!#1
-115#!#nested triggers#!#1#!#0#!#1#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
-124#!#default language#!#0#!#0#!#9999#!#0#!#default language#!#1#!#0
-505#!#network packet size (B)#!#4096#!#512#!#32767#!#4096#!#Sets the default packet size for all the clients being connected#!#1#!#1
-1126#!#default full-text language#!#1033#!#0#!#2147483647#!#1033#!#default full-text language#!#1#!#1
-1127#!#two digit year cutoff#!#2049#!#1753#!#9999#!#2049#!#two digit year cutoff#!#1#!#1
-1534#!#user options#!#0#!#0#!#32767#!#0#!#user options#!#1#!#0
-1555#!#transform noise words#!#0#!#0#!#1#!#0#!#Transform noise words for full-text query#!#1#!#1
-16387#!#SMO and DMO XPs#!#1#!#0#!#1#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
+int#!#nvarchar#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
+103#!#user connections#!#1#!#262143#!#Sets the maximum number of concurrent connections.#!#0#!#1
+115#!#nested triggers#!#0#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
+124#!#default language#!#0#!#9999#!#default language#!#1#!#0
+505#!#network packet size (B)#!#512#!#32767#!#Sets the default packet size for all the clients being connected#!#1#!#1
+1126#!#default full-text language#!#0#!#2147483647#!#default full-text language#!#1#!#1
+1127#!#two digit year cutoff#!#1753#!#9999#!#two digit year cutoff#!#1#!#1
+1534#!#user options#!#0#!#32767#!#user options#!#1#!#0
+1555#!#transform noise words#!#0#!#1#!#Transform noise words for full-text query#!#1#!#1
+16387#!#SMO and DMO XPs#!#0#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
 ~~END~~
 
 
 EXEC sys_configurations_vu_prepare_p1
 GO
 ~~START~~
-int#!#nvarchar#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
-103#!#user connections#!#100#!#1#!#262143#!#100#!#Sets the maximum number of concurrent connections.#!#0#!#1
-115#!#nested triggers#!#1#!#0#!#1#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
-124#!#default language#!#0#!#0#!#9999#!#0#!#default language#!#1#!#0
-505#!#network packet size (B)#!#4096#!#512#!#32767#!#4096#!#Sets the default packet size for all the clients being connected#!#1#!#1
-1126#!#default full-text language#!#1033#!#0#!#2147483647#!#1033#!#default full-text language#!#1#!#1
-1127#!#two digit year cutoff#!#2049#!#1753#!#9999#!#2049#!#two digit year cutoff#!#1#!#1
-1534#!#user options#!#0#!#0#!#32767#!#0#!#user options#!#1#!#0
-1555#!#transform noise words#!#0#!#0#!#1#!#0#!#Transform noise words for full-text query#!#1#!#1
-16387#!#SMO and DMO XPs#!#1#!#0#!#1#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
+int#!#nvarchar#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
+103#!#user connections#!#1#!#262143#!#Sets the maximum number of concurrent connections.#!#0#!#1
+115#!#nested triggers#!#0#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
+124#!#default language#!#0#!#9999#!#default language#!#1#!#0
+505#!#network packet size (B)#!#512#!#32767#!#Sets the default packet size for all the clients being connected#!#1#!#1
+1126#!#default full-text language#!#0#!#2147483647#!#default full-text language#!#1#!#1
+1127#!#two digit year cutoff#!#1753#!#9999#!#two digit year cutoff#!#1#!#1
+1534#!#user options#!#0#!#32767#!#user options#!#1#!#0
+1555#!#transform noise words#!#0#!#1#!#Transform noise words for full-text query#!#1#!#1
+16387#!#SMO and DMO XPs#!#0#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
 ~~END~~
 
 

--- a/test/JDBC/expected/sys-configurations.out
+++ b/test/JDBC/expected/sys-configurations.out
@@ -1,16 +1,16 @@
-SELECT * FROM sys.configurations;
+SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations;
 GO
 ~~START~~
-int#!#nvarchar#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
-103#!#user connections#!#100#!#1#!#262143#!#100#!#Sets the maximum number of concurrent connections.#!#0#!#1
-115#!#nested triggers#!#1#!#0#!#1#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
-124#!#default language#!#0#!#0#!#9999#!#0#!#default language#!#1#!#0
-505#!#network packet size (B)#!#4096#!#512#!#32767#!#4096#!#Sets the default packet size for all the clients being connected#!#1#!#1
-1126#!#default full-text language#!#1033#!#0#!#2147483647#!#1033#!#default full-text language#!#1#!#1
-1127#!#two digit year cutoff#!#2049#!#1753#!#9999#!#2049#!#two digit year cutoff#!#1#!#1
-1534#!#user options#!#0#!#0#!#32767#!#0#!#user options#!#1#!#0
-1555#!#transform noise words#!#0#!#0#!#1#!#0#!#Transform noise words for full-text query#!#1#!#1
-16387#!#SMO and DMO XPs#!#1#!#0#!#1#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
+int#!#nvarchar#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
+103#!#user connections#!#1#!#262143#!#Sets the maximum number of concurrent connections.#!#0#!#1
+115#!#nested triggers#!#0#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
+124#!#default language#!#0#!#9999#!#default language#!#1#!#0
+505#!#network packet size (B)#!#512#!#32767#!#Sets the default packet size for all the clients being connected#!#1#!#1
+1126#!#default full-text language#!#0#!#2147483647#!#default full-text language#!#1#!#1
+1127#!#two digit year cutoff#!#1753#!#9999#!#two digit year cutoff#!#1#!#1
+1534#!#user options#!#0#!#32767#!#user options#!#1#!#0
+1555#!#transform noise words#!#0#!#1#!#Transform noise words for full-text query#!#1#!#1
+16387#!#SMO and DMO XPs#!#0#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
 ~~END~~
 
 

--- a/test/JDBC/input/views/sys-computed_columns-vu-verify.sql
+++ b/test/JDBC/input/views/sys-computed_columns-vu-verify.sql
@@ -21,3 +21,6 @@ GO
 
 Select sys.tsql_get_expr('abc',0)
 GO
+
+Select sys.tsql_get_expr(null, null)
+GO

--- a/test/JDBC/input/views/sys-configurations-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-configurations-vu-prepare.sql
@@ -2,11 +2,11 @@ USE master;
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v1 AS
-SELECT * FROM sys.configurations
+SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p1 AS
-SELECT * FROM sys.configurations
+SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f1()

--- a/test/JDBC/input/views/sys-configurations.sql
+++ b/test/JDBC/input/views/sys-configurations.sql
@@ -1,4 +1,4 @@
-SELECT * FROM sys.configurations;
+SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations;
 GO
 
 -- Verify the sql variant of the all the rows in sys.configurations


### PR DESCRIPTION
### Description

The function [get_rule_expr](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/BABEL_5_X_DEV/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c#L1205) inside of sys.tsql_get_expr crash when the param is null. Adding null check for the input parameters.

Cherry-pick of commit: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3527

### Issues Resolved

BABEL-5460

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
Yes

* **Major version upgrade tests -**
Yes

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).