### PR TITLE
Case insensitivity of column names in UNPIVOT result

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-decl.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-decl.y
@@ -62,6 +62,9 @@
 
 %type <list> tsql_stmtmulti
 %type <list> columnListWithOptAscDesc
+%type <list> columnDefList
+%type <node> columnDefElem
+
 
 %type <boolean> tsql_cluster tsql_opt_cluster
 

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -1904,8 +1904,19 @@ joined_table:
 				}
 		;
 
+columnDefList:
+			columnDefElem								{ $$ = list_make1($1); }
+			| columnDefList ',' columnDefElem				{ $$ = lappend($1, $3); }
+		;
+
+columnDefElem: ColIdDef
+				{
+					$$ = (Node *) makeString($1);
+				}
+		;
+
 tsql_unpivot_clause:
-            '(' columnref FOR columnref IN_P '(' columnList ')' ')'
+            '(' columnref FOR columnref IN_P '(' columnDefList ')' ')'
                 {
 					$$ = (Node *)list_make3($2, $4, $7);
                 }

--- a/test/JDBC/expected/unpivot-vu-cleanup.out
+++ b/test/JDBC/expected/unpivot-vu-cleanup.out
@@ -45,6 +45,8 @@ DROP TABLE [Sales$Data@2024];
 GO
 DROP TABLE [Global_データ_Sales];
 GO
+DROP TABLE Test_Case_Sensitivity;
+GO
 
 -- Drop temporary tables (if they still exist)
 IF OBJECT_ID('tempdb..#temp_sales') IS NOT NULL

--- a/test/JDBC/expected/unpivot-vu-prepare.out
+++ b/test/JDBC/expected/unpivot-vu-prepare.out
@@ -434,3 +434,12 @@ INSERT INTO [Global_データ_Sales] VALUES (1,2,3,4,5);
 GO
 ~~ROW COUNT: 1~~
 
+
+CREATE TABLE Test_Case_Sensitivity (
+    IDENT INT PRIMARY KEY,
+    [Order Number] NVARCHAR(50) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+    OrderStatus NVARCHAR(20) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+    [shipping-address] NVARCHAR(50) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    TOTAL_AMOUNT DECIMAL(15,2)
+);
+GO

--- a/test/JDBC/expected/unpivot-vu-verify.out
+++ b/test/JDBC/expected/unpivot-vu-verify.out
@@ -1538,6 +1538,39 @@ int#!#numeric#!#nvarchar
 ~~END~~
 
 
+-- BABEL-5761 Case insensitivity of column names in UNPIVOT result
+        -- Uppercase column names in unpivot source list
+SELECT [ID_番号], [Amount_金額], [Quarter_四半期]
+FROM [Global_データ_Sales]
+UNPIVOT (
+    [Amount_金額] FOR [Quarter_四半期] IN (
+        [Q1_売上],
+        [Q2_売上]
+    )
+) AS [Global_分析];
+GO
+~~START~~
+int#!#numeric#!#nvarchar
+1#!#4.00#!#Q1_売上
+1#!#5.00#!#Q2_売上
+~~END~~
+
+
+SELECT COLUMN_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS 
+WHERE TABLE_NAME = 'Test_Case_Sensitivity' 
+    AND TABLE_SCHEMA = 'dbo' 
+ORDER BY ORDINAL_POSITION;
+GO
+~~START~~
+nvarchar
+IDENT
+Order Number
+OrderStatus
+shipping-address
+TOTAL_AMOUNT
+~~END~~
+
 
 -- KNOWN ISSUES
     -- BABEL-5677 - Support more variations of UNPIVOT Syntax
@@ -1565,21 +1598,5 @@ int#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#nvarchar
 2#!#Cust B#!#P#!#150#!#250#!#200#!#<NULL>#!#150#!#q1
 2#!#Cust B#!#P#!#150#!#250#!#200#!#<NULL>#!#250#!#q2
 2#!#Cust B#!#P#!#150#!#250#!#200#!#<NULL>#!#200#!#q3
-~~END~~
-
-        -- Uppercase column names in unpivot source list
-SELECT [ID_番号], [Amount_金額], [Quarter_四半期]
-FROM [Global_データ_Sales]
-UNPIVOT (
-    [Amount_金額] FOR [Quarter_四半期] IN (
-        [Q1_売上],
-        [Q2_売上]
-    )
-) AS [Global_分析];
-GO
-~~START~~
-int#!#numeric#!#nvarchar
-1#!#4.00#!#q1_売上
-1#!#5.00#!#q2_売上
 ~~END~~
 

--- a/test/JDBC/input/unpivot-vu-cleanup.sql
+++ b/test/JDBC/input/unpivot-vu-cleanup.sql
@@ -45,6 +45,8 @@ DROP TABLE [Sales$Data@2024];
 GO
 DROP TABLE [Global_データ_Sales];
 GO
+DROP TABLE Test_Case_Sensitivity;
+GO
 
 -- Drop temporary tables (if they still exist)
 IF OBJECT_ID('tempdb..#temp_sales') IS NOT NULL

--- a/test/JDBC/input/unpivot-vu-prepare.sql
+++ b/test/JDBC/input/unpivot-vu-prepare.sql
@@ -398,3 +398,12 @@ GO
 
 INSERT INTO [Global_データ_Sales] VALUES (1,2,3,4,5);
 GO
+
+CREATE TABLE Test_Case_Sensitivity (
+    IDENT INT PRIMARY KEY,
+    [Order Number] NVARCHAR(50) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+    OrderStatus NVARCHAR(20) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL,
+    [shipping-address] NVARCHAR(50) COLLATE SQL_Latin1_General_CP1_CI_AS NULL,
+    TOTAL_AMOUNT DECIMAL(15,2)
+);
+GO

--- a/test/JDBC/input/unpivot-vu-verify.sql
+++ b/test/JDBC/input/unpivot-vu-verify.sql
@@ -843,6 +843,24 @@ UNPIVOT (
 ) AS [Global_分析];
 GO
 
+-- BABEL-5761 Case insensitivity of column names in UNPIVOT result
+        -- Uppercase column names in unpivot source list
+SELECT [ID_番号], [Amount_金額], [Quarter_四半期]
+FROM [Global_データ_Sales]
+UNPIVOT (
+    [Amount_金額] FOR [Quarter_四半期] IN (
+        [Q1_売上],
+        [Q2_売上]
+    )
+) AS [Global_分析];
+GO
+
+SELECT COLUMN_NAME 
+FROM INFORMATION_SCHEMA.COLUMNS 
+WHERE TABLE_NAME = 'Test_Case_Sensitivity' 
+    AND TABLE_SCHEMA = 'dbo' 
+ORDER BY ORDINAL_POSITION;
+GO
 
 -- KNOWN ISSUES
     -- BABEL-5677 - Support more variations of UNPIVOT Syntax
@@ -853,14 +871,4 @@ GO
         -- Extra columns in result set when `SELECT alias.*`
 SELECT unpvt.* FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
-GO
-        -- Uppercase column names in unpivot source list
-SELECT [ID_番号], [Amount_金額], [Quarter_四半期]
-FROM [Global_データ_Sales]
-UNPIVOT (
-    [Amount_金額] FOR [Quarter_四半期] IN (
-        [Q1_売上],
-        [Q2_売上]
-    )
-) AS [Global_分析];
 GO


### PR DESCRIPTION
### Description

Added duplicate rules of ColumnList and ColumnElem and replaced it in unpivot_clause rule
Testing to see if this results in capitalized column names retained in unpivot result (combined with engine change)

### Issues Resolved

Task: BABEL-5761

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).