### PR TITLE
Update Alter Table Action for Enable/Disable trigger all syntax

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -521,11 +521,11 @@ tsql_enable_disable_trigger:
 
 					if ($1)
 					{
-						n1->subtype = AT_EnableTrigAll;
+						n1->subtype = AT_EnableTrigUser;
 					}
 					else
 					{
-						n1->subtype = AT_DisableTrigAll;
+						n1->subtype = AT_DisableTrigUser;
 					}
 
 					n2->relation = $5;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1811,6 +1811,10 @@ public:
 
 			rewritten_query_fragment.emplace(std::make_pair(ctx->start->getStartIndex(), std::make_pair(::getFullText(ctx), str)));
 		}
+		else if(ctx->TRIGGER() && ctx->ALL())
+		{
+			rewritten_query_fragment.emplace(std::make_pair(ctx->ALL()->getSymbol()->getStartIndex(),std::make_pair(::getFullText(ctx->ALL()), "USER")));
+		}
 	}
 
 	void exitEnable_trigger(TSqlParser::Enable_triggerContext *ctx) override

--- a/test/JDBC/expected/BABEL-5645.out
+++ b/test/JDBC/expected/BABEL-5645.out
@@ -1,0 +1,181 @@
+-- setup
+CREATE TABLE parent(a int primary key);
+GO
+CREATE TABLE child(b int, foreign key (b) references parent(a) ON UPDATE CASCADE);
+GO
+CREATE TRIGGER trig1 on child AFTER UPDATE AS BEGIN SELECT 1 END
+GO
+INSERT INTO parent values(1)
+INSERT INTO child values(1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+~~START~~
+varchar#!#bit
+trig1#!#0
+~~END~~
+
+
+-- check if trigger enabled, as well as fkey action works
+UPDATE parent set a=2 where a=1
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+SELECT * from parent;select * from child;
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+ALTER TABLE child disable trigger all
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+~~START~~
+varchar#!#bit
+trig1#!#1
+~~END~~
+
+
+-- check if only trigger disabled and not fkey action
+UPDATE parent set a=3 where a=2
+GO
+~~ROW COUNT: 1~~
+
+SELECT * from parent;select * from child;
+GO
+~~START~~
+int
+3
+~~END~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+
+ALTER TABLE child enable trigger all
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+~~START~~
+varchar#!#bit
+trig1#!#0
+~~END~~
+
+
+-- check  if trigger renabled
+UPDATE parent set a=4 where a=3
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+SELECT * from parent;select * from child;
+GO
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+
+DISABLE trigger all on child;
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+~~START~~
+varchar#!#bit
+trig1#!#1
+~~END~~
+
+
+-- check  if only trigger disabled and not fkey action
+UPDATE parent set a=5 where a=4
+GO
+~~ROW COUNT: 1~~
+
+SELECT * from parent;select * from child;
+GO
+~~START~~
+int
+5
+~~END~~
+
+~~START~~
+int
+5
+~~END~~
+
+
+ENABLE trigger all on child;
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+~~START~~
+varchar#!#bit
+trig1#!#0
+~~END~~
+
+
+-- check  if trigger renabled
+UPDATE parent set a=6 where a=5
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 1~~
+
+SELECT * from parent;select * from child;
+GO
+~~START~~
+int
+6
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+
+-- cleanup
+DROP TABLE child;DROP TABLE parent;
+GO

--- a/test/JDBC/input/BABEL-5645.sql
+++ b/test/JDBC/input/BABEL-5645.sql
@@ -1,0 +1,77 @@
+-- setup
+CREATE TABLE parent(a int primary key);
+GO
+CREATE TABLE child(b int, foreign key (b) references parent(a) ON UPDATE CASCADE);
+GO
+CREATE TRIGGER trig1 on child AFTER UPDATE AS BEGIN SELECT 1 END
+GO
+INSERT INTO parent values(1)
+INSERT INTO child values(1)
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+
+-- check if trigger enabled, as well as fkey action works
+UPDATE parent set a=2 where a=1
+GO
+SELECT * from parent;select * from child;
+GO
+
+ALTER TABLE child disable trigger all
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+
+-- check if only trigger disabled and not fkey action
+UPDATE parent set a=3 where a=2
+GO
+SELECT * from parent;select * from child;
+GO
+
+
+ALTER TABLE child enable trigger all
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+
+-- check  if trigger renabled
+UPDATE parent set a=4 where a=3
+GO
+SELECT * from parent;select * from child;
+GO
+
+DISABLE trigger all on child;
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+
+-- check  if only trigger disabled and not fkey action
+UPDATE parent set a=5 where a=4
+GO
+SELECT * from parent;select * from child;
+GO
+
+ENABLE trigger all on child;
+GO
+
+-- check metadata
+select name,is_disabled from sys.triggers
+GO
+
+-- check  if trigger renabled
+UPDATE parent set a=6 where a=5
+GO
+SELECT * from parent;select * from child;
+GO
+
+-- cleanup
+DROP TABLE child;DROP TABLE parent;
+GO


### PR DESCRIPTION
### Description

To Disable FKEY Action Triggers we need superuser privileges [code reference](https://github.com/postgres/postgres/blob/master/src/backend/commands/trigger.c#L1773-L1777) , But for tsql we only need to disable user defined triggers , You can see the difference between ALL vs USER Enable/Disable  [here](https://github.com/postgres/postgres/blob/master/src/backend/commands/tablecmds.c#L5542-L5564) . We should specify the  `AT_[Disable/Enable]TrigUser` command for  `ENABLE/DISABLE TRIGGER ALL` Syntax instead of `AT_[Disable/Enable]TrigAll` 

### Issues Resolved

BABEL-5645
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>
### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).