### PR TITLE
Fix the test case for alter view due to recent schema ownership change

### DIFF
--- a/test/JDBC/expected/alter-view-vu-verify.out
+++ b/test/JDBC/expected/alter-view-vu-verify.out
@@ -358,6 +358,25 @@ int#!#varchar#!#varchar
 ~~END~~
 
 
+ALTER VIEW guest.alter_v1 AS SELECT a FROM alter_t;
+GO
+SELECT * FROM guest.alter_v1;
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+~~END~~
+
+
 SELECT * FROM dbo.alter_v1;
 GO
 ~~START~~

--- a/test/JDBC/expected/alter-view-vu-verify.out
+++ b/test/JDBC/expected/alter-view-vu-verify.out
@@ -336,14 +336,26 @@ GO
 ~~ERROR (Message: view "non_existent_view" does not exist)~~
 
 
+GRANT SELECT on alter_t TO guest;
+GO
 -- Alter View with Schema name (Checking views with same name in different schemas)
-CREATE OR ALTER VIEW guest.alter_v1 AS SELECT a, b FROM alter_t;
+CREATE OR ALTER VIEW guest.alter_v1 AS SELECT a, b, c FROM alter_t;
 GO
 SELECT * FROM guest.alter_v1;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: permission denied for table alter_t)~~
+~~START~~
+int#!#varchar#!#varchar
+1#!#a#!#a
+2#!#b#!#b
+3#!#c#!#c
+4#!#d#!#d
+5#!#e#!#e
+6#!#f#!#f
+7#!#g#!#g
+8#!#h#!#h
+9#!#i#!#i
+10#!#j#!#j
+~~END~~
 
 
 SELECT * FROM dbo.alter_v1;

--- a/test/JDBC/input/alter/alter-view-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-view-vu-verify.sql
@@ -118,8 +118,10 @@ GO
 Alter view non_existent_view AS SELECT a, b FROM alter_t;
 GO
 
+GRANT SELECT on alter_t TO guest;
+GO
 -- Alter View with Schema name (Checking views with same name in different schemas)
-CREATE OR ALTER VIEW guest.alter_v1 AS SELECT a, b FROM alter_t;
+CREATE OR ALTER VIEW guest.alter_v1 AS SELECT a, b, c FROM alter_t;
 GO
 SELECT * FROM guest.alter_v1;
 GO

--- a/test/JDBC/input/alter/alter-view-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-view-vu-verify.sql
@@ -126,6 +126,11 @@ GO
 SELECT * FROM guest.alter_v1;
 GO
 
+ALTER VIEW guest.alter_v1 AS SELECT a FROM alter_t;
+GO
+SELECT * FROM guest.alter_v1;
+GO
+
 SELECT * FROM dbo.alter_v1;
 GO
 


### PR DESCRIPTION
### Description

Fixed the test case which tried to check Alter view correctly works if schema name is specified and doesn't alter other schema's view which has same name. This fix came due to recent change with schema ownership (#3595).
Test Change: Granted SELECT permission to the schema "guest" to select from view.

### Issues Resolved
No-JIRA
Signed-off-by: Rahul Parande rparande@amazon.com
### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).