### PR TITLE
[OSS-ONLY] Add expected output for restricted_objects cleanup test

### DIFF
--- a/test/JDBC/expected/parallel_query/restricted_objects-vu-cleanup.out
+++ b/test/JDBC/expected/parallel_query/restricted_objects-vu-cleanup.out
@@ -1,0 +1,105 @@
+-- tsql
+USE msdb;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p1 FROM babel_5146_owner_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p2 FROM babel_5146_owner_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p3 FROM babel_5146_owner_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p1 FROM babel_5146_ddladmin_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p2 FROM babel_5146_ddladmin_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p3 FROM babel_5146_ddladmin_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p1 FROM babel_5146_case_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p2 FROM babel_5146_case_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p3 FROM babel_5146_case_u;
+GO
+
+REVOKE CONNECT FROM babel_5146_owner_u;
+GO
+
+REVOKE CONNECT FROM babel_5146_ddladmin_u;
+GO
+
+REVOKE CONNECT FROM babel_5146_case_u;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p1 TO guest;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p2 TO guest;
+GO
+
+REVOKE EXECUTE ON babel_5146_prepare_p3 TO guest;
+GO
+
+DROP PROCEDURE IF EXISTS babel_5146_prepare_p1;
+GO
+
+DROP PROCEDURE IF EXISTS babel_5146_prepare_p2;
+GO
+
+DROP PROCEDURE IF EXISTS babel_5146_prepare_p3;
+GO
+
+REVOKE CONNECT FROM guest;
+GO
+
+DROP USER babel_5146_owner_u;
+GO
+
+DROP USER babel_5146_ddladmin_u;
+GO
+
+DROP USER babel_5146_case_u;
+GO
+
+-- Drop test logins
+DROP LOGIN babel_5146_owner_l;
+GO
+
+DROP LOGIN babel_5146_ddladmin_l;
+GO
+
+DROP LOGIN babel_5146_case_l;
+GO
+
+-- psql
+-- Need to terminate active session before cleaning up the login
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'babel_5146_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE msdb;
+GO
+
+DROP LOGIN babel_5146_user_l1;
+GO


### PR DESCRIPTION
### Description

This commit adds expected output file for `restricted_objects` cleanup test to resolve failing test due to output differences. This ensures the test passes correctly in parallel query mode.

### Issues Resolved

N/A

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).