### PR TITLE
Handle storing original index name through cached plan

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2460,9 +2460,21 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				   DestReceiver *dest,
 				   QueryCompletion *qc)
 {
-	Node	   *parsetree = pstmt->utilityStmt;
+	Node	   *parsetree;
 	ParseState *pstate = make_parsestate(NULL);
 
+	/*
+	 * If the given node tree is read-only, make a copy to ensure that parse
+	 * transformations don't damage the original tree.  This could be
+	 * refactored to avoid making unnecessary copies in more cases, but it's
+	 * not clear that it's worth a great deal of trouble over.  Statements
+	 * that are complex enough to be expensive to copy are exactly the ones
+	 * we'd need to copy, so that only marginal savings seem possible.
+	 */
+	if (readOnlyTree)
+		pstmt = copyObject(pstmt);
+
+	parsetree = pstmt->utilityStmt;
 	pstate->p_sourcetext = queryString;
 
 	if (process_utility_stmt_explain_only_mode(queryString, parsetree))

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4407,7 +4407,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				if (sql_dialect == SQL_DIALECT_TSQL &&
 					strcmp(queryString, CREATE_FULLTEXT_INDEX) != 0) /* Skip fulltext indexes since they don't even have an original name */
 				{
-					char    	*original_name = stmt->idxname != NULL ? pstrdup(stmt->idxname) : NULL;
+					char    	*original_name = stmt->idxname != NULL ? stmt->idxname : NULL;
 					List    	*partition_schemes = stmt->excludeOpNames;
 
 					stmt->excludeOpNames = NIL;
@@ -4435,7 +4435,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 					}
 					if (original_name && !stmt->isconstraint)
+					{
+						/* Store the original index name in reloptions */
 						exec_add_original_index_name(stmt->idxname, stmt->relation->schemaname, original_name);
+						/* Restore the original index name in TopMemoryContext so that cached plan remains valid */
+						stmt->idxname = original_name;
+					}
 					return;
 				}
 				break;

--- a/test/JDBC/expected/index_original_name.out
+++ b/test/JDBC/expected/index_original_name.out
@@ -1,0 +1,76 @@
+CREATE TABLE index_original_name_t1(id INT, name VARCHAR);
+GO
+
+CREATE PROCEDURE index_original_name_p1 AS
+	CREATE INDEX index_original_name_i1 ON index_original_name_t1(id);
+	SELECT name FROM sys.indexes WHERE name LIKE 'index_original_name_%';
+	DROP INDEX index_original_name_i1 ON index_original_name_t1;
+GO
+
+EXEC index_original_name_p1;
+GO
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+EXEC index_original_name_p1;
+GO
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+EXEC index_original_name_p1;
+GO
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+EXEC index_original_name_p1;
+GO
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+
+DECLARE @handle int;
+DECLARE @batch NVARCHAR(500);
+SET @batch = '
+CREATE INDEX index_original_name_i1 ON index_original_name_t1(id);
+SELECT name FROM sys.indexes WHERE name LIKE ''index_original_name_%'';
+DROP INDEX index_original_name_i1 ON index_original_name_t1;
+'
+EXEC SP_PREPARE @handle OUT, NULL, @batch
+EXEC SP_EXECUTE @handle
+EXEC SP_EXECUTE @handle
+EXEC SP_EXECUTE @handle
+EXEC SP_EXECUTE @handle
+GO
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+~~START~~
+varchar
+index_original_name_i1
+~~END~~
+
+
+DROP PROCEDURE index_original_name_p1;
+GO
+DROP TABLE index_original_name_t1;
+GO

--- a/test/JDBC/input/index_original_name.sql
+++ b/test/JDBC/input/index_original_name.sql
@@ -1,0 +1,36 @@
+CREATE TABLE index_original_name_t1(id INT, name VARCHAR);
+GO
+
+CREATE PROCEDURE index_original_name_p1 AS
+	CREATE INDEX index_original_name_i1 ON index_original_name_t1(id);
+	SELECT name FROM sys.indexes WHERE name LIKE 'index_original_name_%';
+	DROP INDEX index_original_name_i1 ON index_original_name_t1;
+GO
+
+EXEC index_original_name_p1;
+GO
+EXEC index_original_name_p1;
+GO
+EXEC index_original_name_p1;
+GO
+EXEC index_original_name_p1;
+GO
+
+DECLARE @handle int;
+DECLARE @batch NVARCHAR(500);
+SET @batch = '
+CREATE INDEX index_original_name_i1 ON index_original_name_t1(id);
+SELECT name FROM sys.indexes WHERE name LIKE ''index_original_name_%'';
+DROP INDEX index_original_name_i1 ON index_original_name_t1;
+'
+EXEC SP_PREPARE @handle OUT, NULL, @batch
+EXEC SP_EXECUTE @handle
+EXEC SP_EXECUTE @handle
+EXEC SP_EXECUTE @handle
+EXEC SP_EXECUTE @handle
+GO
+
+DROP PROCEDURE index_original_name_p1;
+GO
+DROP TABLE index_original_name_t1;
+GO


### PR DESCRIPTION
### Description
Previously, index created through cached plan was being created with a wrong/
invalid name as we were modifying the index name in index statement with composed
index name. This composed index name was being allocated in the `SPI` context which
gets destroyed at the end of the query execution so index name in the cached plan was
pointing to a freed memory address.

Fix this by keeping the original index in the IndexStmt node so that it still remains in the
cached plan.

Task: BABEL-1517
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).