### PR TITLE
handle conversion of empty string to datetime

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -1646,7 +1646,7 @@ BEGIN
             v_month := substr(v_datestring, 5, 2);
             v_year := substr(v_datestring, 1, 4);
         END IF;
-    ELSIF (v_datetimestring ~* HHMMSSFS_REGEXP)
+    ELSIF (v_datetimestring ~* HHMMSSFS_REGEXP OR length(v_datetimestring) = 0)
     THEN
         v_day := '01';
         v_month := '01';

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.5.0--4.6.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.5.0--4.6.0.sql
@@ -1041,10 +1041,6 @@ CREATE OR REPLACE FUNCTION sys.json_query(json_string text, path text default '$
 RETURNS sys.NVARCHAR_JSON
 AS 'babelfishpg_tsql', 'tsql_json_query' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
--- Drops the temporary procedure used by the upgrade script.
--- Please have this be one of the last statements executed in this upgrade script.
-DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
-
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();
 
@@ -1082,6 +1078,610 @@ END;
 $BODY$
 LANGUAGE plpgsql
 STABLE;
+
+-- adding empty string to datetime in babelfish_conv_string_to_datetime sys 
+ALTER FUNCTION sys.babelfish_conv_string_to_datetime RENAME TO babelfish_conv_string_to_datetime_deprecated_in_5_2_0;
+
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'babelfish_conv_string_to_datetime_deprecated_in_5_2_0');
+
+CREATE OR REPLACE FUNCTION sys.babelfish_conv_string_to_datetime(IN p_datatype TEXT,
+                                                                     IN p_datetimestring TEXT,
+                                                                     IN p_style NUMERIC DEFAULT 0)
+RETURNS TIMESTAMP WITHOUT TIME ZONE
+AS
+$BODY$
+DECLARE
+    v_day VARCHAR COLLATE "C";
+    v_year VARCHAR COLLATE "C";
+    v_month VARCHAR COLLATE "C";
+    v_style SMALLINT;
+    v_scale SMALLINT;
+    v_hours VARCHAR COLLATE "C";
+    v_hijridate DATE;
+    v_minutes VARCHAR COLLATE "C";
+    v_seconds VARCHAR COLLATE "C";
+    v_fseconds VARCHAR COLLATE "C";
+    v_datatype VARCHAR COLLATE "C";
+    v_timepart VARCHAR COLLATE "C";
+    v_leftpart VARCHAR COLLATE "C";
+    v_middlepart VARCHAR COLLATE "C";
+    v_rightpart VARCHAR COLLATE "C";
+    v_datestring VARCHAR COLLATE "C";
+    v_err_message VARCHAR COLLATE "C";
+    v_date_format VARCHAR COLLATE "C";
+    v_res_datatype VARCHAR COLLATE "C";
+    v_datetimestring VARCHAR COLLATE "C";
+    v_datatype_groups TEXT[];
+    v_regmatch_groups TEXT[];
+    v_lang_metadata_json JSONB;
+    v_compmonth_regexp VARCHAR COLLATE "C";
+    v_resdatetime TIMESTAMP(6) WITHOUT TIME ZONE;
+    CONVERSION_LANG CONSTANT VARCHAR COLLATE "C" := '';
+    DATE_FORMAT CONSTANT VARCHAR COLLATE "C" := '';
+    DAYMM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    FULLYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{4})';
+    SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2})';
+    COMPYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := '(\d{1,2}|\d{4})';
+    AMPM_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:[AP]M)';
+    MASKSEP_REGEXP CONSTANT VARCHAR COLLATE "C" := '(?:\.|-|/)';
+    TIMEUNIT_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,2}\s*';
+    FRACTSECS_REGEXP CONSTANT VARCHAR COLLATE "C" := '\s*\d{1,9}\s*';
+    DATATYPE_REGEXP CONSTANT VARCHAR COLLATE "C" := '^(DATETIME|SMALLDATETIME|DATETIME2)\s*(?:\()?\s*((?:-)?\d+)?\s*(?:\))?$';
+    DIGITREPRESENT_REGEXP CONSTANT VARCHAR COLLATE "C" := '^\-?\d+\.?(?:\d+)?$';
+    HHMMSSFS_PART_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP, AMPM_REGEXP, '?|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                    TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '(?:\.|\:)', FRACTSECS_REGEXP, AMPM_REGEXP, '?');
+    HHMMSSFS_DOT_PART_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat(TIMEUNIT_REGEXP, AMPM_REGEXP, '|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\.', FRACTSECS_REGEXP, AMPM_REGEXP, '?|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, AMPM_REGEXP, '?|',
+                                                        TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '\:', TIMEUNIT_REGEXP, '(?:\.)', FRACTSECS_REGEXP, AMPM_REGEXP, '?');
+    HHMMSSFS_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')$');
+    DEFMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '$');
+    DEFMASK1_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '$');
+    DEFMASK2_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)\s*', COMPYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK2_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK2_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK3_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)\s*', DAYMM_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK3_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', DAYMM_REGEXP, '$');
+    DEFMASK3_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '$');
+    DEFMASK4_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)',
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK4_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)$');
+    DEFMASK4_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)$');
+    DEFMASK5_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)',
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK5_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)$');
+    DEFMASK5_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s+', COMPYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)$');
+    DEFMASK6_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK6_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '$');
+    DEFMASK6_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', FULLYEAR_REGEXP, '\s+', DAYMM_REGEXP, '$');
+    DEFMASK7_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', DAYMM_REGEXP, '\s*,\s*', COMPYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK7_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', DAYMM_REGEXP, '\s*,\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK7_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', DAYMM_REGEXP, '\s*,\s*', COMPYEAR_REGEXP, '$');
+    DEFMASK8_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '*\s*($comp_month$)',
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK8_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '?\s*($comp_month$)$');
+    DEFMASK8_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)$');
+    DEFMASK9_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                 MASKSEP_REGEXP, '*\s*($comp_month$)\s*', FULLYEAR_REGEXP,
+                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK9_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '?\s*($comp_month$)\s*', FULLYEAR_REGEXP, '$');
+    DEFMASK9_2_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', MASKSEP_REGEXP, '\s*($comp_month$)\s*', FULLYEAR_REGEXP, '$');
+    DEFMASK10_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                  DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', MASKSEP_REGEXP, '\s*', COMPYEAR_REGEXP,
+                                                  '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DEFMASK10_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*($comp_month$)\s*', MASKSEP_REGEXP, '\s*', COMPYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_COMPYEAR1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                                 DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', COMPYEAR_REGEXP,
+                                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DOT_SLASH_DASH_COMPYEAR1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', COMPYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_SHORTYEAR_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', SHORTYEAR_REGEXP, '$');
+    DOT_SLASH_DASH_FULLYEAR1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                                 DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', DAYMM_REGEXP, '\s*(?:\.|/|-)\s*', FULLYEAR_REGEXP,
+                                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    DOT_SLASH_DASH_FULLYEAR1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', FULLYEAR_REGEXP, '$');
+    FULLYEAR_DOT_SLASH_DASH1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*',
+                                                                 FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP,
+                                                                 '\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    FULLYEAR_DOT_SLASH_DASH1_1_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^', FULLYEAR_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '\s*', MASKSEP_REGEXP, '\s*', DAYMM_REGEXP, '$');
+    SHORT_DIGITMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*\d{6}\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+    FULL_DIGITMASK1_0_REGEXP CONSTANT VARCHAR COLLATE "C" := pg_catalog.concat('^(', HHMMSSFS_PART_REGEXP, ')?\s*\d{8}\s*(', HHMMSSFS_PART_REGEXP, ')?$');
+BEGIN
+    v_datatype := pg_catalog.btrim(p_datatype);
+    v_datetimestring := pg_catalog.upper(pg_catalog.btrim(p_datetimestring));
+    v_style := floor(p_style)::SMALLINT;
+
+    v_datatype_groups := regexp_matches(v_datatype, DATATYPE_REGEXP, 'gi');
+
+    v_res_datatype := pg_catalog.upper(v_datatype_groups[1]);
+    v_scale := v_datatype_groups[2]::SMALLINT;
+
+    IF (v_res_datatype IS NULL) THEN
+        RAISE datatype_mismatch;
+    ELSIF (v_res_datatype <> 'DATETIME2' AND v_scale IS NOT NULL)
+    THEN
+        RAISE invalid_indicator_parameter_value;
+    ELSIF (coalesce(v_scale, 0) NOT BETWEEN 0 AND 7)
+    THEN
+        RAISE interval_field_overflow;
+    ELSIF (v_scale IS NULL) THEN
+        v_scale := 7;
+    END IF;
+
+    IF (scale(p_style) > 0) THEN
+        RAISE most_specific_type_mismatch;
+    ELSIF (NOT ((v_style BETWEEN 0 AND 14) OR
+             (v_style BETWEEN 20 AND 25) OR
+             (v_style BETWEEN 100 AND 114) OR
+             (v_style IN (120, 121, 126, 127, 130, 131))) AND
+             v_res_datatype = 'DATETIME2')
+    THEN
+        RAISE invalid_parameter_value;
+    END IF;
+
+    v_timepart := pg_catalog.btrim(substring(v_datetimestring, HHMMSSFS_PART_REGEXP));
+    v_datestring := pg_catalog.btrim(regexp_replace(v_datetimestring, HHMMSSFS_PART_REGEXP, '', 'gi'));
+
+    BEGIN
+        v_lang_metadata_json := sys.babelfish_get_lang_metadata_json(CONVERSION_LANG);
+    EXCEPTION
+        WHEN OTHERS THEN
+        RAISE invalid_escape_sequence;
+    END;
+
+    v_date_format := coalesce(nullif(DATE_FORMAT, ''), v_lang_metadata_json ->> 'date_format');
+
+    v_compmonth_regexp := array_to_string(array_cat(ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_shortnames')),
+                                                    ARRAY(SELECT jsonb_array_elements_text(v_lang_metadata_json -> 'months_names'))), '|');
+
+    IF (v_datetimestring ~* pg_catalog.replace(DEFMASK1_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK2_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK3_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK4_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK5_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK6_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK7_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK8_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK9_0_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+        v_datetimestring ~* pg_catalog.replace(DEFMASK10_0_REGEXP, '$comp_month$', v_compmonth_regexp))
+    THEN
+        IF ((v_style IN (127, 130, 131) AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+            (v_style IN (130, 131) AND v_res_datatype = 'DATETIME2'))
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF ((v_datestring ~* pg_catalog.replace(DEFMASK1_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK2_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK3_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK4_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK5_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK6_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK7_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK8_2_REGEXP, '$comp_month$', v_compmonth_regexp) OR
+             v_datestring ~* pg_catalog.replace(DEFMASK9_2_REGEXP, '$comp_month$', v_compmonth_regexp)) AND
+            v_res_datatype = 'DATETIME2')
+        THEN
+            RAISE invalid_datetime_format;
+        END IF;
+
+        IF (v_datestring ~* pg_catalog.replace(DEFMASK1_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK1_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK2_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK2_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK3_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK3_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[3];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK4_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK4_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK5_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK5_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[3], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[2]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK6_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK6_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[3];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := v_regmatch_groups[2];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK7_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK7_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[2];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK8_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK8_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := '01';
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := v_regmatch_groups[1];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK9_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK9_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := '01';
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[1], v_lang_metadata_json);
+            v_year := v_regmatch_groups[2];
+
+        ELSIF (v_datestring ~* pg_catalog.replace(DEFMASK10_1_REGEXP, '$comp_month$', v_compmonth_regexp))
+        THEN
+            v_regmatch_groups := regexp_matches(v_datestring, pg_catalog.replace(DEFMASK10_1_REGEXP, '$comp_month$', v_compmonth_regexp), 'gi');
+            v_day := v_regmatch_groups[1];
+            v_month := sys.babelfish_get_monthnum_by_name(v_regmatch_groups[2], v_lang_metadata_json);
+            v_year := sys.babelfish_get_full_year(v_regmatch_groups[3]);
+        ELSE
+            RAISE invalid_character_value_for_cast;
+        END IF;
+    ELSIF (v_datetimestring ~* DOT_SLASH_DASH_COMPYEAR1_0_REGEXP)
+    THEN
+        IF (v_style IN (6, 7, 8, 9, 12, 13, 14, 24, 100, 106, 107, 108, 109, 112, 113, 114, 130) AND
+            v_res_datatype = 'DATETIME2')
+        THEN
+            RAISE invalid_regular_expression;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, DOT_SLASH_DASH_COMPYEAR1_1_REGEXP, 'gi');
+        v_leftpart := v_regmatch_groups[1];
+        v_middlepart := v_regmatch_groups[2];
+        v_rightpart := v_regmatch_groups[3];
+
+        IF (v_datestring ~* DOT_SLASH_DASH_SHORTYEAR_REGEXP)
+        THEN
+            IF ((v_style NOT IN (0, 1, 2, 3, 4, 5, 10, 11) AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                (v_style NOT IN (0, 1, 2, 3, 4, 5, 10, 11, 12) AND v_res_datatype = 'DATETIME2'))
+            THEN
+                RAISE invalid_datetime_format;
+            END IF;
+
+            IF ((v_style IN (1, 10) AND v_date_format <> 'MDY' AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                (v_style IN (0, 1, 10) AND v_date_format NOT IN ('DMY', 'DYM', 'MYD', 'YMD', 'YDM') AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                (v_style IN (0, 1, 10, 22) AND v_date_format NOT IN ('DMY', 'DYM', 'MYD', 'YMD', 'YDM') AND v_res_datatype = 'DATETIME2') OR
+                (v_style IN (1, 10, 22) AND v_date_format IN ('DMY', 'DYM', 'MYD', 'YMD', 'YDM') AND v_res_datatype = 'DATETIME2'))
+            THEN
+                v_day := v_middlepart;
+                v_month := v_leftpart;
+                v_year := sys.babelfish_get_full_year(v_rightpart);
+
+            ELSIF ((v_style IN (2, 11) AND v_date_format <> 'YMD') OR
+                   (v_style IN (0, 2, 11) AND v_date_format = 'YMD'))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+                v_year := sys.babelfish_get_full_year(v_leftpart);
+
+            ELSIF ((v_style IN (3, 4, 5) AND v_date_format <> 'DMY') OR
+                   (v_style IN (0, 3, 4, 5) AND v_date_format = 'DMY'))
+            THEN
+                v_day := v_leftpart;
+                v_month := v_middlepart;
+                v_year := sys.babelfish_get_full_year(v_rightpart);
+
+            ELSIF (v_style = 0 AND v_date_format = 'DYM')
+            THEN
+                v_day = v_leftpart;
+                v_month = v_rightpart;
+                v_year = sys.babelfish_get_full_year(v_middlepart);
+
+            ELSIF (v_style = 0 AND v_date_format = 'MYD')
+            THEN
+                v_day := v_rightpart;
+                v_month := v_leftpart;
+                v_year = sys.babelfish_get_full_year(v_middlepart);
+
+            ELSIF (v_style = 0 AND v_date_format = 'YDM')
+            THEN
+                IF (v_res_datatype = 'DATETIME2') THEN
+                    RAISE character_not_in_repertoire;
+                END IF;
+
+                v_day := v_middlepart;
+                v_month := v_rightpart;
+                v_year := sys.babelfish_get_full_year(v_leftpart);
+            ELSE
+                RAISE invalid_character_value_for_cast;
+            END IF;
+        ELSIF (v_datestring ~* DOT_SLASH_DASH_FULLYEAR1_1_REGEXP)
+        THEN
+            IF (v_style NOT IN (0, 20, 21, 101, 102, 103, 104, 105, 110, 111, 120, 121, 130, 131) AND
+                v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+            THEN
+                RAISE invalid_datetime_format;
+            ELSIF (v_style IN (130, 131) AND v_res_datatype = 'SMALLDATETIME') THEN
+                RAISE invalid_character_value_for_cast;
+            END IF;
+
+            v_year := v_rightpart;
+            IF (v_leftpart::SMALLINT <= 12)
+            THEN
+                IF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                    (v_style IN (0, 103, 104, 105, 130, 131) AND ((v_date_format = 'DMY' AND v_res_datatype = 'DATETIME2') OR
+                    (v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2'))) OR
+                    (v_style IN (103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype = 'DATETIME2'))
+                THEN
+                    v_day := v_leftpart;
+                    v_month := v_middlepart;
+
+                ELSIF ((v_style IN (20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                       (v_style IN (0, 20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM') AND v_res_datatype IN ('DATETIME', 'SMALLDATETIME')) OR
+                       (v_style IN (101, 110) AND v_date_format IN ('DMY', 'DYM', 'MYD', 'YDM') AND v_res_datatype = 'DATETIME2') OR
+                       (v_style IN (0, 101, 110) AND v_date_format NOT IN ('DMY', 'DYM', 'MYD', 'YDM') AND v_res_datatype = 'DATETIME2'))
+                THEN
+                    v_day := v_middlepart;
+                    v_month := v_leftpart;
+                END IF;
+            ELSE
+                IF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                    (v_style IN (0, 103, 104, 105, 130, 131) AND ((v_date_format = 'DMY' AND v_res_datatype = 'DATETIME2') OR
+                    (v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2'))) OR
+                    (v_style IN (103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype = 'DATETIME2'))
+                THEN
+                    v_day := v_leftpart;
+                    v_month := v_middlepart;
+                ELSE
+                    IF (v_res_datatype = 'DATETIME2') THEN
+                        RAISE invalid_datetime_format;
+                    END IF;
+
+                    RAISE invalid_character_value_for_cast;
+                END IF;
+            END IF;
+        END IF;
+    ELSIF (v_datetimestring ~* FULLYEAR_DOT_SLASH_DASH1_0_REGEXP)
+    THEN
+        IF (v_style NOT IN (0, 20, 21, 101, 102, 103, 104, 105, 110, 111, 120, 121, 130, 131) AND
+            v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+        THEN
+            RAISE invalid_datetime_format;
+        ELSIF (v_style IN (6, 7, 8, 9, 12, 13, 14, 24, 100, 106, 107, 108, 109, 112, 113, 114, 130) AND
+            v_res_datatype = 'DATETIME2')
+        THEN
+            RAISE invalid_regular_expression;
+        ELSIF (v_style IN (130, 131) AND v_res_datatype = 'SMALLDATETIME')
+        THEN
+            RAISE invalid_character_value_for_cast;
+        END IF;
+
+        v_regmatch_groups := regexp_matches(v_datestring, FULLYEAR_DOT_SLASH_DASH1_1_REGEXP, 'gi');
+        v_year := v_regmatch_groups[1];
+        v_middlepart := v_regmatch_groups[2];
+        v_rightpart := v_regmatch_groups[3];
+
+        IF ((v_res_datatype IN ('DATETIME', 'SMALLDATETIME') AND v_rightpart::SMALLINT <= 12) OR v_res_datatype = 'DATETIME2')
+        THEN
+            IF ((v_style IN (20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2') OR
+                (v_style IN (0, 20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM') AND v_res_datatype <> 'DATETIME2') OR
+                (v_style IN (0, 20, 21, 23, 25, 101, 102, 110, 111, 120, 121, 126, 127) AND v_res_datatype = 'DATETIME2'))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+
+            ELSIF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                    v_style IN (0, 103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM'))
+            THEN
+                v_day := v_middlepart;
+                v_month := v_rightpart;
+            END IF;
+        ELSIF (v_res_datatype IN ('DATETIME', 'SMALLDATETIME') AND v_rightpart::SMALLINT > 12)
+        THEN
+            IF ((v_style IN (20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format IN ('DMY', 'DYM', 'YDM')) OR
+                (v_style IN (0, 20, 21, 101, 102, 110, 111, 120, 121) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')))
+            THEN
+                v_day := v_rightpart;
+                v_month := v_middlepart;
+
+            ELSIF ((v_style IN (103, 104, 105, 130, 131) AND v_date_format NOT IN ('DMY', 'DYM', 'YDM')) OR
+                   (v_style IN (0, 103, 104, 105, 130, 131) AND v_date_format IN ('DMY', 'DYM', 'YDM')))
+            THEN
+                RAISE invalid_character_value_for_cast;
+            END IF;
+        END IF;
+    ELSIF (v_datetimestring ~* SHORT_DIGITMASK1_0_REGEXP OR
+           v_datetimestring ~* FULL_DIGITMASK1_0_REGEXP)
+    THEN
+        IF (v_style = 127 AND v_res_datatype <> 'DATETIME2')
+        THEN
+            RAISE invalid_datetime_format;
+        ELSIF (v_style IN (130, 131) AND v_res_datatype = 'SMALLDATETIME')
+        THEN
+            RAISE invalid_character_value_for_cast;
+        END IF;
+
+        IF (v_datestring ~* '^\d{6}$')
+        THEN
+            v_day := substr(v_datestring, 5, 2);
+            v_month := substr(v_datestring, 3, 2);
+            v_year := sys.babelfish_get_full_year(substr(v_datestring, 1, 2));
+
+        ELSIF (v_datestring ~* '^\d{8}$')
+        THEN
+            v_day := substr(v_datestring, 7, 2);
+            v_month := substr(v_datestring, 5, 2);
+            v_year := substr(v_datestring, 1, 4);
+        END IF;
+    ELSIF (v_datetimestring ~* HHMMSSFS_REGEXP OR length(v_datetimestring) = 0)
+    THEN
+        v_day := '01';
+        v_month := '01';
+        v_year := '1900';
+    ELSIF (v_datetimestring ~* DIGITREPRESENT_REGEXP)
+    THEN
+        v_resdatetime = CAST('1900-01-01 00:00:00.0' AS sys.DATETIME) + v_datetimestring::NUMERIC;
+        RETURN v_resdatetime;
+    ELSE
+        RAISE invalid_datetime_format;
+    END IF;
+
+    IF (((v_datetimestring ~* HHMMSSFS_PART_REGEXP AND v_res_datatype = 'DATETIME2') OR
+        (v_datetimestring ~* SHORT_DIGITMASK1_0_REGEXP OR v_datetimestring ~* FULL_DIGITMASK1_0_REGEXP OR
+          v_datetimestring ~* FULLYEAR_DOT_SLASH_DASH1_0_REGEXP OR v_datetimestring ~* DOT_SLASH_DASH_FULLYEAR1_0_REGEXP)) AND
+        v_style IN (130, 131))
+    THEN
+        v_hijridate := sys.babelfish_conv_hijri_to_greg(v_day, v_month, v_year) - 1;
+        v_day = to_char(v_hijridate, 'DD');
+        v_month = to_char(v_hijridate, 'MM');
+        v_year = to_char(v_hijridate, 'YYYY');
+    END IF;
+
+    v_hours := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'HOURS'), '0');
+    v_minutes := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'MINUTES'), '0');
+    v_seconds := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'SECONDS'), '0');
+    v_fseconds := coalesce(sys.babelfish_get_timeunit_from_string(v_timepart, 'FRACTSECONDS'), '0');
+
+    IF ((v_res_datatype IN ('DATETIME', 'SMALLDATETIME') OR
+         (v_res_datatype = 'DATETIME2' AND v_timepart !~* HHMMSSFS_DOT_PART_REGEXP)) AND
+        char_length(v_fseconds) > 3)
+    THEN
+        RAISE invalid_datetime_format;
+    END IF;
+
+    BEGIN
+        IF (v_res_datatype IN ('DATETIME', 'SMALLDATETIME'))
+        THEN
+            v_resdatetime := sys.datetimefromparts(v_year, v_month, v_day,
+                                                                 v_hours, v_minutes, v_seconds,
+                                                                 rpad(v_fseconds, 3, '0'));
+            IF (v_res_datatype = 'SMALLDATETIME' AND
+                to_char(v_resdatetime, 'SS') <> '00')
+            THEN
+                IF (to_char(v_resdatetime, 'SS')::SMALLINT >= 30) THEN
+                    v_resdatetime := v_resdatetime + INTERVAL '1 minute';
+                END IF;
+
+                v_resdatetime := to_timestamp(to_char(v_resdatetime, 'DD.MM.YYYY.HH24.MI'), 'DD.MM.YYYY.HH24.MI');
+            END IF;
+        ELSIF (v_res_datatype = 'DATETIME2')
+        THEN
+            v_fseconds := sys.babelfish_get_microsecs_from_fractsecs(v_fseconds, v_scale);
+            v_seconds := pg_catalog.concat_ws('.', v_seconds, v_fseconds);
+            v_resdatetime := make_timestamp(v_year::SMALLINT, v_month::SMALLINT, v_day::SMALLINT,
+                                            v_hours::SMALLINT, v_minutes::SMALLINT, v_seconds::NUMERIC);
+        END IF;
+    EXCEPTION
+        WHEN datetime_field_overflow THEN
+            RAISE invalid_datetime_format;
+        WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+
+        IF (v_err_message ~* 'Cannot construct data type') THEN
+            RAISE invalid_character_value_for_cast;
+        END IF;
+    END;
+
+    RETURN v_resdatetime;
+EXCEPTION
+    WHEN most_specific_type_mismatch THEN
+        RAISE USING MESSAGE := 'Argument data type NUMERIC is invalid for argument 3 of conv_string_to_datetime function.',
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('The style %s is not supported for conversions from VARCHAR to %s.', v_style, v_res_datatype),
+                    DETAIL := 'Use of incorrect "style" parameter value during conversion process.',
+                    HINT := 'Change "style" parameter to the proper value and try again.';
+
+    WHEN invalid_regular_expression THEN
+        RAISE USING MESSAGE := pg_catalog.format('The input character string doesn''t follow style %s.', v_style),
+                    DETAIL := 'Selected "style" param value isn''t valid for conversion of passed character string.',
+                    HINT := 'Either change the input character string or use a different style.';
+
+    WHEN datatype_mismatch THEN
+        RAISE USING MESSAGE := 'Data type should be one of these values: ''DATETIME'', ''SMALLDATETIME'', ''DATETIME2''/''DATETIME2(n)''.',
+                    DETAIL := 'Use of incorrect "datatype" parameter value during conversion process.',
+                    HINT := 'Change "datatype" parameter to the proper value and try again.';
+
+    WHEN invalid_indicator_parameter_value THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid attributes specified for data type %s.', v_res_datatype),
+                    DETAIL := 'Use of incorrect scale value, which is not corresponding to specified data type.',
+                    HINT := 'Change data type scale component or select different data type and try again.';
+
+    WHEN interval_field_overflow THEN
+        RAISE USING MESSAGE := pg_catalog.format('Specified scale %s is invalid.', v_scale),
+                    DETAIL := 'Use of incorrect data type scale value during conversion process.',
+                    HINT := 'Change scale component of data type parameter to be in range [0..7] and try again.';
+
+    WHEN invalid_datetime_format THEN
+        RAISE USING MESSAGE := CASE v_res_datatype
+                                  WHEN 'SMALLDATETIME' THEN 'Conversion failed when converting character string to SMALLDATETIME data type.'
+                                  ELSE 'Conversion failed when converting date and time from character string.'
+                               END,
+                    DETAIL := 'Incorrect using of pair of input parameters values during conversion process.',
+                    HINT := 'Check the input parameters values, correct them if needed, and try again.';
+
+    WHEN invalid_character_value_for_cast THEN
+        RAISE USING MESSAGE := 'The conversion of a VARCHAR data type to a DATETIME data type resulted in an out-of-range value.',
+                    DETAIL := 'Use of incorrect pair of input parameter values during conversion process.',
+                    HINT := 'Check input parameter values, correct them if needed, and try again.';
+
+    WHEN character_not_in_repertoire THEN
+        RAISE USING MESSAGE := 'The YDM date format isn''t supported when converting from this string format to date and time.',
+                    DETAIL := 'Use of incorrect DATE_FORMAT constant value regarding string format parameter during conversion process.',
+                    HINT := 'Change DATE_FORMAT constant to one of these values: MDY|DMY|DYM, recompile function and try again.';
+
+    WHEN invalid_escape_sequence THEN
+        RAISE USING MESSAGE := pg_catalog.format('Invalid CONVERSION_LANG constant value - ''%s''. Allowed values are: ''English'', ''Deutsch'', etc.',
+                                      CONVERSION_LANG),
+                    DETAIL := 'Compiled incorrect CONVERSION_LANG constant value in function''s body.',
+                    HINT := 'Correct CONVERSION_LANG constant value in function''s body, recompile it and try again.';
+
+    WHEN invalid_text_representation THEN
+        GET STACKED DIAGNOSTICS v_err_message = MESSAGE_TEXT;
+        v_err_message := substring(pg_catalog.lower(v_err_message), 'integer\:\s\"(.*)\"');
+
+        RAISE USING MESSAGE := pg_catalog.format('Error while trying to convert "%s" value to SMALLINT data type.',
+                                      v_err_message),
+                    DETAIL := 'Passed argument value contains illegal characters.',
+                    HINT := 'Correct passed argument value, remove all illegal characters.';
+END;
+$BODY$
+LANGUAGE plpgsql
+STABLE
+RETURNS NULL ON NULL INPUT;
+
+-- Drops the temporary procedure used by the upgrade script.
+-- Please have this be one of the last statements executed in this upgrade script.
+DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
 
 -- Reset search_path to not affect any subsequent scripts
 SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/test/JDBC/expected/babel_datetime-vu-cleanup.out
+++ b/test/JDBC/expected/babel_datetime-vu-cleanup.out
@@ -11,3 +11,9 @@ drop procedure babel_datetime_vu_procedure
 go
 drop function babel_datetime_vu_function1
 go
+DROP VIEW babel_datetime_empty_string_vw
+GO
+DROP PROCEDURE babel_datetime_empty_string_p
+GO
+DROP FUNCTION babel_datetime_empty_string_f()
+GO

--- a/test/JDBC/expected/babel_datetime-vu-prepare.out
+++ b/test/JDBC/expected/babel_datetime-vu-prepare.out
@@ -100,3 +100,15 @@ BEGIN
 	RETURN @inputdate
 END
 GO
+
+-- convert string to datetime test
+CREATE VIEW babel_datetime_empty_string_vw as (SELECT CONVERT(datetime, ''));
+GO
+CREATE PROCEDURE babel_datetime_empty_string_p as (SELECT CONVERT(datetime, ''));
+GO
+CREATE FUNCTION babel_datetime_empty_string_f()
+RETURNS datetime AS
+BEGIN
+RETURN (SELECT CONVERT(datetime, ''));
+END
+GO

--- a/test/JDBC/expected/babel_datetime-vu-verify.out
+++ b/test/JDBC/expected/babel_datetime-vu-verify.out
@@ -1136,3 +1136,35 @@ varchar
 2023-06-15 14:30:45.123
 ~~END~~
 
+
+-- convert string to datetime test
+DECLARE @emptyString VARCHAR(10) = '';
+SELECT CONVERT(datetime, @emptyString) AS EmptyStringResult;
+GO
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+
+
+SELECT * FROM babel_datetime_empty_string_vw
+GO
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+
+EXEC babel_datetime_empty_string_p
+GO
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+
+SELECT babel_datetime_empty_string_f()
+GO
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+

--- a/test/JDBC/input/babel_datetime-vu-cleanup.sql
+++ b/test/JDBC/input/babel_datetime-vu-cleanup.sql
@@ -11,3 +11,9 @@ drop procedure babel_datetime_vu_procedure
 go
 drop function babel_datetime_vu_function1
 go
+DROP VIEW babel_datetime_empty_string_vw
+GO
+DROP PROCEDURE babel_datetime_empty_string_p
+GO
+DROP FUNCTION babel_datetime_empty_string_f()
+GO

--- a/test/JDBC/input/babel_datetime-vu-prepare.sql
+++ b/test/JDBC/input/babel_datetime-vu-prepare.sql
@@ -64,3 +64,15 @@ BEGIN
 	RETURN @inputdate
 END
 GO
+
+-- convert string to datetime test
+CREATE VIEW babel_datetime_empty_string_vw as (SELECT CONVERT(datetime, ''));
+GO
+CREATE PROCEDURE babel_datetime_empty_string_p as (SELECT CONVERT(datetime, ''));
+GO
+CREATE FUNCTION babel_datetime_empty_string_f()
+RETURNS datetime AS
+BEGIN
+RETURN (SELECT CONVERT(datetime, ''));
+END
+GO

--- a/test/JDBC/input/babel_datetime-vu-verify.sql
+++ b/test/JDBC/input/babel_datetime-vu-verify.sql
@@ -432,3 +432,15 @@ GO
 
 SELECT babel_datetime_vu_function1(0x0000B02200EF28C1)
 GO
+
+-- convert string to datetime test
+DECLARE @emptyString VARCHAR(10) = '';
+SELECT CONVERT(datetime, @emptyString) AS EmptyStringResult;
+GO
+
+SELECT * FROM babel_datetime_empty_string_vw
+GO
+EXEC babel_datetime_empty_string_p
+GO
+SELECT babel_datetime_empty_string_f()
+GO


### PR DESCRIPTION
### Description


The conversion of empty strings to datetime (CONVERT(datetime, '')) shows inconsistent behavior between versions 4.x and 5.x. While a previous fix addressed this across all versions, it had to be [reverted](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2660) due to PostgreSQL parallel worker limitations. Specifically, helper functions were executing in parallel despite being marked PARALLEL UNSAFE, and sub-transactions aren't supported in parallel workers before PG17 (per [PostgreSQL community discussion](https://www.postgresql.org/message-id/CAHewXNkSYVYktt0KW8RtfNMDYi4Stn7OJtuTqeo+c3He1xoFXQ@mail.gmail.com)).

This PR resolves the issue by implementing empty string handling directly in the sys.babelfish_conv_string_to_datetime functions, ensuring proper functionality in version 4.x while maintaining compatibility with PostgreSQL's parallel processing constraints.

### Issues Resolved

[BABEL-5687](https://jira.rds.a2z.com/browse/BABEL-5687)


### Test Scenarios Covered ###
* **Use case based -** Yes


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).