### PR TITLE
Fix incorrect file name in upgrade schedule

### DIFF
--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -476,4 +476,4 @@ BABEL-NUMERIC_EXPR
 BABEL-5467
 test_conv_float_to_varchar_char_before_17_4
 round_return_type_test-before-16_9-or-17_5
-test_conv_int_to_varbinary_binary_before_16_3_or_15_7_or_15_6
+test_conv_int_to_varbinary_binary_before_16_3_or_15_7

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -565,4 +565,4 @@ test_conv_float_to_varchar_char_before_17_4
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 round_return_type_test-before-16_9-or-17_5
 alter-view
-test_conv_int_to_varbinary_binary_before_17_5_or_16_9_or_16_9
+test_conv_int_to_varbinary_binary_before_17_5_or_16_9


### PR DESCRIPTION
### Description
In https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3597 , few upgrade schedule had wrong file name added , fixing them to reference correct name

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).