### PR TITLE
Fix ANTLR query mutator sanity check condition

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -710,10 +710,7 @@ void PLtsql_expr_query_mutator::run()
 					
 		if (orig_text.length() == 0 || orig_text.c_str(), query.substr(offset, orig_text.length()) == orig_text) // local_id maybe already deleted in some cases such as select-assignment. check here if it still exists)
 		{
-			/*
-			 * Note: The original test (offset - cursor < 0) never worked as intended because both offset and cursor are unsigned.
-			 * This has been corrected to (offset < cursor) to properly detect multiple mutations on the same position.
-			 */
+			/* detect multiple mutations on the same position */
 			if (offset < cursor)
 			{
 				throw PGErrorWrapperException(ERROR, ERRCODE_INTERNAL_ERROR, 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -710,13 +710,15 @@ void PLtsql_expr_query_mutator::run()
 					
 		if (orig_text.length() == 0 || orig_text.c_str(), query.substr(offset, orig_text.length()) == orig_text) // local_id maybe already deleted in some cases such as select-assignment. check here if it still exists)
 		{
-			// Note: the test below does not work, and has never worked, because size_t will not be negative, 
-			// and the result of the subtraction is also of type size_t.
-			// This test has been in the code since day 1. 
-			// When making the test work, some test cases will start failing as they run into this condition 
-			// (test table_variable_xact_errors and two variants). Therefore, not touching the test for now.
-			if (offset - cursor < 0)
-				throw PGErrorWrapperException(ERROR, ERRCODE_INTERNAL_ERROR, "can't mutate an internal query. might be due to multiple mutations on the same position", 0, 0);
+			/*
+			 * Note: The original test (offset - cursor < 0) never worked as intended because both offset and cursor are unsigned.
+			 * This has been corrected to (offset < cursor) to properly detect multiple mutations on the same position.
+			 */
+			if (offset < cursor)
+			{
+				throw PGErrorWrapperException(ERROR, ERRCODE_INTERNAL_ERROR, 
+					"Can't mutate an internal query: detected multiple mutations on the same position", 0, 0);
+			}
 			if (offset - cursor > 0) // if offset==cursor, no need to copy
 				rewritten_query += query.substr(cursor, offset - cursor); // copy substring of expr->query. ranged [cursor, offset)
 			rewritten_query += repl_text;


### PR DESCRIPTION
### Description

The original sanity check in the query mutator `(offset - cursor < 0)` was ineffective due to unsigned integer arithmetic. This commit replaces it with a correct condition `(offset < cursor)` to properly detect multiple mutations on the same position.

### Issues Resolved

BABEL-5201

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).