### PR TITLE
Fix alter-view code to incorporate group_ad_session logic

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2840,7 +2840,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 												stmt->view->relname)));
 							}
 							/* View doesn't exist - create it */
-							address = DefineView(stmt, queryString, pstmt->stmt_location, pstmt->stmt_len);
+							if (prev_ProcessUtility)
+								prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+													queryEnv, dest, qc);
+							else
+								standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+														queryEnv, dest, qc);							
 							CommandCounterIncrement();
 						}
 						/* View exists */
@@ -2859,8 +2864,18 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 			
 							/* Create new view */
 							stmt->replace = true; 
-							address = DefineView(stmt, queryString, pstmt->stmt_location, pstmt->stmt_len);
+							if (prev_ProcessUtility)
+								prev_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+													queryEnv, dest, qc);
+							else
+								standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
+														queryEnv, dest, qc);							
 							CommandCounterIncrement();
+
+							/* Get the new view's ObjectAddress */
+							address.objectId = RangeVarGetRelid(stmt->view, NoLock, false);
+							address.classId = RelationRelationId;
+							address.objectSubId = 0;
 							
 							/* Store the view definition in babelfish_view_def */
 							if(store_view_definition_hook)


### PR DESCRIPTION
### Description

Replaced direct engine API call with ProcessUtility hook in ALTER VIEW handling so that other extensions like `group_ad_session` can properly interact with view operations.

This change replaces DefineView calls with ProcessUtility hook calls to maintain consistency with how other DDL operations are handled in Babelfish.

signed off by: Rahul Parande rparande@amazon.com
### Issues Resolved

No-JIRA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).