### PR TITLE
Alter procedure/function will unexpectly delete pg_depend records

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3706,7 +3706,7 @@ pltsql_store_func_default_positions(ObjectAddress address, List *parameters, con
  * Update 'function_args' in 'sys.babelfish_schema_permissions' 
  */
 void
-alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, List *parameters, int objtypeInt, Oid oid)
+alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, List *parameters, int objtypeInt)
 {
 	Relation	bbf_schema_rel;
 	TupleDesc	bbf_schema_dsc;

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -26,8 +26,7 @@ extern void pltsql_store_func_default_positions(ObjectAddress address,
                                                 bool with_recompile);
 extern void alter_bbf_schema_permissions_catalog(ObjectWithArgs *owa, 
                                                     List *parameters,
-                                                    int objtypeInt,
-                                                    Oid oid);
+                                                    int objtypeInt);
 extern Oid  get_tsql_trigger_oid(List *object,
                                  const char *tsql_trigger_name,
                                  bool object_from_input);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -142,7 +142,6 @@ static void call_prev_ProcessUtility(PlannedStmt *pstmt,
 						 QueryCompletion *qc);
 static void set_pgtype_byval(List *name, bool byval);
 static void pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, Oid *oid, Acl **acl, bool *isSameFunc, bool is_proc);
-static void pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -2715,6 +2714,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						else if (!isSameProc) /* i.e. different signature */
 						{
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
+							CommandCounterIncrement();
 						}
 
 						if(tbltypStmt)
@@ -2769,7 +2769,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 							/* Need CCI between commands */
 							CommandCounterIncrement();
+						}
 
+						/* if this is the same procedure, it will update the existing one */
+						address = CreateFunction(pstate, cfs);
+						if (tbltypStmt)
+						{
 							/*
 							 * Update dependency on oldoid
 							 */
@@ -2777,27 +2782,31 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							tbltyp.objectId = typenameTypeId(pstate,
 															cfs->returnType);
 							tbltyp.objectSubId = 0;
-							recordDependencyOn(&tbltyp, &originalFunc, DEPENDENCY_INTERNAL);
+							recordDependencyOn(&tbltyp, &address, DEPENDENCY_INTERNAL);
 						}
-
-						/* if this is the same procedure, it will update the existing one */
-						address = CreateFunction(pstate, cfs);
 						/* Update function/procedure related metadata in babelfish catalog */
 						pltsql_store_func_default_positions(address, cfs->parameters, queryString, origname_location, with_recompile);
 						/* Increase counter after bbf_func_ext modified in pltsql_store_func_default_positions*/
 						CommandCounterIncrement();
-						pg_proc_update_oid_acl(address, oldoid, proacl);
-						if (!isSameProc) {
-						       /*
+						/* Clean up table entries for the create function statement if applicable*/
+						if (address.objectId != oldoid)
+						{
+							/*
+							 * if this is the same procedure, it'll update the existing one,
+							 * in such case, should not delete dependent records
+							 */
+							deleteDependencyRecordsFor(DefaultAclRelationId, oldoid, false);
+							deleteDependencyRecordsFor(ProcedureRelationId, oldoid, false);
+							deleteSharedDependencyRecordsFor(ProcedureRelationId, oldoid, 0);
+						}
+						if (!isSameProc) 
+						{
+						    /*
 							* When the signatures differ we need to manually update the 'function_args' column in 
 							* the 'bbf_schema_permissions' catalog
 							*/
-							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype, oldoid);
+							alter_bbf_schema_permissions_catalog(stmt->func, cfs->parameters, stmt->objtype);
 						}
-						/* Clean up table entries for the create function statement */
-						deleteDependencyRecordsFor(DefaultAclRelationId, address.objectId, false);
-						deleteDependencyRecordsFor(ProcedureRelationId, address.objectId, false);
-						deleteSharedDependencyRecordsFor(ProcedureRelationId, address.objectId, 0);
 						CommitTransactionCommand();
 					}
 					PG_FINALLY();
@@ -4857,65 +4866,6 @@ pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, 
 	funcOid = LookupFuncWithArgs(stmt->objtype, stmt->func, true);
 
 	*isSameFunc = OidIsValid(funcOid);
-}
-
-/*
- * Update the oid and acl of a pg_proc entry given its address
- */
-static void
-pg_proc_update_oid_acl(ObjectAddress address, Oid oid, Acl *acl)
-{
-	Relation		rel;
-	HeapTuple		proctup;
-	Form_pg_proc	form_proctup;
-	char		*physical_schemaname;
-
-	Datum		values[Natts_pg_proc];
-	bool		nulls[Natts_pg_proc];
-	bool		replaces[Natts_pg_proc];
-	HeapTuple	newtup;
-
-	proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(address.objectId));
-	if (!HeapTupleIsValid(proctup))
-		return;
-
-	form_proctup = (Form_pg_proc) GETSTRUCT(proctup);
-
-	if (!is_pltsql_language_oid(form_proctup->prolang))
-	{
-		ReleaseSysCache(proctup);
-		return;
-	}
-
-	physical_schemaname = get_namespace_name(form_proctup->pronamespace);
-	if (physical_schemaname == NULL)
-	{
-		elog(ERROR,
-				"Could not find physical schemaname for %u",
-				 form_proctup->pronamespace);
-	}
-
-	rel = table_open(ProcedureRelationId, RowExclusiveLock);
-
-	memset(values, 0, sizeof(values));
-	memset(nulls, 0, sizeof(nulls));
-	memset(replaces, 0, sizeof(replaces));
-	values[Anum_pg_proc_oid - 1] = ObjectIdGetDatum(oid);
-	replaces[Anum_pg_proc_oid - 1] = true;
-	if(acl)
-		values[Anum_pg_proc_proacl - 1] = PointerGetDatum(acl);
-	else
-		nulls[Anum_pg_proc_proacl - 1] = true;
-	replaces[Anum_pg_proc_proacl - 1] = true;
-
-	newtup = heap_modify_tuple(proctup, RelationGetDescr(rel), values, nulls, replaces);
-	CatalogTupleUpdate(rel, &newtup->t_self, newtup);
-
-	/* Clean up */
-	ReleaseSysCache(proctup);
-	heap_freetuple(newtup);
-
-	table_close(rel, RowExclusiveLock);
 }
 
 /*

--- a/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-cleanup.out
@@ -1,0 +1,56 @@
+use master;
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo' order by funcname;
+go
+~~START~~
+varchar#!#varchar
+alter_func_mvu_f1#!#alter_func_db_dbo
+alter_func_mvu_f4#!#alter_func_db_dbo
+alter_func_mvu_f5#!#alter_func_db_dbo
+~~END~~
+
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo' order by funcname;
+go
+~~START~~
+varchar#!#varchar
+alter_proc_p1#!#alter_proc_db_dbo
+alter_proc_p3#!#alter_proc_db_dbo
+~~END~~
+
+
+drop database alter_proc_db
+go
+
+drop database alter_func_db
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
+go
+~~START~~
+varchar#!#varchar
+~~END~~
+
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
+go
+~~START~~
+varchar#!#varchar
+~~END~~
+
+
+-- psql currentSchema=master_dbo,public
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_func_db_dbo');
+go
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#varchar
+~~END~~
+
+
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_proc_db_dbo');
+go
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#varchar
+~~END~~
+

--- a/test/JDBC/expected/alter-mvu-test-vu-prepare.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-prepare.out
@@ -1,0 +1,61 @@
+create database alter_func_db;
+go
+
+use alter_func_db
+go
+
+
+CREATE TABLE alter_func_users ([Id] int, [firstname] varchar(50), [lastname] varchar(50), [email] varchar(50));
+CREATE TABLE alter_func_orders ([Id] int, [userid] int, [productid] int, [quantity] int, [orderdate] Date);
+INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (2, 'e', 'l', 'testemail2');
+INSERT INTO alter_func_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
+GO
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+
+create function alter_func_mvu_f1() returns int begin return 2 end
+go
+
+alter function alter_func_mvu_f1(@param1 int) returns int begin return @param1 end
+go
+
+create function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_orders)
+go
+
+create function alter_func_mvu_f5() returns @result TABLE([Id] int) as begin insert @result select 1 return end
+go
+
+alter function alter_func_mvu_f5()
+returns @result TABLE(Id int) as begin
+insert into @result values (2)
+return
+end
+go
+
+use master;
+go
+
+CREATE database alter_proc_db
+GO
+
+use alter_proc_db
+GO
+
+CREATE PROCEDURE alter_proc_p1 
+AS
+    select * from alter_proc_users
+GO
+
+alter procedure alter_proc_p1 @dateParam date as select @dateParam
+go
+
+create procedure alter_proc_p3 as select 1
+go
+
+alter procedure alter_proc_p3 as select 4
+GO

--- a/test/JDBC/expected/alter-mvu-test-vu-verify.out
+++ b/test/JDBC/expected/alter-mvu-test-vu-verify.out
@@ -1,0 +1,52 @@
+use alter_func_db
+go
+
+select alter_func_mvu_f1(10);
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select alter_func_mvu_f4();
+go
+~~START~~
+varchar
+(1,1,1,5,2023-06-25)
+(2,1,1,6,2023-06-25)
+~~END~~
+
+
+select Id from alter_func_mvu_f5();
+go
+~~START~~
+int
+2
+~~END~~
+
+
+use alter_proc_db
+go
+
+exec alter_proc_p1 @dateParam = '2020-01-01'
+go
+~~START~~
+date
+2020-01-01
+~~END~~
+
+
+exec alter_proc_p3;
+go
+~~START~~
+int
+4
+~~END~~
+
+
+use alter_func_db
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-cleanup.sql
@@ -1,0 +1,27 @@
+use master;
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo' order by funcname;
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo' order by funcname;
+go
+
+drop database alter_proc_db
+go
+
+drop database alter_func_db
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_func_mvu%' and nspname = 'alter_func_db_dbo'
+go
+
+SELECT funcname, nspname FROM sys.babelfish_function_ext WHERE funcname LIKE 'alter_proc%' and nspname = 'alter_proc_db_dbo'
+go
+
+-- psql currentSchema=master_dbo,public
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_func_db_dbo');
+go
+
+select * from pg_depend where refobjid = (select oid from pg_namespace where nspname = 'alter_proc_db_dbo');
+go

--- a/test/JDBC/input/alter/alter-mvu-test-vu-prepare.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-prepare.sql
@@ -1,0 +1,57 @@
+create database alter_func_db;
+go
+
+use alter_func_db
+go
+
+CREATE TABLE alter_func_users ([Id] int, [firstname] varchar(50), [lastname] varchar(50), [email] varchar(50));
+CREATE TABLE alter_func_orders ([Id] int, [userid] int, [productid] int, [quantity] int, [orderdate] Date);
+
+INSERT INTO alter_func_users VALUES (1, 'j', 'o', 'testemail'), (2, 'e', 'l', 'testemail2');
+INSERT INTO alter_func_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
+GO
+
+create function alter_func_mvu_f1() returns int begin return 2 end
+go
+
+alter function alter_func_mvu_f1(@param1 int) returns int begin return @param1 end
+go
+
+create function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_orders)
+go
+
+create function alter_func_mvu_f5() returns @result TABLE([Id] int) as begin insert @result select 1 return end
+go
+
+alter function alter_func_mvu_f5()
+returns @result TABLE(Id int) as begin
+insert into @result values (2)
+return
+end
+go
+
+use master;
+go
+
+CREATE database alter_proc_db
+GO
+
+use alter_proc_db
+GO
+
+CREATE PROCEDURE alter_proc_p1 
+AS
+    select * from alter_proc_users
+GO
+
+alter procedure alter_proc_p1 @dateParam date as select @dateParam
+go
+
+create procedure alter_proc_p3 as select 1
+go
+
+alter procedure alter_proc_p3 as select 4
+GO

--- a/test/JDBC/input/alter/alter-mvu-test-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-mvu-test-vu-verify.sql
@@ -1,0 +1,26 @@
+use alter_func_db
+go
+
+select alter_func_mvu_f1(10);
+go
+
+select alter_func_mvu_f4();
+go
+
+select Id from alter_func_mvu_f5();
+go
+
+use alter_proc_db
+go
+
+exec alter_proc_p1 @dateParam = '2020-01-01'
+go
+
+exec alter_proc_p3;
+go
+
+use alter_func_db
+go
+
+alter function alter_func_mvu_f4() returns TABLE as return (select * from alter_func_users)
+go

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -12,5 +12,6 @@ ignore#!#test_search_path
 ignore#!#db_owner-vu-prepare
 ignore#!#db_owner-vu-verify
 ignore#!#db_owner-vu-cleanup
-
-
+ignore#!#alter-mvu-test-vu-prepare
+ignore#!#alter-mvu-test-vu-verify
+ignore#!#alter-mvu-test-vu-cleanup

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -600,3 +600,4 @@ test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
+alter-mvu-test


### PR DESCRIPTION
Backgroud:
In our previous implementation of the ALTER PROCEDURE/FUNCTION feature, we followed these steps to update metadata:

Create a new procedure/function
Replace the new OID with the old OID in the pg_proc metadata
Clean up pg_depend/pg_shdepend records referencing the new OID
Analysis: When creating a new procedure/function (step 1):

If the parameter list remains unchanged, the Create new function/procedure api will not insert new tuple but updating the existing tuple and return the old tuple oid. In this case, the old OID and new OID are identical, making the pg_depend records cleanup unnecessary.
If the parameter list changed, it missed to do anything about the pg_depend/pg_shdepend records created by the new ID, it'll leave inconsistent tuple in the pg_depend/pg_shdepend database.
The replacing of new OID (step 2) with the old OID is not necessary, since there's no other issues need to be concerned, and it's an over-design.
Fix:
For issue 1: Skip pg_depend records cleanup when old OID equals new OID.
For issue 2: Do not replace the new OID with the old OID, and just delete the pg_depend/pg_shdepend records referencing the old OID

Test:
Add extra mvu test for alter proc/function, add the mvu test into latest schedule only, since it'll not pass other mvu test.
Issue-resolved: BABEL-5601

