### PR TITLE
Fix for Crash in get_bbf_pivot_tuplestore

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -4937,15 +4937,14 @@ get_bbf_pivot_tuplestore(const char 	*sourcetext,
 			 * the hash table
 			 */
 			catname = SPI_getvalue(spi_tuple, spi_tupdesc, ncols - 1);
-			catname_lower = downcase_identifier(catname, strlen(catname), false, false);
-			if (catname_lower != NULL)
-			{
-				bbf_pivot_HashTableLookup(bbf_pivot_hash, catname_lower, catdesc);
+            if (catname != NULL) {
+                catname_lower = downcase_identifier(catname, strlen(catname), false, false);
+                bbf_pivot_HashTableLookup(bbf_pivot_hash, catname_lower, catdesc);
 
-				if (catdesc)
-					values[catdesc->attidx + non_pivot_columns] =
-						SPI_getvalue(spi_tuple, spi_tupdesc, ncols);
-			}
+                if (catdesc)
+                    values[catdesc->attidx + non_pivot_columns] =
+                        SPI_getvalue(spi_tuple, spi_tupdesc, ncols);
+            }
 
 			if (ncols > 2)
 			{

--- a/test/JDBC/expected/pivot-vu-cleanup.out
+++ b/test/JDBC/expected/pivot-vu-cleanup.out
@@ -109,6 +109,9 @@ GO
 DROP TABLE SalesDataPivot;
 GO
 
+DROP VIEW vw_SalesPivot;
+GO
+
 DROP TABLE pivot_schema.products_sch;
 GO
 

--- a/test/JDBC/expected/pivot-vu-cleanup.out
+++ b/test/JDBC/expected/pivot-vu-cleanup.out
@@ -106,6 +106,9 @@ GO
 DROP TABLE products;
 GO
 
+DROP TABLE SalesDataPivot;
+GO
+
 DROP TABLE pivot_schema.products_sch;
 GO
 

--- a/test/JDBC/expected/pivot-vu-prepare.out
+++ b/test/JDBC/expected/pivot-vu-prepare.out
@@ -1385,3 +1385,16 @@ INSERT INTO SalesDataPivot VALUES
 GO
 ~~ROW COUNT: 6~~
 
+
+CREATE VIEW vw_SalesPivot
+AS
+SELECT extra_column, [0], [1], [2], [3], [4]
+FROM
+    (SELECT pivot_column, aggregate_column, extra_column
+     FROM SalesDataPivot) AS table_source
+PIVOT
+(
+    AVG(aggregate_column)
+    FOR pivot_column IN ([0], [1], [2], [3], [4])
+) AS PivotTable;
+GO

--- a/test/JDBC/expected/pivot-vu-prepare.out
+++ b/test/JDBC/expected/pivot-vu-prepare.out
@@ -1367,3 +1367,21 @@ PIVOT (
     FOR StoreID IN ([1], [2], [3],[4], [5])
 ) AS pvt
 GO
+
+CREATE TABLE SalesDataPivot (
+    pivot_column INT,
+    aggregate_column FLOAT,
+    extra_column VARCHAR(50)
+);
+GO
+
+INSERT INTO SalesDataPivot VALUES
+    (0, 10.5, 'A'),
+    (1, 15.2, 'B'),
+    (2, 12.8, 'C'),
+    (3, 18.3, 'D'),
+    (4, 14.1, 'E'),
+    (NULL, 20.0, 'F');
+GO
+~~ROW COUNT: 6~~
+

--- a/test/JDBC/expected/pivot-vu-verify.out
+++ b/test/JDBC/expected/pivot-vu-verify.out
@@ -2508,3 +2508,16 @@ E#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#14.1
 F#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 
+
+SELECT * FROM vw_SalesPivot;
+GO
+~~START~~
+varchar#!#float#!#float#!#float#!#float#!#float
+A#!#10.5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+B#!#<NULL>#!#15.2#!#<NULL>#!#<NULL>#!#<NULL>
+C#!#<NULL>#!#<NULL>#!#12.8#!#<NULL>#!#<NULL>
+D#!#<NULL>#!#<NULL>#!#<NULL>#!#18.3#!#<NULL>
+E#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#14.1
+F#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+

--- a/test/JDBC/expected/pivot-vu-verify.out
+++ b/test/JDBC/expected/pivot-vu-verify.out
@@ -2486,3 +2486,25 @@ varchar#!#int#!#int#!#int#!#int#!#int
 OrderNumbers#!#19#!#19#!#19#!#16#!#14
 ~~END~~
 
+
+-- BABEL-5603
+SELECT extra_column, [0], [1], [2], [3], [4]
+FROM
+    (SELECT pivot_column, aggregate_column, extra_column
+     FROM SalesDataPivot) AS table_source
+PIVOT
+(
+    AVG(aggregate_column)
+    FOR pivot_column IN ([0], [1], [2], [3], [4])
+) AS PivotTable;
+GO
+~~START~~
+varchar#!#float#!#float#!#float#!#float#!#float
+A#!#10.5#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+B#!#<NULL>#!#15.2#!#<NULL>#!#<NULL>#!#<NULL>
+C#!#<NULL>#!#<NULL>#!#12.8#!#<NULL>#!#<NULL>
+D#!#<NULL>#!#<NULL>#!#<NULL>#!#18.3#!#<NULL>
+E#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#14.1
+F#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+~~END~~
+

--- a/test/JDBC/input/pivot-vu-cleanup.sql
+++ b/test/JDBC/input/pivot-vu-cleanup.sql
@@ -109,6 +109,9 @@ GO
 DROP TABLE SalesDataPivot;
 GO
 
+DROP VIEW vw_SalesPivot;
+GO
+
 DROP TABLE pivot_schema.products_sch;
 GO
 

--- a/test/JDBC/input/pivot-vu-cleanup.sql
+++ b/test/JDBC/input/pivot-vu-cleanup.sql
@@ -106,6 +106,9 @@ GO
 DROP TABLE products;
 GO
 
+DROP TABLE SalesDataPivot;
+GO
+
 DROP TABLE pivot_schema.products_sch;
 GO
 

--- a/test/JDBC/input/pivot-vu-prepare.sql
+++ b/test/JDBC/input/pivot-vu-prepare.sql
@@ -909,3 +909,16 @@ INSERT INTO SalesDataPivot VALUES
     (4, 14.1, 'E'),
     (NULL, 20.0, 'F');
 GO
+
+CREATE VIEW vw_SalesPivot
+AS
+SELECT extra_column, [0], [1], [2], [3], [4]
+FROM
+    (SELECT pivot_column, aggregate_column, extra_column
+     FROM SalesDataPivot) AS table_source
+PIVOT
+(
+    AVG(aggregate_column)
+    FOR pivot_column IN ([0], [1], [2], [3], [4])
+) AS PivotTable;
+GO

--- a/test/JDBC/input/pivot-vu-prepare.sql
+++ b/test/JDBC/input/pivot-vu-prepare.sql
@@ -893,3 +893,19 @@ PIVOT (
     FOR StoreID IN ([1], [2], [3],[4], [5])
 ) AS pvt
 GO
+
+CREATE TABLE SalesDataPivot (
+    pivot_column INT,
+    aggregate_column FLOAT,
+    extra_column VARCHAR(50)
+);
+GO
+
+INSERT INTO SalesDataPivot VALUES
+    (0, 10.5, 'A'),
+    (1, 15.2, 'B'),
+    (2, 12.8, 'C'),
+    (3, 18.3, 'D'),
+    (4, 14.1, 'E'),
+    (NULL, 20.0, 'F');
+GO

--- a/test/JDBC/input/pivot-vu-verify.sql
+++ b/test/JDBC/input/pivot-vu-verify.sql
@@ -983,3 +983,15 @@ GO
 -- TEST VIEW HAS SAME SCHEMA NAME AS SOURCE TABLE'S
 SELECT * FROM pivot_schema.QUAL_NAME_VIEW ORDER BY 1
 GO
+
+-- BABEL-5603
+SELECT extra_column, [0], [1], [2], [3], [4]
+FROM
+    (SELECT pivot_column, aggregate_column, extra_column
+     FROM SalesDataPivot) AS table_source
+PIVOT
+(
+    AVG(aggregate_column)
+    FOR pivot_column IN ([0], [1], [2], [3], [4])
+) AS PivotTable;
+GO

--- a/test/JDBC/input/pivot-vu-verify.sql
+++ b/test/JDBC/input/pivot-vu-verify.sql
@@ -995,3 +995,6 @@ PIVOT
     FOR pivot_column IN ([0], [1], [2], [3], [4])
 ) AS PivotTable;
 GO
+
+SELECT * FROM vw_SalesPivot;
+GO


### PR DESCRIPTION
### Description

The crash occurred in the `get_bbf_pivot_tuplestore` function. The root cause of the crash was that the code did not properly handle the case where the pivot column value in the input data was _NULL_.

Specifically, the code had the following lines:

```
catname = SPI_getvalue(spi_tuple, spi_tupdesc, ncols - 1);
catname_lower = downcase_identifier(catname, strlen(catname), false, false);
```

The issue was that if `catname` was _NULL_, calling `strlen(catname)` would result in a crash.

To fix the issue, the code has been updated to first check if `catname` is not _NULL_ before proceeding to process it.

### Issues Resolved

Task: BABEL-5603

### Test Scenarios Covered ###
* **Use case based -**
```
INSERT INTO SalesDataPivot VALUES
    (0, 10.5, 'A'),
     ...
    (4, 14.1, 'E'),
    (NULL, 20.0, 'F');  -- NULL value for category
GO

SELECT extra_column, [0], [1], [2], [3], [4]
FROM
    (SELECT pivot_column, aggregate_column, extra_column
     FROM SalesDataPivot) AS table_source
PIVOT
(
    AVG(aggregate_column)
    FOR pivot_column IN ([0], [1], [2], [3], [4])
) AS PivotTable;
GO
```


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).