### PR TITLE
Avoid checking permission of Babelfish temp tables on parallel worker

### DIFF
--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -77,6 +77,7 @@ OBJS += src/extendedproperty.o
 OBJS += src/fts.o
 OBJS += src/fts_parser.o
 OBJS += src/pltsql_partition.o
+OBJS += src/bbf_parallel_query.o
 
 export ANTLR4_JAVA_BIN=java
 export ANTLR4_RUNTIME_LIB=-lantlr4-runtime

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -152,9 +152,9 @@ bbf_ParallelQueryMain(shm_toc *toc)
 bool
 bbf_ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 {
-	if (prev_ExecCheckOneRelPerms_hook && (*prev_ExecCheckOneRelPerms_hook)(perminfo))
+	if (prev_ExecCheckOneRelPerms_hook && !(*prev_ExecCheckOneRelPerms_hook)(perminfo))
 	{
-		return true;
+		return false;
 	}
 
 	if (!OidIsValid(perminfo->relid))

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -17,6 +17,7 @@
 #include "utils/acl.h"
 #include "utils/elog.h"
 #include "utils/lsyscache.h"
+#include "utils/queryenvironment.h"
 
 #include "bbf_parallel_query.h"
 #include "pltsql.h"
@@ -81,7 +82,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 			if (rte->rtekind == RTE_RELATION &&
 				OidIsValid(rte->relid) &&
-				get_rel_persistence(rte->relid) == RELPERSISTENCE_TEMP)
+				get_ENR_withoid(currentQueryEnv, rte->relid, ENR_TSQL_TEMP) != NULL)
 			{
 				/* probably (re)do perm check */
 				RTEPermissionInfo *perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -134,7 +134,7 @@ bbf_ParallelQueryMain(shm_toc *toc)
 		(*prev_ParallelQueryMain_hook)(toc);
 
 	/* Another line of defense to make sure no regular backend calls this function. */
-	if (IsBabelfishParallelWorker())
+	if (!IsBabelfishParallelWorker())
 	{
 		return;
 	}

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -2,6 +2,7 @@
 #include "postgres.h"
 
 #include "access/parallel.h"
+#include "catalog/pg_class.h"
 #include "executor/executor.h"
 #include "fmgr.h"
 #include "nodes/bitmapset.h"
@@ -80,7 +81,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 			if (rte->rtekind == RTE_RELATION &&
 				OidIsValid(rte->relid) &&
-				get_rel_persistence(rte->relid) == 't')
+				get_rel_persistence(rte->relid) == RELPERSISTENCE_TEMP)
 			{
 				/* probably (re)do perm check */
 				RTEPermissionInfo *perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -1,0 +1,148 @@
+
+#include "postgres.h"
+
+#include "access/parallel.h"
+#include "fmgr.h"
+#include "nodes/bitmapset.h"
+#include "nodes/execnodes.h"
+#include "nodes/nodes.h"
+#include "nodes/parsenodes.h"
+#include "nodes/pg_list.h"
+#include "parser/parser.h"
+#include "storage/shm_toc.h"
+#include "utils/elog.h"
+#include "utils/lsyscache.h"
+
+#include "bbf_parallel_query.h"
+
+/*
+ * temp_relids - maintains relid list of temp table shared by leader node. This should be
+ * strictly accessed within parallel worker context.
+ */
+static Bitmapset   *temp_relids = NULL;
+
+/*
+ * string representation of list of temp table oids computed by Leader node to be shared
+ * with parallel worker.
+ */
+static char		   *temp_relids_str = NULL;
+
+/*
+ * In Babelfish, Any user under given session should be able access the temp tables. 
+ * And Postgres doesn't allow parallel scan on temp tables. But it still does the permission
+ * check on temp tables under parallel workers. But since Babelfish temp tables implemented
+ * using ENR, it can't be accessed inside Parallel worker.
+ * 
+ * So we would like to avoid permission checking on temp tables under parallel workers while
+ * ensuring that Leader node does require permission checks on temp table.
+ * 
+ * In order to achieve this, we (probably re)do permission checks on temp tables and share
+ * the list of oids with parallel worker. And parallel worker will avoid permission check
+ * on these oids.
+ */
+
+
+/*
+ * bbf_ExecInitParallelPlan -- implements ExecInitParallelPlan_hook.
+ * It iterates through es_range_tables checking persistence of given relation. Probably,
+ * re-do permission checking (better to redo perm checking instead of never doing it) if
+ * relation is temp table and adds oid/relid to the set. This set will be shared with
+ * parallel worker so that parallel worker avoids permission check on temp tables.
+ */
+void 
+bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
+{
+	if (prev_ExecInitParallelPlan_hook)
+		(*prev_ExecInitParallelPlan_hook)(estate, pcxt, estimate);
+
+	if (sql_dialect != SQL_DIALECT_TSQL)
+		return;
+
+	if (estimate)
+	{
+		ListCell   *lc;
+		Bitmapset  *temp_relids_local = NULL;
+
+		foreach(lc, estate->es_range_table)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+			if (rte->rtekind == RTE_RELATION &&
+				OidIsValid(rte->relid) && 
+				get_rel_persistence(rte->relid) == 't')
+			{
+				temp_relids_local = bms_add_member(temp_relids_local, rte->relid);
+			}
+		}
+		temp_relids_str = bmsToString(temp_relids_local);
+
+		/*
+		 * Estimate extra context for Babelfish
+		 */
+		shm_toc_estimate_chunk(&pcxt->estimator, strlen(temp_relids_str) + 1);
+		shm_toc_estimate_keys(&pcxt->estimator, 1);
+	}
+	else
+	{
+		char *temp_relids_space;
+
+		/*temp_relids_str will never be NULL even if there is no temp tables in the query. */
+		if (temp_relids_str == NULL)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("Unexpected list of temp table relids")));
+		}
+
+		temp_relids_space = shm_toc_allocate(pcxt->toc, strlen(temp_relids_str) + 1);
+		memcpy(temp_relids_space, temp_relids_str, strlen(temp_relids_str) + 1);
+		shm_toc_insert(pcxt->toc, BABELFISH_PARALLEL_KEY_TEMP_RELIDS, temp_relids_space);
+
+		/* And reset temp_relids_str */
+		pfree(temp_relids_str);
+		temp_relids_str = NULL;
+	}
+}
+/*
+ * bbf_ParallelQueryMain -- implements ParallelQueryMain_hook.
+ * It constructs temp_relids which represents oid list of temp tables communicated by Leader node.
+ * warning: should stricktly call under parallel worker.
+ */
+void
+bbf_ParallelQueryMain(shm_toc *toc)
+{
+	if (prev_ParallelQueryMain_hook)
+		(*prev_ParallelQueryMain_hook)(toc);
+
+	/* Another line of defense to make sure no regular backend calls this function. */
+	if (!IsBabelfishParallelWorker())
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_INTERNAL_ERROR),
+			 errmsg("Invalid attempt to build set of relids")));
+	}
+
+	temp_relids = (Bitmapset *) stringToNode(shm_toc_lookup(toc,
+															BABELFISH_PARALLEL_KEY_TEMP_RELIDS,
+															false));
+}
+
+/*
+ * IsBabelfishTempTable -- implements skip_ExecutorCheckPerms_hook.
+ * Returns true if provided relid is Babelfish temp table. Note that temp_relids must have
+ * communicated by Leader node.
+ * warning: should stricktly call under parallel worker.
+ */
+bool
+IsBabelfishTempTable(Oid relid)
+{
+	/* Another line of defense to make sure no regular backend calls this function. */
+	if (!IsBabelfishParallelWorker())
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_INTERNAL_ERROR),
+			 errmsg("Invalid attempt to build set of relids")));
+	}
+
+	return bms_is_member(relid, temp_relids);
+}
+

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -76,16 +76,28 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 	{
 		ListCell   *lc;
 		Bitmapset  *temp_relids_local = NULL;
+		temp_relids_str = NULL;
 
 		foreach(lc, estate->es_range_table)
 		{
+			RTEPermissionInfo *perminfo;
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 			if (rte->rtekind == RTE_RELATION &&
 				OidIsValid(rte->relid) &&
 				get_rel_persistence(rte->relid) == RELPERSISTENCE_TEMP)
 			{
+				if (estate->es_plannedstmt == NULL ||
+					list_length(estate->es_plannedstmt->permInfos) == 0)
+				{
+					/* If there is RTE present then corresponding permInfo must be there */
+					ereport(ERROR,
+							(errcode(ERRCODE_INTERNAL_ERROR),
+							errmsg("Perminfo corresponding to temporary table couldn't be found")));
+				}
+
+				/* getRTEPermissionInfo would return valid perfInfo, error will be raised otherwise */
+				perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);
 				/* probably (re)do perm check */
-				RTEPermissionInfo *perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);
 				if (!ExecCheckOneRelPerms_wrapper(perminfo))
 				{
 					aclcheck_error(ACLCHECK_NO_PRIV,
@@ -111,7 +123,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 		if (temp_relids_str == NULL)
 		{
 			ereport(ERROR,
-					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("Unexpected list of temp table relids")));
 		}
 
@@ -157,7 +169,7 @@ bbf_ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 	if (!OidIsValid(perminfo->relid))
 	{
 		ereport(ERROR,
-			(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+			(errcode(ERRCODE_INTERNAL_ERROR),
 			 errmsg("Unexpected perminfo is found")));
 	}
 

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -53,6 +53,9 @@ static char		   *temp_relids_str = NULL;
  * re-do permission checking (better to redo perm checking instead of never doing it) if
  * relation is temp table and adds oid/relid to the set. This set will be shared with
  * parallel worker so that parallel worker avoids permission check on temp tables.
+ * When estimate = true passed then caller wants to estimate a dynamic shared memory (DSM)
+ * needed by this extension to communicate additional context.
+ * When estimate = false then caller wants to insert additional context to DSM.
  */
 void 
 bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
@@ -131,11 +134,9 @@ bbf_ParallelQueryMain(shm_toc *toc)
 		(*prev_ParallelQueryMain_hook)(toc);
 
 	/* Another line of defense to make sure no regular backend calls this function. */
-	if (!IsBabelfishParallelWorker())
+	if (IsBabelfishParallelWorker())
 	{
-		ereport(ERROR,
-			(errcode(ERRCODE_INTERNAL_ERROR),
-			 errmsg("Invalid attempt to build set of relids")));
+		return;
 	}
 
 	temp_relids = (Bitmapset *) stringToNode(shm_toc_lookup(toc,

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -22,7 +22,7 @@
 
 /*
  * temp_relids - maintains relid list of temp table shared by leader node. This should be
- * strictly accessed within parallel worker context.
+* strictly accessed within parallel worker context.
  */
 static Bitmapset   *temp_relids = NULL;
 
@@ -81,7 +81,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 			{
 				/* probably (re)do perm check */
 				RTEPermissionInfo *perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);
-				if (!ExecCheckOneRelPerms(perminfo))
+				if (!ExecCheckOneRelPerms_wrapper(perminfo))
 				{
 					aclcheck_error(ACLCHECK_NO_PRIV,
 									get_relkind_objtype(get_rel_relkind(perminfo->relid)),
@@ -144,22 +144,31 @@ bbf_ParallelQueryMain(shm_toc *toc)
 }
 
 /*
- * IsBabelfishTempTable -- implements skip_ExecutorCheckPerms_hook.
- * Returns true if provided relid is Babelfish temp table. Note that temp_relids must have
- * communicated by Leader node.
- * warning: should stricktly call under parallel worker.
+ * bbf_ExecCheckOneRelPerms -- implements ExecCheckOneRelPerms_hook.
+ * Returns true if this is Babelfish parallel worker and provided relid is Babelfish temp table. 
+ * Note that temp_relids must have communicated by Leader node.
  */
 bool
-IsBabelfishTempTable(Oid relid)
+bbf_ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 {
-	/* Another line of defense to make sure no regular backend calls this function. */
-	if (!IsBabelfishParallelWorker())
+	if (prev_ExecCheckOneRelPerms_hook && (*prev_ExecCheckOneRelPerms_hook)(perminfo))
 	{
-		ereport(ERROR,
-			(errcode(ERRCODE_INTERNAL_ERROR),
-			 errmsg("Invalid attempt to build set of relids")));
+		return true;
 	}
 
-	return bms_is_member(relid, temp_relids);
+	if (!OidIsValid(perminfo->relid))
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+			 errmsg("Unexpected perminfo is found")));
+	}
+
+	/* Let regular permission check happen if its not Babelfish parallel worker. */
+	if (!IsBabelfishParallelWorker())
+	{
+		return false;
+	}
+
+	return bms_is_member(perminfo->relid, temp_relids);
 }
 

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -92,7 +92,8 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 					/* If there is RTE present then corresponding permInfo must be there */
 					ereport(ERROR,
 							(errcode(ERRCODE_INTERNAL_ERROR),
-							errmsg("Perminfo corresponding to temporary table couldn't be found")));
+							errmsg("Failed to check permission of the temporary table because " \
+									"corresponding Perminfo is not found while launching parallel worker(s)")));
 				}
 
 				/* getRTEPermissionInfo would return valid perfInfo, error will be raised otherwise */
@@ -170,7 +171,7 @@ bbf_ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_INTERNAL_ERROR),
-			 errmsg("Unexpected perminfo is found")));
+			 errmsg("Invalid Oid is found while checking permission of the relation")));
 	}
 
 	/* Let regular permission check happen if its not Babelfish parallel worker. */

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -152,11 +152,6 @@ bbf_ParallelQueryMain(shm_toc *toc)
 bool
 bbf_ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 {
-	if (prev_ExecCheckOneRelPerms_hook && !(*prev_ExecCheckOneRelPerms_hook)(perminfo))
-	{
-		return false;
-	}
-
 	if (!OidIsValid(perminfo->relid))
 	{
 		ereport(ERROR,

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -8,12 +8,16 @@
 #include "nodes/nodes.h"
 #include "nodes/parsenodes.h"
 #include "nodes/pg_list.h"
+#include "miscadmin.h"
+#include "parser/parse_relation.h"
 #include "parser/parser.h"
 #include "storage/shm_toc.h"
+#include "utils/acl.h"
 #include "utils/elog.h"
 #include "utils/lsyscache.h"
 
 #include "bbf_parallel_query.h"
+#include "pltsql.h"
 
 /*
  * temp_relids - maintains relid list of temp table shared by leader node. This should be
@@ -55,7 +59,11 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 	if (prev_ExecInitParallelPlan_hook)
 		(*prev_ExecInitParallelPlan_hook)(estate, pcxt, estimate);
 
-	if (sql_dialect != SQL_DIALECT_TSQL)
+	/*
+	 * Dialect check is not sufficient because parallel worker might be needed while
+	 * doing plpgsql function scan on leader node.
+	 */
+	if (!IS_TDS_CONN())
 		return;
 
 	if (estimate)

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -82,7 +82,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 			if (rte->rtekind == RTE_RELATION &&
 				OidIsValid(rte->relid) &&
-				get_ENR_withoid(currentQueryEnv, rte->relid, ENR_TSQL_TEMP) != NULL)
+				get_rel_persistence(rte->relid) == RELPERSISTENCE_TEMP)
 			{
 				/* probably (re)do perm check */
 				RTEPermissionInfo *perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -2,6 +2,7 @@
 #include "postgres.h"
 
 #include "access/parallel.h"
+#include "executor/executor.h"
 #include "fmgr.h"
 #include "nodes/bitmapset.h"
 #include "nodes/execnodes.h"
@@ -75,9 +76,17 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 			if (rte->rtekind == RTE_RELATION &&
-				OidIsValid(rte->relid) && 
+				OidIsValid(rte->relid) &&
 				get_rel_persistence(rte->relid) == 't')
 			{
+				/* probably (re)do perm check */
+				RTEPermissionInfo *perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);
+				if (!ExecCheckOneRelPerms(perminfo))
+				{
+					aclcheck_error(ACLCHECK_NO_PRIV,
+									get_relkind_objtype(get_rel_relkind(perminfo->relid)),
+									get_rel_name(perminfo->relid));
+				}
 				temp_relids_local = bms_add_member(temp_relids_local, rte->relid);
 			}
 		}

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
@@ -9,7 +9,6 @@
 
 extern ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook;
 extern ParallelQueryMain_hook_type prev_ParallelQueryMain_hook;
-extern ExecCheckOneRelPerms_hook_type prev_ExecCheckOneRelPerms_hook;
 
 extern void bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate);
 extern void bbf_ParallelQueryMain(shm_toc *toc);

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
@@ -8,8 +8,8 @@
 
 extern ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook;
 extern ParallelQueryMain_hook_type prev_ParallelQueryMain_hook;
-
+extern ExecCheckOneRelPerms_hook_type prev_ExecCheckOneRelPerms_hook;
 
 extern void bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate);
 extern void bbf_ParallelQueryMain(shm_toc *toc);
-extern bool IsBabelfishTempTable(Oid relid);
+extern bool bbf_ExecCheckOneRelPerms(RTEPermissionInfo *perminfo);

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
@@ -1,3 +1,4 @@
+#include "executor/executor.h"
 #include "executor/execParallel.h"
 #include "fmgr.h"
 #include "nodes/execnodes.h"

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
@@ -1,0 +1,15 @@
+#include "executor/execParallel.h"
+#include "fmgr.h"
+#include "nodes/execnodes.h"
+
+/* Key for sharing additional context for Babelfish */
+#define BABELFISH_PARALLEL_KEY_FIXED		UINT64CONST(0xBBF0000000000001)
+#define BABELFISH_PARALLEL_KEY_TEMP_RELIDS	UINT64CONST(0xBBF0000000000002)
+
+extern ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook;
+extern ParallelQueryMain_hook_type prev_ParallelQueryMain_hook;
+
+
+extern void bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate);
+extern void bbf_ParallelQueryMain(shm_toc *toc);
+extern bool IsBabelfishTempTable(Oid relid);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -326,6 +326,7 @@ static bbf_check_member_has_direct_priv_to_grant_role_hook_type prev_bbf_check_m
 static validateCachedPlanSearchPath_hook_type prev_validateCachedPlanSearchPath_hook = NULL;
 ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook = NULL;
 ParallelQueryMain_hook_type prev_ParallelQueryMain_hook = NULL;
+ExecCheckOneRelPerms_hook_type prev_ExecCheckOneRelPerms_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -575,7 +576,8 @@ InstallExtendedHooks(void)
 	prev_ExecInitParallelPlan_hook = ExecInitParallelPlan_hook;
 	ExecInitParallelPlan_hook = bbf_ExecInitParallelPlan;
 
-	skip_ExecutorCheckPerms_hook = IsBabelfishTempTable;
+	prev_ExecCheckOneRelPerms_hook = ExecCheckOneRelPerms_hook;
+	ExecCheckOneRelPerms_hook = bbf_ExecCheckOneRelPerms;
 }
 
 void
@@ -661,7 +663,7 @@ UninstallExtendedHooks(void)
 	is_bbf_tds_connection_hook = NULL;
 	ParallelQueryMain_hook = prev_ParallelQueryMain_hook;
 	ExecInitParallelPlan_hook = prev_ExecInitParallelPlan_hook;
-	skip_ExecutorCheckPerms_hook = NULL;
+	ExecCheckOneRelPerms_hook = prev_ExecCheckOneRelPerms_hook;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -87,6 +87,7 @@
 #include "multidb.h"
 #include "tsql_analyze.h"
 #include "table_variable_mvcc.h"
+#include "bbf_parallel_query.h"
 
 #define TDS_NUMERIC_MAX_PRECISION	38
 extern bool babelfish_dump_restore;
@@ -323,6 +324,8 @@ static ExecFuncProc_AclCheck_hook_type prev_ExecFuncProc_AclCheck_hook = NULL;
 static bbf_execute_grantstmt_as_dbsecadmin_hook_type prev_bbf_execute_grantstmt_as_dbsecadmin_hook = NULL;
 static bbf_check_member_has_direct_priv_to_grant_role_hook_type prev_bbf_check_member_has_direct_priv_to_grant_role_hook = NULL;
 static validateCachedPlanSearchPath_hook_type prev_validateCachedPlanSearchPath_hook = NULL;
+ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook = NULL;
+ParallelQueryMain_hook_type prev_ParallelQueryMain_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -565,6 +568,14 @@ InstallExtendedHooks(void)
 	prev_validateCachedPlanSearchPath_hook = validateCachedPlanSearchPath_hook;
 	validateCachedPlanSearchPath_hook = pltsql_validateCachedPlanSearchPath;
 	is_bbf_tds_connection_hook = is_bbf_tds_connection;
+
+	prev_ParallelQueryMain_hook = ParallelQueryMain_hook;
+	ParallelQueryMain_hook = bbf_ParallelQueryMain;
+
+	prev_ExecInitParallelPlan_hook = ExecInitParallelPlan_hook;
+	ExecInitParallelPlan_hook = bbf_ExecInitParallelPlan;
+
+	skip_ExecutorCheckPerms_hook = IsBabelfishTempTable;
 }
 
 void
@@ -648,6 +659,9 @@ UninstallExtendedHooks(void)
 	pltsql_get_object_identity_event_trigger_hook = NULL;
 	pltsql_allow_storing_init_privs_hook = NULL;
 	is_bbf_tds_connection_hook = NULL;
+	ParallelQueryMain_hook = prev_ParallelQueryMain_hook;
+	ExecInitParallelPlan_hook = prev_ExecInitParallelPlan_hook;
+	skip_ExecutorCheckPerms_hook = NULL;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -326,7 +326,6 @@ static bbf_check_member_has_direct_priv_to_grant_role_hook_type prev_bbf_check_m
 static validateCachedPlanSearchPath_hook_type prev_validateCachedPlanSearchPath_hook = NULL;
 ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook = NULL;
 ParallelQueryMain_hook_type prev_ParallelQueryMain_hook = NULL;
-ExecCheckOneRelPerms_hook_type prev_ExecCheckOneRelPerms_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -576,7 +575,6 @@ InstallExtendedHooks(void)
 	prev_ExecInitParallelPlan_hook = ExecInitParallelPlan_hook;
 	ExecInitParallelPlan_hook = bbf_ExecInitParallelPlan;
 
-	prev_ExecCheckOneRelPerms_hook = ExecCheckOneRelPerms_hook;
 	ExecCheckOneRelPerms_hook = bbf_ExecCheckOneRelPerms;
 }
 
@@ -663,7 +661,7 @@ UninstallExtendedHooks(void)
 	is_bbf_tds_connection_hook = NULL;
 	ParallelQueryMain_hook = prev_ParallelQueryMain_hook;
 	ExecInitParallelPlan_hook = prev_ExecInitParallelPlan_hook;
-	ExecCheckOneRelPerms_hook = prev_ExecCheckOneRelPerms_hook;
+	ExecCheckOneRelPerms_hook = NULL;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -20,6 +20,7 @@
 #include "guc.h"
 #include "storage/shm_toc.h"
 #include "collation.h"
+#include "bbf_parallel_query.h"
 
 /* Core Session Properties */
 

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -1,4 +1,5 @@
 -- tsql
+-- setup
 CREATE LOGIN l1 WITH PASSWORD = '12345678'
 GO
 
@@ -28,11 +29,9 @@ GO
 USE master
 GO
 
--- psql
-ANALYSE;
-GO
-
 -- psql user=l1 password=12345678
+-- setup
+-- create parallel safe function under schema_for_l1 where user is authorised to create
 CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
 RETURNS TABLE (a INT) AS 
 $$ BEGIN
@@ -42,18 +41,39 @@ LANGUAGE plpgsql
 PARALLEL SAFE;
 GO
 
+
 -- psql
--- Permission check on temp table in Postgres
--- Not everyone can access temp table
-create temp table test_tbl(a int);
+-- Test permission check on temp table from Postgres
+create table reg_test (a int)
 GO
 
-insert into test_tbl values (1)
+insert into reg_test values (1)
 GO
 ~~ROW COUNT: 1~~
 
 
-select * from test_tbl
+create temp table parallel_test(a int);
+GO
+
+insert into parallel_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+ANALYSE;
+GO
+
+-- function which tries to access temp table using parallel execution
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from parallel_test
 GO
 ~~START~~
 int4
@@ -61,22 +81,73 @@ int4
 ~~END~~
 
 
+-- temp table as a outer scan and should not be scanned using parallel worker
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~START~~
+int4#!#int4
+1#!#1
+~~END~~
+
+
+-- following would throw an error under parallel execution
+select * from f1()
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+-- Not everyone can access temp table
+-- Permission denied error should be raised whe l1 tries to access to temp table parallel_test
 set role l1;
 GO
 
--- Permission denied error because l1 does not have access to temp table test_tbl
-select * from test_tbl
+-- should result in permission error
+select * from parallel_test
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied for table test_tbl
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from f1()
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table reg_test
     Server SQLState: 42501)~~
 
 
 reset role
 GO
 
+DROP FUNCTION f1()
+GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO
+
+
 -- tsql user=l1 password=12345678
+-- testing permission on temp table from Babelfish endpoint
 -- verify that only temp table permission check is skipped under parallel worker
 SELECT * FROM pq_t
 GO
@@ -85,6 +156,7 @@ GO
 ~~ERROR (Message: permission denied for table pq_t)~~
 
 
+-- function schema_for_l1.f1() access regular table so permission check shouldnt be skipped even under parallel worker
 SELECT * FROM schema_for_l1.f1()
 GO
 ~~START~~
@@ -102,6 +174,7 @@ GO
 ~~ROW COUNT: 1~~
 
 
+-- temp table as a outer scan and user has permission to access regular table
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 ~~ERROR (Code: 33557097)~~
@@ -116,12 +189,18 @@ GO
 ~~ERROR (Message: permission denied for table pq_t)~~
 
 
--- any user can access local temp table created under given session
-GO
-
 USE pq_db
 GO
 
+select current_user
+GO
+~~START~~
+varchar
+pq_db_u1
+~~END~~
+
+
+-- any user can access local temp table created under given session
 select * from #temp;
 GO
 ~~START~~
@@ -133,9 +212,6 @@ int
 USE master
 GO
 
-DROP TABLE #temp;
-GO
-
 -- tsql
 CREATE TABLE #temp (a int)
 GO
@@ -143,7 +219,6 @@ GO
 INSERT INTO #temp VALUES (1)
 GO
 ~~ROW COUNT: 1~~
-
 
 SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
 SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
@@ -179,8 +254,8 @@ off
 
 SET BABELFISH_STATISTICS PROFILE ON
 GO
-
--- temp table on outer side
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 ~~START~~
@@ -203,27 +278,30 @@ Hash Join (actual rows=1 loops=1)
 ~~END~~
 
 
--- temp table on outer side
-SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id;
 GO
 ~~START~~
 int#!#int
 1#!#1
 2#!#<NULL>
-5#!#<NULL>
-4#!#<NULL>
 3#!#<NULL>
+4#!#<NULL>
+5#!#<NULL>
 ~~END~~
 
 ~~START~~
 text
-Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a
-Hash Right Join (actual rows=5 loops=1)
-  Hash Cond: ("#temp".a = pq_t.id)
-  ->  Seq Scan on "#temp" (actual rows=1 loops=1)
-  ->  Hash (actual rows=5 loops=1)
-        Buckets: 1024  Batches: 1  Memory Usage: 9kB
-        ->  Seq Scan on pq_t (actual rows=5 loops=1)
+Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id
+Sort (actual rows=5 loops=1)
+  Sort Key: pq_t.id NULLS FIRST
+  Sort Method: quicksort  Memory: 25kB
+  ->  Hash Right Join (actual rows=5 loops=1)
+        Hash Cond: ("#temp".a = pq_t.id)
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+        ->  Hash (actual rows=5 loops=1)
+              ->  Seq Scan on pq_t (actual rows=5 loops=1)
 ~~END~~
 
 
@@ -292,16 +370,16 @@ GO
 CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
 GO
 
--- Insert sample data
 INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
 GO
 ~~ROW COUNT: 3~~
 
 
+-- table type
 CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
 GO
 
--- table valued parameter on outerside
+-- check table valued parameter on outer side scanned on leader node only
 DECLARE @SalaryUpdateTable SalaryUpdateType;
 -- Insert values into the table variable
 INSERT INTO @SalaryUpdateTable VALUES
@@ -332,7 +410,8 @@ BEGIN
         su.NewSalary,
         su.EffectiveDate
     FROM Employees e
-    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID;
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID
+    ORDER BY EmployeeID;
 END;
 GO
 
@@ -362,52 +441,4 @@ DROP TYPE SalaryUpdateType
 GO
 
 DROP TABLE Employees;
-GO
-
--- psql
-create temp table parallel_test (a int)
-GO
-
-create table reg_test (a int)
-GO
-
-insert into reg_test values (1)
-GO
-~~ROW COUNT: 1~~
-
-
-insert into parallel_test values (1)
-GO
-~~ROW COUNT: 1~~
-
-
-CREATE OR REPLACE FUNCTION f1()
-RETURNS TABLE (id INT) AS 
-$$ BEGIN
-    RETURN QUERY (SELECT a FROM parallel_test);
-END; $$
-LANGUAGE plpgsql
-PARALLEL SAFE;
-GO
-
-select * from f1()
-GO
-~~START~~
-int4
-1
-~~END~~
-
-
-select * from reg_test r join parallel_test p on r.a = p.a
-GO
-~~START~~
-int4#!#int4
-1#!#1
-~~END~~
-
-
-drop table parallel_test
-GO
-
-drop table reg_test
 GO

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -1,0 +1,187 @@
+-- tsql
+CREATE LOGIN l1 WITH PASSWORD = '12345678'
+GO
+
+CREATE USER l1
+GO
+
+CREATE TABLE pq_t (id INT)
+GO
+
+INSERT INTO pq_t VALUES (1), (2);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE SCHEMA schema_for_l1 AUTHORIZATION l1
+GO
+
+CREATE DATABASE pq_db
+GO
+
+USE pq_db
+GO
+
+CREATE USER pq_db_u1 FOR LOGIN l1
+GO
+
+USE master
+GO
+
+-- psql user=l1 password=12345678
+CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
+RETURNS TABLE (a INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT id FROM pq_t);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+-- tsql user=l1 password=12345678
+SELECT * FROM pq_t
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT * FROM schema_for_l1.f1()
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT set_config('debug_parallel_query', 1, false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+SELECT * FROM schema_for_l1.f1()
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT set_config('debug_parallel_query', 0, false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT set_config('debug_parallel_query', 1, false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT set_config('debug_parallel_query', 0, false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SELECT set_config('debug_parallel_query', 1, false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT set_config('debug_parallel_query', 0, false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+-- any user can access local temp table created under given session
+GO
+
+USE pq_db
+GO
+
+select * from #temp;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE master
+GO
+
+DROP TABLE #temp;
+GO
+
+-- psql
+DROP FUNCTION master_schema_for_l1.f1()
+GO
+
+-- tsql
+DROP SCHEMA schema_for_l1;
+GO
+
+DROP DATABASE pq_db
+GO
+
+-- terminate-tsql-conn user=l1 password=12345678
+GO
+
+-- terminate-psql-conn user=l1 password=12345678
+GO
+
+-- tsql
+DROP TABLE pq_t
+GO
+DROP USER l1
+GO
+DROP LOGIN l1;
+GO

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -353,11 +353,6 @@ GO
 
 create table reg_test (a int)
 GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: relation "reg_test" already exists
-    Server SQLState: 42P07)~~
-
 
 insert into reg_test values (1)
 GO
@@ -408,6 +403,11 @@ GO
 ~~START~~
 int4#!#int4
 1#!#1
-1#!#1
 ~~END~~
 
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -42,6 +42,38 @@ LANGUAGE plpgsql
 PARALLEL SAFE;
 GO
 
+-- psql
+create temp table test_tbl(a int);
+GO
+
+insert into test_tbl values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+select * from test_tbl
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+-- In Postgres, not everyone can access temp table
+set role l1;
+GO
+
+select * from test_tbl
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table test_tbl
+    Server SQLState: 42501)~~
+
+
+reset role
+GO
+
 -- tsql user=l1 password=12345678
 SELECT * FROM pq_t
 GO

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -43,6 +43,8 @@ PARALLEL SAFE;
 GO
 
 -- psql
+-- Permission check on temp table in Postgres
+-- Not everyone can access temp table
 create temp table test_tbl(a int);
 GO
 
@@ -59,10 +61,10 @@ int4
 ~~END~~
 
 
--- In Postgres, not everyone can access temp table
 set role l1;
 GO
 
+-- Permission denied error because l1 does not have access to temp table test_tbl
 select * from test_tbl
 GO
 ~~ERROR (Code: 0)~~
@@ -75,6 +77,7 @@ reset role
 GO
 
 -- tsql user=l1 password=12345678
+-- verify that only temp table permission check is skipped under parallel worker
 SELECT * FROM pq_t
 GO
 ~~ERROR (Code: 33557097)~~
@@ -177,6 +180,7 @@ off
 SET BABELFISH_STATISTICS PROFILE ON
 GO
 
+-- temp table on outer side
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 ~~START~~
@@ -199,6 +203,7 @@ Hash Join (actual rows=1 loops=1)
 ~~END~~
 
 
+-- temp table on outer side
 SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
 GO
 ~~START~~
@@ -283,6 +288,7 @@ DROP LOGIN l1;
 GO
 
 -- tsql
+-- table valued parameter should behave same as normal temp table
 CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
 GO
 
@@ -295,6 +301,7 @@ GO
 CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
 GO
 
+-- table valued parameter on outerside
 DECLARE @SalaryUpdateTable SalaryUpdateType;
 -- Insert values into the table variable
 INSERT INTO @SalaryUpdateTable VALUES
@@ -311,6 +318,45 @@ int
 3
 ~~END~~
 
+
+CREATE PROCEDURE UpdateEmployeeSalaries
+    @SalaryUpdates SalaryUpdateType READONLY
+AS
+BEGIN
+    -- Join TVP with regular table to get employee details with new salaries
+    SELECT 
+        e.EmployeeID,
+        e.FirstName,
+        e.LastName,
+        e.Department,
+        su.NewSalary,
+        su.EffectiveDate
+    FROM Employees e
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID;
+END;
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+-- Execute the stored procedure
+EXEC UpdateEmployeeSalaries @SalaryUpdateTable;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#numeric#!#date
+1#!#John#!#Doe#!#IT#!#75000.00#!#2025-01-01
+2#!#Jane#!#Smith#!#HR#!#65000.00#!#2025-01-01
+3#!#Mike#!#Johnson#!#IT#!#70000.00#!#2025-01-01
+~~END~~
+
+
+DROP PROCEDURE UpdateEmployeeSalaries
+GO
 
 DROP TYPE SalaryUpdateType
 GO

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -28,6 +28,10 @@ GO
 USE master
 GO
 
+-- psql
+ANALYSE;
+GO
+
 -- psql user=l1 password=12345678
 CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
 RETURNS TABLE (a INT) AS 
@@ -161,6 +165,127 @@ GO
 DROP TABLE #temp;
 GO
 
+-- tsql
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SELECT set_config('babelfishpg_tsql.memory', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM pq_t where id IN (select a from #temp)
+Hash Join (actual rows=1 loops=1)
+  Hash Cond: ("#temp".a = pq_t.id)
+  ->  HashAggregate (actual rows=1 loops=1)
+        Group Key: "#temp".a
+        Batches: 1  Memory Usage: 40kB
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+  ->  Hash (actual rows=2 loops=1)
+        Buckets: 1024  Batches: 1  Memory Usage: 9kB
+        ->  Seq Scan on pq_t (actual rows=2 loops=1)
+~~END~~
+
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#<NULL>
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a
+Hash Right Join (actual rows=2 loops=1)
+  Hash Cond: ("#temp".a = pq_t.id)
+  ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+  ->  Hash (actual rows=2 loops=1)
+        Buckets: 1024  Batches: 1  Memory Usage: 9kB
+        ->  Seq Scan on pq_t (actual rows=2 loops=1)
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'on', false)
+SELECT set_config('babelfishpg_tsql.memory', 'on', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
 -- psql
 DROP FUNCTION master_schema_for_l1.f1()
 GO
@@ -221,3 +346,68 @@ GO
 
 DROP TABLE Employees;
 GO
+
+-- psql
+create temp table parallel_test (a int)
+GO
+
+create table reg_test (a int)
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: relation "reg_test" already exists
+    Server SQLState: 42P07)~~
+
+
+insert into reg_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+insert into parallel_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from f1()
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+set debug_parallel_query=1
+GO
+
+select * from f1()
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: cannot access temporary tables during a parallel operation
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+parallel worker
+    Server SQLState: 25000)~~
+
+
+set debug_parallel_query=0
+GO
+
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~START~~
+int4#!#int4
+1#!#1
+1#!#1
+~~END~~
+

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -185,3 +185,39 @@ DROP USER l1
 GO
 DROP LOGIN l1;
 GO
+
+-- tsql
+CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
+GO
+
+-- Insert sample data
+INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+select count(*) FROM Employees e
+    INNER JOIN @SalaryUpdateTable su ON e.EmployeeID = su.EmployeeID;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+DROP TYPE SalaryUpdateType
+GO
+
+DROP TABLE Employees;
+GO

--- a/test/JDBC/expected/parallel_query/Test_parallel_query.out
+++ b/test/JDBC/expected/parallel_query/Test_parallel_query.out
@@ -1,4 +1,5 @@
 -- tsql
+-- setup
 CREATE LOGIN l1 WITH PASSWORD = '12345678'
 GO
 
@@ -28,11 +29,9 @@ GO
 USE master
 GO
 
--- psql
-ANALYSE;
-GO
-
 -- psql user=l1 password=12345678
+-- setup
+-- create parallel safe function under schema_for_l1 where user is authorised to create
 CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
 RETURNS TABLE (a INT) AS 
 $$ BEGIN
@@ -42,18 +41,39 @@ LANGUAGE plpgsql
 PARALLEL SAFE;
 GO
 
+
 -- psql
--- Permission check on temp table in Postgres
--- Not everyone can access temp table
-create temp table test_tbl(a int);
+-- Test permission check on temp table from Postgres
+create table reg_test (a int)
 GO
 
-insert into test_tbl values (1)
+insert into reg_test values (1)
 GO
 ~~ROW COUNT: 1~~
 
 
-select * from test_tbl
+create temp table parallel_test(a int);
+GO
+
+insert into parallel_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+ANALYSE;
+GO
+
+-- function which tries to access temp table using parallel execution
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from parallel_test
 GO
 ~~START~~
 int4
@@ -61,22 +81,77 @@ int4
 ~~END~~
 
 
-set role l1;
+-- temp table as a outer scan and should not be scanned using parallel worker
+select * from reg_test r join parallel_test p on r.a = p.a
 GO
+~~START~~
+int4#!#int4
+1#!#1
+~~END~~
 
--- Permission denied error because l1 does not have access to temp table test_tbl
-select * from test_tbl
+
+-- following would throw an error under parallel execution
+select * from f1()
 GO
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: permission denied for table test_tbl
+~~ERROR (Message: ERROR: cannot access temporary tables during a parallel operation
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+parallel worker
+    Server SQLState: 25000)~~
+
+
+-- Not everyone can access temp table
+-- Permission denied error should be raised whe l1 tries to access to temp table parallel_test
+set role l1;
+GO
+
+-- should result in permission error
+select * from parallel_test
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from f1()
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+parallel worker
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table reg_test
     Server SQLState: 42501)~~
 
 
 reset role
 GO
 
+DROP FUNCTION f1()
+GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO
+
+
 -- tsql user=l1 password=12345678
+-- testing permission on temp table from Babelfish endpoint
 -- verify that only temp table permission check is skipped under parallel worker
 SELECT * FROM pq_t
 GO
@@ -85,6 +160,7 @@ GO
 ~~ERROR (Message: permission denied for table pq_t)~~
 
 
+-- function schema_for_l1.f1() access regular table so permission check shouldnt be skipped even under parallel worker
 SELECT * FROM schema_for_l1.f1()
 GO
 ~~START~~
@@ -102,6 +178,7 @@ GO
 ~~ROW COUNT: 1~~
 
 
+-- temp table as a outer scan and user has permission to access regular table
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 ~~ERROR (Code: 33557097)~~
@@ -116,12 +193,18 @@ GO
 ~~ERROR (Message: permission denied for table pq_t)~~
 
 
--- any user can access local temp table created under given session
-GO
-
 USE pq_db
 GO
 
+select current_user
+GO
+~~START~~
+varchar
+pq_db_u1
+~~END~~
+
+
+-- any user can access local temp table created under given session
 select * from #temp;
 GO
 ~~START~~
@@ -133,9 +216,6 @@ int
 USE master
 GO
 
-DROP TABLE #temp;
-GO
-
 -- tsql
 CREATE TABLE #temp (a int)
 GO
@@ -143,7 +223,6 @@ GO
 INSERT INTO #temp VALUES (1)
 GO
 ~~ROW COUNT: 1~~
-
 
 SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
 SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
@@ -179,8 +258,8 @@ off
 
 SET BABELFISH_STATISTICS PROFILE ON
 GO
-
--- temp table on outer side
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 ~~START~~
@@ -206,30 +285,34 @@ Hash Join (actual rows=1 loops=1)
 ~~END~~
 
 
--- temp table on outer side
-SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id;
 GO
 ~~START~~
 int#!#int
 1#!#1
 2#!#<NULL>
-5#!#<NULL>
-4#!#<NULL>
 3#!#<NULL>
+4#!#<NULL>
+5#!#<NULL>
 ~~END~~
 
 ~~START~~
 text
-Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a
-Hash Right Join (actual rows=5 loops=1)
-  Hash Cond: ("#temp".a = pq_t.id)
-  ->  Seq Scan on "#temp" (actual rows=1 loops=1)
-  ->  Hash (actual rows=5 loops=1)
-        Buckets: 1024  Batches: 1  Memory Usage: 9kB
-        ->  Gather (actual rows=5 loops=1)
-              Workers Planned: 1
-              Workers Launched: 1
-              ->  Parallel Seq Scan on pq_t (actual rows=2 loops=2)
+Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id
+Sort (actual rows=5 loops=1)
+  Sort Key: pq_t.id NULLS FIRST
+  Sort Method: quicksort  Memory: 25kB
+  ->  Hash Right Join (actual rows=5 loops=1)
+        Hash Cond: ("#temp".a = pq_t.id)
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+        ->  Hash (actual rows=5 loops=1)
+              Buckets: 1024  Batches: 1  Memory Usage: 9kB
+              ->  Gather (actual rows=5 loops=1)
+                    Workers Planned: 1
+                    Workers Launched: 1
+                    ->  Parallel Seq Scan on pq_t (actual rows=2 loops=2)
 ~~END~~
 
 
@@ -298,16 +381,16 @@ GO
 CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
 GO
 
--- Insert sample data
 INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
 GO
 ~~ROW COUNT: 3~~
 
 
+-- table type
 CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
 GO
 
--- table valued parameter on outerside
+-- check table valued parameter on outer side scanned on leader node only
 DECLARE @SalaryUpdateTable SalaryUpdateType;
 -- Insert values into the table variable
 INSERT INTO @SalaryUpdateTable VALUES
@@ -338,7 +421,8 @@ BEGIN
         su.NewSalary,
         su.EffectiveDate
     FROM Employees e
-    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID;
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID
+    ORDER BY EmployeeID;
 END;
 GO
 
@@ -368,55 +452,4 @@ DROP TYPE SalaryUpdateType
 GO
 
 DROP TABLE Employees;
-GO
-
--- psql
-create temp table parallel_test (a int)
-GO
-
-create table reg_test (a int)
-GO
-
-insert into reg_test values (1)
-GO
-~~ROW COUNT: 1~~
-
-
-insert into parallel_test values (1)
-GO
-~~ROW COUNT: 1~~
-
-
-CREATE OR REPLACE FUNCTION f1()
-RETURNS TABLE (id INT) AS 
-$$ BEGIN
-    RETURN QUERY (SELECT a FROM parallel_test);
-END; $$
-LANGUAGE plpgsql
-PARALLEL SAFE;
-GO
-
-select * from f1()
-GO
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: cannot access temporary tables during a parallel operation
-  Where: SQL statement "(SELECT a FROM parallel_test)"
-PL/pgSQL function f1() line 2 at RETURN QUERY
-parallel worker
-    Server SQLState: 25000)~~
-
-
-select * from reg_test r join parallel_test p on r.a = p.a
-GO
-~~START~~
-int4#!#int4
-1#!#1
-~~END~~
-
-
-drop table parallel_test
-GO
-
-drop table reg_test
 GO

--- a/test/JDBC/expected/parallel_query/Test_parallel_query.out
+++ b/test/JDBC/expected/parallel_query/Test_parallel_query.out
@@ -163,7 +163,10 @@ Hash Join (actual rows=1 loops=1)
         ->  Seq Scan on "#temp" (actual rows=1 loops=1)
   ->  Hash (actual rows=5 loops=1)
         Buckets: 1024  Batches: 1  Memory Usage: 9kB
-        ->  Seq Scan on pq_t (actual rows=5 loops=1)
+        ->  Gather (actual rows=5 loops=1)
+              Workers Planned: 1
+              Workers Launched: 1
+              ->  Parallel Seq Scan on pq_t (actual rows=2 loops=2)
 ~~END~~
 
 
@@ -186,7 +189,10 @@ Hash Right Join (actual rows=5 loops=1)
   ->  Seq Scan on "#temp" (actual rows=1 loops=1)
   ->  Hash (actual rows=5 loops=1)
         Buckets: 1024  Batches: 1  Memory Usage: 9kB
-        ->  Seq Scan on pq_t (actual rows=5 loops=1)
+        ->  Gather (actual rows=5 loops=1)
+              Workers Planned: 1
+              Workers Launched: 1
+              ->  Parallel Seq Scan on pq_t (actual rows=2 loops=2)
 ~~END~~
 
 
@@ -314,10 +320,13 @@ GO
 
 select * from f1()
 GO
-~~START~~
-int4
-1
-~~END~~
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: cannot access temporary tables during a parallel operation
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+parallel worker
+    Server SQLState: 25000)~~
 
 
 select * from reg_test r join parallel_test p on r.a = p.a

--- a/test/JDBC/expected/parallel_query/Test_parallel_query.out
+++ b/test/JDBC/expected/parallel_query/Test_parallel_query.out
@@ -42,6 +42,38 @@ LANGUAGE plpgsql
 PARALLEL SAFE;
 GO
 
+-- psql
+create temp table test_tbl(a int);
+GO
+
+insert into test_tbl values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+select * from test_tbl
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+-- In Postgres, not everyone can access temp table
+set role l1;
+GO
+
+select * from test_tbl
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table test_tbl
+    Server SQLState: 42501)~~
+
+
+reset role
+GO
+
 -- tsql user=l1 password=12345678
 SELECT * FROM pq_t
 GO

--- a/test/JDBC/expected/parallel_query/Test_parallel_query.out
+++ b/test/JDBC/expected/parallel_query/Test_parallel_query.out
@@ -43,6 +43,8 @@ PARALLEL SAFE;
 GO
 
 -- psql
+-- Permission check on temp table in Postgres
+-- Not everyone can access temp table
 create temp table test_tbl(a int);
 GO
 
@@ -59,10 +61,10 @@ int4
 ~~END~~
 
 
--- In Postgres, not everyone can access temp table
 set role l1;
 GO
 
+-- Permission denied error because l1 does not have access to temp table test_tbl
 select * from test_tbl
 GO
 ~~ERROR (Code: 0)~~
@@ -75,6 +77,7 @@ reset role
 GO
 
 -- tsql user=l1 password=12345678
+-- verify that only temp table permission check is skipped under parallel worker
 SELECT * FROM pq_t
 GO
 ~~ERROR (Code: 33557097)~~
@@ -177,6 +180,7 @@ off
 SET BABELFISH_STATISTICS PROFILE ON
 GO
 
+-- temp table on outer side
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 ~~START~~
@@ -202,6 +206,7 @@ Hash Join (actual rows=1 loops=1)
 ~~END~~
 
 
+-- temp table on outer side
 SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
 GO
 ~~START~~
@@ -289,6 +294,7 @@ DROP LOGIN l1;
 GO
 
 -- tsql
+-- table valued parameter should behave same as normal temp table
 CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
 GO
 
@@ -301,6 +307,7 @@ GO
 CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
 GO
 
+-- table valued parameter on outerside
 DECLARE @SalaryUpdateTable SalaryUpdateType;
 -- Insert values into the table variable
 INSERT INTO @SalaryUpdateTable VALUES
@@ -317,6 +324,45 @@ int
 3
 ~~END~~
 
+
+CREATE PROCEDURE UpdateEmployeeSalaries
+    @SalaryUpdates SalaryUpdateType READONLY
+AS
+BEGIN
+    -- Join TVP with regular table to get employee details with new salaries
+    SELECT 
+        e.EmployeeID,
+        e.FirstName,
+        e.LastName,
+        e.Department,
+        su.NewSalary,
+        su.EffectiveDate
+    FROM Employees e
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID;
+END;
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+-- Execute the stored procedure
+EXEC UpdateEmployeeSalaries @SalaryUpdateTable;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#numeric#!#date
+1#!#John#!#Doe#!#IT#!#75000.00#!#2025-01-01
+2#!#Jane#!#Smith#!#HR#!#65000.00#!#2025-01-01
+3#!#Mike#!#Johnson#!#IT#!#70000.00#!#2025-01-01
+~~END~~
+
+
+DROP PROCEDURE UpdateEmployeeSalaries
+GO
 
 DROP TYPE SalaryUpdateType
 GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -1,0 +1,120 @@
+-- tsql
+CREATE LOGIN l1 WITH PASSWORD = '12345678'
+GO
+
+CREATE USER l1
+GO
+
+CREATE TABLE pq_t (id INT)
+GO
+
+INSERT INTO pq_t VALUES (1), (2);
+GO
+
+CREATE SCHEMA schema_for_l1 AUTHORIZATION l1
+GO
+
+CREATE DATABASE pq_db
+GO
+
+USE pq_db
+GO
+
+CREATE USER pq_db_u1 FOR LOGIN l1
+GO
+
+USE master
+GO
+
+-- psql user=l1 password=12345678
+CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
+RETURNS TABLE (a INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT id FROM pq_t);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+-- tsql user=l1 password=12345678
+SELECT * FROM pq_t
+GO
+
+SELECT * FROM schema_for_l1.f1()
+GO
+
+SELECT set_config('debug_parallel_query', 1, false)
+GO
+
+SELECT * FROM schema_for_l1.f1()
+GO
+
+SELECT set_config('debug_parallel_query', 0, false)
+GO
+
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+
+SELECT set_config('debug_parallel_query', 1, false)
+GO
+
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+
+SELECT set_config('debug_parallel_query', 0, false)
+GO
+
+SELECT set_config('debug_parallel_query', 1, false)
+GO
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+
+SELECT set_config('debug_parallel_query', 0, false)
+GO
+
+-- any user can access local temp table created under given session
+GO
+
+USE pq_db
+GO
+
+select * from #temp;
+GO
+
+USE master
+GO
+
+DROP TABLE #temp;
+GO
+
+-- psql
+DROP FUNCTION master_schema_for_l1.f1()
+GO
+
+-- tsql
+DROP SCHEMA schema_for_l1;
+GO
+
+DROP DATABASE pq_db
+GO
+
+-- terminate-tsql-conn user=l1 password=12345678
+GO
+
+-- terminate-psql-conn user=l1 password=12345678
+GO
+
+-- tsql
+DROP TABLE pq_t
+GO
+DROP USER l1
+GO
+DROP LOGIN l1;
+GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -1,5 +1,6 @@
 -- parallel_query_expected
 -- tsql
+-- setup
 CREATE LOGIN l1 WITH PASSWORD = '12345678'
 GO
 
@@ -27,11 +28,9 @@ GO
 USE master
 GO
 
--- psql
-ANALYSE;
-GO
-
 -- psql user=l1 password=12345678
+-- setup
+-- create parallel safe function under schema_for_l1 where user is authorised to create
 CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
 RETURNS TABLE (a INT) AS 
 $$ BEGIN
@@ -41,33 +40,82 @@ LANGUAGE plpgsql
 PARALLEL SAFE;
 GO
 
+-- Test permission check on temp table from Postgres
+
 -- psql
--- Permission check on temp table in Postgres
+create table reg_test (a int)
+GO
+
+insert into reg_test values (1)
+GO
+
+create temp table parallel_test(a int);
+GO
+
+insert into parallel_test values (1)
+GO
+
+ANALYSE;
+GO
+
+-- function which tries to access temp table using parallel execution
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from parallel_test
+GO
+
+-- temp table as a outer scan and should not be scanned using parallel worker
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+
+-- following would throw an error under parallel execution
+select * from f1()
+GO
+
 -- Not everyone can access temp table
-create temp table test_tbl(a int);
-GO
-
-insert into test_tbl values (1)
-GO
-
-select * from test_tbl
-GO
-
+-- Permission denied error should be raised whe l1 tries to access to temp table parallel_test
 set role l1;
 GO
 
--- Permission denied error because l1 does not have access to temp table test_tbl
-select * from test_tbl
+-- should result in permission error
+select * from parallel_test
+GO
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from f1()
+GO
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from reg_test r join parallel_test p on r.a = p.a
 GO
 
 reset role
 GO
+
+DROP FUNCTION f1()
+GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO
+
+-- testing permission on temp table from Babelfish endpoint
 
 -- tsql user=l1 password=12345678
 -- verify that only temp table permission check is skipped under parallel worker
 SELECT * FROM pq_t
 GO
 
+-- function schema_for_l1.f1() access regular table so permission check shouldnt be skipped even under parallel worker
 SELECT * FROM schema_for_l1.f1()
 GO
 
@@ -77,25 +125,24 @@ GO
 INSERT INTO #temp VALUES (1)
 GO
 
+-- temp table as a outer scan and user has permission to access regular table
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 
 SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
 GO
 
--- any user can access local temp table created under given session
-GO
-
 USE pq_db
 GO
 
+select current_user
+GO
+
+-- any user can access local temp table created under given session
 select * from #temp;
 GO
 
 USE master
-GO
-
-DROP TABLE #temp;
 GO
 
 -- tsql
@@ -104,7 +151,6 @@ GO
 
 INSERT INTO #temp VALUES (1)
 GO
-
 SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
 SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
 SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
@@ -114,13 +160,14 @@ GO
 
 SET BABELFISH_STATISTICS PROFILE ON
 GO
-
--- temp table on outer side
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 
--- temp table on outer side
-SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id;
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF
@@ -163,14 +210,14 @@ GO
 CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
 GO
 
--- Insert sample data
 INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
 GO
 
+-- table type
 CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
 GO
 
--- table valued parameter on outerside
+-- check table valued parameter on outer side scanned on leader node only
 DECLARE @SalaryUpdateTable SalaryUpdateType;
 -- Insert values into the table variable
 INSERT INTO @SalaryUpdateTable VALUES
@@ -194,7 +241,8 @@ BEGIN
         su.NewSalary,
         su.EffectiveDate
     FROM Employees e
-    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID;
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID
+    ORDER BY EmployeeID;
 END;
 GO
 
@@ -215,38 +263,4 @@ DROP TYPE SalaryUpdateType
 GO
 
 DROP TABLE Employees;
-GO
-
--- psql
-create temp table parallel_test (a int)
-GO
-
-create table reg_test (a int)
-GO
-
-insert into reg_test values (1)
-GO
-
-insert into parallel_test values (1)
-GO
-
-CREATE OR REPLACE FUNCTION f1()
-RETURNS TABLE (id INT) AS 
-$$ BEGIN
-    RETURN QUERY (SELECT a FROM parallel_test);
-END; $$
-LANGUAGE plpgsql
-PARALLEL SAFE;
-GO
-
-select * from f1()
-GO
-
-select * from reg_test r join parallel_test p on r.a = p.a
-GO
-
-drop table parallel_test
-GO
-
-drop table reg_test
 GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -219,3 +219,9 @@ GO
 
 select * from reg_test r join parallel_test p on r.a = p.a
 GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -26,6 +26,10 @@ GO
 USE master
 GO
 
+-- psql
+ANALYSE;
+GO
+
 -- psql user=l1 password=12345678
 CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
 RETURNS TABLE (a INT) AS 
@@ -94,6 +98,39 @@ GO
 DROP TABLE #temp;
 GO
 
+-- tsql
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SELECT set_config('babelfishpg_tsql.memory', 'off', false)
+GO
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'on', false)
+SELECT set_config('babelfishpg_tsql.memory', 'on', false)
+GO
+
 -- psql
 DROP FUNCTION master_schema_for_l1.f1()
 GO
@@ -144,4 +181,41 @@ DROP TYPE SalaryUpdateType
 GO
 
 DROP TABLE Employees;
+GO
+
+-- psql
+create temp table parallel_test (a int)
+GO
+
+create table reg_test (a int)
+GO
+
+insert into reg_test values (1)
+GO
+
+insert into parallel_test values (1)
+GO
+
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from f1()
+GO
+
+set debug_parallel_query=1
+GO
+
+select * from f1()
+GO
+
+set debug_parallel_query=0
+GO
+
+select * from reg_test r join parallel_test p on r.a = p.a
 GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -118,3 +118,30 @@ DROP USER l1
 GO
 DROP LOGIN l1;
 GO
+
+-- tsql
+CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
+GO
+
+-- Insert sample data
+INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
+GO
+
+CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+select count(*) FROM Employees e
+    INNER JOIN @SalaryUpdateTable su ON e.EmployeeID = su.EmployeeID;
+GO
+
+DROP TYPE SalaryUpdateType
+GO
+
+DROP TABLE Employees;
+GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -1,3 +1,4 @@
+-- parallel_query_expected
 -- tsql
 CREATE LOGIN l1 WITH PASSWORD = '12345678'
 GO
@@ -8,7 +9,7 @@ GO
 CREATE TABLE pq_t (id INT)
 GO
 
-INSERT INTO pq_t VALUES (1), (2);
+INSERT INTO pq_t VALUES (1), (2), (3), (4) , (5);
 GO
 
 CREATE SCHEMA schema_for_l1 AUTHORIZATION l1
@@ -47,15 +48,6 @@ GO
 SELECT * FROM schema_for_l1.f1()
 GO
 
-SELECT set_config('debug_parallel_query', 1, false)
-GO
-
-SELECT * FROM schema_for_l1.f1()
-GO
-
-SELECT set_config('debug_parallel_query', 0, false)
-GO
-
 CREATE TABLE #temp (a int)
 GO
 
@@ -65,22 +57,7 @@ GO
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 
-SELECT set_config('debug_parallel_query', 1, false)
-GO
-
-SELECT * FROM pq_t where id IN (select a from #temp)
-GO
-
-SELECT set_config('debug_parallel_query', 0, false)
-GO
-
-SELECT set_config('debug_parallel_query', 1, false)
-GO
-
 SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
-GO
-
-SELECT set_config('debug_parallel_query', 0, false)
 GO
 
 -- any user can access local temp table created under given session
@@ -206,15 +183,6 @@ PARALLEL SAFE;
 GO
 
 select * from f1()
-GO
-
-set debug_parallel_query=1
-GO
-
-select * from f1()
-GO
-
-set debug_parallel_query=0
 GO
 
 select * from reg_test r join parallel_test p on r.a = p.a

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -42,6 +42,8 @@ PARALLEL SAFE;
 GO
 
 -- psql
+-- Permission check on temp table in Postgres
+-- Not everyone can access temp table
 create temp table test_tbl(a int);
 GO
 
@@ -51,10 +53,10 @@ GO
 select * from test_tbl
 GO
 
--- In Postgres, not everyone can access temp table
 set role l1;
 GO
 
+-- Permission denied error because l1 does not have access to temp table test_tbl
 select * from test_tbl
 GO
 
@@ -62,6 +64,7 @@ reset role
 GO
 
 -- tsql user=l1 password=12345678
+-- verify that only temp table permission check is skipped under parallel worker
 SELECT * FROM pq_t
 GO
 
@@ -112,9 +115,11 @@ GO
 SET BABELFISH_STATISTICS PROFILE ON
 GO
 
+-- temp table on outer side
 SELECT * FROM pq_t where id IN (select a from #temp)
 GO
 
+-- temp table on outer side
 SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
 GO
 
@@ -154,6 +159,7 @@ DROP LOGIN l1;
 GO
 
 -- tsql
+-- table valued parameter should behave same as normal temp table
 CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
 GO
 
@@ -164,6 +170,7 @@ GO
 CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
 GO
 
+-- table valued parameter on outerside
 DECLARE @SalaryUpdateTable SalaryUpdateType;
 -- Insert values into the table variable
 INSERT INTO @SalaryUpdateTable VALUES
@@ -172,6 +179,36 @@ INSERT INTO @SalaryUpdateTable VALUES
 (3, 70000.00, '2025-01-01');
 select count(*) FROM Employees e
     INNER JOIN @SalaryUpdateTable su ON e.EmployeeID = su.EmployeeID;
+GO
+
+CREATE PROCEDURE UpdateEmployeeSalaries
+    @SalaryUpdates SalaryUpdateType READONLY
+AS
+BEGIN
+    -- Join TVP with regular table to get employee details with new salaries
+    SELECT 
+        e.EmployeeID,
+        e.FirstName,
+        e.LastName,
+        e.Department,
+        su.NewSalary,
+        su.EffectiveDate
+    FROM Employees e
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID;
+END;
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+-- Execute the stored procedure
+EXEC UpdateEmployeeSalaries @SalaryUpdateTable;
+GO
+
+DROP PROCEDURE UpdateEmployeeSalaries
 GO
 
 DROP TYPE SalaryUpdateType

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -41,6 +41,26 @@ LANGUAGE plpgsql
 PARALLEL SAFE;
 GO
 
+-- psql
+create temp table test_tbl(a int);
+GO
+
+insert into test_tbl values (1)
+GO
+
+select * from test_tbl
+GO
+
+-- In Postgres, not everyone can access temp table
+set role l1;
+GO
+
+select * from test_tbl
+GO
+
+reset role
+GO
+
 -- tsql user=l1 password=12345678
 SELECT * FROM pq_t
 GO


### PR DESCRIPTION
### Description

Consider following facts,

Babelfish temp tables are implemented using ENR which is not shared between different backends. So if Parallel worker
tries to check permissions on Babelfish then it will fail.

Any user should be able to access Babelfish temp tables under given session.

Postgres by default does not allow parallel operations on temp tables. Attempt to do so will result in run time error.

Due to above facts, we should avoid permission check on temp tables within parallel workers while ensuring that leader
does required permission check on other tables. This commits achieves this behaviour by implementating following three
hooks,

bbf_ParallelQueryMain_hook -- implements ParallelQueryMain_hook. It constructs Bitmapset (list of temp table oids)
by looping through es_range_table checking if given relation is temp table, checks permission if it is and add it to the
set. It will then pass this set of temp table defined under current with Parallel workers.

bbf_ExecInitParallelPlan -- implements ExecInitParallelPlan_hook. Parallel workers will gather additional details (oid set of
temp table) passed by Leader node. This set will later be used to avoid checking permissions on temp tables.

bbf_ExecCheckOneRelPerms_hook -- implements ExecCheckOneRelPerms_hook. It will avoid permission check relation
if relid is part of the set of oids constructed using bbf_ExecInitParallelPlan. 

### Issues Resolved

BABEL-5703

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).