### PR TITLE
Fix stmt_len for PlannedStmt structure of internal statements

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -3226,7 +3226,7 @@ create_guest_role_for_db(const char *dbname)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = res_stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 18;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,
@@ -4284,7 +4284,7 @@ grant_perms_to_objects_in_schema(const char *schema_name,
 				wrapper->canSetTag = false;
 				wrapper->utilityStmt = (Node *) grant;
 				wrapper->stmt_location = 0;
-				wrapper->stmt_len = 1;
+				wrapper->stmt_len = 0;
 
 				/* do this step */
 				ProcessUtility(wrapper,
@@ -4402,7 +4402,7 @@ exec_internal_grant_on_function(Oid objectId)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = (Node *) grant;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 1;
+			wrapper->stmt_len = 0;
 
 			GetUserIdAndSecContext(&save_userid, &save_sec_context);
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -920,7 +920,7 @@ drop_bbf_db(const char *dbname, bool missing_ok, bool force_drop)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 16;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -4207,7 +4207,7 @@ exec_stmt_fulltextindex(PLtsql_execstate *estate, PLtsql_stmt_fulltextindex *stm
 	wrapper->canSetTag = false;
 	wrapper->utilityStmt = res_stmt;
 	wrapper->stmt_location = 0;
-	wrapper->stmt_len = 1;
+	wrapper->stmt_len = 0;
 
 	/* do this step */
 	ProcessUtility(wrapper,

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -1895,7 +1895,7 @@ exec_add_original_index_name(char *idxname, char *schemaname, char *original_nam
 	wrapper->canSetTag = false;
 	wrapper->utilityStmt = stmt;
 	wrapper->stmt_location = 0;
-	wrapper->stmt_len = strlen(query_str);
+	wrapper->stmt_len = 0;
 
 	ProcessUtility(wrapper,
 				   "(ALTER INDEX )",

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -2165,7 +2165,7 @@ sp_addrole(PG_FUNCTION_ARGS)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 16;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,
@@ -2307,7 +2307,7 @@ sp_droprole(PG_FUNCTION_ARGS)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 16;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,
@@ -2479,7 +2479,7 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 16;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,
@@ -2645,7 +2645,7 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 16;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,
@@ -3861,7 +3861,7 @@ sp_rename_internal(PG_FUNCTION_ARGS)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 16;
+			wrapper->stmt_len = 0;
 
 			/* do this step */
 			ProcessUtility(wrapper,

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -663,7 +663,7 @@ grant_revoke_role_to_login(const char* login, const char *role_name, const char 
 	wrapper->canSetTag = false;
 	wrapper->utilityStmt = stmt;
 	wrapper->stmt_location = 0;
-	wrapper->stmt_len = 23;
+	wrapper->stmt_len = 0;
 
 	/* do this step */
 	ProcessUtility(wrapper,
@@ -1152,7 +1152,7 @@ drop_all_logins(PG_FUNCTION_ARGS)
 				wrapper->canSetTag = false;
 				wrapper->utilityStmt = stmt;
 				wrapper->stmt_location = 0;
-				wrapper->stmt_len = 16;
+				wrapper->stmt_len = 0;
 
 				/* do this step */
 				ProcessUtility(wrapper,
@@ -1512,7 +1512,7 @@ add_existing_users_to_catalog(PG_FUNCTION_ARGS)
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			wrapper->stmt_len = 34;
+			wrapper->stmt_len = 0;
 
 			/* Run the built query */
 			ProcessUtility(wrapper,


### PR DESCRIPTION
### Description

This commit fixes all the instances of stmt_len being set incorrectly when preparing a PlannedStmt explicitly. It will fail for the modules/extension which utilises CleanQuerytext() function since there is an assert there which ensures supplied stmt_len pointer should be less than or equal to query length.

Here, stmt_len is being set to 0 which denotes that we want to consider "rest of the string"(i.e. till the end) starting from stmt_location for current execution.

Issue: BABEL-5726

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).