### PR TITLE
Fix the expected output of alter-view due to change in object ownership

### DIFF
--- a/test/JDBC/expected/alter-view-vu-verify.out
+++ b/test/JDBC/expected/alter-view-vu-verify.out
@@ -341,19 +341,9 @@ CREATE OR ALTER VIEW guest.alter_v1 AS SELECT a, b FROM alter_t;
 GO
 SELECT * FROM guest.alter_v1;
 GO
-~~START~~
-int#!#varchar
-1#!#a
-2#!#b
-3#!#c
-4#!#d
-5#!#e
-6#!#f
-7#!#g
-8#!#h
-9#!#i
-10#!#j
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table alter_t)~~
 
 
 SELECT * FROM dbo.alter_v1;


### PR DESCRIPTION
### Description

Fix the expected output of alter-view due to change in object ownership


### Issues Resolved

No-JIRA
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).