### PR TITLE
Creating before 16_10 or 17_6 files for sys.fn_varbintohexsubstring function

### DIFF
--- a/test/JDBC/expected/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-cleanup.out
+++ b/test/JDBC/expected/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-cleanup.out
@@ -1,0 +1,37 @@
+DROP VIEW fn_varbintohexsubstring_vu_prepare_view
+GO
+
+DROP PROC fn_varbintohexsubstring_vu_prepare_proc
+GO
+
+DROP FUNCTION fn_varbintohexsubstring_vu_prepare_func
+GO
+
+DROP TABLE babel_5654_t1
+GO
+
+DROP TABLE babel_5654_t2
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: table "babel_5654_t2" does not exist)~~
+
+
+DROP TABLE babel_5654_t3
+GO
+~~ERROR (Code: 3701)~~
+
+~~ERROR (Message: table "babel_5654_t3" does not exist)~~
+
+
+DROP TYPE SetPrefixType
+GO
+
+DROP TYPE ExpressionType
+GO
+
+DROP TYPE StartOffsetType
+GO
+
+DROP TYPE SubstrLengthType
+GO

--- a/test/JDBC/expected/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-prepare.out
+++ b/test/JDBC/expected/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-prepare.out
@@ -1,0 +1,77 @@
+-- Create dependant objects
+CREATE VIEW fn_varbintohexsubstring_vu_prepare_view AS
+SELECT sys.fn_varbintohexsubstring(1,0x1234, 1, 4)
+GO
+
+CREATE PROC fn_varbintohexsubstring_vu_prepare_proc AS
+SELECT sys.fn_varbintohexsubstring(1,0x1234, 1, 4)
+GO
+
+CREATE FUNCTION fn_varbintohexsubstring_vu_prepare_func()
+RETURNS nvarchar(128)
+AS
+BEGIN
+RETURN sys.fn_varbintohexsubstring(1,0x1234, 1, 4)
+END
+GO
+
+CREATE TABLE babel_5654_t1 (set_prefix sys.BIT,
+                            expression sys.varbinary(MAX),
+                            start_offset INT,
+                            substr_length INT,
+                            CHECK (sys.fn_varbintohexsubstring(set_prefix, expression, start_offset, substr_length) != NULL));
+GO
+
+INSERT INTO babel_5654_t1 VALUES (0,0x123486534659789876435656,1,4)
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE babel_5654_t2 (set_prefix sys.BIT,
+                            expression sys.varbinary(MAX),
+                            start_offset INT,
+                            substr_length INT,
+                            [varbintohexsubstring] AS sys.fn_varbintohexsubstring(set_prefix, expression, start_offset, substr_length));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: generation expression is not immutable)~~
+
+
+INSERT INTO babel_5654_t2 VALUES (0,0x3486534659789876435656,1,4)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_5654_t2" does not exist)~~
+
+
+CREATE TYPE SetPrefixType from sys.bit;
+GO
+
+CREATE TYPE ExpressionType from sys.varbinary(MAX);
+GO
+
+CREATE TYPE StartOffsetType from int;
+GO
+
+CREATE TYPE SubstrLengthType from int;
+GO
+
+CREATE TABLE babel_5654_t3 (set_prefix SetPrefixType,
+                            expression ExpressionType,
+                            start_offset StartOffsetType,
+                            substr_length SubstrLengthType,
+                            [varbintohexsubstring] AS sys.fn_varbintohexsubstring(set_prefix, expression, start_offset, substr_length));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: generation expression is not immutable)~~
+
+
+INSERT INTO babel_5654_t3 VALUES (0,0x3486534659789876435656,1,4)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_5654_t3" does not exist)~~
+
+

--- a/test/JDBC/expected/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-verify.out
+++ b/test/JDBC/expected/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-verify.out
@@ -1,0 +1,263 @@
+-- dependent objects
+SELECT * FROM fn_varbintohexsubstring_vu_prepare_view
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+EXEC fn_varbintohexsubstring_vu_prepare_proc
+GO
+~~START~~
+nvarchar
+0x1234
+~~END~~
+
+
+SELECT * FROM fn_varbintohexsubstring_vu_prepare_func()
+GO
+~~START~~
+nvarchar
+0x1234
+~~END~~
+
+
+-- NULL expression results in NULL output
+SELECT sys.fn_varbintohexsubstring(0,0x,1,3);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(0,CAST(NULL AS VARBINARY),1,4);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+-- if substr_length is NULL, negative, zero or greater than length of expression, set substr_length as length of expression
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,NULL);
+GO
+~~START~~
+nvarchar
+0x123486534659789876435656
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(1, 0x123486534659789876435656, 1, -5);
+GO
+~~START~~
+nvarchar
+0x123486534659789876435656
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,0);
+GO
+~~START~~
+nvarchar
+0x123486534659789876435656
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,100);
+GO
+~~START~~
+nvarchar
+0x123486534659789876435656
+~~END~~
+
+
+-- if substr_length is out of bounds of the expression, then len is set to the length of expression - start_offset
+SELECT sys.fn_varbintohexsubstring(1, 0x123486534659789876435656, 3, 20);
+GO
+~~START~~
+nvarchar
+0x86534659789876435656
+~~END~~
+
+
+-- if set_prefix is NULL or 0, no prefix is added
+SELECT sys.fn_varbintohexsubstring(NULL,0x123486534659789876435656,1,4);
+GO
+~~START~~
+nvarchar
+12348653
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(0,0x123486534659789876435656,1,4);
+GO
+~~START~~
+nvarchar
+12348653
+~~END~~
+
+
+-- if set_prefix is 1 or any other integer except 0, prefix is added
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,4);
+GO
+~~START~~
+nvarchar
+0x12348653
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(52,0x123486534659789876435656,1,4);
+GO
+~~START~~
+nvarchar
+0x12348653
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(-81,0x123486534659789876435656,1,4);
+GO
+~~START~~
+nvarchar
+0x12348653
+~~END~~
+
+
+-- if start_offset is NULL or 0 or negative, return NULL
+SELECT sys.fn_varbintohexsubstring(1,0x87243478679,NULL,4);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(1,0x87243478679,CAST(NULL AS INT),4);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(1,0x87243478679,0,4);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(1, 0x123456, -1, 2);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+-- if start_offset is out of bound, return NULL
+SELECT sys.fn_varbintohexsubstring(1, 0x123456, 100, 2);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+-- NULL edge cases
+SELECT sys.fn_varbintohexsubstring(NULL,NULL,NULL,NULL);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(NULL,0x8675235657899765,NULL,NULL);
+GO
+~~START~~
+nvarchar
+<NULL>
+~~END~~
+
+
+SELECT sys.fn_varbintohexsubstring(NULL,0x8675235657899765,2,NULL);
+GO
+~~START~~
+nvarchar
+75235657899765
+~~END~~
+
+
+--negative test as varbinary only consists of 0-9 and A-F
+SELECT sys.fn_varbintohexsubstring(1,0x1452J5S4, 2, 4);  
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '.' at line 2 and character position 10)~~
+
+
+-- negative test gives error as the expression datatype is not varbinary
+SELECT sys.fn_varbintohexsubstring(1,'1A2B3C4D', 2, 4);  
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+
+
+-- validate check constraint
+INSERT INTO babel_5654_t1 VALUES (0,0x123486534659789876435656,1,4)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_5654_t1 VALUES (1,0x123486534659789876435656,1,4)
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO babel_5654_t1 VALUES (1,0x123486534659789876435656,3,4)
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM babel_5654_t1
+GO
+~~START~~
+bit#!#varbinary#!#int#!#int
+0#!#123486534659789876435656#!#1#!#4
+0#!#123486534659789876435656#!#1#!#4
+1#!#123486534659789876435656#!#1#!#4
+1#!#123486534659789876435656#!#3#!#4
+~~END~~
+
+
+-- computed columns
+INSERT INTO babel_5654_t2 VALUES (1,0x23486534659789876435656,3,4)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_5654_t2" does not exist)~~
+
+
+SELECT * FROM babel_5654_t2 WHERE [varbintohexsubstring] = sys.fn_varbintohexsubstring(1,0x23486534659789876435656,3,4)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_5654_t2" does not exist)~~
+
+
+-- computed columns with user defined datatypes
+INSERT INTO babel_5654_t3 VALUES (1,0x23486534659789876435656,3,4)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_5654_t3" does not exist)~~
+
+
+SELECT * FROM babel_5654_t3 WHERE [varbintohexsubstring] = sys.fn_varbintohexsubstring(1,0x23486534659789876435656,3,4)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "babel_5654_t3" does not exist)~~
+

--- a/test/JDBC/input/functions/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-cleanup.sql
+++ b/test/JDBC/input/functions/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-cleanup.sql
@@ -1,0 +1,29 @@
+DROP VIEW fn_varbintohexsubstring_vu_prepare_view
+GO
+
+DROP PROC fn_varbintohexsubstring_vu_prepare_proc
+GO
+
+DROP FUNCTION fn_varbintohexsubstring_vu_prepare_func
+GO
+
+DROP TABLE babel_5654_t1
+GO
+
+DROP TABLE babel_5654_t2
+GO
+
+DROP TABLE babel_5654_t3
+GO
+
+DROP TYPE SetPrefixType
+GO
+
+DROP TYPE ExpressionType
+GO
+
+DROP TYPE StartOffsetType
+GO
+
+DROP TYPE SubstrLengthType
+GO

--- a/test/JDBC/input/functions/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-prepare.sql
+++ b/test/JDBC/input/functions/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-prepare.sql
@@ -1,0 +1,59 @@
+-- Create dependant objects
+CREATE VIEW fn_varbintohexsubstring_vu_prepare_view AS
+SELECT sys.fn_varbintohexsubstring(1,0x1234, 1, 4)
+GO
+
+CREATE PROC fn_varbintohexsubstring_vu_prepare_proc AS
+SELECT sys.fn_varbintohexsubstring(1,0x1234, 1, 4)
+GO
+
+CREATE FUNCTION fn_varbintohexsubstring_vu_prepare_func()
+RETURNS nvarchar(128)
+AS
+BEGIN
+RETURN sys.fn_varbintohexsubstring(1,0x1234, 1, 4)
+END
+GO
+
+CREATE TABLE babel_5654_t1 (set_prefix sys.BIT,
+                            expression sys.varbinary(MAX),
+                            start_offset INT,
+                            substr_length INT,
+                            CHECK (sys.fn_varbintohexsubstring(set_prefix, expression, start_offset, substr_length) != NULL));
+GO
+
+INSERT INTO babel_5654_t1 VALUES (0,0x123486534659789876435656,1,4)
+GO
+
+CREATE TABLE babel_5654_t2 (set_prefix sys.BIT,
+                            expression sys.varbinary(MAX),
+                            start_offset INT,
+                            substr_length INT,
+                            [varbintohexsubstring] AS sys.fn_varbintohexsubstring(set_prefix, expression, start_offset, substr_length));
+GO
+
+INSERT INTO babel_5654_t2 VALUES (0,0x3486534659789876435656,1,4)
+GO
+
+CREATE TYPE SetPrefixType from sys.bit;
+GO
+
+CREATE TYPE ExpressionType from sys.varbinary(MAX);
+GO
+
+CREATE TYPE StartOffsetType from int;
+GO
+
+CREATE TYPE SubstrLengthType from int;
+GO
+
+CREATE TABLE babel_5654_t3 (set_prefix SetPrefixType,
+                            expression ExpressionType,
+                            start_offset StartOffsetType,
+                            substr_length SubstrLengthType,
+                            [varbintohexsubstring] AS sys.fn_varbintohexsubstring(set_prefix, expression, start_offset, substr_length));
+GO
+
+INSERT INTO babel_5654_t3 VALUES (0,0x3486534659789876435656,1,4)
+GO
+

--- a/test/JDBC/input/functions/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-verify.sql
+++ b/test/JDBC/input/functions/sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-verify.sql
@@ -1,0 +1,111 @@
+-- dependent objects
+SELECT * FROM fn_varbintohexsubstring_vu_prepare_view
+GO
+
+EXEC fn_varbintohexsubstring_vu_prepare_proc
+GO
+
+SELECT * FROM fn_varbintohexsubstring_vu_prepare_func()
+GO
+
+-- NULL expression results in NULL output
+SELECT sys.fn_varbintohexsubstring(0,0x,1,3);
+GO
+
+SELECT sys.fn_varbintohexsubstring(0,CAST(NULL AS VARBINARY),1,4);
+GO
+
+-- if substr_length is NULL, negative, zero or greater than length of expression, set substr_length as length of expression
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,NULL);
+GO
+
+SELECT sys.fn_varbintohexsubstring(1, 0x123486534659789876435656, 1, -5);
+GO
+
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,0);
+GO
+
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,100);
+GO
+
+-- if substr_length is out of bounds of the expression, then len is set to the length of expression - start_offset
+SELECT sys.fn_varbintohexsubstring(1, 0x123486534659789876435656, 3, 20);
+GO
+
+-- if set_prefix is NULL or 0, no prefix is added
+SELECT sys.fn_varbintohexsubstring(NULL,0x123486534659789876435656,1,4);
+GO
+
+SELECT sys.fn_varbintohexsubstring(0,0x123486534659789876435656,1,4);
+GO
+
+-- if set_prefix is 1 or any other integer except 0, prefix is added
+SELECT sys.fn_varbintohexsubstring(1,0x123486534659789876435656,1,4);
+GO
+
+SELECT sys.fn_varbintohexsubstring(52,0x123486534659789876435656,1,4);
+GO
+
+SELECT sys.fn_varbintohexsubstring(-81,0x123486534659789876435656,1,4);
+GO
+
+-- if start_offset is NULL or 0 or negative, return NULL
+SELECT sys.fn_varbintohexsubstring(1,0x87243478679,NULL,4);
+GO
+
+SELECT sys.fn_varbintohexsubstring(1,0x87243478679,CAST(NULL AS INT),4);
+GO
+
+SELECT sys.fn_varbintohexsubstring(1,0x87243478679,0,4);
+GO
+
+SELECT sys.fn_varbintohexsubstring(1, 0x123456, -1, 2);
+GO
+
+-- if start_offset is out of bound, return NULL
+SELECT sys.fn_varbintohexsubstring(1, 0x123456, 100, 2);
+GO
+
+-- NULL edge cases
+SELECT sys.fn_varbintohexsubstring(NULL,NULL,NULL,NULL);
+GO
+
+SELECT sys.fn_varbintohexsubstring(NULL,0x8675235657899765,NULL,NULL);
+GO
+
+SELECT sys.fn_varbintohexsubstring(NULL,0x8675235657899765,2,NULL);
+GO
+
+--negative test as varbinary only consists of 0-9 and A-F
+SELECT sys.fn_varbintohexsubstring(1,0x1452J5S4, 2, 4);  
+GO
+
+-- negative test gives error as the expression datatype is not varbinary
+SELECT sys.fn_varbintohexsubstring(1,'1A2B3C4D', 2, 4);  
+GO
+
+-- validate check constraint
+INSERT INTO babel_5654_t1 VALUES (0,0x123486534659789876435656,1,4)
+GO
+INSERT INTO babel_5654_t1 VALUES (1,0x123486534659789876435656,1,4)
+GO
+INSERT INTO babel_5654_t1 VALUES (1,0x123486534659789876435656,3,4)
+GO
+
+SELECT * FROM babel_5654_t1
+GO
+
+-- computed columns
+INSERT INTO babel_5654_t2 VALUES (1,0x23486534659789876435656,3,4)
+GO
+
+SELECT * FROM babel_5654_t2 WHERE [varbintohexsubstring] = sys.fn_varbintohexsubstring(1,0x23486534659789876435656,3,4)
+GO
+
+-- computed columns with user defined datatypes
+INSERT INTO babel_5654_t3 VALUES (1,0x23486534659789876435656,3,4)
+GO
+
+SELECT * FROM babel_5654_t3 WHERE [varbintohexsubstring] = sys.fn_varbintohexsubstring(1,0x23486534659789876435656,3,4)
+GO
+ 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -574,3 +574,8 @@ ignore#!#test_conv_int_to_varbinary_binary_before_17_5_or_16_9-vu-cleanup
 ignore#!#test_constraint_like-16-6-vu-prepare
 ignore#!#test_constraint_like-16-6-vu-verify
 ignore#!#test_constraint_like-16-6-vu-cleanup
+
+# These tests are meant for upgrade scenario prior to 17_6 or 16_10 release
+ignore#!#sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-prepare
+ignore#!#sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-verify
+ignore#!#sys-fn-varbintohexsubstring-before-16_10-or-17_6-vu-cleanup

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -608,9 +608,8 @@ test_conv_float_to_varchar_char
 BABEL-5467
 sys_credentials
 sys_server_permissions
-sys_sql_logins
 sys-login-property
-sys-fn-varbintohexsubstring
+sys-fn-varbintohexsubstring-before-16_10-or-17_6
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
 test_constraint_like


### PR DESCRIPTION
### Description

This PR adds version-specific definition files for the sys.fn_varbintohexsubstring function for dummy support prior to 16.0 and 17.6 and full support after that.

Signed-off-by: Shreya Rai [shreyaxr@amazon.com](mailto:shreyaxr@amazon.com)