### PR TITLE
Add coalesce node support for computed columns

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_ruleutils.c
@@ -1449,7 +1449,17 @@ get_rule_expr(Node *node, deparse_context *context,
 					appendStringInfoChar(buf, ')');
 			}
 			break;
+		
+		case T_CoalesceExpr:
+			{
+				CoalesceExpr *coalesceexpr = (CoalesceExpr *) node;
 
+				appendStringInfoString(buf, "COALESCE(");
+				get_rule_expr((Node *) coalesceexpr->args, context, true);
+				appendStringInfoChar(buf, ')');
+			}
+			break;
+		
 		case T_SetToDefault:
 			appendStringInfoString(buf, "DEFAULT");
 			break;

--- a/test/JDBC/expected/sys-computed_columns-vu-prepare.out
+++ b/test/JDBC/expected/sys-computed_columns-vu-prepare.out
@@ -4,6 +4,7 @@ GO
 CREATE TABLE sys_computed_columns_vu_prepare_t1 ( 
   scc_first_number smallint,
   scc_second_number money,
-  scc_multiplied AS scc_first_number * scc_second_number
+  scc_multiplied AS scc_first_number * scc_second_number,
+  scc_coalesce_col AS COALESCE(scc_first_number, 10) PERSISTED
 )
 GO

--- a/test/JDBC/expected/sys-computed_columns-vu-verify.out
+++ b/test/JDBC/expected/sys-computed_columns-vu-verify.out
@@ -25,11 +25,12 @@ scc_multiplied#!#(scc_first_number * scc_second_number)
 ~~END~~
 
 
-Select sys.tsql_get_expr(adbin, adrelid) FROM pg_attrdef WHERE adrelid = (select oid from pg_class where relname='sys_computed_columns_vu_prepare_t1')
+Select sys.tsql_get_expr(adbin, adrelid) as text FROM pg_attrdef WHERE adrelid = (select oid from pg_class where relname='sys_computed_columns_vu_prepare_t1') ORDER BY text
 GO
 ~~START~~
 text
 (scc_first_number * scc_second_number)
+COALESCE(CAST((scc_first_number) AS int), 10)
 ~~END~~
 
 
@@ -63,4 +64,5 @@ GO
 text
 <NULL>
 ~~END~~
+
 

--- a/test/JDBC/input/views/sys-computed_columns-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-computed_columns-vu-prepare.sql
@@ -4,6 +4,7 @@ GO
 CREATE TABLE sys_computed_columns_vu_prepare_t1 ( 
   scc_first_number smallint,
   scc_second_number money,
-  scc_multiplied AS scc_first_number * scc_second_number
+  scc_multiplied AS scc_first_number * scc_second_number,
+  scc_coalesce_col AS COALESCE(scc_first_number, 10) PERSISTED
 )
 GO

--- a/test/JDBC/input/views/sys-computed_columns-vu-verify.sql
+++ b/test/JDBC/input/views/sys-computed_columns-vu-verify.sql
@@ -10,7 +10,7 @@ WHERE name in ('scc_first_number', 'scc_second_number', 'scc_multiplied')
 ORDER BY name
 GO
 
-Select sys.tsql_get_expr(adbin, adrelid) FROM pg_attrdef WHERE adrelid = (select oid from pg_class where relname='sys_computed_columns_vu_prepare_t1')
+Select sys.tsql_get_expr(adbin, adrelid) as text FROM pg_attrdef WHERE adrelid = (select oid from pg_class where relname='sys_computed_columns_vu_prepare_t1') ORDER BY text
 GO
 
 Select sys.tsql_get_expr('scc_second_number',123)
@@ -24,3 +24,4 @@ GO
 
 Select sys.tsql_get_expr(null, null)
 GO
+


### PR DESCRIPTION
### Description

We invoke sys.tsql_get_expr function for getting the column definition in sys.computed_columns. At present tsql_get_expr function doesn't support Coalesce type in computed columns and return null when we try to obtain computed column expression containing Coalesce expression. Adding support for Coalesce node types for computed column expressions.

### Issues Resolved

Task: Babel-5460

Signed-off-by: Sharath BP <sharatbp@amazon.com>
(cherry picked from commit ad1d7629526a309466ec375a78529b19208ae479)

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
Yes

* **Major version upgrade tests -**
Yes

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).