### PR TITLE
Remove babelfishpg_common--3.10.0--4.0.0 upgrade script

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.10.0--4.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.10.0--4.0.0.sql
@@ -1,2 +1,0 @@
--- complain if script is sourced in psql, rather than via ALTER EXTENSION
-\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '4.0.0'" to load this file. \quit


### PR DESCRIPTION
This change removes babelfishpg_common--3.10.0--4.0.0 upgrade script since we are not bumping common version in 3X