### PR TITLE
Use stable version of CMAKE to resolve ANTLR build failures

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -8,10 +8,12 @@ runs:
         curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
         sudo apt-get update --fix-missing -y
-        sudo apt-get install gcc-9 uuid-dev openjdk-21-jre libicu-dev libxml2-dev openssl libssl-dev python3-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison mssql-tools unixodbc-dev libsybdb5 freetds-dev freetds-common gdal-bin libgdal-dev libgeos-dev gdb libkrb5-dev
+        sudo apt-get install gcc-9 uuid-dev openjdk-21-jre libicu-dev libxml2-dev openssl libssl-dev python3-dev libossp-uuid-dev libpq-dev pkg-config g++ build-essential bison mssql-tools unixodbc-dev libsybdb5 freetds-dev freetds-common gdal-bin libgdal-dev libgeos-dev gdb libkrb5-dev
         sudo apt install -y ccache
         sudo apt-get install lcov
         sudo /usr/sbin/update-ccache-symlinks
-        echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-        source ~/.bashrc && echo $PATH
+        # Install CMAKE 3.20.6
+        wget -q https://github.com/Kitware/CMake/releases/download/v3.20.6/cmake-3.20.6-linux-x86_64.sh
+        echo "y" | sudo bash ./cmake-3.20.6-linux-x86_64.sh --prefix=/usr/local
+        echo "PATH=/usr/local/cmake-3.20.6-linux-x86_64/bin:/usr/lib/ccache:$PATH" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
### Description

This commit addresses build failures with ANTLR that were occurring due to recent updates to CMake. To resolve the issue, the commit updates the CMake version used in the build process to a stable 3.20.6 release.


Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).