### PR TITLE
Avoid checking permission of Babelfish temp tables on parallel worker

### DIFF
--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -76,6 +76,7 @@ OBJS += src/table_variable_mvcc.o
 OBJS += src/extendedproperty.o
 OBJS += src/fts.o
 OBJS += src/fts_parser.o
+OBJS += src/bbf_parallel_query.o
 
 export ANTLR4_JAVA_BIN=java
 export ANTLR4_RUNTIME_LIB=-lantlr4-runtime

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -48,7 +48,6 @@ static char		   *temp_relids_str = NULL;
  * on these oids.
  */
 
-
 /*
  * bbf_ExecInitParallelPlan -- implements ExecInitParallelPlan_hook.
  * It iterates through es_range_tables checking persistence of given relation. Probably,
@@ -132,6 +131,8 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 void
 bbf_ParallelQueryMain(shm_toc *toc)
 {
+	char *temp_relids_local;
+
 	if (prev_ParallelQueryMain_hook)
 		(*prev_ParallelQueryMain_hook)(toc);
 
@@ -141,9 +142,11 @@ bbf_ParallelQueryMain(shm_toc *toc)
 		return;
 	}
 
-	temp_relids = (Bitmapset *) stringToNode(shm_toc_lookup(toc,
-															BABELFISH_PARALLEL_KEY_TEMP_RELIDS,
-															false));
+	temp_relids_local = pstrdup(shm_toc_lookup(toc,
+											   BABELFISH_PARALLEL_KEY_TEMP_RELIDS,
+											   false));
+	temp_relids = stringToBms(temp_relids_local);
+	pfree(temp_relids_local);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -1,0 +1,172 @@
+
+#include "postgres.h"
+
+#include "access/parallel.h"
+#include "catalog/pg_class.h"
+#include "executor/executor.h"
+#include "fmgr.h"
+#include "nodes/bitmapset.h"
+#include "nodes/execnodes.h"
+#include "nodes/nodes.h"
+#include "nodes/parsenodes.h"
+#include "nodes/pg_list.h"
+#include "miscadmin.h"
+#include "parser/parse_relation.h"
+#include "parser/parser.h"
+#include "storage/shm_toc.h"
+#include "utils/acl.h"
+#include "utils/elog.h"
+#include "utils/lsyscache.h"
+#include "utils/queryenvironment.h"
+
+#include "bbf_parallel_query.h"
+#include "pltsql.h"
+
+/*
+ * temp_relids - maintains relid list of temp table shared by leader node. This should be
+* strictly accessed within parallel worker context.
+ */
+static Bitmapset   *temp_relids = NULL;
+
+/*
+ * string representation of list of temp table oids computed by Leader node to be shared
+ * with parallel worker.
+ */
+static char		   *temp_relids_str = NULL;
+
+/*
+ * In Babelfish, Any user under given session should be able access the temp tables. 
+ * And Postgres doesn't allow parallel scan on temp tables. But it still does the permission
+ * check on temp tables under parallel workers. But since Babelfish temp tables implemented
+ * using ENR, it can't be accessed inside Parallel worker.
+ * 
+ * So we would like to avoid permission checking on temp tables under parallel workers while
+ * ensuring that Leader node does require permission checks on temp table.
+ * 
+ * In order to achieve this, we (probably re)do permission checks on temp tables and share
+ * the list of oids with parallel worker. And parallel worker will avoid permission check
+ * on these oids.
+ */
+
+
+/*
+ * bbf_ExecInitParallelPlan -- implements ExecInitParallelPlan_hook.
+ * It iterates through es_range_tables checking persistence of given relation. Probably,
+ * re-do permission checking (better to redo perm checking instead of never doing it) if
+ * relation is temp table and adds oid/relid to the set. This set will be shared with
+ * parallel worker so that parallel worker avoids permission check on temp tables.
+ * When estimate = true passed then caller wants to estimate a dynamic shared memory (DSM)
+ * needed by this extension to communicate additional context.
+ * When estimate = false then caller wants to insert additional context to DSM.
+ */
+void 
+bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
+{
+	if (prev_ExecInitParallelPlan_hook)
+		(*prev_ExecInitParallelPlan_hook)(estate, pcxt, estimate);
+
+	/*
+	 * Dialect check is not sufficient because parallel worker might be needed while
+	 * doing plpgsql function scan on leader node.
+	 */
+	if (!IS_TDS_CONN())
+		return;
+
+	if (estimate)
+	{
+		ListCell   *lc;
+		Bitmapset  *temp_relids_local = NULL;
+		temp_relids_str = NULL;
+
+		foreach(lc, estate->es_range_table)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+			if (rte->rtekind == RTE_RELATION &&
+				OidIsValid(rte->relid) &&
+				get_rel_persistence(rte->relid) == RELPERSISTENCE_TEMP)
+			{
+				/* probably (re)do perm check */
+				if (!ExecCheckRTEPerms_wrapper(rte))
+				{
+					aclcheck_error(ACLCHECK_NO_PRIV,
+									get_relkind_objtype(get_rel_relkind(rte->relid)),
+									get_rel_name(rte->relid));
+				}
+				temp_relids_local = bms_add_member(temp_relids_local, rte->relid);
+			}
+		}
+		temp_relids_str = bmsToString(temp_relids_local);
+
+		/*
+		 * Estimate extra context for Babelfish
+		 */
+		shm_toc_estimate_chunk(&pcxt->estimator, strlen(temp_relids_str) + 1);
+		shm_toc_estimate_keys(&pcxt->estimator, 1);
+	}
+	else
+	{
+		char *temp_relids_space;
+
+		/*temp_relids_str will never be NULL even if there is no temp tables in the query. */
+		if (temp_relids_str == NULL)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Unexpected list of temp table relids")));
+		}
+
+		temp_relids_space = shm_toc_allocate(pcxt->toc, strlen(temp_relids_str) + 1);
+		memcpy(temp_relids_space, temp_relids_str, strlen(temp_relids_str) + 1);
+		shm_toc_insert(pcxt->toc, BABELFISH_PARALLEL_KEY_TEMP_RELIDS, temp_relids_space);
+
+		/* And reset temp_relids_str */
+		pfree(temp_relids_str);
+		temp_relids_str = NULL;
+	}
+}
+/*
+ * bbf_ParallelQueryMain -- implements ParallelQueryMain_hook.
+ * It constructs temp_relids which represents oid list of temp tables communicated by Leader node.
+ * warning: should stricktly call under parallel worker.
+ */
+void
+bbf_ParallelQueryMain(shm_toc *toc)
+{
+	if (prev_ParallelQueryMain_hook)
+		(*prev_ParallelQueryMain_hook)(toc);
+
+	/* Another line of defense to make sure no regular backend calls this function. */
+	if (!IsBabelfishParallelWorker())
+	{
+		return;
+	}
+
+	temp_relids = (Bitmapset *) stringToNode(shm_toc_lookup(toc,
+															BABELFISH_PARALLEL_KEY_TEMP_RELIDS,
+															false));
+}
+
+/*
+ * bbf_ExecCheckRTEPerms -- implements ExecCheckRTEPerms_hook.
+ * Returns true if this is Babelfish parallel worker and provided relid is Babelfish temp table. 
+ * Note that temp_relids must have communicated by Leader node.
+ */
+bool
+bbf_ExecCheckRTEPerms(RangeTblEntry *rte)
+{
+	if (!OidIsValid(rte->relid))
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_INTERNAL_ERROR),
+			 errmsg("Invalid Oid is found while checking permission of the relation")));
+	}
+
+	/* Let regular permission check happen if its not Babelfish parallel worker. */
+	if (!IsBabelfishParallelWorker())
+	{
+		return false;
+	}
+
+	return bms_is_member(rte->relid, temp_relids);
+}
+

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -131,8 +131,6 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 void
 bbf_ParallelQueryMain(shm_toc *toc)
 {
-	char *temp_relids_local;
-
 	if (prev_ParallelQueryMain_hook)
 		(*prev_ParallelQueryMain_hook)(toc);
 
@@ -142,11 +140,9 @@ bbf_ParallelQueryMain(shm_toc *toc)
 		return;
 	}
 
-	temp_relids_local = pstrdup(shm_toc_lookup(toc,
-											   BABELFISH_PARALLEL_KEY_TEMP_RELIDS,
-											   false));
-	temp_relids = stringToBms(temp_relids_local);
-	pfree(temp_relids_local);
+	temp_relids = stringToBms(shm_toc_lookup(toc,
+											 BABELFISH_PARALLEL_KEY_TEMP_RELIDS,
+											 false));
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.h
@@ -1,0 +1,15 @@
+#include "executor/executor.h"
+#include "executor/execParallel.h"
+#include "fmgr.h"
+#include "nodes/execnodes.h"
+
+/* Key for sharing additional context for Babelfish */
+#define BABELFISH_PARALLEL_KEY_FIXED		UINT64CONST(0xBBF0000000000001)
+#define BABELFISH_PARALLEL_KEY_TEMP_RELIDS	UINT64CONST(0xBBF0000000000002)
+
+extern ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook;
+extern ParallelQueryMain_hook_type prev_ParallelQueryMain_hook;
+
+extern void bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate);
+extern void bbf_ParallelQueryMain(shm_toc *toc);
+extern bool bbf_ExecCheckRTEPerms(RangeTblEntry *rte);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -71,6 +71,7 @@
 #include "multidb.h"
 #include "tsql_analyze.h"
 #include "table_variable_mvcc.h"
+#include "bbf_parallel_query.h"
 
 #define TDS_NUMERIC_MAX_PRECISION	38
 extern bool babelfish_dump_restore;
@@ -256,6 +257,8 @@ static exec_tsql_cast_value_hook_type pre_exec_tsql_cast_value_hook = NULL;
 static pltsql_pgstat_end_function_usage_hook_type prev_pltsql_pgstat_end_function_usage_hook = NULL;
 static pltsql_unique_constraint_nulls_ordering_hook_type prev_pltsql_unique_constraint_nulls_ordering_hook = NULL;
 static ExecFuncProc_AclCheck_hook_type prev_ExecFuncProc_AclCheck_hook = NULL;
+ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook = NULL;
+ParallelQueryMain_hook_type prev_ParallelQueryMain_hook = NULL;
 
 /*****************************************
  * 			Install / Uninstall
@@ -453,6 +456,14 @@ InstallExtendedHooks(void)
 	ExecFuncProc_AclCheck_hook = pltsql_ExecFuncProc_AclCheck;
 	
 	pltsql_get_object_identity_event_trigger_hook = pltsql_get_object_identity_event_trigger;
+
+	prev_ParallelQueryMain_hook = ParallelQueryMain_hook;
+	ParallelQueryMain_hook = bbf_ParallelQueryMain;
+
+	prev_ExecInitParallelPlan_hook = ExecInitParallelPlan_hook;
+	ExecInitParallelPlan_hook = bbf_ExecInitParallelPlan;
+
+	ExecCheckRTEPerms_hook = bbf_ExecCheckRTEPerms;
 }
 
 void
@@ -528,6 +539,9 @@ UninstallExtendedHooks(void)
 	bbf_InitializeParallelDSM_hook = NULL;
 	bbf_ParallelWorkerMain_hook = NULL;
 	pltsql_get_object_identity_event_trigger_hook = NULL;
+	ParallelQueryMain_hook = prev_ParallelQueryMain_hook;
+	ExecInitParallelPlan_hook = prev_ExecInitParallelPlan_hook;
+	ExecCheckRTEPerms_hook = NULL;
 }
 
 /*****************************************

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -26,6 +26,7 @@
 #include "commands/trigger.h"
 #include "collation.h"
 #include "executor/spi.h"
+#include "libpq/libpq-be.h"
 #include "optimizer/planner.h"
 #include "utils/expandedrecord.h"
 #include "utils/plancache.h"
@@ -1864,6 +1865,8 @@ extern common_utility_plugin *common_utility_plugin_ptr;
 
 #define IS_TDS_CLIENT() (*pltsql_protocol_plugin_ptr && \
 						 (*pltsql_protocol_plugin_ptr)->is_tds_client)
+
+#define IS_TDS_CONN() (MyProcPort && MyProcPort->is_tds_conn)
 
 extern Oid	procid_var;
 extern uint64 rowcount_var;

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -18,6 +18,7 @@
 #include "pltsql.h"
 #include "guc.h"
 #include "storage/shm_toc.h"
+#include "bbf_parallel_query.h"
 
 /* Core Session Properties */
 

--- a/test/JDBC/expected/Test_parallel_query.out
+++ b/test/JDBC/expected/Test_parallel_query.out
@@ -1,0 +1,444 @@
+-- tsql
+-- setup
+CREATE LOGIN l1 WITH PASSWORD = '12345678'
+GO
+
+CREATE USER l1
+GO
+
+CREATE TABLE pq_t (id INT)
+GO
+
+INSERT INTO pq_t VALUES (1), (2), (3), (4) , (5);
+GO
+~~ROW COUNT: 5~~
+
+
+CREATE SCHEMA schema_for_l1 AUTHORIZATION l1
+GO
+
+CREATE DATABASE pq_db
+GO
+
+USE pq_db
+GO
+
+CREATE USER pq_db_u1 FOR LOGIN l1
+GO
+
+USE master
+GO
+
+-- psql user=l1 password=12345678
+-- setup
+-- create parallel safe function under schema_for_l1 where user is authorised to create
+CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
+RETURNS TABLE (a INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT id FROM pq_t);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+
+-- psql
+-- Test permission check on temp table from Postgres
+create table reg_test (a int)
+GO
+
+insert into reg_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+create temp table parallel_test(a int);
+GO
+
+insert into parallel_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+ANALYSE;
+GO
+
+-- function which tries to access temp table using parallel execution
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from parallel_test
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+-- temp table as a outer scan and should not be scanned using parallel worker
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~START~~
+int4#!#int4
+1#!#1
+~~END~~
+
+
+-- following would throw an error under parallel execution
+select * from f1()
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+-- Not everyone can access temp table
+-- Permission denied error should be raised whe l1 tries to access to temp table parallel_test
+set role l1;
+GO
+
+-- should result in permission error
+select * from parallel_test
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from f1()
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table reg_test
+    Server SQLState: 42501)~~
+
+
+reset role
+GO
+
+DROP FUNCTION f1()
+GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO
+
+
+-- tsql user=l1 password=12345678
+-- testing permission on temp table from Babelfish endpoint
+-- verify that only temp table permission check is skipped under parallel worker
+SELECT * FROM pq_t
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+-- function schema_for_l1.f1() access regular table so permission check shouldnt be skipped even under parallel worker
+SELECT * FROM schema_for_l1.f1()
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- temp table as a outer scan and user has permission to access regular table
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+USE pq_db
+GO
+
+select current_user
+GO
+~~START~~
+varchar
+pq_db_u1
+~~END~~
+
+
+-- any user can access local temp table created under given session
+select * from #temp;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE master
+GO
+
+-- tsql
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SELECT set_config('babelfishpg_tsql.memory', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM pq_t where id IN (select a from #temp)
+Hash Join (actual rows=1 loops=1)
+  Hash Cond: ("#temp".a = pq_t.id)
+  ->  HashAggregate (actual rows=1 loops=1)
+        Group Key: "#temp".a
+        Batches: 1  Memory Usage: 40kB
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+  ->  Hash (actual rows=5 loops=1)
+        Buckets: 1024  Batches: 1  Memory Usage: 9kB
+        ->  Seq Scan on pq_t (actual rows=5 loops=1)
+~~END~~
+
+
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id;
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#<NULL>
+3#!#<NULL>
+4#!#<NULL>
+5#!#<NULL>
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id
+Sort (actual rows=5 loops=1)
+  Sort Key: pq_t.id NULLS FIRST
+  Sort Method: quicksort  Memory: 25kB
+  ->  Hash Right Join (actual rows=5 loops=1)
+        Hash Cond: ("#temp".a = pq_t.id)
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+        ->  Hash (actual rows=5 loops=1)
+              ->  Seq Scan on pq_t (actual rows=5 loops=1)
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'on', false)
+SELECT set_config('babelfishpg_tsql.memory', 'on', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+-- psql
+DROP FUNCTION master_schema_for_l1.f1()
+GO
+
+-- tsql
+DROP SCHEMA schema_for_l1;
+GO
+
+DROP DATABASE pq_db
+GO
+
+-- terminate-tsql-conn user=l1 password=12345678
+GO
+
+-- terminate-psql-conn user=l1 password=12345678
+GO
+
+-- tsql
+DROP TABLE pq_t
+GO
+DROP USER l1
+GO
+DROP LOGIN l1;
+GO
+
+-- tsql
+-- table valued parameter should behave same as normal temp table
+CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
+GO
+
+INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
+GO
+~~ROW COUNT: 3~~
+
+
+-- table type
+CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
+GO
+
+-- check table valued parameter on outer side scanned on leader node only
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+select count(*) FROM Employees e
+    INNER JOIN @SalaryUpdateTable su ON e.EmployeeID = su.EmployeeID;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+CREATE PROCEDURE UpdateEmployeeSalaries
+    @SalaryUpdates SalaryUpdateType READONLY
+AS
+BEGIN
+    -- Join TVP with regular table to get employee details with new salaries
+    SELECT 
+        e.EmployeeID,
+        e.FirstName,
+        e.LastName,
+        e.Department,
+        su.NewSalary,
+        su.EffectiveDate
+    FROM Employees e
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID
+    ORDER BY EmployeeID;
+END;
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+-- Execute the stored procedure
+EXEC UpdateEmployeeSalaries @SalaryUpdateTable;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#numeric#!#date
+1#!#John#!#Doe#!#IT#!#75000.00#!#2025-01-01
+2#!#Jane#!#Smith#!#HR#!#65000.00#!#2025-01-01
+3#!#Mike#!#Johnson#!#IT#!#70000.00#!#2025-01-01
+~~END~~
+
+
+DROP PROCEDURE UpdateEmployeeSalaries
+GO
+
+DROP TYPE SalaryUpdateType
+GO
+
+DROP TABLE Employees;
+GO

--- a/test/JDBC/expected/parallel_query/Test_parallel_query.out
+++ b/test/JDBC/expected/parallel_query/Test_parallel_query.out
@@ -1,0 +1,455 @@
+-- tsql
+-- setup
+CREATE LOGIN l1 WITH PASSWORD = '12345678'
+GO
+
+CREATE USER l1
+GO
+
+CREATE TABLE pq_t (id INT)
+GO
+
+INSERT INTO pq_t VALUES (1), (2), (3), (4) , (5);
+GO
+~~ROW COUNT: 5~~
+
+
+CREATE SCHEMA schema_for_l1 AUTHORIZATION l1
+GO
+
+CREATE DATABASE pq_db
+GO
+
+USE pq_db
+GO
+
+CREATE USER pq_db_u1 FOR LOGIN l1
+GO
+
+USE master
+GO
+
+-- psql user=l1 password=12345678
+-- setup
+-- create parallel safe function under schema_for_l1 where user is authorised to create
+CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
+RETURNS TABLE (a INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT id FROM pq_t);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+
+-- psql
+-- Test permission check on temp table from Postgres
+create table reg_test (a int)
+GO
+
+insert into reg_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+create temp table parallel_test(a int);
+GO
+
+insert into parallel_test values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+ANALYSE;
+GO
+
+-- function which tries to access temp table using parallel execution
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from parallel_test
+GO
+~~START~~
+int4
+1
+~~END~~
+
+
+-- temp table as a outer scan and should not be scanned using parallel worker
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~START~~
+int4#!#int4
+1#!#1
+~~END~~
+
+
+-- following would throw an error under parallel execution
+select * from f1()
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: cannot access temporary tables during a parallel operation
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+parallel worker
+    Server SQLState: 25000)~~
+
+
+-- Not everyone can access temp table
+-- Permission denied error should be raised whe l1 tries to access to temp table parallel_test
+set role l1;
+GO
+
+-- should result in permission error
+select * from parallel_test
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from f1()
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table parallel_test
+  Where: SQL statement "(SELECT a FROM parallel_test)"
+PL/pgSQL function f1() line 2 at RETURN QUERY
+parallel worker
+    Server SQLState: 42501)~~
+
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table reg_test
+    Server SQLState: 42501)~~
+
+
+reset role
+GO
+
+DROP FUNCTION f1()
+GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO
+
+
+-- tsql user=l1 password=12345678
+-- testing permission on temp table from Babelfish endpoint
+-- verify that only temp table permission check is skipped under parallel worker
+SELECT * FROM pq_t
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+-- function schema_for_l1.f1() access regular table so permission check shouldnt be skipped even under parallel worker
+SELECT * FROM schema_for_l1.f1()
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- temp table as a outer scan and user has permission to access regular table
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table pq_t)~~
+
+
+USE pq_db
+GO
+
+select current_user
+GO
+~~START~~
+varchar
+pq_db_u1
+~~END~~
+
+
+-- any user can access local temp table created under given session
+select * from #temp;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+USE master
+GO
+
+-- tsql
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+~~ROW COUNT: 1~~
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SELECT set_config('babelfishpg_tsql.memory', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM pq_t where id IN (select a from #temp)
+Hash Join (actual rows=1 loops=1)
+  Hash Cond: ("#temp".a = pq_t.id)
+  ->  HashAggregate (actual rows=1 loops=1)
+        Group Key: "#temp".a
+        Batches: 1  Memory Usage: 40kB
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+  ->  Hash (actual rows=5 loops=1)
+        Buckets: 1024  Batches: 1  Memory Usage: 9kB
+        ->  Gather (actual rows=5 loops=1)
+              Workers Planned: 1
+              Workers Launched: 1
+              ->  Parallel Seq Scan on pq_t (actual rows=2 loops=2)
+~~END~~
+
+
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id;
+GO
+~~START~~
+int#!#int
+1#!#1
+2#!#<NULL>
+3#!#<NULL>
+4#!#<NULL>
+5#!#<NULL>
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id
+Sort (actual rows=5 loops=1)
+  Sort Key: pq_t.id NULLS FIRST
+  Sort Method: quicksort  Memory: 25kB
+  ->  Hash Right Join (actual rows=5 loops=1)
+        Hash Cond: ("#temp".a = pq_t.id)
+        ->  Seq Scan on "#temp" (actual rows=1 loops=1)
+        ->  Hash (actual rows=5 loops=1)
+              Buckets: 1024  Batches: 1  Memory Usage: 9kB
+              ->  Gather (actual rows=5 loops=1)
+                    Workers Planned: 1
+                    Workers Launched: 1
+                    ->  Parallel Seq Scan on pq_t (actual rows=2 loops=2)
+~~END~~
+
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'on', false)
+SELECT set_config('babelfishpg_tsql.memory', 'on', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+-- psql
+DROP FUNCTION master_schema_for_l1.f1()
+GO
+
+-- tsql
+DROP SCHEMA schema_for_l1;
+GO
+
+DROP DATABASE pq_db
+GO
+
+-- terminate-tsql-conn user=l1 password=12345678
+GO
+
+-- terminate-psql-conn user=l1 password=12345678
+GO
+
+-- tsql
+DROP TABLE pq_t
+GO
+DROP USER l1
+GO
+DROP LOGIN l1;
+GO
+
+-- tsql
+-- table valued parameter should behave same as normal temp table
+CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
+GO
+
+INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
+GO
+~~ROW COUNT: 3~~
+
+
+-- table type
+CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
+GO
+
+-- check table valued parameter on outer side scanned on leader node only
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+select count(*) FROM Employees e
+    INNER JOIN @SalaryUpdateTable su ON e.EmployeeID = su.EmployeeID;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+CREATE PROCEDURE UpdateEmployeeSalaries
+    @SalaryUpdates SalaryUpdateType READONLY
+AS
+BEGIN
+    -- Join TVP with regular table to get employee details with new salaries
+    SELECT 
+        e.EmployeeID,
+        e.FirstName,
+        e.LastName,
+        e.Department,
+        su.NewSalary,
+        su.EffectiveDate
+    FROM Employees e
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID
+    ORDER BY EmployeeID;
+END;
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+-- Execute the stored procedure
+EXEC UpdateEmployeeSalaries @SalaryUpdateTable;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#numeric#!#date
+1#!#John#!#Doe#!#IT#!#75000.00#!#2025-01-01
+2#!#Jane#!#Smith#!#HR#!#65000.00#!#2025-01-01
+3#!#Mike#!#Johnson#!#IT#!#70000.00#!#2025-01-01
+~~END~~
+
+
+DROP PROCEDURE UpdateEmployeeSalaries
+GO
+
+DROP TYPE SalaryUpdateType
+GO
+
+DROP TABLE Employees;
+GO

--- a/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
+++ b/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
@@ -1,5 +1,5 @@
 -- sla 10000
--- sla_for_parallel_query_enforced 15000
+-- sla_for_parallel_query_enforced 16000
 -- tsql
 CREATE DATABASE db1
 GO

--- a/test/JDBC/input/Test_parallel_query.mix
+++ b/test/JDBC/input/Test_parallel_query.mix
@@ -1,0 +1,266 @@
+-- parallel_query_expected
+-- tsql
+-- setup
+CREATE LOGIN l1 WITH PASSWORD = '12345678'
+GO
+
+CREATE USER l1
+GO
+
+CREATE TABLE pq_t (id INT)
+GO
+
+INSERT INTO pq_t VALUES (1), (2), (3), (4) , (5);
+GO
+
+CREATE SCHEMA schema_for_l1 AUTHORIZATION l1
+GO
+
+CREATE DATABASE pq_db
+GO
+
+USE pq_db
+GO
+
+CREATE USER pq_db_u1 FOR LOGIN l1
+GO
+
+USE master
+GO
+
+-- psql user=l1 password=12345678
+-- setup
+-- create parallel safe function under schema_for_l1 where user is authorised to create
+CREATE OR REPLACE FUNCTION master_schema_for_l1.f1()
+RETURNS TABLE (a INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT id FROM pq_t);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+-- Test permission check on temp table from Postgres
+
+-- psql
+create table reg_test (a int)
+GO
+
+insert into reg_test values (1)
+GO
+
+create temp table parallel_test(a int);
+GO
+
+insert into parallel_test values (1)
+GO
+
+ANALYSE;
+GO
+
+-- function which tries to access temp table using parallel execution
+CREATE OR REPLACE FUNCTION f1()
+RETURNS TABLE (id INT) AS 
+$$ BEGIN
+    RETURN QUERY (SELECT a FROM parallel_test);
+END; $$
+LANGUAGE plpgsql
+PARALLEL SAFE;
+GO
+
+select * from parallel_test
+GO
+
+-- temp table as a outer scan and should not be scanned using parallel worker
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+
+-- following would throw an error under parallel execution
+select * from f1()
+GO
+
+-- Not everyone can access temp table
+-- Permission denied error should be raised whe l1 tries to access to temp table parallel_test
+set role l1;
+GO
+
+-- should result in permission error
+select * from parallel_test
+GO
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from f1()
+GO
+
+-- should result in permission error irrespective of whether parallel execution or not
+select * from reg_test r join parallel_test p on r.a = p.a
+GO
+
+reset role
+GO
+
+DROP FUNCTION f1()
+GO
+
+drop table parallel_test
+GO
+
+drop table reg_test
+GO
+
+-- testing permission on temp table from Babelfish endpoint
+
+-- tsql user=l1 password=12345678
+-- verify that only temp table permission check is skipped under parallel worker
+SELECT * FROM pq_t
+GO
+
+-- function schema_for_l1.f1() access regular table so permission check shouldnt be skipped even under parallel worker
+SELECT * FROM schema_for_l1.f1()
+GO
+
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+
+-- temp table as a outer scan and user has permission to access regular table
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a;
+GO
+
+USE pq_db
+GO
+
+select current_user
+GO
+
+-- any user can access local temp table created under given session
+select * from #temp;
+GO
+
+USE master
+GO
+
+-- tsql
+CREATE TABLE #temp (a int)
+GO
+
+INSERT INTO #temp VALUES (1)
+GO
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SELECT set_config('babelfishpg_tsql.memory', 'off', false)
+GO
+
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t where id IN (select a from #temp)
+GO
+
+-- temp table on outer side which should be scanned using paralell worker
+-- regular table on inner side may get scanned using parallel worker
+SELECT * FROM pq_t LEFT JOIN #temp ON id = a order by id;
+GO
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'on', false)
+SELECT set_config('babelfishpg_tsql.memory', 'on', false)
+GO
+
+-- psql
+DROP FUNCTION master_schema_for_l1.f1()
+GO
+
+-- tsql
+DROP SCHEMA schema_for_l1;
+GO
+
+DROP DATABASE pq_db
+GO
+
+-- terminate-tsql-conn user=l1 password=12345678
+GO
+
+-- terminate-psql-conn user=l1 password=12345678
+GO
+
+-- tsql
+DROP TABLE pq_t
+GO
+DROP USER l1
+GO
+DROP LOGIN l1;
+GO
+
+-- tsql
+-- table valued parameter should behave same as normal temp table
+CREATE TABLE Employees (EmployeeID INT PRIMARY KEY, FirstName VARCHAR(50), LastName VARCHAR(50), Department VARCHAR(50));
+GO
+
+INSERT INTO Employees VALUES (1, 'John', 'Doe', 'IT'), (2, 'Jane', 'Smith', 'HR'), (3, 'Mike', 'Johnson', 'IT');
+GO
+
+-- table type
+CREATE TYPE SalaryUpdateType AS TABLE(EmployeeID INT, NewSalary DECIMAL(10,2), EffectiveDate DATE);
+GO
+
+-- check table valued parameter on outer side scanned on leader node only
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+select count(*) FROM Employees e
+    INNER JOIN @SalaryUpdateTable su ON e.EmployeeID = su.EmployeeID;
+GO
+
+CREATE PROCEDURE UpdateEmployeeSalaries
+    @SalaryUpdates SalaryUpdateType READONLY
+AS
+BEGIN
+    -- Join TVP with regular table to get employee details with new salaries
+    SELECT 
+        e.EmployeeID,
+        e.FirstName,
+        e.LastName,
+        e.Department,
+        su.NewSalary,
+        su.EffectiveDate
+    FROM Employees e
+    INNER JOIN @SalaryUpdates su ON e.EmployeeID = su.EmployeeID
+    ORDER BY EmployeeID;
+END;
+GO
+
+DECLARE @SalaryUpdateTable SalaryUpdateType;
+-- Insert values into the table variable
+INSERT INTO @SalaryUpdateTable VALUES
+(1, 75000.00, '2025-01-01'),
+(2, 65000.00, '2025-01-01'),
+(3, 70000.00, '2025-01-01');
+-- Execute the stored procedure
+EXEC UpdateEmployeeSalaries @SalaryUpdateTable;
+GO
+
+DROP PROCEDURE UpdateEmployeeSalaries
+GO
+
+DROP TYPE SalaryUpdateType
+GO
+
+DROP TABLE Employees;
+GO


### PR DESCRIPTION
Consider following facts,

1. Babelfish temp tables are implemented using ENR which is not shared between different backends. So if Parallel worker tries to check permissions on Babelfish then it will fail.
2. Any user should be able to access Babelfish temp tables under given session.
3. Postgres by default does not allow parallel operations on temp tables. Attempt to do so will result in run time error.

Due to above facts, we should avoid permission check on temp tables within parallel workers while ensuring that leader does required permission check on other tables. This commits achieves this behaviour by implementating following three hooks,

bbf_ParallelQueryMain_hook -- implements ParallelQueryMain_hook. It constructs Bitmapset (list of temp table oids) by looping through es_range_table checking if given relation is temp table, checks permission if it is and add it to the set. It will then pass this set of temp table defined under current with Parallel workers.

bbf_ExecInitParallelPlan -- implements ExecInitParallelPlan_hook. Parallel workers will gather additional details (oid set of temp table) passed by Leader node. This set will later be used to avoid checking permissions on temp tables.

bbf_ ExecCheckRTEPerms_hook -- implements ExecCheckOneRelPerms_hook. It will avoid permission check relation if relid is part of the set of oids constructed using bbf_ExecInitParallelPlan.

Task: BABEL-5703
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>
(cherry picked from commit 6da7ff0cdd28175795e3180ae32cd3798bc0a182)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).