### PR TITLE
Reseed identity for new table created using select into and only inherit nullability for simple queries

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -904,7 +904,7 @@ pltsql_ExecFuncProc_AclCheck(Oid funcid)
 	Oid userid = GetUserId();
 
 	/* In TDS client, the permissions might need to be checked against session user. */
-	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperatio())
+	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
 	{
 		Oid schema_id = get_func_namespace(funcid);
 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -903,7 +903,12 @@ pltsql_ExecFuncProc_AclCheck(Oid funcid)
 {
 	Oid userid = GetUserId();
 
-	/* In TDS client, the permissions might need to be checked against session user. */
+	/*
+	 * In TDS client, the permissions might need to be checked against session user.
+	 * Do not do this when in SECURITY_RESTRICTED_OPERATION because in this context
+	 * we temprorarily switch to a different user to execute some internal subcommands.
+	 * For example see reseed_identity_post_select_into
+	 */
 	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
 	{
 		Oid schema_id = get_func_namespace(funcid);
@@ -958,6 +963,7 @@ pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	/*
 	 * In TDS client, the RTE permissions might need to be checked against login mapped to given checkAsUser,
 	 * if it is valid, otherwise permissions are checked against session user (current login).
+	 * For SECURITY_RESTRICTED_OPERATION handling see comments in pltsql_ExecFuncProc_AclCheck
 	 */
 	if (IS_TDS_CLIENT() && queryDesc->plannedstmt != NULL && !InSecurityRestrictedOperation())
 	{

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -904,7 +904,7 @@ pltsql_ExecFuncProc_AclCheck(Oid funcid)
 	Oid userid = GetUserId();
 
 	/* In TDS client, the permissions might need to be checked against session user. */
-	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
+	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperatio())
 	{
 		Oid schema_id = get_func_namespace(funcid);
 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -904,7 +904,7 @@ pltsql_ExecFuncProc_AclCheck(Oid funcid)
 	Oid userid = GetUserId();
 
 	/* In TDS client, the permissions might need to be checked against session user. */
-	if (IS_TDS_CLIENT())
+	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperatio())
 	{
 		Oid schema_id = get_func_namespace(funcid);
 
@@ -959,7 +959,7 @@ pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	 * In TDS client, the RTE permissions might need to be checked against login mapped to given checkAsUser,
 	 * if it is valid, otherwise permissions are checked against session user (current login).
 	 */
-	if (IS_TDS_CLIENT() && queryDesc->plannedstmt != NULL)
+	if (IS_TDS_CLIENT() && queryDesc->plannedstmt != NULL && !InSecurityRestrictedOperation())
 	{
 		ListCell	*lc;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6765,32 +6765,24 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 		Index identity_ressortgroupref = 0;
 		List *modifiedTargetList = NIL;
 
-		bool persist_identity = true;
+		/*
+		 * currently we only carry over identity and nullability for
+		 * simple query with a single relation in from expression
+		 */
+		bool persist_identity_and_nullability = false;
 
 		/*
 		 * In T-SQL, identity property of column in destination
 		 * table is not persisted if the SELECT ... INTO statement
 		 * does not contain a single base relation
 		 */
-		if (q->jointree && q->jointree->fromlist != NIL)
+		if (q->jointree && q->jointree->fromlist != NIL && list_length(q->jointree->fromlist) == 1)
 		{
-			if (list_length(q->jointree->fromlist) > 1)
-				persist_identity = false;
-			else
+			RangeTblRef		*rtr = linitial(q->jointree->fromlist);
+			if (IsA(rtr, RangeTblRef))
 			{
-				Node *n_from = (Node *) linitial(q->jointree->fromlist);
-
-				if (!IsA(n_from, RangeTblRef))
-					persist_identity = false;
-				else
-				{
-					RangeTblRef		*rtr = (RangeTblRef *) n_from;
-					RangeTblEntry	*rte = rt_fetch(rtr->rtindex, q->rtable);
-
-					/* Do not persist identity if not an ordinary relation */
-					if (rte->rtekind != RTE_RELATION)
-						persist_identity = false;
-				}
+				RangeTblEntry	*rte = rt_fetch(rtr->rtindex, q->rtable);
+				persist_identity_and_nullability = rte->rtekind == RTE_RELATION;
 			}
 		}
 
@@ -6881,7 +6873,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				lcmd->def = (Node *)def;
 				altstmt->cmds = lappend(altstmt->cmds, lcmd);
 			}
-			else if (tle->expr && IsA(tle->expr, Var) && OidIsValid(tle->resorigtbl))
+			else if (persist_identity_and_nullability && tle->expr && IsA(tle->expr, Var) && OidIsValid(tle->resorigtbl))
 			{
 				HeapTuple	attrtup = SearchSysCacheAttNum(tle->resorigtbl, tle->resorigcol);
 
@@ -6902,7 +6894,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 						altstmt->cmds = lappend(altstmt->cmds, lcmd);
 					}
 
-					if (attrStruct->attidentity && persist_identity)
+					if (attrStruct->attidentity)
 					{
 						Constraint *constraint;
 
@@ -7003,9 +6995,11 @@ void pltsql_bbfSelectIntoUtility(ParseState *pstate, PlannedStmt *pstmt, const c
 
 			ProcessUtility(wrapper, queryString, false, PROCESS_UTILITY_SUBCOMMAND, params, NULL, None_Receiver, NULL);
 		}
-		if (stmts != NIL)
-			CommandCounterIncrement();
+
+		CommandCounterIncrement();
 	}
+
+	reseed_identity_post_select_into(address->objectId);
 }
 
 void

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6782,7 +6782,8 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 			if (IsA(rtr, RangeTblRef))
 			{
 				RangeTblEntry	*rte = rt_fetch(rtr->rtindex, q->rtable);
-				persist_identity_and_nullability = rte->rtekind == RTE_RELATION;
+				if (rte->rtekind == RTE_RELATION && rte->relkind == RELKIND_RELATION)
+					persist_identity_and_nullability = true;
 			}
 		}
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6877,6 +6877,8 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 			else if (persist_identity_and_nullability && tle->expr && IsA(tle->expr, Var) && OidIsValid(tle->resorigtbl))
 			{
 				HeapTuple	attrtup = SearchSysCacheAttNum(tle->resorigtbl, tle->resorigcol);
+				/* set to false if same column appears twice in select list */
+				bool     	persists_identity = true;
 
 				if (HeapTupleIsValid(attrtup))
 				{
@@ -6895,13 +6897,26 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 						altstmt->cmds = lappend(altstmt->cmds, lcmd);
 					}
 
+					/* We found one identity column but first check if it does not occur again target list */
 					if (attrStruct->attidentity)
 					{
-						Constraint *constraint;
+						ListCell *lc;
 
 						if (seen_identity)
 							ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
 									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
+
+						foreach (lc, q->targetList)
+						{
+							TargetEntry *tle_inner_loop = (TargetEntry *)lfirst(lc);
+							if (tle_inner_loop->resno != tle->resno && tle_inner_loop->expr && IsA(tle_inner_loop->expr, Var) &&
+							    tle_inner_loop->resorigtbl == tle->resorigtbl && tle_inner_loop->resorigcol == tle->resorigcol)
+								persists_identity = false;
+						}
+					}
+					if (attrStruct->attidentity && persists_identity)
+					{
+						Constraint *constraint;
 
 						seen_identity = true;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6897,15 +6897,16 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 						altstmt->cmds = lappend(altstmt->cmds, lcmd);
 					}
 
-					/* We found one identity column but first check if it does not occur again target list */
 					if (attrStruct->attidentity)
 					{
 						ListCell *lc;
 
-						if (seen_identity)
-							ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
-
+						/*
+						 * Validate that this column does not appear again in the target list
+						 * For cases like SELECT id, id INTO new_table FROM source_table; and
+						 * id is an identity column, we do not want to throw an error for
+						 * multiple identity instead silently skip persisting the identity property
+						 */
 						foreach (lc, q->targetList)
 						{
 							TargetEntry *tle_inner_loop = (TargetEntry *)lfirst(lc);
@@ -6917,6 +6918,11 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 					if (attrStruct->attidentity && persists_identity)
 					{
 						Constraint *constraint;
+
+						/* Identity function already seen in target list */
+						if (seen_identity)
+							ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
+									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
 
 						seen_identity = true;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6745,37 +6745,21 @@ get_identity_into_args(Node *node)
 static List *
 transformSelectIntoStmt(CreateTableAsStmt *stmt)
 {
-	List *result;
+	List *result = NIL;
 	ListCell *elements;
-	AlterTableStmt *altstmt;
-	IntoClause *into;
-	Node *n;
+	AlterTableStmt *altstmt = NULL;
 
-	n = stmt->query;
-	into = stmt->into;
-	result = NIL;
-	altstmt = NULL;
-
-	if (n && n->type == T_Query)
+	if (stmt->query && IsA(stmt->query, Query))
 	{
-		Query *q = (Query *)n;
+		Query *q = (Query *) stmt->query;
 		bool seen_identity = false;
-		bool ordinality_changed = false;
-		AttrNumber current_resno = 0;
-		Index identity_ressortgroupref = 0;
-		List *modifiedTargetList = NIL;
 
 		/*
-		 * currently we only carry over identity and nullability for
-		 * simple query with a single relation in from expression
+		 * currently we only inherit identity and nullability for
+		 * simple query i.e. a single relation in from expression
 		 */
 		bool persist_identity_and_nullability = false;
 
-		/*
-		 * In T-SQL, identity property of column in destination
-		 * table is not persisted if the SELECT ... INTO statement
-		 * does not contain a single base relation
-		 */
 		if (q->jointree && q->jointree->fromlist != NIL && list_length(q->jointree->fromlist) == 1)
 		{
 			RangeTblRef		*rtr = linitial(q->jointree->fromlist);
@@ -6787,7 +6771,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 		}
 
 		altstmt = makeNode(AlterTableStmt);
-		altstmt->relation = into->rel;
+		altstmt->relation = stmt->into->rel;
 		altstmt->objtype = OBJECT_TABLE;
 		altstmt->cmds = NIL;
 
@@ -6813,7 +6797,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 
 				if (seen_identity)
 					ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
+									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", stmt->into->rel->relname)));
 
 				if (tle->resname == NULL)
 					ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR), errmsg("Incorrect syntax near the keyword 'INTO'")));
@@ -6850,8 +6834,6 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				}
 
 				seen_identity = true;
-				ordinality_changed = true;
-				identity_ressortgroupref = tle->ressortgroupref; /** Save this Index to modify sortClause and distinctClause*/
 
 				/** Add alter table add identity node after Select Into statement */
 				constraint = makeNode(Constraint);
@@ -6872,6 +6854,8 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				lcmd->missing_ok = false;
 				lcmd->def = (Node *)def;
 				altstmt->cmds = lappend(altstmt->cmds, lcmd);
+
+				tle->resjunk = true;
 			}
 			else if (persist_identity_and_nullability && tle->expr && IsA(tle->expr, Var) && OidIsValid(tle->resorigtbl))
 			{
@@ -6900,7 +6884,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 
 						if (seen_identity)
 							ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
+									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", stmt->into->rel->relname)));
 
 						seen_identity = true;
 
@@ -6921,43 +6905,9 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 						altstmt->cmds = lappend(altstmt->cmds, lcmd);
 					}
 
-					current_resno += 1;
-					tle->resno = current_resno;
-					modifiedTargetList = lappend(modifiedTargetList, tle);
-
 					ReleaseSysCache(attrtup);
 				}
 			}
-			else
-			{
-				current_resno += 1;
-				tle->resno = current_resno;
-				modifiedTargetList = lappend(modifiedTargetList, tle);
-			}
-		}
-		q->targetList = modifiedTargetList;
-
-		if (ordinality_changed)
-		{
-			if (q->sortClause)
-			{
-				List *modifiedSortClause = NIL;
-				ListCell *olitem;
-				foreach (olitem, q->sortClause)
-				{
-					Node *sortnode = (Node *)lfirst(olitem);
-					if (IsA(sortnode, SortGroupClause))
-					{
-						SortGroupClause *sortcl = (SortGroupClause *)sortnode;
-						if (sortcl->tleSortGroupRef != identity_ressortgroupref)
-							modifiedSortClause = lappend(modifiedSortClause, sortcl);
-					}
-				}
-				q->sortClause = modifiedSortClause;
-			}
-
-			if (q->distinctClause && list_length(q->distinctClause) > (identity_ressortgroupref - 1))
-				q->distinctClause = list_delete_nth_cell(q->distinctClause, identity_ressortgroupref - 1);
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6745,21 +6745,37 @@ get_identity_into_args(Node *node)
 static List *
 transformSelectIntoStmt(CreateTableAsStmt *stmt)
 {
-	List *result = NIL;
+	List *result;
 	ListCell *elements;
-	AlterTableStmt *altstmt = NULL;
+	AlterTableStmt *altstmt;
+	IntoClause *into;
+	Node *n;
 
-	if (stmt->query && IsA(stmt->query, Query))
+	n = stmt->query;
+	into = stmt->into;
+	result = NIL;
+	altstmt = NULL;
+
+	if (n && n->type == T_Query)
 	{
-		Query *q = (Query *) stmt->query;
+		Query *q = (Query *)n;
 		bool seen_identity = false;
+		bool ordinality_changed = false;
+		AttrNumber current_resno = 0;
+		Index identity_ressortgroupref = 0;
+		List *modifiedTargetList = NIL;
 
 		/*
-		 * currently we only inherit identity and nullability for
-		 * simple query i.e. a single relation in from expression
+		 * currently we only carry over identity and nullability for
+		 * simple query with a single relation in from expression
 		 */
 		bool persist_identity_and_nullability = false;
 
+		/*
+		 * In T-SQL, identity property of column in destination
+		 * table is not persisted if the SELECT ... INTO statement
+		 * does not contain a single base relation
+		 */
 		if (q->jointree && q->jointree->fromlist != NIL && list_length(q->jointree->fromlist) == 1)
 		{
 			RangeTblRef		*rtr = linitial(q->jointree->fromlist);
@@ -6771,7 +6787,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 		}
 
 		altstmt = makeNode(AlterTableStmt);
-		altstmt->relation = stmt->into->rel;
+		altstmt->relation = into->rel;
 		altstmt->objtype = OBJECT_TABLE;
 		altstmt->cmds = NIL;
 
@@ -6797,7 +6813,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 
 				if (seen_identity)
 					ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", stmt->into->rel->relname)));
+									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
 
 				if (tle->resname == NULL)
 					ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR), errmsg("Incorrect syntax near the keyword 'INTO'")));
@@ -6834,6 +6850,8 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				}
 
 				seen_identity = true;
+				ordinality_changed = true;
+				identity_ressortgroupref = tle->ressortgroupref; /** Save this Index to modify sortClause and distinctClause*/
 
 				/** Add alter table add identity node after Select Into statement */
 				constraint = makeNode(Constraint);
@@ -6854,8 +6872,6 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 				lcmd->missing_ok = false;
 				lcmd->def = (Node *)def;
 				altstmt->cmds = lappend(altstmt->cmds, lcmd);
-
-				tle->resjunk = true;
 			}
 			else if (persist_identity_and_nullability && tle->expr && IsA(tle->expr, Var) && OidIsValid(tle->resorigtbl))
 			{
@@ -6884,7 +6900,7 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 
 						if (seen_identity)
 							ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", stmt->into->rel->relname)));
+									errmsg("Attempting to add multiple identity columns to table \"%s\" using the SELECT INTO statement.", into->rel->relname)));
 
 						seen_identity = true;
 
@@ -6905,9 +6921,43 @@ transformSelectIntoStmt(CreateTableAsStmt *stmt)
 						altstmt->cmds = lappend(altstmt->cmds, lcmd);
 					}
 
+					current_resno += 1;
+					tle->resno = current_resno;
+					modifiedTargetList = lappend(modifiedTargetList, tle);
+
 					ReleaseSysCache(attrtup);
 				}
 			}
+			else
+			{
+				current_resno += 1;
+				tle->resno = current_resno;
+				modifiedTargetList = lappend(modifiedTargetList, tle);
+			}
+		}
+		q->targetList = modifiedTargetList;
+
+		if (ordinality_changed)
+		{
+			if (q->sortClause)
+			{
+				List *modifiedSortClause = NIL;
+				ListCell *olitem;
+				foreach (olitem, q->sortClause)
+				{
+					Node *sortnode = (Node *)lfirst(olitem);
+					if (IsA(sortnode, SortGroupClause))
+					{
+						SortGroupClause *sortcl = (SortGroupClause *)sortnode;
+						if (sortcl->tleSortGroupRef != identity_ressortgroupref)
+							modifiedSortClause = lappend(modifiedSortClause, sortcl);
+					}
+				}
+				q->sortClause = modifiedSortClause;
+			}
+
+			if (q->distinctClause && list_length(q->distinctClause) > (identity_ressortgroupref - 1))
+				q->distinctClause = list_delete_nth_cell(q->distinctClause, identity_ressortgroupref - 1);
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2332,6 +2332,7 @@ extern void pltsql_resetcache_identity(void);
 extern int64 pltsql_setval_identity(Oid seqid, int64 val, int64 last_val);
 extern int64 last_scope_identity_value(void);
 extern Oid	get_table_identity(Oid tableOid);
+extern void reseed_identity_post_select_into(Oid relid);
 
 /*
  * Functions in linked_servers.c

--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -16,6 +16,7 @@
 #include "access/tupdesc.h"
 #include "catalog/dependency.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_sequence.h"
 #include "commands/defrem.h"
 #include "commands/sequence.h"
 #include "parser/parser.h"
@@ -23,6 +24,7 @@
 #include "utils/builtins.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
+#include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
 #include "multidb.h"
@@ -469,4 +471,101 @@ pltsql_revert_last_scope_identity(int nest_level)
 	old_top = last_used_scope_seq_identity;
 	last_used_scope_seq_identity = old_top->prev;
 	pfree(old_top);
+}
+
+void
+reseed_identity_post_select_into(Oid relid)
+{
+	Oid            relowner;
+	Oid            save_userid;
+	int            save_sec_context;
+	int            saved_sql_dialect;
+	bool           is_identity_increasing;
+	const char     *schema_name;
+	const char     *table_name;
+	const char     *seq_name;
+	const char     *identity_colname = NULL;
+	Relation       rel;
+	TupleDesc      tupdesc;
+	HeapTuple      pgstuple;
+	StringInfoData querybuf;
+
+	rel = RelationIdGetRelation(relid);
+
+	relowner = rel->rd_rel->relowner;
+	schema_name = quote_identifier(get_namespace_name_or_temp(RelationGetNamespace(rel)));
+	table_name = quote_identifier(RelationGetRelationName(rel));
+
+	tupdesc = RelationGetDescr(rel);
+
+	for (AttrNumber attnum = 0; attnum < tupdesc->natts; attnum++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum);
+
+		if (attr->attidentity)
+		{
+			pgstuple = SearchSysCache1(SEQRELID, get_table_identity(relid));
+			if (!HeapTupleIsValid(pgstuple))
+				elog(ERROR, "cache lookup failed for sequence %u", relid);
+
+			is_identity_increasing = ((Form_pg_sequence) GETSTRUCT(pgstuple))->seqincrement > 0;
+			seq_name = quote_identifier(get_rel_name(((Form_pg_sequence) GETSTRUCT(pgstuple))->seqrelid));
+
+			ReleaseSysCache(pgstuple);
+			identity_colname = quote_identifier(NameStr(attr->attname));
+			break;
+		}
+	}
+
+	if (!identity_colname || !schema_name || !table_name || !OidIsValid(relowner))
+	{
+		RelationClose(rel);
+		return;
+	}
+
+	initStringInfo(&querybuf);
+
+	appendStringInfo(&querybuf,
+					 "SELECT pg_catalog.setval('%s.%s', (SELECT pg_catalog.%s(%s) FROM %s.%s))",
+					 schema_name,
+					 seq_name,
+					 is_identity_increasing ? "max" : "min",
+					 identity_colname,
+					 schema_name,
+					 table_name);
+
+	RelationClose(rel);
+
+	saved_sql_dialect = sql_dialect;
+	GetUserIdAndSecContext(&save_userid, &save_sec_context);
+
+	PG_TRY();
+	{
+		int 	rc;
+
+		sql_dialect = SQL_DIALECT_PG;
+
+		if ((rc = SPI_connect()) < 0)
+			elog(ERROR, "SPI_connect() failed in SELECT INTO "
+					"with return code %d", rc);
+
+		/* The new table could already be transferred to schema owner and current user may not have privs for it */
+		SetUserIdAndSecContext(relowner, save_sec_context | SECURITY_RESTRICTED_OPERATION);
+
+		rc = SPI_execute(querybuf.data, false, 0);
+		if (rc != SPI_OK_SELECT)
+			elog(ERROR, "SPI_connect() failed in SELECT INTO "
+						"with return code %d", rc);
+
+		if (SPI_finish() != SPI_OK_FINISH)
+			elog(ERROR, "SPI_finish failed");
+	}
+	PG_FINALLY();
+	{
+		SetUserIdAndSecContext(save_userid, save_sec_context);
+		sql_dialect = saved_sql_dialect;
+	}
+	PG_END_TRY();
+
+	pfree(querybuf.data);
 }

--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -522,8 +522,10 @@ reseed_identity_post_select_into(Oid relid)
 
 	RelationClose(rel);
 
-	if (!identity_colname || !OidIsValid(relowner))
+	if (!identity_colname)
 		return;
+	if (!OidIsValid(relowner))
+		elog(ERROR, "Invalid owner for relation with oid %u", relid);
 
 	initStringInfo(&querybuf);
 

--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -480,7 +480,7 @@ reseed_identity_post_select_into(Oid relid)
 	Oid            save_userid;
 	int            save_sec_context;
 	int            saved_sql_dialect;
-	bool           is_identity_increasing;
+	bool           is_identity_increasing = false;
 	const char     *schema_name;
 	const char     *table_name;
 	const char     *seq_name;

--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -487,7 +487,6 @@ reseed_identity_post_select_into(Oid relid)
 	const char     *identity_colname = NULL;
 	Relation       rel;
 	TupleDesc      tupdesc;
-	HeapTuple      pgstuple;
 	StringInfoData querybuf;
 
 	rel = RelationIdGetRelation(relid);
@@ -498,30 +497,33 @@ reseed_identity_post_select_into(Oid relid)
 
 	tupdesc = RelationGetDescr(rel);
 
-	for (AttrNumber attnum = 0; attnum < tupdesc->natts; attnum++)
+	for (AttrNumber attnum = 1; attnum <= RelationGetNumberOfAttributes(rel); attnum++)
 	{
-		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum);
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, attnum - 1);
+		Oid               seq_relid;
+		HeapTuple         pgstuple;
 
-		if (attr->attidentity)
-		{
-			pgstuple = SearchSysCache1(SEQRELID, get_table_identity(relid));
-			if (!HeapTupleIsValid(pgstuple))
-				elog(ERROR, "cache lookup failed for sequence %u", relid);
+		if (!attr->attidentity)
+			continue;
 
-			is_identity_increasing = ((Form_pg_sequence) GETSTRUCT(pgstuple))->seqincrement > 0;
-			seq_name = quote_identifier(get_rel_name(((Form_pg_sequence) GETSTRUCT(pgstuple))->seqrelid));
+		seq_relid = getIdentitySequence(rel, attnum, false);
 
-			ReleaseSysCache(pgstuple);
-			identity_colname = quote_identifier(NameStr(attr->attname));
-			break;
-		}
+		pgstuple = SearchSysCache1(SEQRELID, ObjectIdGetDatum(seq_relid));
+		if (!HeapTupleIsValid(pgstuple))
+			elog(ERROR, "cache lookup failed for sequence %u", relid);
+
+		is_identity_increasing = ((Form_pg_sequence) GETSTRUCT(pgstuple))->seqincrement > 0;
+		seq_name = quote_identifier(get_rel_name(seq_relid));
+		identity_colname = quote_identifier(NameStr(attr->attname));
+
+		ReleaseSysCache(pgstuple);
+		break;
 	}
 
-	if (!identity_colname || !schema_name || !table_name || !OidIsValid(relowner))
-	{
-		RelationClose(rel);
+	RelationClose(rel);
+
+	if (!identity_colname || !OidIsValid(relowner))
 		return;
-	}
 
 	initStringInfo(&querybuf);
 
@@ -533,8 +535,6 @@ reseed_identity_post_select_into(Oid relid)
 					 identity_colname,
 					 schema_name,
 					 table_name);
-
-	RelationClose(rel);
 
 	saved_sql_dialect = sql_dialect;
 	GetUserIdAndSecContext(&save_userid, &save_sec_context);

--- a/contrib/babelfishpg_tsql/src/pltsql_identity.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_identity.c
@@ -481,9 +481,9 @@ reseed_identity_post_select_into(Oid relid)
 	int            save_sec_context;
 	int            saved_sql_dialect;
 	bool           is_identity_increasing = false;
-	const char     *schema_name;
-	const char     *table_name;
-	const char     *seq_name;
+	const char     *schema_name = NULL;
+	const char     *table_name = NULL;
+	const char     *seq_name = NULL;
 	const char     *identity_colname = NULL;
 	Relation       rel;
 	TupleDesc      tupdesc;

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -1,3 +1,4 @@
+-- tsql
 create database db_select_into
 go
 
@@ -741,7 +742,7 @@ GO
 
 ~~ERROR (Message: null value in column "id1" of relation "#t1" violates not-null constraint)~~
 
-SELECT * FROM #t1
+SELECT * FROM #t1 ORDER BY id
 GO
 ~~START~~
 int#!#int
@@ -771,9 +772,89 @@ GO
 ~~ROW COUNT: 1~~
 
 
-
-DROP VIEW babel_5661_source_view
+-- db_ddladmin should be able to run SELECT INTO
+CREATE LOGIN babel_5661_login WITH PASSWORD = '12345678'
+GO
+CREATE USER babel_5661_user FOR LOGIN babel_5661_login
+GO
+ALTER ROLE db_ddladmin ADD MEMBER babel_5661_user
 GO
 
-DROP TABLE babel_5661_source
+GRANT SELECT ON babel_5661_source TO babel_5661_user
+GO
+
+-- tsql user=babel_5661_login password=12345678
+SELECT * INTO #t1 FROM babel_5661_source
+GO
+INSERT INTO #t1 VALUES (-100)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #t1 ORDER BY id
+GO
+~~START~~
+int#!#int
+-100#!#-100
+-99#!#-99
+-11#!#-11
+-10#!#-10
+-6#!#-6
+-5#!#-5
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+99#!#99
+~~END~~
+
+
+-- terminate-tsql-conn user=babel_5661_login password=12345678
+
+-- tsql
+-- Left Join should not carry over nullability
+CREATE TABLE babel_5661_SourceTable (
+    ID INT PRIMARY KEY,
+    Name VARCHAR(50),
+    Value INT
+);
+GO
+
+CREATE TABLE babel_5661_ConfigTable (
+    ConfigID INT PRIMARY KEY,
+    IsActive BIT NOT NULL
+);
+GO
+
+INSERT INTO babel_5661_SourceTable (ID, Name, Value)
+VALUES 
+    (1, 'Item 1', 100),
+    (2, 'Item 2', 200);
+GO
+~~ROW COUNT: 2~~
+
+
+INSERT INTO babel_5661_ConfigTable (ConfigID, IsActive)
+VALUES 
+    (1, 1);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT 
+    s.ID,
+    s.Name,
+    c.IsActive  -- This will be NULL for row 2
+INTO babel_5661_NewTable
+FROM babel_5661_SourceTable s
+LEFT JOIN babel_5661_ConfigTable c ON s.ID = c.ConfigID;
+GO
+
+
+DROP VIEW IF EXISTS babel_5661_source_view
+GO
+DROP TABLE IF EXISTS babel_5661_source, babel_5661_SourceTable, babel_5661_ConfigTable, babel_5661_NewTable
+GO
+DROP LOGIN babel_5661_login
+GO
+DROP USER babel_5661_user
 GO

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -551,7 +551,7 @@ GO
 
 SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id < 99
 GO
--- Identity should start from 7 even though source tables identity next value is 100
+-- Identity should start from 12 even though source tables identity next value is 100
 INSERT INTO #babel_5661_new4 VALUES (12)
 GO
 ~~ROW COUNT: 1~~
@@ -703,7 +703,7 @@ GO
 
 SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id > -99
 GO
--- Identity should start from 7 even though source tables identity next value is 100
+-- Identity should start from 12 even though source tables identity next value is 100
 INSERT INTO #babel_5661_new4 VALUES (-12)
 GO
 ~~ROW COUNT: 1~~

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -119,7 +119,7 @@ go
 int#!#nvarchar
 1#!#First
 1#!#First_dup
-2#!#Second
+3#!#Second
 ~~END~~
 
 
@@ -142,7 +142,7 @@ go
 ~~START~~
 smallint#!#numeric
 2#!#2.222
-4#!#3.333
+6#!#3.333
 ~~END~~
 
 
@@ -165,7 +165,7 @@ go
 ~~START~~
 smallint#!#nvarchar
 3#!#Third
-6#!#Fourth
+9#!#Fourth
 ~~END~~
 
 
@@ -188,7 +188,7 @@ go
 ~~START~~
 float#!#bigint
 4.4#!#4
-5.5#!#8
+5.5#!#12
 ~~END~~
 
 
@@ -211,12 +211,12 @@ go
 ~~START~~
 bigint#!#real
 5#!#5.567
-10#!#6.789
+15#!#6.789
 ~~END~~
 
 
 -- FROM clause contains joins from multiple tables
--- Should not fail as identity should not be persisted but nullability should
+-- Should not fail as identity & nullability should not be persisted
 select *
 into dest_table_join
 from dest_table_1 t1
@@ -230,24 +230,20 @@ go
 int#!#nvarchar#!#smallint#!#numeric
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 ~~END~~
 
 
--- Should fail. Violate NOT NULL constraint
+-- Should not fail. Violate NOT NULL constraint
 insert into dest_table_join ([Col2]) values (NULL)
 go
-~~ERROR (Code: 515)~~
-
-~~ERROR (Message: null value in column "col1" of relation "dest_table_join" violates not-null constraint)~~
+~~ROW COUNT: 1~~
 
 
--- Should fail. Violate NOT NULL constraint on other column
+-- Should not fail. Violate NOT NULL constraint on other column
 insert into dest_table_join ([Col2]) values ('Join')
 go
-~~ERROR (Code: 515)~~
-
-~~ERROR (Message: null value in column "col1" of relation "dest_table_join" violates not-null constraint)~~
+~~ROW COUNT: 1~~
 
 
 insert into dest_table_join ([Col1], [Col2], [Col3], [Col4]) values (99, 'Join', 88, 9.867)
@@ -259,9 +255,11 @@ select * from dest_table_join order by [Col1], [Col2]
 go
 ~~START~~
 int#!#nvarchar#!#smallint#!#numeric
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+<NULL>#!#Join#!#<NULL>#!#<NULL>
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 99#!#Join#!#88#!#9.867
 ~~END~~
 
@@ -283,9 +281,9 @@ go
 int#!#nvarchar
 1#!#First
 1#!#First_dup
-2#!#Second
+3#!#Second
 3#!#Third
-6#!#Fourth
+9#!#Fourth
 ~~END~~
 
 
@@ -306,13 +304,13 @@ select * from dest_table_union order by [Col1]
 go
 ~~START~~
 int#!#nvarchar
-<NULL>#!#<NULL>
 <NULL>#!#Union
+<NULL>#!#<NULL>
 1#!#First_dup
 1#!#First
-2#!#Second
 3#!#Third
-6#!#Fourth
+3#!#Second
+9#!#Fourth
 ~~END~~
 
 
@@ -332,24 +330,20 @@ go
 int#!#nvarchar#!#smallint#!#numeric
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
 ~~END~~
 
 
--- Should fail. Violate NOT NULL constraint
+-- Should not fail. Violate NOT NULL constraint
 insert into dest_table_sub_join ([Col1]) values (NULL)
 go
-~~ERROR (Code: 515)~~
-
-~~ERROR (Message: null value in column "col1" of relation "dest_table_sub_join" violates not-null constraint)~~
+~~ROW COUNT: 1~~
 
 
--- Should fail. Violate NOT NULL constraint on other column
+-- Should not fail. Violate NOT NULL constraint on other column
 insert into dest_table_sub_join ([Col1]) values (200)
 go
-~~ERROR (Code: 515)~~
-
-~~ERROR (Message: null value in column "col2" of relation "dest_table_sub_join" violates not-null constraint)~~
+~~ROW COUNT: 1~~
 
 
 insert into dest_table_sub_join ([Col1], [Col2], [Col3], [Col4]) values (209, 'Sub-Join', 78, 8.567)
@@ -361,9 +355,11 @@ select * from dest_table_sub_join order by [Col1], [Col2]
 go
 ~~START~~
 int#!#nvarchar#!#smallint#!#numeric
+<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 1#!#First#!#2#!#2.222
 1#!#First_dup#!#2#!#2.222
-2#!#Second#!#4#!#3.333
+3#!#Second#!#6#!#3.333
+200#!#<NULL>#!#<NULL>#!#<NULL>
 209#!#Sub-Join#!#78#!#8.567
 ~~END~~
 
@@ -418,3 +414,164 @@ go
 
 drop schema sch_select_into_master
 go
+
+
+
+
+
+--------------------------------------
+------------- BABEL-5661 -------------
+--------------------------------------
+-- New table created using SELECT INTO should reseed its identity column
+-- to max or min value of its identity column depending upon wheter the 
+-- identity is increasing or decreasing. The new tables identity sequence
+-- next value does not depend upon the source tables identity sequecne
+-- current value
+-- INCREASING IDENTITY
+-- id1 represent expected identity value
+CREATE TABLE babel_5661_source (id INT IDENTITY(1,1), id1 INT)
+GO
+INSERT INTO babel_5661_source VALUES (1), (2), (3), (4), (5), (6)
+GO
+~~ROW COUNT: 6~~
+
+
+SELECT * INTO #babel_5661_new1 FROM babel_5661_source
+GO
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+~~END~~
+
+-- identity should start from 7
+INSERT INTO #babel_5661_new1 VALUES (7)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+7#!#7
+~~END~~
+
+
+-- filter rows using where clause so that new table's identity != source tables's identity
+SELECT * INTO #babel_5661_new2 FROM babel_5661_source WHERE id1 < 4
+GO
+-- identity should start from 4
+INSERT INTO #babel_5661_new2 VALUES (4)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new2 ORDER BY id
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+~~END~~
+
+
+-- Reseed the source table's identity but that should not affect new tables identity next val
+DBCC CHECKIDENT ('dbo.babel_5661_source', RESEED, 9);
+GO
+SELECT * INTO #babel_5661_new3 FROM babel_5661_source
+GO
+-- Identity should start from 7 even though source tables identity next value is 10
+INSERT INTO #babel_5661_new3 VALUES (7)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new3 ORDER BY id
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+7#!#7
+~~END~~
+
+
+-- Source table's next identity value should be 10 since we did DBCC reseed previously
+INSERT INTO babel_5661_source VALUES (10)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM babel_5661_source ORDER BY id
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+10#!#10
+~~END~~
+
+
+-- enable SET IDENTITY INSERT on source table and do random inserts
+SET IDENTITY_INSERT dbo.babel_5661_source ON
+GO
+
+INSERT INTO babel_5661_source (id, id1) VALUES (11, 11)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_5661_source (id, id1) VALUES (99, 99)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_5661_source (id, id1) VALUES (-99, -99)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id < 99
+GO
+-- Identity should start from 7 even though source tables identity next value is 100
+INSERT INTO #babel_5661_new4 VALUES (12)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new4 ORDER BY id
+GO
+~~START~~
+int#!#int
+-99#!#-99
+1#!#1
+2#!#2
+3#!#3
+4#!#4
+5#!#5
+6#!#6
+10#!#10
+11#!#11
+12#!#12
+~~END~~
+
+
+
+DROP TABLE babel_5661_source
+GO

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -771,6 +771,47 @@ INSERT INTO #t5 VALUES (1, 1)
 GO
 ~~ROW COUNT: 1~~
 
+-- mix of identity function and duplicate identity columns should
+-- simply skip identity column and pick identity function
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'ignore';
+go
+
+SELECT id AS a, id AS b, IDENTITY(int, 1, 1) AS c INTO #t15 FROM babel_5661_source
+GO
+SELECT id AS a, IDENTITY(int, 1, 1) AS c, id AS b INTO #t16 FROM babel_5661_source
+GO
+SELECT IDENTITY(int, 1, 1) AS c, id AS b, id AS a INTO #t17 FROM babel_5661_source
+GO
+
+INSERT INTO #t15 VALUES (1, 1)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO #t16 VALUES (1, 1)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO #t17 VALUES (1, 1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Single identity column and identity function is not okay
+SELECT id AS a, IDENTITY(int, 1, 1) AS c INTO #t15 FROM babel_5661_source
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attempting to add multiple identity columns to table "#t15" using the SELECT INTO statement.)~~
+
+SELECT IDENTITY(int, 1, 1) AS c, id AS b INTO #t16 FROM babel_5661_source
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attempting to add multiple identity columns to table "#t16" using the SELECT INTO statement.)~~
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'strict';
+go
+
 
 -- db_ddladmin should be able to run SELECT INTO
 CREATE LOGIN babel_5661_login WITH PASSWORD = '12345678'

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -763,6 +763,14 @@ GO
 ~~ROW COUNT: 1~~
 
 
+-- if identity column has multiple occurence then we should not carry it to new table
+SELECT id AS a, id AS b INTO #t5 FROM babel_5661_source
+GO
+INSERT INTO #t5 VALUES (1, 1)
+GO
+~~ROW COUNT: 1~~
+
+
 
 DROP VIEW babel_5661_source_view
 GO

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -429,7 +429,7 @@ go
 -- current value
 -- INCREASING IDENTITY
 -- id1 represent expected identity value
-CREATE TABLE babel_5661_source (id INT IDENTITY(1,1), id1 INT)
+CREATE TABLE babel_5661_source (id INT IDENTITY(1,1), id1 INT NOT NULL)
 GO
 INSERT INTO babel_5661_source VALUES (1), (2), (3), (4), (5), (6)
 GO
@@ -724,6 +724,48 @@ int#!#int
 ~~END~~
 
 
+
+-- Identity and nullability should be carried over when source is temp table
+CREATE TABLE #t (id INT IDENTITY(1,1), id1 INT NOT NULL)
+GO
+SELECT * INTO #t1 FROM #t
+GO
+
+INSERT INTO #t1 values (1)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO #t1 values (NULL)
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "id1" of relation "#t1" violates not-null constraint)~~
+
+SELECT * FROM #t1
+GO
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+
+CREATE VIEW babel_5661_source_view AS SELECT * FROM babel_5661_source;
+GO
+
+-- Identity and nullability should NOT be carried over when source is view
+SELECT * INTO #t2 FROM babel_5661_source_view ORDER BY id
+GO
+
+-- this should pass because neither identity nor nullability should be carried over for view as source table
+-- in future we may change this
+INSERT INTO #t2 values (1, NULL)
+GO
+~~ROW COUNT: 1~~
+
+
+
+DROP VIEW babel_5661_source_view
+GO
 
 DROP TABLE babel_5661_source
 GO

--- a/test/JDBC/expected/select_into-identity-notnull.out
+++ b/test/JDBC/expected/select_into-identity-notnull.out
@@ -575,3 +575,155 @@ int#!#int
 
 DROP TABLE babel_5661_source
 GO
+DROP TABLE #babel_5661_new1, #babel_5661_new2, #babel_5661_new3, #babel_5661_new4
+GO
+
+
+-- DECREASING IDENTITY
+-- id1 represent expected identity value
+CREATE TABLE babel_5661_source (id INT IDENTITY(-1,-1), id1 INT)
+GO
+INSERT INTO babel_5661_source VALUES (-1), (-2), (-3), (-4), (-5), (-6)
+GO
+~~ROW COUNT: 6~~
+
+
+SELECT * INTO #babel_5661_new1 FROM babel_5661_source
+GO
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+~~START~~
+int#!#int
+-6#!#-6
+-5#!#-5
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+~~END~~
+
+-- identity should start from 7
+INSERT INTO #babel_5661_new1 VALUES (-7)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+~~START~~
+int#!#int
+-7#!#-7
+-6#!#-6
+-5#!#-5
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+~~END~~
+
+
+-- filter rows using where clause so that new table's identity != source tables's identity
+SELECT * INTO #babel_5661_new2 FROM babel_5661_source WHERE id1 > -4
+GO
+-- identity should start from 4
+INSERT INTO #babel_5661_new2 VALUES (-4)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new2 ORDER BY id
+GO
+~~START~~
+int#!#int
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+~~END~~
+
+
+-- Reseed the source table's identity but that should not affect new tables identity next val
+DBCC CHECKIDENT ('dbo.babel_5661_source', RESEED, -9);
+GO
+SELECT * INTO #babel_5661_new3 FROM babel_5661_source
+GO
+-- Identity should start from 7 even though source tables identity next value is 10
+INSERT INTO #babel_5661_new3 VALUES (-7)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new3 ORDER BY id
+GO
+~~START~~
+int#!#int
+-7#!#-7
+-6#!#-6
+-5#!#-5
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+~~END~~
+
+
+-- Source table's next identity value should be 10 since we did DBCC reseed previously
+INSERT INTO babel_5661_source VALUES (-10)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM babel_5661_source ORDER BY id
+GO
+~~START~~
+int#!#int
+-10#!#-10
+-6#!#-6
+-5#!#-5
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+~~END~~
+
+
+-- enable SET IDENTITY INSERT on source table and do random inserts
+SET IDENTITY_INSERT dbo.babel_5661_source ON
+GO
+
+INSERT INTO babel_5661_source (id, id1) VALUES (-11, -11)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_5661_source (id, id1) VALUES (99, 99)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_5661_source (id, id1) VALUES (-99, -99)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id > -99
+GO
+-- Identity should start from 7 even though source tables identity next value is 100
+INSERT INTO #babel_5661_new4 VALUES (-12)
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM #babel_5661_new4 ORDER BY id
+GO
+~~START~~
+int#!#int
+-12#!#-12
+-11#!#-11
+-10#!#-10
+-6#!#-6
+-5#!#-5
+-4#!#-4
+-3#!#-3
+-2#!#-2
+-1#!#-1
+99#!#99
+~~END~~
+
+
+
+DROP TABLE babel_5661_source
+GO

--- a/test/JDBC/input/select_into-identity-notnull.mix
+++ b/test/JDBC/input/select_into-identity-notnull.mix
@@ -437,6 +437,33 @@ SELECT id AS a, id AS b INTO #t5 FROM babel_5661_source
 GO
 INSERT INTO #t5 VALUES (1, 1)
 GO
+-- mix of identity function and duplicate identity columns should
+-- simply skip identity column and pick identity function
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'ignore';
+go
+
+SELECT id AS a, id AS b, IDENTITY(int, 1, 1) AS c INTO #t15 FROM babel_5661_source
+GO
+SELECT id AS a, IDENTITY(int, 1, 1) AS c, id AS b INTO #t16 FROM babel_5661_source
+GO
+SELECT IDENTITY(int, 1, 1) AS c, id AS b, id AS a INTO #t17 FROM babel_5661_source
+GO
+
+INSERT INTO #t15 VALUES (1, 1)
+GO
+INSERT INTO #t16 VALUES (1, 1)
+GO
+INSERT INTO #t17 VALUES (1, 1)
+GO
+
+-- Single identity column and identity function is not okay
+SELECT id AS a, IDENTITY(int, 1, 1) AS c INTO #t15 FROM babel_5661_source
+GO
+SELECT IDENTITY(int, 1, 1) AS c, id AS b INTO #t16 FROM babel_5661_source
+GO
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_identity_function', 'strict';
+go
+
 
 -- db_ddladmin should be able to run SELECT INTO
 CREATE LOGIN babel_5661_login WITH PASSWORD = '12345678'

--- a/test/JDBC/input/select_into-identity-notnull.mix
+++ b/test/JDBC/input/select_into-identity-notnull.mix
@@ -331,7 +331,7 @@ GO
 
 SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id < 99
 GO
--- Identity should start from 7 even though source tables identity next value is 100
+-- Identity should start from 12 even though source tables identity next value is 100
 INSERT INTO #babel_5661_new4 VALUES (12)
 GO
 SELECT * FROM #babel_5661_new4 ORDER BY id
@@ -400,7 +400,7 @@ GO
 
 SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id > -99
 GO
--- Identity should start from 7 even though source tables identity next value is 100
+-- Identity should start from 12 even though source tables identity next value is 100
 INSERT INTO #babel_5661_new4 VALUES (-12)
 GO
 SELECT * FROM #babel_5661_new4 ORDER BY id

--- a/test/JDBC/input/select_into-identity-notnull.mix
+++ b/test/JDBC/input/select_into-identity-notnull.mix
@@ -1,3 +1,4 @@
+-- tsql
 create database db_select_into
 go
 
@@ -416,7 +417,7 @@ INSERT INTO #t1 values (1)
 GO
 INSERT INTO #t1 values (NULL)
 GO
-SELECT * FROM #t1
+SELECT * FROM #t1 ORDER BY id
 GO
 
 CREATE VIEW babel_5661_source_view AS SELECT * FROM babel_5661_source;
@@ -437,9 +438,68 @@ GO
 INSERT INTO #t5 VALUES (1, 1)
 GO
 
-
-DROP VIEW babel_5661_source_view
+-- db_ddladmin should be able to run SELECT INTO
+CREATE LOGIN babel_5661_login WITH PASSWORD = '12345678'
+GO
+CREATE USER babel_5661_user FOR LOGIN babel_5661_login
+GO
+ALTER ROLE db_ddladmin ADD MEMBER babel_5661_user
 GO
 
-DROP TABLE babel_5661_source
+GRANT SELECT ON babel_5661_source TO babel_5661_user
+GO
+
+-- tsql user=babel_5661_login password=12345678
+SELECT * INTO #t1 FROM babel_5661_source
+GO
+INSERT INTO #t1 VALUES (-100)
+GO
+SELECT * FROM #t1 ORDER BY id
+GO
+
+-- terminate-tsql-conn user=babel_5661_login password=12345678
+
+-- tsql
+-- Left Join should not carry over nullability
+CREATE TABLE babel_5661_SourceTable (
+    ID INT PRIMARY KEY,
+    Name VARCHAR(50),
+    Value INT
+);
+GO
+
+CREATE TABLE babel_5661_ConfigTable (
+    ConfigID INT PRIMARY KEY,
+    IsActive BIT NOT NULL
+);
+GO
+
+INSERT INTO babel_5661_SourceTable (ID, Name, Value)
+VALUES 
+    (1, 'Item 1', 100),
+    (2, 'Item 2', 200);
+GO
+
+INSERT INTO babel_5661_ConfigTable (ConfigID, IsActive)
+VALUES 
+    (1, 1);
+GO
+
+SELECT 
+    s.ID,
+    s.Name,
+    c.IsActive  -- This will be NULL for row 2
+INTO babel_5661_NewTable
+FROM babel_5661_SourceTable s
+LEFT JOIN babel_5661_ConfigTable c ON s.ID = c.ConfigID;
+GO
+
+
+DROP VIEW IF EXISTS babel_5661_source_view
+GO
+DROP TABLE IF EXISTS babel_5661_source, babel_5661_SourceTable, babel_5661_ConfigTable, babel_5661_NewTable
+GO
+DROP LOGIN babel_5661_login
+GO
+DROP USER babel_5661_user
 GO

--- a/test/JDBC/input/select_into-identity-notnull.sql
+++ b/test/JDBC/input/select_into-identity-notnull.sql
@@ -339,3 +339,72 @@ GO
 
 DROP TABLE babel_5661_source
 GO
+DROP TABLE #babel_5661_new1, #babel_5661_new2, #babel_5661_new3, #babel_5661_new4
+GO
+
+-- DECREASING IDENTITY
+
+-- id1 represent expected identity value
+CREATE TABLE babel_5661_source (id INT IDENTITY(-1,-1), id1 INT)
+GO
+INSERT INTO babel_5661_source VALUES (-1), (-2), (-3), (-4), (-5), (-6)
+GO
+
+SELECT * INTO #babel_5661_new1 FROM babel_5661_source
+GO
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+-- identity should start from 7
+INSERT INTO #babel_5661_new1 VALUES (-7)
+GO
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+
+-- filter rows using where clause so that new table's identity != source tables's identity
+SELECT * INTO #babel_5661_new2 FROM babel_5661_source WHERE id1 > -4
+GO
+-- identity should start from 4
+INSERT INTO #babel_5661_new2 VALUES (-4)
+GO
+SELECT * FROM #babel_5661_new2 ORDER BY id
+GO
+
+-- Reseed the source table's identity but that should not affect new tables identity next val
+DBCC CHECKIDENT ('dbo.babel_5661_source', RESEED, -9);
+GO
+SELECT * INTO #babel_5661_new3 FROM babel_5661_source
+GO
+-- Identity should start from 7 even though source tables identity next value is 10
+INSERT INTO #babel_5661_new3 VALUES (-7)
+GO
+SELECT * FROM #babel_5661_new3 ORDER BY id
+GO
+
+-- Source table's next identity value should be 10 since we did DBCC reseed previously
+INSERT INTO babel_5661_source VALUES (-10)
+GO
+SELECT * FROM babel_5661_source ORDER BY id
+GO
+
+-- enable SET IDENTITY INSERT on source table and do random inserts
+SET IDENTITY_INSERT dbo.babel_5661_source ON
+GO
+
+INSERT INTO babel_5661_source (id, id1) VALUES (-11, -11)
+GO
+INSERT INTO babel_5661_source (id, id1) VALUES (99, 99)
+GO
+INSERT INTO babel_5661_source (id, id1) VALUES (-99, -99)
+GO
+
+SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id > -99
+GO
+-- Identity should start from 7 even though source tables identity next value is 100
+INSERT INTO #babel_5661_new4 VALUES (-12)
+GO
+SELECT * FROM #babel_5661_new4 ORDER BY id
+GO
+
+
+DROP TABLE babel_5661_source
+GO

--- a/test/JDBC/input/select_into-identity-notnull.sql
+++ b/test/JDBC/input/select_into-identity-notnull.sql
@@ -431,6 +431,12 @@ GO
 INSERT INTO #t2 values (1, NULL)
 GO
 
+-- if identity column has multiple occurence then we should not carry it to new table
+SELECT id AS a, id AS b INTO #t5 FROM babel_5661_source
+GO
+INSERT INTO #t5 VALUES (1, 1)
+GO
+
 
 DROP VIEW babel_5661_source_view
 GO

--- a/test/JDBC/input/select_into-identity-notnull.sql
+++ b/test/JDBC/input/select_into-identity-notnull.sql
@@ -276,7 +276,7 @@ go
 -- INCREASING IDENTITY
 
 -- id1 represent expected identity value
-CREATE TABLE babel_5661_source (id INT IDENTITY(1,1), id1 INT)
+CREATE TABLE babel_5661_source (id INT IDENTITY(1,1), id1 INT NOT NULL)
 GO
 INSERT INTO babel_5661_source VALUES (1), (2), (3), (4), (5), (6)
 GO
@@ -405,6 +405,35 @@ GO
 SELECT * FROM #babel_5661_new4 ORDER BY id
 GO
 
+
+-- Identity and nullability should be carried over when source is temp table
+CREATE TABLE #t (id INT IDENTITY(1,1), id1 INT NOT NULL)
+GO
+SELECT * INTO #t1 FROM #t
+GO
+
+INSERT INTO #t1 values (1)
+GO
+INSERT INTO #t1 values (NULL)
+GO
+SELECT * FROM #t1
+GO
+
+CREATE VIEW babel_5661_source_view AS SELECT * FROM babel_5661_source;
+GO
+
+-- Identity and nullability should NOT be carried over when source is view
+SELECT * INTO #t2 FROM babel_5661_source_view ORDER BY id
+GO
+
+-- this should pass because neither identity nor nullability should be carried over for view as source table
+-- in future we may change this
+INSERT INTO #t2 values (1, NULL)
+GO
+
+
+DROP VIEW babel_5661_source_view
+GO
 
 DROP TABLE babel_5661_source
 GO

--- a/test/JDBC/input/select_into-identity-notnull.sql
+++ b/test/JDBC/input/select_into-identity-notnull.sql
@@ -139,7 +139,7 @@ select * from dest_table_5 order by [Col9]
 go
 
 -- FROM clause contains joins from multiple tables
--- Should not fail as identity should not be persisted but nullability should
+-- Should not fail as identity & nullability should not be persisted
 select *
 into dest_table_join
 from dest_table_1 t1
@@ -150,11 +150,11 @@ go
 select * from dest_table_join order by [Col1], [Col2]
 go
 
--- Should fail. Violate NOT NULL constraint
+-- Should not fail. Violate NOT NULL constraint
 insert into dest_table_join ([Col2]) values (NULL)
 go
 
--- Should fail. Violate NOT NULL constraint on other column
+-- Should not fail. Violate NOT NULL constraint on other column
 insert into dest_table_join ([Col2]) values ('Join')
 go
 
@@ -203,11 +203,11 @@ go
 select * from dest_table_sub_join order by [Col1], [Col2]
 go
 
--- Should fail. Violate NOT NULL constraint
+-- Should not fail. Violate NOT NULL constraint
 insert into dest_table_sub_join ([Col1]) values (NULL)
 go
 
--- Should fail. Violate NOT NULL constraint on other column
+-- Should not fail. Violate NOT NULL constraint on other column
 insert into dest_table_sub_join ([Col1]) values (200)
 go
 
@@ -261,3 +261,81 @@ go
 
 drop schema sch_select_into_master
 go
+
+
+--------------------------------------
+------------- BABEL-5661 -------------
+--------------------------------------
+
+-- New table created using SELECT INTO should reseed its identity column
+-- to max or min value of its identity column depending upon wheter the 
+-- identity is increasing or decreasing. The new tables identity sequence
+-- next value does not depend upon the source tables identity sequecne
+-- current value
+
+-- INCREASING IDENTITY
+
+-- id1 represent expected identity value
+CREATE TABLE babel_5661_source (id INT IDENTITY(1,1), id1 INT)
+GO
+INSERT INTO babel_5661_source VALUES (1), (2), (3), (4), (5), (6)
+GO
+
+SELECT * INTO #babel_5661_new1 FROM babel_5661_source
+GO
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+-- identity should start from 7
+INSERT INTO #babel_5661_new1 VALUES (7)
+GO
+SELECT * FROM #babel_5661_new1 ORDER BY id
+GO
+
+-- filter rows using where clause so that new table's identity != source tables's identity
+SELECT * INTO #babel_5661_new2 FROM babel_5661_source WHERE id1 < 4
+GO
+-- identity should start from 4
+INSERT INTO #babel_5661_new2 VALUES (4)
+GO
+SELECT * FROM #babel_5661_new2 ORDER BY id
+GO
+
+-- Reseed the source table's identity but that should not affect new tables identity next val
+DBCC CHECKIDENT ('dbo.babel_5661_source', RESEED, 9);
+GO
+SELECT * INTO #babel_5661_new3 FROM babel_5661_source
+GO
+-- Identity should start from 7 even though source tables identity next value is 10
+INSERT INTO #babel_5661_new3 VALUES (7)
+GO
+SELECT * FROM #babel_5661_new3 ORDER BY id
+GO
+
+-- Source table's next identity value should be 10 since we did DBCC reseed previously
+INSERT INTO babel_5661_source VALUES (10)
+GO
+SELECT * FROM babel_5661_source ORDER BY id
+GO
+
+-- enable SET IDENTITY INSERT on source table and do random inserts
+SET IDENTITY_INSERT dbo.babel_5661_source ON
+GO
+
+INSERT INTO babel_5661_source (id, id1) VALUES (11, 11)
+GO
+INSERT INTO babel_5661_source (id, id1) VALUES (99, 99)
+GO
+INSERT INTO babel_5661_source (id, id1) VALUES (-99, -99)
+GO
+
+SELECT * INTO #babel_5661_new4 FROM babel_5661_source WHERE id < 99
+GO
+-- Identity should start from 7 even though source tables identity next value is 100
+INSERT INTO #babel_5661_new4 VALUES (12)
+GO
+SELECT * FROM #babel_5661_new4 ORDER BY id
+GO
+
+
+DROP TABLE babel_5661_source
+GO


### PR DESCRIPTION
### Description

This commit fixes a couple of thing.
1. Reseed identity sequence for new table created using
SELECT INTO statement. For reseeding we will run a post
Select Into internal sub command.
```
SELECT setval(seq, SELECT MAX(identity_column) FROM new_table);
```
If identity is decreasing then we will use MIN instead of MAX.

2. Only carry over nullability when the query has single
table reference in FROM clause. Table could be either
permanent or temporary.

### Issues Resolved

[BABEL-5661]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).