### PR TITLE
alter procedure/function will unexpectly delete pg_depend records

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3724,7 +3724,7 @@ pltsql_store_func_default_positions(ObjectAddress address, List *parameters, con
  * Update 'function_args' in 'sys.babelfish_schema_permissions' 
  */
 void
-alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, List *parameters, int objtypeInt, Oid oid)
+alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, List *parameters, int objtypeInt)
 {
 	Relation	bbf_schema_rel;
 	TupleDesc	bbf_schema_dsc;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3724,7 +3724,7 @@ pltsql_store_func_default_positions(ObjectAddress address, List *parameters, con
  * Update 'function_args' in 'sys.babelfish_schema_permissions' 
  */
 void
-alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, List *parameters, int objtypeInt)
+alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, List *parameters, int objtypeInt, Oid oid)
 {
 	Relation	bbf_schema_rel;
 	TupleDesc	bbf_schema_dsc;

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -26,8 +26,7 @@ extern void pltsql_store_func_default_positions(ObjectAddress address,
                                                 bool with_recompile);
 extern void alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, 
                                                     List *parameters,
-                                                    int objtypeInt,
-                                                    Oid oid);
+                                                    int objtypeInt);
 extern Oid  get_tsql_trigger_oid(List *object,
                                  const char *tsql_trigger_name,
                                  bool object_from_input);

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -26,8 +26,8 @@ extern void pltsql_store_func_default_positions(ObjectAddress address,
                                                 bool with_recompile);
 extern void alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, 
                                                     List *parameters,
-                                                    int objtypeInt,
-                                                    Oid oid);
+                                                    int objtypeInt
+                                                    );
 extern Oid  get_tsql_trigger_oid(List *object,
                                  const char *tsql_trigger_name,
                                  bool object_from_input);

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -26,8 +26,8 @@ extern void pltsql_store_func_default_positions(ObjectAddress address,
                                                 bool with_recompile);
 extern void alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, 
                                                     List *parameters,
-                                                    int objtypeInt
-                                                    );
+                                                    int objtypeInt,
+                                                    Oid oid);
 extern Oid  get_tsql_trigger_oid(List *object,
                                  const char *tsql_trigger_name,
                                  bool object_from_input);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2729,10 +2729,17 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							*/
 							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
 						}
-						/* Clean up table entries for the create function statement */
-						deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
-						deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
-						deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+						/* Clean up table entries for the create function statement if applicable*/
+						if (address.objectId != oldoid)
+						{
+							/*
+							 * if this is the same procedure, it'll update the existing one,
+							 * in such case, should not delete dependent records
+							 */
+							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
+							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
+							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+						}
 						CommitTransactionCommand();
 					}
 					PG_FINALLY();

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -25,7 +25,6 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
-#include "catalog/pg_depend.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
@@ -63,7 +62,6 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
-#include "utils/fmgroids.h"
 #include "utils/guc_tables.h"
 #include "utils/lsyscache.h"
 #include "utils/plancache.h"
@@ -2649,10 +2647,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							isSameProc = false;
 							CommandCounterIncrement();
 						}
-						else
+						else if (!isSameProc) /* i.e. different signature */
 						{
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
-							CommandCounterIncrement();
 						}
 
 						if(tbltypStmt)
@@ -2724,16 +2721,25 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
 						CommandCounterIncrement();
-						if (oldoid != address.objectId)
-						{
-							pg_proc_update_oid_acl(address, oldoid, proacl);
+						pg_proc_update_oid_acl(address, oldoid, proacl);
+						if (!isSameProc) {
+						       /*
+							* When the signatures differ we need to manually update the 'function_args' column in 
+							* the 'bbf_schema_permissions' catalog
+							*/
 							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
 						}
-						/*
-						* When the signatures differ we need to manually update the 'function_args' column in 
-						* the 'bbf_schema_permissions' catalog
-						*/
 						/* Clean up table entries for the create function statement if applicable*/
+						if (address.objectId != oldoid)
+						{
+							/*
+							 * if this is the same procedure, it'll update the existing one,
+							 * in such case, should not delete dependent records
+							 */
+							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
+							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
+							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+						}
 						CommitTransactionCommand();
 					}
 					PG_FINALLY();
@@ -4796,10 +4802,8 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 static void
 pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
 {
-	Relation		rel,depRel;
-	ScanKeyData 	key[2];
-	SysScanDesc 	scan;
-	HeapTuple		proctup, depTup;
+	Relation		rel;
+	HeapTuple		proctup;
 	Form_pg_proc	form_proctup;
 	char		*physical_schemaname;
 
@@ -4849,53 +4853,6 @@ pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
 	heap_freetuple(newtup);
 
 	table_close(rel, RowExclusiveLock);
-
-	depRel = table_open(DependRelationId, RowExclusiveLock);
-	
-	ScanKeyInit(&key[0],
-		Anum_pg_depend_objid,
-		BTEqualStrategyNumber, F_OIDEQ,
-		ObjectIdGetDatum(address.objectId));
-	ScanKeyInit(&key[1],
-		Anum_pg_depend_refobjid,
-		BTEqualStrategyNumber, F_OIDEQ,
-		ObjectIdGetDatum(address.objectId));
-
-	scan = systable_beginscan(depRel, InvalidOid, false,
-					  NULL, 2, key);
-
-	while (HeapTupleIsValid(depTup = systable_getnext(scan)))
-	{
-		Form_pg_depend foundDep = (Form_pg_depend) GETSTRUCT(depTup);
-		Datum		dep_values[Natts_pg_depend];
-		bool		dep_nulls[Natts_pg_depend];
-		bool		dep_replaces[Natts_pg_depend];
-		HeapTuple	dep_newtup;
-	
-		if (foundDep->objid == address.objectId)
-		{
-			memset(dep_values, 0, sizeof(dep_values));
-			memset(dep_nulls, 0, sizeof(dep_nulls));
-			memset(dep_replaces, 0, sizeof(dep_replaces));
-			dep_values[Anum_pg_depend_objid - 1] = ObjectIdGetDatum(oid);
-			dep_replaces[Anum_pg_depend_objid - 1] = true;
-			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
-			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
-			heap_freetuple(dep_newtup);
-		}
-		if (foundDep->refobjid == address.objectId)
-		{
-			memset(dep_values, 0, sizeof(dep_values));
-			memset(dep_nulls, 0, sizeof(dep_nulls));
-			memset(dep_replaces, 0, sizeof(dep_replaces));
-			dep_values[Anum_pg_depend_refobjid - 1] = ObjectIdGetDatum(oid);
-			dep_replaces[Anum_pg_depend_refobjid - 1] = true;
-			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
-			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
-			heap_freetuple(dep_newtup);
-		}
-	}
-	table_close(depRel, RowExclusiveLock);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -144,7 +144,8 @@ static void call_prev_ProcessUtility(PlannedStmt *pstmt,
 						 QueryCompletion *qc);
 static void set_pgtype_byval(List *name, bool byval);
 static void pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, Oid *oid, Acl **acl, bool *isSameFunc, bool is_proc);
-static void pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl);
+// static void pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl);
+// static void update_dependency(Oid objId, Oid targetOid);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -2652,6 +2653,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						else if (!isSameProc) /* i.e. different signature */
 						{
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
+							CommandCounterIncrement();
 						}
 
 						if(tbltypStmt)
@@ -2706,7 +2708,13 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 							/* Need CCI between commands */
 							CommandCounterIncrement();
+						}
 
+						/* if this is the same procedure, it will update the existing one */
+						address = CreateFunction(pstate, cfs);
+						CommandCounterIncrement();
+						if (tbltypStmt)
+						{
 							/*
 							 * Update dependency on oldoid
 							 */
@@ -2714,11 +2722,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							tbltyp.objectId = typenameTypeId(pstate,
 															cfs->returnType);
 							tbltyp.objectSubId = 0;
-							recordDependencyOn(&tbltyp, &originalFunc, DEPENDENCY_INTERNAL);
+							recordDependencyOn(&tbltyp, &address, DEPENDENCY_INTERNAL);
+							CommandCounterIncrement();
 						}
-
-						/* if this is the same procedure, it will update the existing one */
-						address = CreateFunction(pstate, cfs);
 						/* Update function/procedure related metadata in babelfish catalog */
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
@@ -2733,9 +2739,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
 							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
 							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+							CommandCounterIncrement();
 						}
-						pg_proc_update_oid_acl(address, oldoid, proacl);
-						if (!isSameProc) {
+						// pg_proc_update_oid_acl(address, oldoid, proacl);
+						// CommandCounterIncrement();
+						// update_dependency(address.objectId, oldoid);
+						// CommandCounterIncrement();
+						if (!isSameProc) 
+						{
 						    /*
 							* When the signatures differ we need to manually update the 'function_args' column in 
 							* the 'bbf_schema_permissions' catalog
@@ -4801,109 +4812,96 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 /*
  * Update the oid and acl of a pg_proc entry given its address
  */
-static void
-pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
-{
-	Relation		rel,depRel;
-	ScanKeyData 	key[2];
-	SysScanDesc 	scan;
-	HeapTuple		proctup, depTup;
-	Form_pg_proc	form_proctup;
-	char		*physical_schemaname;
+// static void
+// pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
+// {
+// 	Relation		rel;
+// 	HeapTuple		proctup;
+// 	Form_pg_proc	form_proctup;
+// 	char		*physical_schemaname;
 
-	Datum		values[Natts_pg_proc];
-	bool		nulls[Natts_pg_proc];
-	bool		replaces[Natts_pg_proc];
-	HeapTuple	newtup;
+// 	Datum		values[Natts_pg_proc];
+// 	bool		nulls[Natts_pg_proc];
+// 	bool		replaces[Natts_pg_proc];
+// 	HeapTuple	newtup;
 
-	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
-	if (!HeapTupleIsValid(proctup))
-		return;
+// 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
+// 	if (!HeapTupleIsValid(proctup))
+// 		return;
 
-	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
+// 	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
 
-	if (!is_pltsql_language_oid(form_proctup->prolang))
-	{
-		ReleaseSysCache(proctup);
-		return;
-	}
+// 	if (!is_pltsql_language_oid(form_proctup->prolang))
+// 	{
+// 		ReleaseSysCache(proctup);
+// 		return;
+// 	}
 
-	physical_schemaname = get_namespace_name(form_proctup->pronamespace);
-	if (physical_schemaname == NULL)
-	{
-		elog(ERROR,
-				"Could not find physical schemaname for %u",
-				 form_proctup->pronamespace);
-	}
+// 	physical_schemaname = get_namespace_name(form_proctup->pronamespace);
+// 	if (physical_schemaname == NULL)
+// 	{
+// 		elog(ERROR,
+// 				"Could not find physical schemaname for %u",
+// 				 form_proctup->pronamespace);
+// 	}
 
-	rel = table_open(ProcedureRelationId, RowExclusiveLock);
+// 	rel = table_open(ProcedureRelationId, RowExclusiveLock);
 
-	memset(values, 0, sizeof(values));
-	memset(nulls, 0, sizeof(nulls));
-	memset(replaces, 0, sizeof(replaces));
-	values[Anum_pg_proc_oid - 1] = ObjectIdGetDatum(oid);
-	replaces[Anum_pg_proc_oid - 1] = true;
-	if(acl)
-		values[Anum_pg_proc_proacl - 1] = PointerGetDatum(acl);
-	else
-		nulls[Anum_pg_proc_proacl - 1] = true;
-	replaces[Anum_pg_proc_proacl - 1] = true;
+// 	memset(values, 0, sizeof(values));
+// 	memset(nulls, 0, sizeof(nulls));
+// 	memset(replaces, 0, sizeof(replaces));
+// 	values[Anum_pg_proc_oid - 1] = ObjectIdGetDatum(oid);
+// 	replaces[Anum_pg_proc_oid - 1] = true;
+// 	if(acl)
+// 		values[Anum_pg_proc_proacl - 1] = PointerGetDatum(acl);
+// 	else
+// 		nulls[Anum_pg_proc_proacl - 1] = true;
+// 	replaces[Anum_pg_proc_proacl - 1] = true;
 
-	newtup = heap_modify_tuple(proctup, RelationGetDescr(rel), values, nulls, replaces);
-	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
+// 	newtup = heap_modify_tuple(proctup, RelationGetDescr(rel), values, nulls, replaces);
+// 	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
 
-	/* Clean up */
-	ReleaseSysCache(proctup);
-	heap_freetuple(newtup);
+// 	/* Clean up */
+// 	ReleaseSysCache(proctup);
+// 	heap_freetuple(newtup);
 
-	table_close(rel, RowExclusiveLock);
-	depRel = table_open(DependRelationId, RowExclusiveLock);
+// 	table_close(rel, RowExclusiveLock);
+// }
 
-	ScanKeyInit(&key[0],
-		Anum_pg_depend_objid,
-		BTEqualStrategyNumber, F_OIDEQ,
-		ObjectIdGetDatum(address.objectId));
-	ScanKeyInit(&key[1],
-		Anum_pg_depend_refobjid,
-		BTEqualStrategyNumber, F_OIDEQ,
-		ObjectIdGetDatum(address.objectId));
+// static void
+// update_dependency(Oid objId, Oid targetOid)
+// {
+// 	Relation depRel;
+// 	SysScanDesc 	scan;
+// 	ScanKeyData 	key[1];
+// 	HeapTuple depTup;
+// 	depRel = table_open(DependRelationId, RowExclusiveLock);
 
-	scan = systable_beginscan(depRel, InvalidOid, false,
-					  NULL, 2, key);
+// 	ScanKeyInit(&key[0],
+// 		Anum_pg_depend_objid,
+// 		BTEqualStrategyNumber, F_OIDEQ,
+// 		ObjectIdGetDatum(objId));
+// 	scan = systable_beginscan(depRel, InvalidOid, false,
+// 		NULL, 1, key);
+// 	while (HeapTupleIsValid(depTup = systable_getnext(scan)))
+// 	{
+// 		Datum		dep_values[Natts_pg_depend];
+// 		bool		dep_nulls[Natts_pg_depend];
+// 		bool		dep_replaces[Natts_pg_depend];
+// 		HeapTuple	dep_newtup;
 
-	while (HeapTupleIsValid(depTup = systable_getnext(scan)))
-	{
-		Form_pg_depend foundDep = (Form_pg_depend) GETSTRUCT(depTup);
-		Datum		dep_values[Natts_pg_depend];
-		bool		dep_nulls[Natts_pg_depend];
-		bool		dep_replaces[Natts_pg_depend];
-		HeapTuple	dep_newtup;
-
-		if (foundDep->objid == address.objectId)
-		{
-			memset(dep_values, 0, sizeof(dep_values));
-			memset(dep_nulls, 0, sizeof(dep_nulls));
-			memset(dep_replaces, 0, sizeof(dep_replaces));
-			dep_values[Anum_pg_depend_objid - 1] = ObjectIdGetDatum(oid);
-			dep_replaces[Anum_pg_depend_objid - 1] = true;
-			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
-			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
-			heap_freetuple(dep_newtup);
-		}
-		if (foundDep->refobjid == address.objectId)
-		{
-			memset(dep_values, 0, sizeof(dep_values));
-			memset(dep_nulls, 0, sizeof(dep_nulls));
-			memset(dep_replaces, 0, sizeof(dep_replaces));
-			dep_values[Anum_pg_depend_refobjid - 1] = ObjectIdGetDatum(oid);
-			dep_replaces[Anum_pg_depend_refobjid - 1] = true;
-			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
-			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
-			heap_freetuple(dep_newtup);
-		}
-	}
-	table_close(depRel, RowExclusiveLock);
-}
+// 		memset(dep_values, 0, sizeof(dep_values));
+// 		memset(dep_nulls, 0, sizeof(dep_nulls));
+// 		memset(dep_replaces, 0, sizeof(dep_replaces));
+// 		dep_values[Anum_pg_depend_objid - 1] = ObjectIdGetDatum(targetOid);
+// 		dep_replaces[Anum_pg_depend_objid - 1] = true;
+// 		dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
+// 		CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
+// 		heap_freetuple(dep_newtup);
+// 	}
+// 	systable_endscan(scan);
+// 	table_close(depRel, RowExclusiveLock);
+// }
 
 /*
  * Update the pg_type catalog entry for the given name to have

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2730,9 +2730,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							 * if this is the same procedure, it'll update the existing one,
 							 * in such case, should not delete dependent records
 							 */
-							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
-							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
-							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+							deleteDependencyRecordsFor(DefaultAclRelationId, oldoid, false);
+							deleteDependencyRecordsFor(ProcedureRelationId, oldoid, false);
+							deleteSharedDependencyRecordsFor(ProcedureRelationId, oldoid, 0);
 						}
 						if (!isSameProc) 
 						{

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -25,6 +25,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_depend.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
@@ -62,6 +63,7 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/guc_tables.h"
 #include "utils/lsyscache.h"
 #include "utils/plancache.h"
@@ -2647,9 +2649,10 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							isSameProc = false;
 							CommandCounterIncrement();
 						}
-						else if (!isSameProc) /* i.e. different signature */
+						else
 						{
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
+							CommandCounterIncrement();
 						}
 
 						if(tbltypStmt)
@@ -2721,25 +2724,16 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
 						CommandCounterIncrement();
-						pg_proc_update_oid_acl(address, oldoid, proacl);
-						if (!isSameProc) {
-						       /*
-							* When the signatures differ we need to manually update the 'function_args' column in 
-							* the 'bbf_schema_permissions' catalog
-							*/
+						if (oldoid != address.objectId)
+						{
+							pg_proc_update_oid_acl(address, oldoid, proacl);
 							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
 						}
+						/*
+						* When the signatures differ we need to manually update the 'function_args' column in 
+						* the 'bbf_schema_permissions' catalog
+						*/
 						/* Clean up table entries for the create function statement if applicable*/
-						if (address.objectId != oldoid)
-						{
-							/*
-							 * if this is the same procedure, it'll update the existing one,
-							 * in such case, should not delete dependent records
-							 */
-							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
-							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
-							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
-						}
 						CommitTransactionCommand();
 					}
 					PG_FINALLY();
@@ -4802,8 +4796,10 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 static void
 pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
 {
-	Relation		rel;
-	HeapTuple		proctup;
+	Relation		rel,depRel;
+	ScanKeyData 	key[2];
+	SysScanDesc 	scan;
+	HeapTuple		proctup, depTup;
 	Form_pg_proc	form_proctup;
 	char		*physical_schemaname;
 
@@ -4853,6 +4849,53 @@ pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
 	heap_freetuple(newtup);
 
 	table_close(rel, RowExclusiveLock);
+
+	depRel = table_open(DependRelationId, RowExclusiveLock);
+	
+	ScanKeyInit(&key[0],
+		Anum_pg_depend_objid,
+		BTEqualStrategyNumber, F_OIDEQ,
+		ObjectIdGetDatum(address.objectId));
+	ScanKeyInit(&key[1],
+		Anum_pg_depend_refobjid,
+		BTEqualStrategyNumber, F_OIDEQ,
+		ObjectIdGetDatum(address.objectId));
+
+	scan = systable_beginscan(depRel, InvalidOid, false,
+					  NULL, 2, key);
+
+	while (HeapTupleIsValid(depTup = systable_getnext(scan)))
+	{
+		Form_pg_depend foundDep = (Form_pg_depend) GETSTRUCT(depTup);
+		Datum		dep_values[Natts_pg_depend];
+		bool		dep_nulls[Natts_pg_depend];
+		bool		dep_replaces[Natts_pg_depend];
+		HeapTuple	dep_newtup;
+	
+		if (foundDep->objid == address.objectId)
+		{
+			memset(dep_values, 0, sizeof(dep_values));
+			memset(dep_nulls, 0, sizeof(dep_nulls));
+			memset(dep_replaces, 0, sizeof(dep_replaces));
+			dep_values[Anum_pg_depend_objid - 1] = ObjectIdGetDatum(oid);
+			dep_replaces[Anum_pg_depend_objid - 1] = true;
+			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
+			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
+			heap_freetuple(dep_newtup);
+		}
+		if (foundDep->refobjid == address.objectId)
+		{
+			memset(dep_values, 0, sizeof(dep_values));
+			memset(dep_nulls, 0, sizeof(dep_nulls));
+			memset(dep_replaces, 0, sizeof(dep_replaces));
+			dep_values[Anum_pg_depend_refobjid - 1] = ObjectIdGetDatum(oid);
+			dep_replaces[Anum_pg_depend_refobjid - 1] = true;
+			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
+			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
+			heap_freetuple(dep_newtup);
+		}
+	}
+	table_close(depRel, RowExclusiveLock);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -142,6 +142,7 @@ static void call_prev_ProcessUtility(PlannedStmt *pstmt,
 						 QueryCompletion *qc);
 static void set_pgtype_byval(List *name, bool byval);
 static void pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, Oid *oid, Acl **acl, bool *isSameFunc, bool is_proc);
+static void pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -2720,12 +2721,24 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
 						CommandCounterIncrement();
+						pg_proc_update_oid_acl(address, oldoid, proacl);
 						if (!isSameProc) {
 						       /*
 							* When the signatures differ we need to manually update the 'function_args' column in 
 							* the 'bbf_schema_permissions' catalog
 							*/
-							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype);
+							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
+						}
+						/* Clean up table entries for the create function statement if applicable*/
+						if (address.objectId != oldoid)
+						{
+							/*
+							 * if this is the same procedure, it'll update the existing one,
+							 * in such case, should not delete dependent records
+							 */
+							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
+							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
+							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
 						}
 						CommitTransactionCommand();
 					}
@@ -4781,6 +4794,65 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 	funcOid = LookupFuncWithArgs(stmt->objtype, stmt->func, true);
 
 	*isSameFunc = OidIsValid(funcOid);
+}
+
+/*
+ * Update the oid and acl of a pg_proc entry given its address
+ */
+static void
+pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
+{
+	Relation		rel;
+	HeapTuple		proctup;
+	Form_pg_proc	form_proctup;
+	char		*physical_schemaname;
+
+	Datum		values[Natts_pg_proc];
+	bool		nulls[Natts_pg_proc];
+	bool		replaces[Natts_pg_proc];
+	HeapTuple	newtup;
+
+	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
+	if (!HeapTupleIsValid(proctup))
+		return;
+
+	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
+
+	if (!is_pltsql_language_oid(form_proctup->prolang))
+	{
+		ReleaseSysCache(proctup);
+		return;
+	}
+
+	physical_schemaname = get_namespace_name(form_proctup->pronamespace);
+	if (physical_schemaname == NULL)
+	{
+		elog(ERROR,
+				"Could not find physical schemaname for %u",
+				 form_proctup->pronamespace);
+	}
+
+	rel = table_open(ProcedureRelationId, RowExclusiveLock);
+
+	memset(values, 0, sizeof(values));
+	memset(nulls, 0, sizeof(nulls));
+	memset(replaces, 0, sizeof(replaces));
+	values[Anum_pg_proc_oid - 1] = ObjectIdGetDatum(oid);
+	replaces[Anum_pg_proc_oid - 1] = true;
+	if(acl)
+		values[Anum_pg_proc_proacl - 1] = PointerGetDatum(acl);
+	else
+		nulls[Anum_pg_proc_proacl - 1] = true;
+	replaces[Anum_pg_proc_proacl - 1] = true;
+
+	newtup = heap_modify_tuple(proctup, RelationGetDescr(rel), values, nulls, replaces);
+	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
+
+	/* Clean up */
+	ReleaseSysCache(proctup);
+	heap_freetuple(newtup);
+
+	table_close(rel, RowExclusiveLock);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -142,7 +142,6 @@ static void call_prev_ProcessUtility(PlannedStmt *pstmt,
 						 QueryCompletion *qc);
 static void set_pgtype_byval(List *name, bool byval);
 static void pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, Oid *oid, Acl **acl, bool *isSameFunc, bool is_proc);
-static void pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -2721,24 +2720,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
 						CommandCounterIncrement();
-						pg_proc_update_oid_acl(address, oldoid, proacl);
 						if (!isSameProc) {
 						       /*
 							* When the signatures differ we need to manually update the 'function_args' column in 
 							* the 'bbf_schema_permissions' catalog
 							*/
-							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
-						}
-						/* Clean up table entries for the create function statement if applicable*/
-						if (address.objectId != oldoid)
-						{
-							/*
-							 * if this is the same procedure, it'll update the existing one,
-							 * in such case, should not delete dependent records
-							 */
-							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
-							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
-							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype);
 						}
 						CommitTransactionCommand();
 					}
@@ -4794,65 +4781,6 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 	funcOid = LookupFuncWithArgs(stmt->objtype, stmt->func, true);
 
 	*isSameFunc = OidIsValid(funcOid);
-}
-
-/*
- * Update the oid and acl of a pg_proc entry given its address
- */
-static void
-pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
-{
-	Relation		rel;
-	HeapTuple		proctup;
-	Form_pg_proc	form_proctup;
-	char		*physical_schemaname;
-
-	Datum		values[Natts_pg_proc];
-	bool		nulls[Natts_pg_proc];
-	bool		replaces[Natts_pg_proc];
-	HeapTuple	newtup;
-
-	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
-	if (!HeapTupleIsValid(proctup))
-		return;
-
-	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
-
-	if (!is_pltsql_language_oid(form_proctup->prolang))
-	{
-		ReleaseSysCache(proctup);
-		return;
-	}
-
-	physical_schemaname = get_namespace_name(form_proctup->pronamespace);
-	if (physical_schemaname == NULL)
-	{
-		elog(ERROR,
-				"Could not find physical schemaname for %u",
-				 form_proctup->pronamespace);
-	}
-
-	rel = table_open(ProcedureRelationId, RowExclusiveLock);
-
-	memset(values, 0, sizeof(values));
-	memset(nulls, 0, sizeof(nulls));
-	memset(replaces, 0, sizeof(replaces));
-	values[Anum_pg_proc_oid - 1] = ObjectIdGetDatum(oid);
-	replaces[Anum_pg_proc_oid - 1] = true;
-	if(acl)
-		values[Anum_pg_proc_proacl - 1] = PointerGetDatum(acl);
-	else
-		nulls[Anum_pg_proc_proacl - 1] = true;
-	replaces[Anum_pg_proc_proacl - 1] = true;
-
-	newtup = heap_modify_tuple(proctup, RelationGetDescr(rel), values, nulls, replaces);
-	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
-
-	/* Clean up */
-	ReleaseSysCache(proctup);
-	heap_freetuple(newtup);
-
-	table_close(rel, RowExclusiveLock);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -25,7 +25,6 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
-#include "catalog/pg_depend.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
@@ -63,7 +62,6 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
-#include "utils/fmgroids.h"
 #include "utils/guc_tables.h"
 #include "utils/lsyscache.h"
 #include "utils/plancache.h"
@@ -144,8 +142,6 @@ static void call_prev_ProcessUtility(PlannedStmt *pstmt,
 						 QueryCompletion *qc);
 static void set_pgtype_byval(List *name, bool byval);
 static void pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, Oid *oid, Acl **acl, bool *isSameFunc, bool is_proc);
-// static void pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl);
-// static void update_dependency(Oid objId, Oid targetOid);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -2712,7 +2708,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 						/* if this is the same procedure, it will update the existing one */
 						address = CreateFunction(pstate, cfs);
-						CommandCounterIncrement();
 						if (tbltypStmt)
 						{
 							/*
@@ -2723,7 +2718,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 															cfs->returnType);
 							tbltyp.objectSubId = 0;
 							recordDependencyOn(&tbltyp, &address, DEPENDENCY_INTERNAL);
-							CommandCounterIncrement();
 						}
 						/* Update function/procedure related metadata in babelfish catalog */
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
@@ -2739,12 +2733,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
 							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
 							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
-							CommandCounterIncrement();
 						}
-						// pg_proc_update_oid_acl(address, oldoid, proacl);
-						// CommandCounterIncrement();
-						// update_dependency(address.objectId, oldoid);
-						// CommandCounterIncrement();
 						if (!isSameProc) 
 						{
 						    /*
@@ -4808,100 +4797,6 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 
 	*isSameFunc = OidIsValid(funcOid);
 }
-
-/*
- * Update the oid and acl of a pg_proc entry given its address
- */
-// static void
-// pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
-// {
-// 	Relation		rel;
-// 	HeapTuple		proctup;
-// 	Form_pg_proc	form_proctup;
-// 	char		*physical_schemaname;
-
-// 	Datum		values[Natts_pg_proc];
-// 	bool		nulls[Natts_pg_proc];
-// 	bool		replaces[Natts_pg_proc];
-// 	HeapTuple	newtup;
-
-// 	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
-// 	if (!HeapTupleIsValid(proctup))
-// 		return;
-
-// 	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
-
-// 	if (!is_pltsql_language_oid(form_proctup->prolang))
-// 	{
-// 		ReleaseSysCache(proctup);
-// 		return;
-// 	}
-
-// 	physical_schemaname = get_namespace_name(form_proctup->pronamespace);
-// 	if (physical_schemaname == NULL)
-// 	{
-// 		elog(ERROR,
-// 				"Could not find physical schemaname for %u",
-// 				 form_proctup->pronamespace);
-// 	}
-
-// 	rel = table_open(ProcedureRelationId, RowExclusiveLock);
-
-// 	memset(values, 0, sizeof(values));
-// 	memset(nulls, 0, sizeof(nulls));
-// 	memset(replaces, 0, sizeof(replaces));
-// 	values[Anum_pg_proc_oid - 1] = ObjectIdGetDatum(oid);
-// 	replaces[Anum_pg_proc_oid - 1] = true;
-// 	if(acl)
-// 		values[Anum_pg_proc_proacl - 1] = PointerGetDatum(acl);
-// 	else
-// 		nulls[Anum_pg_proc_proacl - 1] = true;
-// 	replaces[Anum_pg_proc_proacl - 1] = true;
-
-// 	newtup = heap_modify_tuple(proctup, RelationGetDescr(rel), values, nulls, replaces);
-// 	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
-
-// 	/* Clean up */
-// 	ReleaseSysCache(proctup);
-// 	heap_freetuple(newtup);
-
-// 	table_close(rel, RowExclusiveLock);
-// }
-
-// static void
-// update_dependency(Oid objId, Oid targetOid)
-// {
-// 	Relation depRel;
-// 	SysScanDesc 	scan;
-// 	ScanKeyData 	key[1];
-// 	HeapTuple depTup;
-// 	depRel = table_open(DependRelationId, RowExclusiveLock);
-
-// 	ScanKeyInit(&key[0],
-// 		Anum_pg_depend_objid,
-// 		BTEqualStrategyNumber, F_OIDEQ,
-// 		ObjectIdGetDatum(objId));
-// 	scan = systable_beginscan(depRel, InvalidOid, false,
-// 		NULL, 1, key);
-// 	while (HeapTupleIsValid(depTup = systable_getnext(scan)))
-// 	{
-// 		Datum		dep_values[Natts_pg_depend];
-// 		bool		dep_nulls[Natts_pg_depend];
-// 		bool		dep_replaces[Natts_pg_depend];
-// 		HeapTuple	dep_newtup;
-
-// 		memset(dep_values, 0, sizeof(dep_values));
-// 		memset(dep_nulls, 0, sizeof(dep_nulls));
-// 		memset(dep_replaces, 0, sizeof(dep_replaces));
-// 		dep_values[Anum_pg_depend_objid - 1] = ObjectIdGetDatum(targetOid);
-// 		dep_replaces[Anum_pg_depend_objid - 1] = true;
-// 		dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
-// 		CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
-// 		heap_freetuple(dep_newtup);
-// 	}
-// 	systable_endscan(scan);
-// 	table_close(depRel, RowExclusiveLock);
-// }
 
 /*
  * Update the pg_type catalog entry for the given name to have

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -25,6 +25,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_depend.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
@@ -62,6 +63,7 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/guc_tables.h"
 #include "utils/lsyscache.h"
 #include "utils/plancache.h"
@@ -2721,14 +2723,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
 						CommandCounterIncrement();
-						pg_proc_update_oid_acl(address, oldoid, proacl);
-						if (!isSameProc) {
-						       /*
-							* When the signatures differ we need to manually update the 'function_args' column in 
-							* the 'bbf_schema_permissions' catalog
-							*/
-							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
-						}
 						/* Clean up table entries for the create function statement if applicable*/
 						if (address.objectId != oldoid)
 						{
@@ -2739,6 +2733,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
 							deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
 							deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
+						}
+						pg_proc_update_oid_acl(address, oldoid, proacl);
+						if (!isSameProc) {
+						    /*
+							* When the signatures differ we need to manually update the 'function_args' column in 
+							* the 'bbf_schema_permissions' catalog
+							*/
+							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype);
 						}
 						CommitTransactionCommand();
 					}
@@ -4802,8 +4804,10 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 static void
 pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
 {
-	Relation		rel;
-	HeapTuple		proctup;
+	Relation		rel,depRel;
+	ScanKeyData 	key[2];
+	SysScanDesc 	scan;
+	HeapTuple		proctup, depTup;
 	Form_pg_proc	form_proctup;
 	char		*physical_schemaname;
 
@@ -4853,6 +4857,52 @@ pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
 	heap_freetuple(newtup);
 
 	table_close(rel, RowExclusiveLock);
+	depRel = table_open(DependRelationId, RowExclusiveLock);
+
+	ScanKeyInit(&key[0],
+		Anum_pg_depend_objid,
+		BTEqualStrategyNumber, F_OIDEQ,
+		ObjectIdGetDatum(address.objectId));
+	ScanKeyInit(&key[1],
+		Anum_pg_depend_refobjid,
+		BTEqualStrategyNumber, F_OIDEQ,
+		ObjectIdGetDatum(address.objectId));
+
+	scan = systable_beginscan(depRel, InvalidOid, false,
+					  NULL, 2, key);
+
+	while (HeapTupleIsValid(depTup = systable_getnext(scan)))
+	{
+		Form_pg_depend foundDep = (Form_pg_depend) GETSTRUCT(depTup);
+		Datum		dep_values[Natts_pg_depend];
+		bool		dep_nulls[Natts_pg_depend];
+		bool		dep_replaces[Natts_pg_depend];
+		HeapTuple	dep_newtup;
+
+		if (foundDep->objid == address.objectId)
+		{
+			memset(dep_values, 0, sizeof(dep_values));
+			memset(dep_nulls, 0, sizeof(dep_nulls));
+			memset(dep_replaces, 0, sizeof(dep_replaces));
+			dep_values[Anum_pg_depend_objid - 1] = ObjectIdGetDatum(oid);
+			dep_replaces[Anum_pg_depend_objid - 1] = true;
+			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
+			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
+			heap_freetuple(dep_newtup);
+		}
+		if (foundDep->refobjid == address.objectId)
+		{
+			memset(dep_values, 0, sizeof(dep_values));
+			memset(dep_nulls, 0, sizeof(dep_nulls));
+			memset(dep_replaces, 0, sizeof(dep_replaces));
+			dep_values[Anum_pg_depend_refobjid - 1] = ObjectIdGetDatum(oid);
+			dep_replaces[Anum_pg_depend_refobjid - 1] = true;
+			dep_newtup = heap_modify_tuple(depTup, RelationGetDescr(depRel), dep_values, dep_nulls, dep_replaces);
+			CatalogTupleUpdate(depRel, &dep_newtup->t_self, dep_newtup);
+			heap_freetuple(dep_newtup);
+		}
+	}
+	table_close(depRel, RowExclusiveLock);
 }
 
 /*

--- a/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
@@ -6,3 +6,17 @@ go
 
 drop database alter_func_db
 go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%'
+go
+~~START~~
+varchar#!#varchar
+~~END~~
+
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%'
+go
+~~START~~
+varchar#!#varchar
+~~END~~
+

--- a/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
@@ -1,17 +1,17 @@
 use master;
 go
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo' order by funcname;
 go
 ~~START~~
 varchar#!#varchar
 alter_func_mvu_f1#!#alter_func_db_dbo
-alter_func_mvu_f5#!#alter_func_db_dbo
 alter_func_mvu_f4#!#alter_func_db_dbo
+alter_func_mvu_f5#!#alter_func_db_dbo
 ~~END~~
 
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo' order by funcname;
 go
 ~~START~~
 varchar#!#varchar

--- a/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
@@ -1,0 +1,8 @@
+use master;
+go
+
+drop database alter_proc_db
+go
+
+drop database alter_func_db
+go

--- a/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
@@ -1,20 +1,39 @@
 use master;
 go
 
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
+go
+~~START~~
+varchar#!#varchar
+alter_func_mvu_f1#!#alter_func_db_dbo
+alter_func_mvu_f5#!#alter_func_db_dbo
+alter_func_mvu_f4#!#alter_func_db_dbo
+~~END~~
+
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
+go
+~~START~~
+varchar#!#varchar
+alter_proc_p1#!#alter_proc_db_dbo
+alter_proc_p3#!#alter_proc_db_dbo
+~~END~~
+
+
 drop database alter_proc_db
 go
 
 drop database alter_func_db
 go
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
 go
 ~~START~~
 varchar#!#varchar
 ~~END~~
 
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
 go
 ~~START~~
 varchar#!#varchar

--- a/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
@@ -20,3 +20,18 @@ go
 varchar#!#varchar
 ~~END~~
 
+
+-- psql currentSchema=master_dbo,public
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_func_db_dbo');
+go
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#varchar
+~~END~~
+
+
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_proc_db_dbo');
+go
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#varchar
+~~END~~
+

--- a/test/JDBC/expected/alter-mvu-test-vu-prepare.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-prepare.out
@@ -1,0 +1,61 @@
+create database alter_func_db;
+go
+
+use alter_func_db
+go
+
+
+CREATE TABLE alter_func_users ([Id] int, [firstname] varchar(50), [lastname] varchar(50), [email] varchar(50));
+CREATE TABLE alter_func_orders ([Id] int, [userid] int, [productid] int, [quantity] int, [orderdate] Date);
+INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (2, 'e', 'l', 'testemail2');
+INSERT INTO alter_func_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
+GO
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+
+create function alter_func_mvu_f1() returns int begin return 2 end
+go
+
+alter function alter_func_mvu_f1(@param1 int) returns int begin return @param1 end
+go
+
+create function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_orders)
+go
+
+create function alter_func_mvu_f5() returns @result TABLE([Id] int) as begin insert @result select 1 return end
+go
+
+alter function alter_func_mvu_f5()
+returns @result TABLE(Id int) as begin
+insert into @result values (2)
+return
+end
+go
+
+use master;
+go
+
+CREATE database alter_proc_db
+GO
+
+use alter_proc_db
+GO
+
+CREATE PROCEDURE alter_proc_p1 
+AS
+    select * from alter_proc_users
+GO
+
+alter procedure alter_proc_p1 @dateParam date as select @dateParam
+go
+
+create procedure alter_proc_p3 as select 1
+go
+
+alter procedure alter_proc_p3 as select 4
+GO

--- a/test/JDBC/expected/alter-mvu-test-vu-verify.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-verify.out
@@ -50,30 +50,3 @@ go
 
 alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
 go
-
-select alter_func_mvu_f4();
-go
-~~START~~
-varchar
-(1,j,o,testemail)
-(2,e,l,testemail2)
-~~END~~
-
-
-drop function alter_func_mvu_f1;
-go
-
-drop function alter_func_mvu_f4;
-go
-
-drop function alter_func_mvu_f5;
-go
-
-use alter_proc_db
-go
-
-drop procedure alter_proc_p1;
-go
-
-drop procedure alter_proc_p3;
-go

--- a/test/JDBC/expected/alter-mvu-test-vu-verify.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-verify.out
@@ -1,0 +1,79 @@
+use alter_func_db
+go
+
+select alter_func_mvu_f1(10);
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select alter_func_mvu_f4();
+go
+~~START~~
+varchar
+(1,1,1,5,2023-06-25)
+(2,1,1,6,2023-06-25)
+~~END~~
+
+
+select Id from alter_func_mvu_f5();
+go
+~~START~~
+int
+2
+~~END~~
+
+
+use alter_proc_db
+go
+
+exec alter_proc_p1 @dateParam = '2020-01-01'
+go
+~~START~~
+date
+2020-01-01
+~~END~~
+
+
+exec alter_proc_p3;
+go
+~~START~~
+int
+4
+~~END~~
+
+
+use alter_func_db
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go
+
+select alter_func_mvu_f4();
+go
+~~START~~
+varchar
+(1,j,o,testemail)
+(2,e,l,testemail2)
+~~END~~
+
+
+drop function alter_func_mvu_f1;
+go
+
+drop function alter_func_mvu_f4;
+go
+
+drop function alter_func_mvu_f5;
+go
+
+use alter_proc_db
+go
+
+drop procedure alter_proc_p1;
+go
+
+drop procedure alter_proc_p3;
+go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
@@ -1,10 +1,10 @@
 use master;
 go
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo' order by funcname;
 go
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo' order by funcname;
 go
 
 drop database alter_proc_db

--- a/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
@@ -1,0 +1,8 @@
+use master;
+go
+
+drop database alter_proc_db
+go
+
+drop database alter_func_db
+go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
@@ -1,16 +1,22 @@
 use master;
 go
 
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
+go
+
 drop database alter_proc_db
 go
 
 drop database alter_func_db
 go
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
 go
 
-SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%'
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
 go
 
 -- psql currentSchema=master_dbo,public

--- a/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
@@ -6,3 +6,9 @@ go
 
 drop database alter_func_db
 go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%'
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%'
+go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
@@ -12,3 +12,10 @@ go
 
 SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%'
 go
+
+-- psql currentSchema=master_dbo,public
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_func_db_dbo');
+go
+
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_proc_db_dbo');
+go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-prepare.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-prepare.sql
@@ -1,0 +1,57 @@
+create database alter_func_db;
+go
+
+use alter_func_db
+go
+
+CREATE TABLE alter_func_users ([Id] int, [firstname] varchar(50), [lastname] varchar(50), [email] varchar(50));
+CREATE TABLE alter_func_orders ([Id] int, [userid] int, [productid] int, [quantity] int, [orderdate] Date);
+
+INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (2, 'e', 'l', 'testemail2');
+INSERT INTO alter_func_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
+GO
+
+create function alter_func_mvu_f1() returns int begin return 2 end
+go
+
+alter function alter_func_mvu_f1(@param1 int) returns int begin return @param1 end
+go
+
+create function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_orders)
+go
+
+create function alter_func_mvu_f5() returns @result TABLE([Id] int) as begin insert @result select 1 return end
+go
+
+alter function alter_func_mvu_f5()
+returns @result TABLE(Id int) as begin
+insert into @result values (2)
+return
+end
+go
+
+use master;
+go
+
+CREATE database alter_proc_db
+GO
+
+use alter_proc_db
+GO
+
+CREATE PROCEDURE alter_proc_p1 
+AS
+    select * from alter_proc_users
+GO
+
+alter procedure alter_proc_p1 @dateParam date as select @dateParam
+go
+
+create procedure alter_proc_p3 as select 1
+go
+
+alter procedure alter_proc_p3 as select 4
+GO

--- a/test/JDBC/input/alter/alter-mvu-test-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-verify.sql
@@ -24,24 +24,3 @@ go
 
 alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
 go
-
-select alter_func_mvu_f4();
-go
-
-drop function alter_func_mvu_f1;
-go
-
-drop function alter_func_mvu_f4;
-go
-
-drop function alter_func_mvu_f5;
-go
-
-use alter_proc_db
-go
-
-drop procedure alter_proc_p1;
-go
-
-drop procedure alter_proc_p3;
-go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-verify.sql
@@ -1,0 +1,47 @@
+use alter_func_db
+go
+
+select alter_func_mvu_f1(10);
+go
+
+select alter_func_mvu_f4();
+go
+
+select Id from alter_func_mvu_f5();
+go
+
+use alter_proc_db
+go
+
+exec alter_proc_p1 @dateParam = '2020-01-01'
+go
+
+exec alter_proc_p3;
+go
+
+use alter_func_db
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go
+
+select alter_func_mvu_f4();
+go
+
+drop function alter_func_mvu_f1;
+go
+
+drop function alter_func_mvu_f4;
+go
+
+drop function alter_func_mvu_f5;
+go
+
+use alter_proc_db
+go
+
+drop procedure alter_proc_p1;
+go
+
+drop procedure alter_proc_p3;
+go

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,9 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+alter-mvu-test-vu-prepare
+alter-mvu-test-vu-verify
+alter-mvu-test-vu-cleanup
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,9 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+alter-procedure-vu-prepare
+alter-procedure-vu-verify
+alter-procedure-vu-cleanup
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,9 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-alter-procedure-vu-prepare
-alter-procedure-vu-verify
-alter-procedure-vu-cleanup
+all
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,9 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-alter-mvu-test-vu-prepare
-alter-mvu-test-vu-verify
-alter-mvu-test-vu-cleanup
+all
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -12,4 +12,6 @@ ignore#!#db_owner-vu-prepare
 ignore#!#db_owner-vu-verify
 ignore#!#db_owner-vu-cleanup
 ignore#!#test_search_path
-
+ignore#!#alter-mvu-test-vu-prepare
+ignore#!#alter-mvu-test-vu-verify
+ignore#!#alter-mvu-test-vu-cleanup

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -607,3 +607,4 @@ sys_sql_logins
 sys-login-property
 sys-fn-varbintohexsubstring
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
+alter-mvu-test


### PR DESCRIPTION
Backgroud:
In our previous implementation of the ALTER PROCEDURE/FUNCTION feature, we followed these steps to update metadata:

1. Create a new procedure/function
2. Replace the new OID with the old OID in the pg_proc metadata
3. Clean up pg_depend/pg_shdepend records referencing the new OID

Analysis: When creating a new procedure/function (step 1):
1. If the parameter list remains unchanged, the Create new function/procedure api will not insert new tuple but updating the existing tuple and return the old tuple oid. In this case, the old OID and new OID are identical, making the pg_depend records cleanup unnecessary.
2. If the parameter list changed, it missed to do anything about the pg_depend/pg_shdepend records created by the new ID, it'll leave inconsistent tuple in the pg_depend/pg_shdepend database.
3. The replacing of new OID (step 2) with the old OID is not necessary, since there's no other issues need to be concerned, and it's an over-design.

Fix:
For issue 1: Skip pg_depend records cleanup when old OID equals new OID.
For issue 2: Do not replace the new OID with the old OID, and just delete the pg_depend/pg_shdepend records referencing the old OID

Test: 
Add extra mvu test for alter proc/function, add the mvu test into latest schedule only, since it'll not pass other mvu test.

Issue-resolved: BABEL-5601




### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).