### PR TITLE
Adding upgrade check for procedure revoke_create_privilege_from_guest_user

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -1714,6 +1714,12 @@ revoke_create_privilege_from_guest_user(PG_FUNCTION_ARGS)
 	HeapTuple		tuple;
 	bool			is_null;
 
+	if (!creating_extension)
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("%s can only be called from an SQL script executed by CREATE/ALTER EXTENSION",
+					"revoke_create_privilege_from_guest_user()")));
+
 	db_rel = table_open(sysdatabases_oid, AccessShareLock);
 	scan = table_beginscan_catalog(db_rel, 0, NULL);
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -1715,10 +1715,10 @@ revoke_create_privilege_from_guest_user(PG_FUNCTION_ARGS)
 	bool			is_null;
 
 	if (!creating_extension)
-	ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("%s can only be called from an SQL script executed by CREATE/ALTER EXTENSION",
-					"revoke_create_privilege_from_guest_user()")));
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("%s can only be called from an SQL script executed by CREATE/ALTER EXTENSION",
+						"revoke_create_privilege_from_guest_user()")));
 
 	db_rel = table_open(sysdatabases_oid, AccessShareLock);
 	scan = table_beginscan_catalog(db_rel, 0, NULL);


### PR DESCRIPTION
### Description

As a part of PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3498 we need to add an upgrade check in upgrade procedure revoke_create_privilege_from_guest_user(), to ensure that it is getting called during upgrade only.

### Issues Resolved

[BABEL-3963]



Signed-off-by: Pranav Jain [pranavjc@amazon.com](mailto:pranavjc@amazon.com)
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).