### PR TITLE
Fix MVU issue for not checking exist of nvarchar_json type

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.1.0--5.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.1.0--5.2.0.sql
@@ -11,15 +11,15 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
 DO
 $body$
 BEGIN
-	IF NOT EXISTS (
-		SELECT  *
-		  FROM pg_type 
-		WHERE typname = 'nvarchar_json')
-	THEN
-		SET enable_domain_typmod = TRUE;
+    IF NOT EXISTS (
+        SELECT  *
+            FROM pg_type 
+        WHERE typname = 'nvarchar_json')
+    THEN
+        SET enable_domain_typmod = TRUE;
         CREATE DOMAIN sys.NVARCHAR_JSON AS sys.NVARCHAR;
         RESET enable_domain_typmod;
-	END IF;
+    END IF;
 END
 $body$;
 

--- a/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.1.0--5.2.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.1.0--5.2.0.sql
@@ -8,9 +8,20 @@
 SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
 
 -- For JSON Functions
-SET enable_domain_typmod = TRUE;
-CREATE DOMAIN sys.NVARCHAR_JSON AS sys.NVARCHAR;
-RESET enable_domain_typmod;
+DO
+$body$
+BEGIN
+	IF NOT EXISTS (
+		SELECT  *
+		  FROM pg_type 
+		WHERE typname = 'nvarchar_json')
+	THEN
+		SET enable_domain_typmod = TRUE;
+        CREATE DOMAIN sys.NVARCHAR_JSON AS sys.NVARCHAR;
+        RESET enable_domain_typmod;
+	END IF;
+END
+$body$;
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_common/sql/varchar.sql
+++ b/contrib/babelfishpg_common/sql/varchar.sql
@@ -367,6 +367,17 @@ CREATE CAST (pg_catalog.float8 AS sys.BPCHAR)
 WITH FUNCTION sys.float82bpchar(pg_catalog.float8, integer, BOOLEAN) AS IMPLICIT;
 
 -- For JSON Functions
-SET enable_domain_typmod = TRUE;
-CREATE DOMAIN sys.NVARCHAR_JSON AS sys.NVARCHAR;
-RESET enable_domain_typmod;
+DO
+$body$
+BEGIN
+	IF NOT EXISTS (
+		SELECT  *
+		  FROM pg_type 
+		WHERE typname = 'nvarchar_json')
+	THEN
+		SET enable_domain_typmod = TRUE;
+        CREATE DOMAIN sys.NVARCHAR_JSON AS sys.NVARCHAR;
+        RESET enable_domain_typmod;
+	END IF;
+END
+$body$;

--- a/contrib/babelfishpg_common/sql/varchar.sql
+++ b/contrib/babelfishpg_common/sql/varchar.sql
@@ -370,14 +370,14 @@ WITH FUNCTION sys.float82bpchar(pg_catalog.float8, integer, BOOLEAN) AS IMPLICIT
 DO
 $body$
 BEGIN
-	IF NOT EXISTS (
-		SELECT  *
-		  FROM pg_type 
-		WHERE typname = 'nvarchar_json')
-	THEN
-		SET enable_domain_typmod = TRUE;
+    IF NOT EXISTS (
+        SELECT  *
+            FROM pg_type 
+        WHERE typname = 'nvarchar_json')
+    THEN
+        SET enable_domain_typmod = TRUE;
         CREATE DOMAIN sys.NVARCHAR_JSON AS sys.NVARCHAR;
         RESET enable_domain_typmod;
-	END IF;
+    END IF;
 END
 $body$;


### PR DESCRIPTION
### Description

The 16_9 to latest MVU is erroring out due to not check the exist of nvarchar_json type before create domain for nvarchar_json type.
This error starts from this pr : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3581 because from this pr merged, the 16_9 will also have the nvarchar_json domain type, so it'll cause a MVU upgrade error when upgrade script try to create a duplicate domain for nvarchar_json type.

### Issues Resolved

Issue will resolve domain replicate issue by checking whether the nvarchar_json type already existed.

### Test case
Pass the Major version upgrade from 16_9 to latest.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).