### PR TITLE
Update logic for LIKE operator for Case Insensitive collation

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -305,6 +305,16 @@ transform_funcexpr(Node *node)
 	return node;
 }
 
+static CollateExpr*
+create_collate_expr(Node *arg, Oid collid)
+{
+	CollateExpr *expr = makeNode(CollateExpr);
+	expr->arg = (Expr *) arg;
+	expr->collOid = collid;
+	expr->location = -1;
+	return expr;
+}
+
 /*
  * If the node is OpExpr and the colaltion is ci_as, then
  * transform the LIKE OpExpr to ILIKE OpExpr:
@@ -321,7 +331,7 @@ transform_funcexpr(Node *node)
 static Node *
 transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_info_t coll_info_of_inputcollid)
 {
-	Node	   *leftop = (Node *) linitial(op->args);
+	Node	   *leftop = copyObject(linitial(op->args));
 	Node	   *rightop = (Node *) lsecond(op->args);
 	Oid			ltypeId = exprType(leftop);
 	Oid			rtypeId = exprType(rightop);
@@ -332,12 +342,12 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 	Operator	optup;
 	Pattern_Prefix_Status pstatus;
 	int			collidx_of_cs_as;
+	CollateExpr *prefix_collate;
 
 	tsql_get_database_or_server_collation_oid_internal(true);
 
 	if (!OidIsValid(database_or_server_collation_oid))
 		return node;
-
 
 	/*
 	 * Find the CS_AS collation corresponding to the CI_AS collation
@@ -388,6 +398,9 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 	if (IsA(leftop, Const) || !IsA(rightop, Const) ||
 		((Const *) rightop)->constisnull)
 	{
+		/* update the collation of left and right node*/
+		linitial(op->args) = (Node *) create_collate_expr(linitial(op->args), op->inputcollid);
+		lsecond(op->args) = (IsA(rightop, Const) && ((Const *) rightop)->constisnull) ? lsecond(op->args) : (Node *) create_collate_expr(lsecond(op->args), op->inputcollid);
 		return node;
 	}
 
@@ -400,8 +413,27 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 	/* If there is no constant prefix then there's nothing more to do */
 	if (pstatus == Pattern_Prefix_None)
 	{
+		/* update the collation of left and right node*/
+		linitial(op->args) = (Node *) create_collate_expr(linitial(op->args), op->inputcollid);
+		lsecond(op->args) = (Node *) create_collate_expr(lsecond(op->args), op->inputcollid);
 		return node;
 	}
+
+	/* 
+	 * We need to do this because the dump considers rightop as Const with COLLATE being added
+	 * whereas during restore, that is considered as CollateExpr while building new expression tree
+	 * which is adding extra parenthesis on rightop when we invoke pg_get_constraintdef() from PG
+	 * We update the righop to equivalent CollateExpr to pick correct collation
+	 * We are clearing collation or else we observe multiple redundant COLLATE
+	 * clause in pg_get_constraintdef(), which will result in error during upgrade/restore
+	 * We also set InvalidOid for highest_sort_key during creation for the same reason,
+	 * later we enclose it withing CollateExpr
+	 */
+	prefix->constcollid = ((Const *) rightop)->constcollid = InvalidOid;
+	
+	prefix_collate = create_collate_expr((Node* ) prefix, coll_info_of_inputcollid.oid);
+
+	Assert(ltypeId == rtypeId);
 
 	/*
 	 * If we found an exact-match pattern, generate an "=" indexqual.
@@ -409,14 +441,17 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 	if (pstatus == Pattern_Prefix_Exact)
 	{
 		op_str = like_entry.is_not_match ? "<>" : "=";
-		optup = compatible_oper(NULL, list_make1(makeString(op_str)), ltypeId, ltypeId,
+		optup = compatible_oper(NULL, list_make1(makeString(op_str)), ltypeId, rtypeId,
 								true, -1);
 		if (optup == (Operator) NULL)
 			return node;
 
 		ret = (Node *) (make_op_with_func(oprid(optup), BOOLOID, false,
-											(Expr *) leftop, (Expr *) prefix,
-											InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup)));
+									(Expr *) leftop,
+									(Expr *) prefix_collate,
+									InvalidOid,
+									coll_info_of_inputcollid.oid,
+									oprfuncid(optup)));
 
 		ReleaseSysCache(optup);
 	}
@@ -428,33 +463,45 @@ transform_from_ci_as_for_likenode(Node *node, OpExpr *op, like_ilike_info_t like
 		Node	   *constant_suffix;
 		Const	   *highest_sort_key;
 
+		/* Always create a CollateExpr on top to match with op->inputcollid */
+		linitial(op->args) = (Node*) create_collate_expr(linitial(op->args), op->inputcollid);
+		lsecond(op->args) = (Node *) create_collate_expr(lsecond(op->args), op->inputcollid);
+
 		/* construct leftop >= pattern */
-		optup = compatible_oper(NULL, list_make1(makeString(">=")), ltypeId, ltypeId,
+		optup = compatible_oper(NULL, list_make1(makeString(">=")), ltypeId, rtypeId,
 								true, -1);
 		if (optup == (Operator) NULL)
 			return node;
+
+		/* Use the original node to create the operator */
 		greater_equal = make_op_with_func(oprid(optup), BOOLOID, false,
-											(Expr *) leftop, (Expr *) prefix,
-											InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
+											(Expr *) leftop, 
+											(Expr *) prefix_collate,
+											InvalidOid,
+											coll_info_of_inputcollid.oid,
+											oprfuncid(optup));
 		ReleaseSysCache(optup);
 		/* construct pattern||E'\uFFFF' */
-		highest_sort_key = makeConst(TEXTOID, -1, coll_info_of_inputcollid.oid, -1,
+		highest_sort_key = makeConst(TEXTOID, -1, InvalidOid, -1,
 										PointerGetDatum(cstring_to_text(SORT_KEY_STR)), false, false);
 
 		optup = compatible_oper(NULL, list_make1(makeString("||")), rtypeId, rtypeId,
 								true, -1);
 		if (optup == (Operator) NULL)
 			return node;
+
 		concat_expr = make_op_with_func(oprid(optup), rtypeId, false,
-										(Expr *) prefix, (Expr *) highest_sort_key,
-										InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));
+										(Expr *) prefix_collate,
+										(Expr *) create_collate_expr((Node* ) highest_sort_key, coll_info_of_inputcollid.oid),
+										coll_info_of_inputcollid.oid, coll_info_of_inputcollid.oid, oprfuncid(optup));
 		ReleaseSysCache(optup);
 		/* construct leftop < pattern */
-		optup = compatible_oper(NULL, list_make1(makeString("<")), ltypeId, ltypeId,
+		optup = compatible_oper(NULL, list_make1(makeString("<")), ltypeId, rtypeId,
 								true, -1);
 		if (optup == (Operator) NULL)
 			return node;
 
+		/* Use the original node to create the operator */
 		less_equal = make_op_with_func(oprid(optup), BOOLOID, false,
 										(Expr *) leftop, (Expr *) concat_expr,
 										InvalidOid, coll_info_of_inputcollid.oid, oprfuncid(optup));

--- a/test/JDBC/expected/babel_collection.out
+++ b/test/JDBC/expected/babel_collection.out
@@ -184,13 +184,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
 Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=3 width=32)
-  Filter: ((c1)::text = 'jones'::text COLLATE "default")
+  Filter: ((c1)::text = 'jones'::text)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 7.700 ms
+Babelfish T-SQL Batch Parsing Time: 7.280 ms
 ~~END~~
 
 
@@ -200,13 +200,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'Jon%'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'Jon%'::text COLLATE "default") AND ((c1)::text >= 'Jon'::text COLLATE "default") AND ((c1)::text < 'Jon?'::text))
+  Filter: (((c1)::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'Jon'::text) AND ((c1)::text < 'Jon?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.145 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 
@@ -216,7 +216,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jone_'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jone_'::text COLLATE "default") AND ((c1)::text >= 'jone'::text COLLATE "default") AND ((c1)::text < 'jone?'::text))
+  Filter: (((c1)::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'jone'::text) AND ((c1)::text < 'jone?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -232,7 +232,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '_one_'
 Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
-  Filter: ((c1)::text ~~* '_one_'::text COLLATE "default")
+  Filter: ((c1)::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -248,13 +248,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '%on%s'
 Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
-  Filter: ((c1)::text ~~* '%on%s'::text COLLATE "default")
+  Filter: ((c1)::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 
@@ -265,13 +265,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'ab%'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'ab%'::text COLLATE "default") AND ((c1)::text >= 'ab'::text COLLATE "default") AND ((c1)::text < 'ab?'::text))
+  Filter: (((c1)::text ~~* 'ab%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'ab'::text) AND ((c1)::text < 'ab?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.146 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -280,13 +280,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'äb%'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'äb%'::text COLLATE "default") AND ((c1)::text >= 'äb'::text COLLATE "default") AND ((c1)::text < 'äb?'::text))
+  Filter: (((c1)::text ~~* 'äb%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'äb'::text) AND ((c1)::text < 'äb?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -295,13 +295,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'ä??_'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'ä??_'::text COLLATE "default") AND ((c1)::text >= 'ä??'::text COLLATE "default") AND ((c1)::text < 'ä???'::text))
+  Filter: (((c1)::text ~~* 'ä??_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'ä??'::text) AND ((c1)::text < 'ä???'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 
@@ -312,13 +312,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
 Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
-  Filter: ((c1)::text <> 'jones'::text COLLATE "default")
+  Filter: ((c1)::text <> 'jones'::text)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 1.323 ms
+Babelfish T-SQL Batch Parsing Time: 0.963 ms
 ~~END~~
 
 
@@ -328,13 +328,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jone%'
 Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
-  Filter: (((c1)::text !~~* 'jone%'::text COLLATE "default") OR ((c1)::text < 'jone'::text COLLATE "default") OR ((c1)::text >= 'jone?'::text))
+  Filter: (((c1)::text !~~* 'jone%'::text COLLATE bbf_unicode_cp1_cs_as) OR ((c1)::text < 'jone'::text) OR ((c1)::text >= 'jone?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.196 ms
 ~~END~~
 
 
@@ -344,13 +344,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'ä%'
 Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
-  Filter: (((c1)::text !~~* 'ä%'::text COLLATE "default") OR ((c1)::text < 'ä'::text COLLATE "default") OR ((c1)::text >= 'ä?'::text))
+  Filter: (((c1)::text !~~* 'ä%'::text COLLATE bbf_unicode_cp1_cs_as) OR ((c1)::text < 'ä'::text) OR ((c1)::text >= 'ä?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.180 ms
 ~~END~~
 
 
@@ -362,13 +362,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '\%ones'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* '\%ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
+  Filter: (((c1)::text ~~* '\%ones'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= '\'::text) AND ((c1)::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 
@@ -378,13 +378,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '\_ones'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* '\_ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
+  Filter: (((c1)::text ~~* '\_ones'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= '\'::text) AND ((c1)::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.128 ms
+Babelfish T-SQL Batch Parsing Time: 0.179 ms
 ~~END~~
 
 
@@ -516,7 +516,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.113 ms
+Babelfish T-SQL Batch Parsing Time: 0.121 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -557,7 +557,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.110 ms
+Babelfish T-SQL Batch Parsing Time: 0.118 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -581,7 +581,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.111 ms
+Babelfish T-SQL Batch Parsing Time: 0.117 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -603,12 +603,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE French_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.131 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -629,12 +629,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE Chinese_PRC_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text COLLATE chinese_prc_ci_as) AND ((c1)::text < 'jo?'::text COLLATE chinese_prc_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.130 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/babel_collection.out
+++ b/test/JDBC/expected/db_collation/babel_collection.out
@@ -184,13 +184,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
 Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=3 width=32)
-  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 7.444 ms
+Babelfish T-SQL Batch Parsing Time: 6.294 ms
 ~~END~~
 
 
@@ -200,13 +200,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'Jon%'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text) AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
 ~~END~~
 
 
@@ -216,23 +216,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jone_'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text))
-  ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
-~~END~~
-
-~~START~~
-text
-Babelfish T-SQL Batch Parsing Time: 0.131 ms
-~~END~~
-
-
-select c1 from testing4 where c1 LIKE '_one_';
-GO
-~~START~~
-text
-Query Text: select c1 from testing4 where c1 LIKE '_one_'
-Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=5 width=32)
-  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE "default")
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text) AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -242,19 +226,35 @@ Babelfish T-SQL Batch Parsing Time: 0.130 ms
 ~~END~~
 
 
+select c1 from testing4 where c1 LIKE '_one_';
+GO
+~~START~~
+text
+Query Text: select c1 from testing4 where c1 LIKE '_one_'
+Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=5 width=32)
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.128 ms
+~~END~~
+
+
 select c1 from testing4 where c1 LIKE '%on%s';
 GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE '%on%s'
 Bitmap Heap Scan on testing4  (cost=11.41..31.16 rows=26 width=32)
-  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 
@@ -265,13 +265,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'ab%'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'ab%'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'ab'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'ab?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'ab%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'ab'::text) AND ((remove_accents_internal((c1)::text))::text < 'ab?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.148 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -280,13 +280,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'äb%'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'ab%'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'ab'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'ab?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'ab%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'ab'::text) AND ((remove_accents_internal((c1)::text))::text < 'ab?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -295,13 +295,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'ä??_'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'abC_'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'abC'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'abC?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'abC_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'abC'::text) AND ((remove_accents_internal((c1)::text))::text < 'abC?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
 ~~END~~
 
 
@@ -312,13 +312,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
 Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
-  Filter: ((remove_accents_internal((c1)::text))::text <> 'jones'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text <> 'jones'::text)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 1.254 ms
+Babelfish T-SQL Batch Parsing Time: 0.957 ms
 ~~END~~
 
 
@@ -328,13 +328,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jone%'
 Bitmap Heap Scan on testing4  (cost=11.56..37.81 rows=648 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text !~~* 'jone%'::text COLLATE "default") OR ((remove_accents_internal((c1)::text))::text < 'jone'::text COLLATE "default") OR ((remove_accents_internal((c1)::text))::text >= 'jone?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text !~~* 'jone%'::text COLLATE bbf_unicode_cp1_cs_as) OR ((remove_accents_internal((c1)::text))::text < 'jone'::text) OR ((remove_accents_internal((c1)::text))::text >= 'jone?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.207 ms
+Babelfish T-SQL Batch Parsing Time: 0.131 ms
 ~~END~~
 
 
@@ -344,13 +344,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'ä%'
 Bitmap Heap Scan on testing4  (cost=11.49..37.74 rows=361 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text !~~* 'a%'::text COLLATE "default") OR ((remove_accents_internal((c1)::text))::text < 'a'::text COLLATE "default") OR ((remove_accents_internal((c1)::text))::text >= 'a?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text !~~* 'a%'::text COLLATE bbf_unicode_cp1_cs_as) OR ((remove_accents_internal((c1)::text))::text < 'a'::text) OR ((remove_accents_internal((c1)::text))::text >= 'a?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
 ~~END~~
 
 
@@ -362,13 +362,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '\%ones'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* '\%ones'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= '\'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < '\?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* '\%ones'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= '\'::text) AND ((remove_accents_internal((c1)::text))::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.149 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 
@@ -378,13 +378,13 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '\_ones'
 Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* '\_ones'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= '\'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < '\?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* '\_ones'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= '\'::text) AND ((remove_accents_internal((c1)::text))::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.131 ms
+Babelfish T-SQL Batch Parsing Time: 0.160 ms
 ~~END~~
 
 
@@ -515,7 +515,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.114 ms
+Babelfish T-SQL Batch Parsing Time: 0.119 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -556,7 +556,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.112 ms
+Babelfish T-SQL Batch Parsing Time: 0.117 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -580,7 +580,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.112 ms
+Babelfish T-SQL Batch Parsing Time: 0.118 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -602,12 +602,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE French_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.130 ms
+Babelfish T-SQL Batch Parsing Time: 0.135 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -628,12 +628,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE Chinese_PRC_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text COLLATE chinese_prc_ci_as) AND ((c1)::text < 'jo?'::text COLLATE chinese_prc_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.129 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/db_collation/test_constraint_like-vu-prepare.out
@@ -1,0 +1,520 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t4_1_col1)::text))::text = ('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col2)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai) THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((sys.remove_accents_internal((status)::text))::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (('abc'::text >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ('abc'::text < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+

--- a/test/JDBC/expected/db_collation/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_constraint_like-vu-verify.out
@@ -1,0 +1,804 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+~~START~~
+varchar
+15% off
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t4_1_col1)::text))::text = ('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col2)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai) THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((sys.remove_accents_internal((status)::text))::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (('abc'::text >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ('abc'::text < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+

--- a/test/JDBC/expected/db_collation/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_like_for_AI-vu-verify.out
@@ -5469,16 +5469,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE bbf_unicode_cp1_ci_ai)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.459 ms
+Babelfish T-SQL Batch Parsing Time: 0.413 ms
 ~~END~~
 
 
@@ -5487,16 +5484,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'Jon%'
-Gather  (cost=0.13..12.28 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
-        Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE bbf_unicode_cp1_ci_ai) AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text COLLATE bbf_unicode_cp1_ci_ai))
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text) AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.175 ms
+Babelfish T-SQL Batch Parsing Time: 0.154 ms
 ~~END~~
 
 
@@ -5505,16 +5499,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jone_'
-Gather  (cost=0.13..12.28 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
-        Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE bbf_unicode_cp1_ci_ai) AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text COLLATE bbf_unicode_cp1_ci_ai))
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text) AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.164 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -5523,16 +5514,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '_one_'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.164 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -5541,16 +5529,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '%on%s'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.163 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -5560,16 +5545,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c2)::text))::text ~~ 'jones'::text)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ 'jones'::text)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.192 ms
+Babelfish T-SQL Batch Parsing Time: 0.170 ms
 ~~END~~
 
 
@@ -5578,16 +5560,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'Jon%'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c2)::text))::text ~~ 'Jon%'::text)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ 'Jon%'::text)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -5596,16 +5575,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jone_'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c2)::text))::text ~~ 'jone_'::text)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ 'jone_'::text)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 
@@ -5614,16 +5590,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE '_one_'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c2)::text))::text ~~ '_one_'::text)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ '_one_'::text)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.163 ms
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
 ~~END~~
 
 
@@ -5632,16 +5605,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE '%on%s'
-Gather  (cost=0.13..12.23 rows=1 width=6)
-  Workers Planned: 1
-  Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: ((remove_accents_internal((c2)::text))::text ~~ '%on%s'::text)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
+  Filter: ((remove_accents_internal((c2)::text))::text ~~ '%on%s'::text)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.163 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
@@ -184,7 +184,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
 Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=3 width=32)
-  Filter: ((c1)::text = 'jones'::text COLLATE "default")
+  Filter: ((c1)::text = 'jones'::text)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -200,7 +200,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'Jon%'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'Jon%'::text COLLATE "default") AND ((c1)::text >= 'Jon'::text COLLATE "default") AND ((c1)::text < 'Jon?'::text))
+  Filter: (((c1)::text ~~* 'Jon%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'Jon'::text) AND ((c1)::text < 'Jon?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -216,7 +216,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jone_'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jone_'::text COLLATE "default") AND ((c1)::text >= 'jone'::text COLLATE "default") AND ((c1)::text < 'jone?'::text))
+  Filter: (((c1)::text ~~* 'jone_'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jone'::text) AND ((c1)::text < 'jone?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -232,7 +232,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '_one_'
 Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
-  Filter: ((c1)::text ~~* '_one_'::text COLLATE "default")
+  Filter: ((c1)::text ~~* '_one_'::text COLLATE chinese_prc_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -248,7 +248,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '%on%s'
 Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
-  Filter: ((c1)::text ~~* '%on%s'::text COLLATE "default")
+  Filter: ((c1)::text ~~* '%on%s'::text COLLATE chinese_prc_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -265,7 +265,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE 'ab%'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'ab%'::text COLLATE "default") AND ((c1)::text >= 'ab'::text COLLATE "default") AND ((c1)::text < 'ab?'::text))
+  Filter: (((c1)::text ~~* 'ab%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'ab'::text) AND ((c1)::text < 'ab?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -280,7 +280,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '?b%'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* '?b%'::text COLLATE "default") AND ((c1)::text >= '?b'::text COLLATE "default") AND ((c1)::text < '?b?'::text))
+  Filter: (((c1)::text ~~* '?b%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= '?b'::text) AND ((c1)::text < '?b?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -295,7 +295,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '???_'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* '???_'::text COLLATE "default") AND ((c1)::text >= '???'::text COLLATE "default") AND ((c1)::text < '????'::text))
+  Filter: (((c1)::text ~~* '???_'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= '???'::text) AND ((c1)::text < '????'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -312,7 +312,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
 Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
-  Filter: ((c1)::text <> 'jones'::text COLLATE "default")
+  Filter: ((c1)::text <> 'jones'::text)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -328,7 +328,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jone%'
 Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
-  Filter: (((c1)::text !~~* 'jone%'::text COLLATE "default") OR ((c1)::text < 'jone'::text COLLATE "default") OR ((c1)::text >= 'jone?'::text))
+  Filter: (((c1)::text !~~* 'jone%'::text COLLATE chinese_prc_cs_as) OR ((c1)::text < 'jone'::text) OR ((c1)::text >= 'jone?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -344,7 +344,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE '?%'
 Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
-  Filter: (((c1)::text !~~* '?%'::text COLLATE "default") OR ((c1)::text < '?'::text COLLATE "default") OR ((c1)::text >= '??'::text))
+  Filter: (((c1)::text !~~* '?%'::text COLLATE chinese_prc_cs_as) OR ((c1)::text < '?'::text) OR ((c1)::text >= '??'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -362,7 +362,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '\%ones'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* '\%ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
+  Filter: (((c1)::text ~~* '\%ones'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= '\'::text) AND ((c1)::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -378,7 +378,7 @@ GO
 text
 Query Text: select c1 from testing4 where c1 LIKE '\_ones'
 Bitmap Heap Scan on testing4  (cost=11.40..32.78 rows=1 width=32)
-  Filter: (((c1)::text ~~* '\_ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
+  Filter: (((c1)::text ~~* '\_ones'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= '\'::text) AND ((c1)::text < '\?'::text))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -601,7 +601,7 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE French_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
@@ -627,7 +627,7 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE Chinese_PRC_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text) AND ((c1)::text < 'jo?'::text))
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-before-17-5-or-16-9-vu-prepare.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-before-17-5-or-16-9-vu-prepare.out
@@ -1,0 +1,520 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* 'A%'::text) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= 'A'::text) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < ('A'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = 'ABC'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text ~~* 'a%'::text) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= 'a'::text) AND ((babel_5608_vu_prepare_t4_2_col1)::text < ('a'::text || '￿'::text COLLATE sys.chinese_prc_ci_as)))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text ~~* (sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t6_col1)::text ~~* (babel_5608_vu_prepare_t6_col2)::text))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text ~~* 'a%'::text) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= 'a'::text) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < ('a'::text || '￿'::text COLLATE sys.chinese_prc_ci_as)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= 'a'::text) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* like_escape('15/% %'::text, '/'::text)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* '%abc'::text))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* 'A%'::text))
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-before-17-5-or-16-9-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-before-17-5-or-16-9-vu-verify.out
@@ -1,0 +1,804 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+~~START~~
+varchar
+15% off
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* 'A%'::text) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= 'A'::text) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < ('A'::text || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = 'ABC'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text ~~* 'a%'::text) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= 'a'::text) AND ((babel_5608_vu_prepare_t4_2_col1)::text < ('a'::text || ('￿'::text COLLATE sys.chinese_prc_ci_as))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text ~~* (sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t6_col1)::text ~~* (babel_5608_vu_prepare_t6_col2)::text))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text ~~* 'a%'::text) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= 'a'::text) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < ('a'::text || ('￿'::text COLLATE sys.chinese_prc_ci_as))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= 'a'::text) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < ('a'::text || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* like_escape('15/% %'::text, '/'::text)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* '%abc'::text))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* 'A%'::text))
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
@@ -1,0 +1,520 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = ('ABC'::text COLLATE sys.chinese_prc_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= ('a'::text COLLATE sys.chinese_prc_ci_as)) AND ((babel_5608_vu_prepare_t4_2_col1)::text < (('a'::text COLLATE sys.chinese_prc_ci_as) || ('￿'::text COLLATE sys.chinese_prc_ci_as))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.chinese_prc_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = ('abc'::text COLLATE sys.chinese_prc_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= ('a'::text COLLATE sys.chinese_prc_ci_as)) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < (('a'::text COLLATE sys.chinese_prc_ci_as) || ('￿'::text COLLATE sys.chinese_prc_ci_as))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.chinese_prc_cs_as) ~~* ('A%'::text COLLATE sys.chinese_prc_cs_as)))
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
@@ -1,0 +1,804 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+~~START~~
+varchar
+15% off
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = ('ABC'::text COLLATE sys.chinese_prc_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= ('a'::text COLLATE sys.chinese_prc_ci_as)) AND ((babel_5608_vu_prepare_t4_2_col1)::text < (('a'::text COLLATE sys.chinese_prc_ci_as) || ('￿'::text COLLATE sys.chinese_prc_ci_as))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.chinese_prc_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = ('abc'::text COLLATE sys.chinese_prc_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= ('a'::text COLLATE sys.chinese_prc_ci_as)) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < (('a'::text COLLATE sys.chinese_prc_ci_as) || ('￿'::text COLLATE sys.chinese_prc_ci_as))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.chinese_prc_cs_as) ~~* ('A%'::text COLLATE sys.chinese_prc_cs_as)))
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
@@ -5469,12 +5469,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.326 ms
+Babelfish T-SQL Batch Parsing Time: 0.246 ms
 ~~END~~
 
 
@@ -5484,12 +5484,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'Jon%'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE bbf_unicode_cp1_ci_ai) AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.125 ms
+Babelfish T-SQL Batch Parsing Time: 0.101 ms
 ~~END~~
 
 
@@ -5499,12 +5499,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jone_'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE bbf_unicode_cp1_ci_ai) AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.109 ms
+Babelfish T-SQL Batch Parsing Time: 0.091 ms
 ~~END~~
 
 
@@ -5514,12 +5514,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '_one_'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.111 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -5529,12 +5529,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '%on%s'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.103 ms
+Babelfish T-SQL Batch Parsing Time: 0.088 ms
 ~~END~~
 
 
@@ -5550,7 +5550,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.130 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5565,7 +5565,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.104 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5580,7 +5580,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.101 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5595,7 +5595,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.106 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5610,7 +5610,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.101 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/babel_collection.out
+++ b/test/JDBC/expected/parallel_query/babel_collection.out
@@ -186,7 +186,7 @@ Query Text: select c1 from testing4 where c1 LIKE 'jones'
 Gather  (cost=11.40..24.02 rows=3 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..24.02 rows=1 width=32)
-        Filter: ((c1)::text = 'jones'::text COLLATE "default")
+        Filter: ((c1)::text = 'jones'::text)
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -204,7 +204,7 @@ Query Text: select c1 from testing4 where c1 LIKE 'Jon%'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'Jon%'::text COLLATE "default") AND ((c1)::text >= 'Jon'::text COLLATE "default") AND ((c1)::text < 'Jon?'::text))
+        Filter: (((c1)::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'Jon'::text) AND ((c1)::text < 'Jon?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -222,7 +222,7 @@ Query Text: select c1 from testing4 where c1 LIKE 'jone_'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'jone_'::text COLLATE "default") AND ((c1)::text >= 'jone'::text COLLATE "default") AND ((c1)::text < 'jone?'::text))
+        Filter: (((c1)::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'jone'::text) AND ((c1)::text < 'jone?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -240,7 +240,7 @@ Query Text: select c1 from testing4 where c1 LIKE '_one_'
 Gather  (cost=11.40..24.02 rows=5 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..24.02 rows=2 width=32)
-        Filter: ((c1)::text ~~* '_one_'::text COLLATE "default")
+        Filter: ((c1)::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -258,7 +258,7 @@ Query Text: select c1 from testing4 where c1 LIKE '%on%s'
 Gather  (cost=11.41..24.03 rows=26 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.41..24.03 rows=8 width=32)
-        Filter: ((c1)::text ~~* '%on%s'::text COLLATE "default")
+        Filter: ((c1)::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -277,7 +277,7 @@ Query Text: select c1 from testing4 where c1 LIKE 'ab%'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'ab%'::text COLLATE "default") AND ((c1)::text >= 'ab'::text COLLATE "default") AND ((c1)::text < 'ab?'::text))
+        Filter: (((c1)::text ~~* 'ab%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'ab'::text) AND ((c1)::text < 'ab?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -294,7 +294,7 @@ Query Text: select c1 from testing4 where c1 LIKE 'äb%'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'äb%'::text COLLATE "default") AND ((c1)::text >= 'äb'::text COLLATE "default") AND ((c1)::text < 'äb?'::text))
+        Filter: (((c1)::text ~~* 'äb%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'äb'::text) AND ((c1)::text < 'äb?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -311,7 +311,7 @@ Query Text: select c1 from testing4 where c1 LIKE 'ä??_'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'ä??_'::text COLLATE "default") AND ((c1)::text >= 'ä??'::text COLLATE "default") AND ((c1)::text < 'ä???'::text))
+        Filter: (((c1)::text ~~* 'ä??_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= 'ä??'::text) AND ((c1)::text < 'ä???'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -330,7 +330,7 @@ Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
 Gather  (cost=11.56..24.18 rows=647 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.56..24.18 rows=209 width=32)
-        Filter: ((c1)::text <> 'jones'::text COLLATE "default")
+        Filter: ((c1)::text <> 'jones'::text)
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -348,7 +348,7 @@ Query Text: select c1 from testing4 where c1 NOT LIKE 'jone%'
 Gather  (cost=11.56..25.23 rows=648 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.56..25.23 rows=209 width=32)
-        Filter: (((c1)::text !~~* 'jone%'::text COLLATE "default") OR ((c1)::text < 'jone'::text COLLATE "default") OR ((c1)::text >= 'jone?'::text))
+        Filter: (((c1)::text !~~* 'jone%'::text COLLATE bbf_unicode_cp1_cs_as) OR ((c1)::text < 'jone'::text) OR ((c1)::text >= 'jone?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -366,7 +366,7 @@ Query Text: select c1 from testing4 where c1 NOT LIKE 'ä%'
 Gather  (cost=11.55..25.22 rows=592 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.55..25.22 rows=191 width=32)
-        Filter: (((c1)::text !~~* 'ä%'::text COLLATE "default") OR ((c1)::text < 'ä'::text COLLATE "default") OR ((c1)::text >= 'ä?'::text))
+        Filter: (((c1)::text !~~* 'ä%'::text COLLATE bbf_unicode_cp1_cs_as) OR ((c1)::text < 'ä'::text) OR ((c1)::text >= 'ä?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -386,7 +386,7 @@ Query Text: select c1 from testing4 where c1 LIKE '\%ones'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* '\%ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
+        Filter: (((c1)::text ~~* '\%ones'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= '\'::text) AND ((c1)::text < '\?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -404,7 +404,7 @@ Query Text: select c1 from testing4 where c1 LIKE '\_ones'
 Gather  (cost=11.40..25.07 rows=1 width=32)
   Workers Planned: 3
   ->  Parallel Bitmap Heap Scan on testing4  (cost=11.40..25.07 rows=1 width=32)
-        Filter: (((c1)::text ~~* '\_ones'::text COLLATE "default") AND ((c1)::text >= '\'::text COLLATE "default") AND ((c1)::text < '\?'::text))
+        Filter: (((c1)::text ~~* '\_ones'::text COLLATE bbf_unicode_cp1_cs_as) AND ((c1)::text >= '\'::text) AND ((c1)::text < '\?'::text))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
@@ -641,7 +641,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
   ->  Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+        Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
@@ -670,7 +670,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
   ->  Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'jo%'::text COLLATE "default") AND ((c1)::text >= 'jo'::text COLLATE "default") AND ((c1)::text < 'jo?'::text))
+        Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text COLLATE chinese_prc_ci_as) AND ((c1)::text < 'jo?'::text COLLATE chinese_prc_ci_as))
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/expected/test_constraint_like-before-17-5-or-16-9-vu-cleanup.out
+++ b/test/JDBC/expected/test_constraint_like-before-17-5-or-16-9-vu-cleanup.out
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/expected/test_constraint_like-before-17-5-or-16-9-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like-before-17-5-or-16-9-vu-prepare.out
@@ -1,0 +1,520 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* 'A%'::text) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= 'A'::text) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < ('A'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = 'ABC'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text ~~* 'a%'::text) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= 'a'::text) AND ((babel_5608_vu_prepare_t4_2_col1)::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text ~~* (sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t6_col1)::text ~~* (babel_5608_vu_prepare_t6_col2)::text))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text ~~* 'a%'::text) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= 'a'::text) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= 'a'::text) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* like_escape('15/% %'::text, '/'::text)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* '%abc'::text))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* 'A%'::text))
+~~END~~
+

--- a/test/JDBC/expected/test_constraint_like-before-17-5-or-16-9-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like-before-17-5-or-16-9-vu-verify.out
@@ -1,0 +1,804 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+~~START~~
+varchar
+15% off
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* 'A%'::text) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= 'A'::text) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < ('A'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = 'ABC'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text ~~* 'a%'::text) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= 'a'::text) AND ((babel_5608_vu_prepare_t4_2_col1)::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text ~~* (sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t6_col1)::text ~~* (babel_5608_vu_prepare_t6_col2)::text))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text ~~* 'a%'::text) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= 'a'::text) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_as)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= 'a'::text) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = 'abc'::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* 'a%'::text) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= 'a'::text) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < ('a'::text || '￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text ~~* (sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~* like_escape('15/% %'::text, '/'::text)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* (sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN ((status)::text ~~* 'act%'::text) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text ~~* '%abc'::text))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK (('abc'::text ~~* 'A%'::text))
+~~END~~
+

--- a/test/JDBC/expected/test_constraint_like-vu-cleanup.out
+++ b/test/JDBC/expected/test_constraint_like-vu-cleanup.out
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/expected/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like-vu-prepare.out
@@ -1,0 +1,520 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = ('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND ((babel_5608_vu_prepare_t4_2_col1)::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+

--- a/test/JDBC/expected/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like-vu-verify.out
@@ -1,0 +1,804 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+~~START~~
+varchar
+15% off
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND ((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) >= ('A'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND (('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) < (('A'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((babel_5608_vu_prepare_t4_1_col1)::text = ('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((babel_5608_vu_prepare_t4_2_col1)::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND ((babel_5608_vu_prepare_t4_2_col1)::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_as)) AND ((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_as) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_as))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text = ('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK (((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) AND (((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text >= ('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai)) AND ((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text < (('a'::text COLLATE sys.bbf_unicode_cp1_ci_ai) || ('￿'::text COLLATE sys.bbf_unicode_cp1_ci_ai))))))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -5470,12 +5470,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text = 'jones'::text COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.432 ms
+Babelfish T-SQL Batch Parsing Time: 0.391 ms
 ~~END~~
 
 
@@ -5485,12 +5485,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'Jon%'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'Jon%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'Jon'::text COLLATE bbf_unicode_cp1_ci_ai) AND ((remove_accents_internal((c1)::text))::text < 'Jon?'::text COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.200 ms
+Babelfish T-SQL Batch Parsing Time: 0.146 ms
 ~~END~~
 
 
@@ -5500,12 +5500,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jone_'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.28 rows=1 width=6)
-  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE "default") AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text))
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jone_'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((c1)::text))::text >= 'jone'::text COLLATE bbf_unicode_cp1_ci_ai) AND ((remove_accents_internal((c1)::text))::text < 'jone?'::text COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 
@@ -5515,12 +5515,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '_one_'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '_one_'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
 ~~END~~
 
 
@@ -5530,12 +5530,12 @@ GO
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE '%on%s'
 Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE "default")
+  Filter: ((remove_accents_internal((c1)::text))::text ~~* '%on%s'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 
@@ -5551,7 +5551,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.177 ms
+Babelfish T-SQL Batch Parsing Time: 0.163 ms
 ~~END~~
 
 
@@ -5566,7 +5566,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.155 ms
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
 ~~END~~
 
 
@@ -5581,7 +5581,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
 ~~END~~
 
 

--- a/test/JDBC/input/test_constraint_like-before-17-5-or-16-9-vu-cleanup.sql
+++ b/test/JDBC/input/test_constraint_like-before-17-5-or-16-9-vu-cleanup.sql
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/input/test_constraint_like-before-17-5-or-16-9-vu-prepare.mix
+++ b/test/JDBC/input/test_constraint_like-before-17-5-or-16-9-vu-prepare.mix
@@ -1,0 +1,355 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO

--- a/test/JDBC/input/test_constraint_like-before-17-5-or-16-9-vu-verify.mix
+++ b/test/JDBC/input/test_constraint_like-before-17-5-or-16-9-vu-verify.mix
@@ -1,0 +1,379 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO

--- a/test/JDBC/input/test_constraint_like-vu-cleanup.sql
+++ b/test/JDBC/input/test_constraint_like-vu-cleanup.sql
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/input/test_constraint_like-vu-prepare.mix
+++ b/test/JDBC/input/test_constraint_like-vu-prepare.mix
@@ -1,0 +1,355 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO

--- a/test/JDBC/input/test_constraint_like-vu-verify.mix
+++ b/test/JDBC/input/test_constraint_like-vu-verify.mix
@@ -1,0 +1,379 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -504,3 +504,8 @@ ignore#!#test_conv_float_to_varchar_char_before_17_4-vu-cleanup
 ignore#!#babel_index_nulls_order-before-16_8-or-17_4-vu-prepare
 ignore#!#babel_index_nulls_order-before-16_8-or-17_4-vu-verify
 ignore#!#babel_index_nulls_order-before-16_8-or-17_4-vu-cleanup
+
+# These tests are meant for upgrade scenario prior to 17_5 or 16_9 release
+ignore#!#test_constraint_like-before-17-5-or-16-9-vu-prepare
+ignore#!#test_constraint_like-before-17-5-or-16-9-vu-verify
+ignore#!#test_constraint_like-before-17-5-or-16-9-vu-cleanup

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -561,3 +561,4 @@ test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
+test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -561,4 +561,3 @@ test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
-test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -559,3 +559,4 @@ cast_nvarchar_test_before_16_5
 test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
+test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -559,4 +559,3 @@ cast_nvarchar_test_before_16_5
 test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
-test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -560,4 +560,3 @@ test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
-test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -560,3 +560,4 @@ test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
+test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -590,3 +590,4 @@ test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char_before_17_4
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
+test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -597,3 +597,4 @@ BABEL-2961
 test_conv_money_to_varchar
 fixeddecimal_modulo
 test_conv_float_to_varchar_char
+test_constraint_like-before-17-5-or-16-9

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -601,3 +601,4 @@ fixeddecimal_modulo
 test_conv_float_to_varchar_char
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
+test_constraint_like


### PR DESCRIPTION
### Description
We have supported LIKE from TSQL side for case insensitive collation by transforming LIKE to ILIKE (this is a PG operator which sorts strings case insensitively based on active locale). We have also introduced optimisation in place for the case when the rightop of the LIKE operator is a Const node and has prefix. Eg:

-- CASE 1
```
SELECT COL FROM TAB WHERE COL LIKE 'ab'
```

-- CASE 2
```
SELECT COL FROM TAB WHERE COL LIKE 'a%'
```

This is the optimisation that we follow:

```
expression LIKE pattern
```

will become if pattern has exact match

```
expression = pattern
```

will become if pattern has prefix match

```
expression ILIKE pattern COLLATE cs_as AND
expression BETWEEN patternConstPrefix AND patternConstPrefix || E'\uFFFF 
```

E’\uFFFF is the highest sort key. We use the BETWEEN operator as in PG we can NOT use index scan for LIKE/ILIKE operator. Whereas introducing BETWEEN will enable us to do so. And the CS_AS collation is used to store the locale info for ILIKE. 

For supporting case insensitive accent insensitive collations like latin1_general_ci_ai , we transform the node firstly by adding a FuncExpr (remove_accents_internal) which removes the accent and then we apply the above logic.

Currently we have observed that we do not comply with the transformation above. Rather than COLLATE CS_AS, we observe COLLATE “default” in query plan. Consider the following query:

-- query (column a is collated with latin1_genetal_ci_as)
```
select a from varchar_tst where a collate chinese_prc_ci_as LIKE 'ab%'
```

-- query plan
```
Filter: (((a)::text ~~* 'ab%'::text COLLATE "default") 
AND ((a)::text >= 'ab'::text COLLATE "default") AND ((a)::text < 'ab?'::text))
```

Even though we observe COLLATE "default" in the query plan, it picks up the correct collation oid during execution. 
However, if we update the collation oid in typeTypeCollation function to pickup database collation oid for string literals in parse tree, we may observe upgrade/restore failure.

We use this task as first step to modify and incorporate improvements for such cases.


### Issues Resolved

Task: BABEL-5608
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).