### PR TITLE
Include unique constraints metadata in sys.objects view (#3658)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1815,15 +1815,19 @@ select
     , CAST(p.principal_id as int) as principal_id
     , CAST(p.schema_id as int) as schema_id
     , CAST(p.parent_object_id as int) as parent_object_id
-    , CAST('PK' as char(2)) as type
-    , CAST('PRIMARY_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(p.type as char(2)) as type
+    , CAST(
+        CASE p.type
+        WHEN 'PK' THEN 'PRIMARY_KEY_CONSTRAINT'
+        WHEN 'UQ' THEN 'UNIQUE_CONSTRAINT'
+        END
+      as sys.nvarchar(60)) as type_desc
     , CAST(p.create_date as sys.datetime) as create_date
     , CAST(p.modify_date as sys.datetime) as modify_date
     , CAST(p.is_ms_shipped as sys.bit) as is_ms_shipped
     , CAST(p.is_published as sys.bit) as is_published
     , CAST(p.is_schema_published as sys.bit) as is_schema_published
 from sys.key_constraints p
-where p.type = 'PK'
 union all
 select
       CAST(pr.name as sys.sysname) as name

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.5.0--4.6.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.5.0--4.6.0.sql
@@ -1045,6 +1045,179 @@ CREATE OR REPLACE FUNCTION sys.json_query(json_string text, path text default '$
 RETURNS sys.NVARCHAR_JSON
 AS 'babelfishpg_tsql', 'tsql_json_query' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+create or replace view sys.objects as
+select
+      CAST(t.name as sys.sysname) as name 
+    , CAST(t.object_id as int) as object_id
+    , CAST(t.principal_id as int) as principal_id
+    , CAST(t.schema_id as int) as schema_id
+    , CAST(t.parent_object_id as int) as parent_object_id
+    , CAST('U' as char(2)) as type
+    , CAST('USER_TABLE' as sys.nvarchar(60)) as type_desc
+    , CAST(t.create_date as sys.datetime) as create_date
+    , CAST(t.modify_date as sys.datetime) as modify_date
+    , CAST(t.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(t.is_published as sys.bit) as is_published
+    , CAST(t.is_schema_published as sys.bit) as is_schema_published
+from  sys.tables t
+union all
+select
+      CAST(v.name as sys.sysname) as name
+    , CAST(v.object_id as int) as object_id
+    , CAST(v.principal_id as int) as principal_id
+    , CAST(v.schema_id as int) as schema_id
+    , CAST(v.parent_object_id as int) as parent_object_id
+    , CAST('V' as char(2)) as type
+    , CAST('VIEW' as sys.nvarchar(60)) as type_desc
+    , CAST(v.create_date as sys.datetime) as create_date
+    , CAST(v.modify_date as sys.datetime) as modify_date
+    , CAST(v.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(v.is_published as sys.bit) as is_published
+    , CAST(v.is_schema_published as sys.bit) as is_schema_published
+from  sys.views v
+union all
+select
+      CAST(f.name as sys.sysname) as name
+    , CAST(f.object_id as int) as object_id
+    , CAST(f.principal_id as int) as principal_id
+    , CAST(f.schema_id as int) as schema_id
+    , CAST(f.parent_object_id as int) as parent_object_id
+    , CAST('F' as char(2)) as type
+    , CAST('FOREIGN_KEY_CONSTRAINT' as sys.nvarchar(60)) as type_desc
+    , CAST(f.create_date as sys.datetime) as create_date
+    , CAST(f.modify_date as sys.datetime) as modify_date
+    , CAST(f.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(f.is_published as sys.bit) as is_published
+    , CAST(f.is_schema_published as sys.bit) as is_schema_published
+ from sys.foreign_keys f
+union all
+select
+      CAST(p.name as sys.sysname) as name
+    , CAST(p.object_id as int) as object_id
+    , CAST(p.principal_id as int) as principal_id
+    , CAST(p.schema_id as int) as schema_id
+    , CAST(p.parent_object_id as int) as parent_object_id
+    , CAST(p.type as char(2)) as type
+    , CAST(
+        CASE p.type
+        WHEN 'PK' THEN 'PRIMARY_KEY_CONSTRAINT'
+        WHEN 'UQ' THEN 'UNIQUE_CONSTRAINT'
+        END
+      as sys.nvarchar(60)) as type_desc
+    , CAST(p.create_date as sys.datetime) as create_date
+    , CAST(p.modify_date as sys.datetime) as modify_date
+    , CAST(p.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(p.is_published as sys.bit) as is_published
+    , CAST(p.is_schema_published as sys.bit) as is_schema_published
+from sys.key_constraints p
+union all
+select
+      CAST(pr.name as sys.sysname) as name
+    , CAST(pr.object_id as int) as object_id
+    , CAST(pr.principal_id as int) as principal_id
+    , CAST(pr.schema_id as int) as schema_id
+    , CAST(pr.parent_object_id as int) as parent_object_id
+    , CAST(pr.type as char(2)) as type
+    , CAST(pr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(pr.create_date as sys.datetime) as create_date
+    , CAST(pr.modify_date as sys.datetime) as modify_date
+    , CAST(pr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(pr.is_published as sys.bit) as is_published
+    , CAST(pr.is_schema_published as sys.bit) as is_schema_published
+ from sys.procedures pr
+union all
+select
+      CAST(tr.name as sys.sysname) as name
+    , CAST(tr.object_id as int) as object_id
+    , CAST(NULL as int) as principal_id
+    , CAST(p.relnamespace as int) as schema_id
+    , CAST(tr.parent_id as int) as parent_object_id
+    , CAST(tr.type as char(2)) as type
+    , CAST(tr.type_desc as sys.nvarchar(60)) as type_desc
+    , CAST(tr.create_date as sys.datetime) as create_date
+    , CAST(tr.modify_date as sys.datetime) as modify_date
+    , CAST(tr.is_ms_shipped as sys.bit) as is_ms_shipped
+    , CAST(0 as sys.bit) as is_published
+    , CAST(0 as sys.bit) as is_schema_published
+  from sys.triggers tr
+  inner join pg_class p on p.oid = tr.parent_id
+union all 
+select
+    CAST(def.name as sys.sysname) as name
+  , CAST(def.object_id as int) as object_id
+  , CAST(def.principal_id as int) as principal_id
+  , CAST(def.schema_id as int) as schema_id
+  , CAST(def.parent_object_id as int) as parent_object_id
+  , CAST(def.type as char(2)) as type
+  , CAST(def.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(def.create_date as sys.datetime) as create_date
+  , CAST(def.modified_date as sys.datetime) as modify_date
+  , CAST(def.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(def.is_published as sys.bit) as is_published
+  , CAST(def.is_schema_published as sys.bit) as is_schema_published
+  from sys.default_constraints def
+union all
+select
+    CAST(chk.name as sys.sysname) as name
+  , CAST(chk.object_id as int) as object_id
+  , CAST(chk.principal_id as int) as principal_id
+  , CAST(chk.schema_id as int) as schema_id
+  , CAST(chk.parent_object_id as int) as parent_object_id
+  , CAST(chk.type as char(2)) as type
+  , CAST(chk.type_desc as sys.nvarchar(60)) as type_desc
+  , CAST(chk.create_date as sys.datetime) as create_date
+  , CAST(chk.modify_date as sys.datetime) as modify_date
+  , CAST(chk.is_ms_shipped as sys.bit) as is_ms_shipped
+  , CAST(chk.is_published as sys.bit) as is_published
+  , CAST(chk.is_schema_published as sys.bit) as is_schema_published
+  from sys.check_constraints chk
+union all
+select
+    CAST(p.relname as sys.sysname) as name
+  , CAST(p.oid as int) as object_id
+  , CAST(null as int) as principal_id
+  , CAST(s.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('SO' as char(2)) as type
+  , CAST('SEQUENCE_OBJECT' as sys.nvarchar(60)) as type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modify_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+from pg_class p
+inner join sys.schemas s on s.schema_id = p.relnamespace
+and p.relkind = 'S'
+union all
+select
+    CAST(('TT_' || tt.name collate "C" || '_' || tt.type_table_object_id) as sys.sysname) as name
+  , CAST(tt.type_table_object_id as int) as object_id
+  , CAST(tt.principal_id as int) as principal_id
+  , CAST(tt.schema_id as int) as schema_id
+  , CAST(0 as int) as parent_object_id
+  , CAST('TT' as char(2)) as type
+  , CAST('TABLE_TYPE' as sys.nvarchar(60)) as type_desc
+  , CAST((select PG_CATALOG.string_agg(
+                    case
+                    when option like 'bbf_rel_create_date=%%' then substring(option, 21)
+                    else NULL
+                    end, ',')
+          from unnest(c.reloptions) as option)
+     as sys.datetime) as create_date
+  , CAST((select PG_CATALOG.string_agg(
+                    case
+                    when option like 'bbf_rel_create_date=%%' then substring(option, 21)
+                    else NULL
+                    end, ',')
+          from unnest(c.reloptions) as option)
+     as sys.datetime) as modify_date
+  , CAST(1 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+from sys.table_types tt
+inner join pg_class c on tt.type_table_object_id = c.oid;
+GRANT SELECT ON sys.objects TO PUBLIC;
+
 DO $$
 DECLARE
     old_function_exists boolean;

--- a/test/JDBC/expected/ISC-Table_Constraints-vu-verify.out
+++ b/test/JDBC/expected/ISC-Table_Constraints-vu-verify.out
@@ -78,7 +78,6 @@ master#!#sch1#!#tbl_pk_pkey#!#master#!#sch1#!#tbl_pk#!#PRIMARY KEY#!#NO#!#NO
 
 
 -- verify from sys.objects
--- Note: sys.objects not showing unique constraints currently
 select constraint_name, constraint_schema, table_name, constraint_type from information_schema.table_constraints where table_name in ('tbl_pk','tbl_fk') order by constraint_name, constraint_schema;
 select name, schema_name(schema_id) as schname, object_name(parent_object_id),type_desc from sys.objects where type in ('C','F','PK','UQ') and object_name(parent_object_id) in ('tbl_pk','tbl_fk') order by name, schname;
 go
@@ -102,6 +101,8 @@ tbl_fk_a_fkey#!#dbo#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_a_fkey#!#sch1#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_pkey#!#dbo#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT
 tbl_fk_pkey#!#sch1#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT
+tbl_pk_c_key#!#dbo#!#tbl_pk#!#UNIQUE_CONSTRAINT
+tbl_pk_c_key#!#sch1#!#tbl_pk#!#UNIQUE_CONSTRAINT
 tbl_pk_d_check#!#dbo#!#tbl_pk#!#CHECK_CONSTRAINT
 tbl_pk_d_check#!#sch1#!#tbl_pk#!#CHECK_CONSTRAINT
 tbl_pk_pkey#!#dbo#!#tbl_pk#!#PRIMARY_KEY_CONSTRAINT

--- a/test/JDBC/expected/ISC-Table_Constraints.out
+++ b/test/JDBC/expected/ISC-Table_Constraints.out
@@ -94,7 +94,6 @@ master#!#sch1#!#tbl_pk_pkey#!#master#!#sch1#!#tbl_pk#!#PRIMARY KEY#!#NO#!#NO
 
 
 -- verify from sys.objects
--- Note: sys.objects not showing unique constraints currently
 select constraint_name, constraint_schema, table_name, constraint_type from information_schema.table_constraints order by constraint_name, constraint_schema;
 select name, schema_name(schema_id) as schname, object_name(parent_object_id),type_desc from sys.objects where type in ('C','F','PK','UQ') order by name, schname;
 go
@@ -118,6 +117,8 @@ tbl_fk_a_fkey#!#dbo#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_a_fkey#!#sch1#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_pkey#!#dbo#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT
 tbl_fk_pkey#!#sch1#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT
+tbl_pk_c_key#!#dbo#!#tbl_pk#!#UNIQUE_CONSTRAINT
+tbl_pk_c_key#!#sch1#!#tbl_pk#!#UNIQUE_CONSTRAINT
 tbl_pk_d_check#!#dbo#!#tbl_pk#!#CHECK_CONSTRAINT
 tbl_pk_d_check#!#sch1#!#tbl_pk#!#CHECK_CONSTRAINT
 tbl_pk_pkey#!#dbo#!#tbl_pk#!#PRIMARY_KEY_CONSTRAINT
@@ -349,7 +350,6 @@ master#!#sch1#!#tbl_pk_pkey#!#master#!#sch1#!#tbl_pk#!#PRIMARY KEY#!#NO#!#NO
 
 
 -- verify from sys.objects
--- Note: sys.objects not showing unique constraints currently
 select constraint_name, constraint_schema, table_name, constraint_type from information_schema.table_constraints order by constraint_name, constraint_schema;
 select name, schema_name(schema_id) as schname, object_name(parent_object_id),type_desc from sys.objects where type in ('C','F','PK','UQ') order by name, schname;
 go
@@ -373,6 +373,8 @@ tbl_fk_a_fkey#!#dbo#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_a_fkey#!#sch1#!#tbl_fk#!#FOREIGN_KEY_CONSTRAINT
 tbl_fk_pkey#!#dbo#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT
 tbl_fk_pkey#!#sch1#!#tbl_fk#!#PRIMARY_KEY_CONSTRAINT
+tbl_pk_c_key#!#dbo#!#tbl_pk#!#UNIQUE_CONSTRAINT
+tbl_pk_c_key#!#sch1#!#tbl_pk#!#UNIQUE_CONSTRAINT
 tbl_pk_d_check#!#dbo#!#tbl_pk#!#CHECK_CONSTRAINT
 tbl_pk_d_check#!#sch1#!#tbl_pk#!#CHECK_CONSTRAINT
 tbl_pk_pkey#!#dbo#!#tbl_pk#!#PRIMARY_KEY_CONSTRAINT

--- a/test/JDBC/expected/object_id_index_conflict-vu-cleanup.out
+++ b/test/JDBC/expected/object_id_index_conflict-vu-cleanup.out
@@ -18,7 +18,13 @@ GO
 ALTER TABLE object_id_conflict_t DROP CONSTRAINT IF EXISTS unq_name;
 GO
 
+ALTER TABLE object_id_conflict_t2 DROP CONSTRAINT IF EXISTS unq_num;
+GO
+
 -- Table cleanup
+DROP TABLE IF EXISTS object_id_conflict_t2;
+GO
+
 DROP TABLE IF EXISTS object_id_conflict_parent_t;
 GO
 

--- a/test/JDBC/expected/object_id_index_conflict-vu-prepare.out
+++ b/test/JDBC/expected/object_id_index_conflict-vu-prepare.out
@@ -33,3 +33,7 @@ GO
 
 CREATE INDEX object_id_idx_parent_id ON object_id_conflict_t (parent_id);
 GO
+
+-- Test for unique constraints metadata for CREATE/ALTER TABLE
+CREATE TABLE object_id_conflict_t2 (id INT, num INT CONSTRAINT unq_num UNIQUE);
+GO

--- a/test/JDBC/expected/object_id_index_conflict-vu-verify.out
+++ b/test/JDBC/expected/object_id_index_conflict-vu-verify.out
@@ -67,3 +67,29 @@ int
 <NULL>
 ~~END~~
 
+
+
+-- Unique constraints metadata test
+-- CREATE TABLE constraint
+SELECT o.name AS constraint_name,
+       o.type,
+       o.type_desc
+FROM sys.objects o WHERE o.parent_object_id = OBJECT_ID('object_id_conflict_t2') AND o.type = 'UQ';
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+unq_num#!#UQ#!#UNIQUE_CONSTRAINT
+~~END~~
+
+
+-- ALTER TABLE constraint
+SELECT o.name AS constraint_name,
+       o.type,
+       o.type_desc
+FROM sys.objects o WHERE o.parent_object_id = OBJECT_ID('object_id_conflict_t') AND o.type = 'UQ';
+GO
+~~START~~
+varchar#!#char#!#nvarchar
+unq_name#!#UQ#!#UNIQUE_CONSTRAINT
+~~END~~
+

--- a/test/JDBC/input/ISC-Table_Constraints-vu-verify.mix
+++ b/test/JDBC/input/ISC-Table_Constraints-vu-verify.mix
@@ -22,7 +22,6 @@ select * from information_schema.table_constraints where table_name in ('tbl_pk'
 go
 
 -- verify from sys.objects
--- Note: sys.objects not showing unique constraints currently
 select constraint_name, constraint_schema, table_name, constraint_type from information_schema.table_constraints where table_name in ('tbl_pk','tbl_fk') order by constraint_name, constraint_schema;
 select name, schema_name(schema_id) as schname, object_name(parent_object_id),type_desc from sys.objects where type in ('C','F','PK','UQ') and object_name(parent_object_id) in ('tbl_pk','tbl_fk') order by name, schname;
 go

--- a/test/JDBC/input/ISC-Table_Constraints.mix
+++ b/test/JDBC/input/ISC-Table_Constraints.mix
@@ -47,7 +47,6 @@ select * from information_schema.table_constraints where table_name in ('tbl_pk'
 go
 
 -- verify from sys.objects
--- Note: sys.objects not showing unique constraints currently
 select constraint_name, constraint_schema, table_name, constraint_type from information_schema.table_constraints order by constraint_name, constraint_schema;
 
 select name, schema_name(schema_id) as schname, object_name(parent_object_id),type_desc from sys.objects where type in ('C','F','PK','UQ') order by name, schname;
@@ -210,7 +209,6 @@ select * from information_schema.table_constraints where table_name in ('tbl_pk'
 go
 
 -- verify from sys.objects
--- Note: sys.objects not showing unique constraints currently
 select constraint_name, constraint_schema, table_name, constraint_type from information_schema.table_constraints order by constraint_name, constraint_schema;
 
 select name, schema_name(schema_id) as schname, object_name(parent_object_id),type_desc from sys.objects where type in ('C','F','PK','UQ') order by name, schname;

--- a/test/JDBC/input/object_id_index_conflict-vu-cleanup.sql
+++ b/test/JDBC/input/object_id_index_conflict-vu-cleanup.sql
@@ -18,7 +18,13 @@ GO
 ALTER TABLE object_id_conflict_t DROP CONSTRAINT IF EXISTS unq_name;
 GO
 
+ALTER TABLE object_id_conflict_t2 DROP CONSTRAINT IF EXISTS unq_num;
+GO
+
 -- Table cleanup
+DROP TABLE IF EXISTS object_id_conflict_t2;
+GO
+
 DROP TABLE IF EXISTS object_id_conflict_parent_t;
 GO
 

--- a/test/JDBC/input/object_id_index_conflict-vu-prepare.sql
+++ b/test/JDBC/input/object_id_index_conflict-vu-prepare.sql
@@ -33,3 +33,7 @@ GO
 
 CREATE INDEX object_id_idx_parent_id ON object_id_conflict_t (parent_id);
 GO
+
+-- Test for unique constraints metadata for CREATE/ALTER TABLE
+CREATE TABLE object_id_conflict_t2 (id INT, num INT CONSTRAINT unq_num UNIQUE);
+GO

--- a/test/JDBC/input/object_id_index_conflict-vu-verify.sql
+++ b/test/JDBC/input/object_id_index_conflict-vu-verify.sql
@@ -37,3 +37,19 @@ GO
 
 SELECT OBJECT_ID('object_id_idx_parent_id');
 GO
+
+-- Unique constraints metadata test
+
+-- CREATE TABLE constraint
+SELECT o.name AS constraint_name,
+       o.type,
+       o.type_desc
+FROM sys.objects o WHERE o.parent_object_id = OBJECT_ID('object_id_conflict_t2') AND o.type = 'UQ';
+GO
+
+-- ALTER TABLE constraint
+SELECT o.name AS constraint_name,
+       o.type,
+       o.type_desc
+FROM sys.objects o WHERE o.parent_object_id = OBJECT_ID('object_id_conflict_t') AND o.type = 'UQ';
+GO


### PR DESCRIPTION
### Description

This commit rectifies the type check for fetching metadata of both primary key and unique constraints from sys.key_constraints catalog inorder to correctly populate sys.objects view.

Cherry-pick PR for #3658 

### Issues Resolved

BABEL-5712

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).