### PR TITLE
Properly reseed the new table's identity sequence after SELECT ... INTO

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -158,7 +158,7 @@ extern PLtsql_function *find_cached_batch(int handle);
 extern void apply_post_compile_actions(PLtsql_function *func, InlineCodeBlockArgs *args);
 Datum		sp_prepare(PG_FUNCTION_ARGS);
 Datum		sp_unprepare(PG_FUNCTION_ARGS);
-static List *transformSelectIntoStmt(CreateTableAsStmt *stmt);
+static List *transformSelectIntoStmt(CreateTableAsStmt *stmt, Oid *seqoid);
 static char *get_oid_type_string(int type_oid);
 static int64 get_identity_into_args(Node *node);
 extern char *construct_unique_index_name(char *index_name, char *relation_name);
@@ -6727,7 +6727,7 @@ get_identity_into_args(Node *node)
 }
 
 static List *
-transformSelectIntoStmt(CreateTableAsStmt *stmt)
+transformSelectIntoStmt(CreateTableAsStmt *stmt, Oid *seqoid)
 {
 	List *result;
 	ListCell *elements;
@@ -6895,11 +6895,12 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
 
 						seen_identity = true;
+						*seqoid = get_table_identity(tle->resorigtbl);
 
 						constraint = makeNode(Constraint);
 						constraint->contype = CONSTR_IDENTITY;
 						constraint->generated_when = attrStruct->attidentity;
-						constraint->options = sequence_options(get_table_identity(tle->resorigtbl));
+						constraint->options = sequence_options(*seqoid);
 						constraint->location = -1;
 
 						/*
@@ -6966,7 +6967,9 @@ void pltsql_bbfSelectIntoUtility(ParseState *pstate, PlannedStmt *pstmt, const c
 
 	Node *parsetree = pstmt->utilityStmt;
 	List *stmts;
-	stmts = transformSelectIntoStmt((CreateTableAsStmt *)parsetree);
+	Oid seqoid = InvalidOid;
+
+	stmts = transformSelectIntoStmt((CreateTableAsStmt *)parsetree, &seqoid);
 	while (stmts != NIL)
 	{
 		Node *stmt = (Node *)linitial(stmts);
@@ -6989,6 +6992,28 @@ void pltsql_bbfSelectIntoUtility(ParseState *pstate, PlannedStmt *pstmt, const c
 		}
 		if (stmts != NIL)
 			CommandCounterIncrement();
+	}
+
+	/* If we have an identity column */
+	if (OidIsValid(seqoid) && OidIsValid(address->objectId))
+	{
+		Oid current_user_id = InvalidOid;
+
+		/* We assume session user to cover for cross-db cases */
+		PG_TRY();
+		{
+			current_user_id = GetUserId();
+			SetCurrentRoleId(GetSessionUserId(), false);
+
+			DirectFunctionCall2(setval_oid,
+				ObjectIdGetDatum(get_table_identity(address->objectId)),
+				Int64GetDatum(DirectFunctionCall1(pg_sequence_last_value, ObjectIdGetDatum(seqoid))));
+		}
+		PG_FINALLY();
+		{
+			SetCurrentRoleId(current_user_id, false);
+		}
+		PG_END_TRY();
 	}
 }
 

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -119,7 +119,7 @@ go
 int#!#nvarchar
 1#!#First
 1#!#First_dup
-2#!#Second
+3#!#Second
 ~~END~~
 
 
@@ -142,7 +142,7 @@ go
 ~~START~~
 smallint#!#numeric
 2#!#2.222
-4#!#3.333
+6#!#3.333
 ~~END~~
 
 
@@ -165,7 +165,7 @@ go
 ~~START~~
 smallint#!#nvarchar
 3#!#Third
-6#!#Fourth
+9#!#Fourth
 ~~END~~
 
 
@@ -188,7 +188,7 @@ go
 ~~START~~
 float#!#bigint
 4.4#!#4
-5.5#!#8
+5.5#!#12
 ~~END~~
 
 
@@ -211,7 +211,7 @@ go
 ~~START~~
 bigint#!#real
 5#!#5.567
-10#!#6.789
+15#!#6.789
 ~~END~~
 
 
@@ -230,7 +230,7 @@ go
 int#!#nvarchar#!#smallint#!#numeric
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 ~~END~~
 
 
@@ -261,7 +261,7 @@ go
 int#!#nvarchar#!#smallint#!#numeric
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 99#!#Join#!#88#!#9.867
 ~~END~~
 
@@ -283,9 +283,9 @@ go
 int#!#nvarchar
 1#!#First
 1#!#First_dup
-2#!#Second
+3#!#Second
 3#!#Third
-6#!#Fourth
+9#!#Fourth
 ~~END~~
 
 
@@ -306,13 +306,13 @@ select * from dest_table_union order by [Col1]
 go
 ~~START~~
 int#!#nvarchar
-<NULL>#!#<NULL>
 <NULL>#!#Union
+<NULL>#!#<NULL>
 1#!#First_dup
 1#!#First
-2#!#Second
 3#!#Third
-6#!#Fourth
+3#!#Second
+9#!#Fourth
 ~~END~~
 
 
@@ -332,7 +332,7 @@ go
 int#!#nvarchar#!#smallint#!#numeric
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 ~~END~~
 
 
@@ -363,7 +363,7 @@ go
 int#!#nvarchar#!#smallint#!#numeric
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 209#!#Sub-Join#!#78#!#8.567
 ~~END~~
 


### PR DESCRIPTION
### Description

Previously, the target table formed from SELECT ... INTO would have the
identity column reseeded to the start value. Consequently, any new
inserts to the identity column would begin with the start value of the
sequence. The expectation is the next value of the identity column
should be determined by the source table's column.

In this commit, we fix this by checking if the target table has an
identity column, we will set the associated sequence's current value to
the last value returned by the sequence associated with the source
table's identity column.

Task: BABEL-5661
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Issues Resolved

BABEL-5661

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).