### PR TITLE
Chunk server_hello into size of 4096 during SSL handshake

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -193,7 +193,6 @@ SslWrite(BIO * h, const char *buf, int size)
 static int
 SslHandShakeWrite(BIO * h, const char *buf, int size)
 {
-	#define SSL_MAX_PACKET_SIZE 4096
 	StringInfoData	str;
 	char		tmp[2];
 	uint16_t	tsize;
@@ -205,18 +204,18 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 	if (size < 0)
 		return size;
 
-	/* Process data in chunks of SSL_MAX_PACKET_SIZE */
-	while (size > 0)
+	/* Process data in chunks of TDS_DEFAULT_INIT_PACKET_SIZE */
+	while (size > 0 || (size == packet_id)) /* Special handling when the size of first packet is 0 */
 	{
-		int chunk_size = (size > (SSL_MAX_PACKET_SIZE - TDS_PACKET_HEADER_SIZE)) ?
-							(SSL_MAX_PACKET_SIZE - TDS_PACKET_HEADER_SIZE) :
+		int chunk_size = (size > (TDS_DEFAULT_INIT_PACKET_SIZE - TDS_PACKET_HEADER_SIZE)) ?
+							(TDS_DEFAULT_INIT_PACKET_SIZE - TDS_PACKET_HEADER_SIZE) :
 							size;
 
 		initStringInfo(&str);
 		appendStringInfoChar(&str, TDS_PRELOGIN);
 
 		/* Set EOM flag only for the last packet */
-		if (size <= (SSL_MAX_PACKET_SIZE - TDS_PACKET_HEADER_SIZE))
+		if (size <= (TDS_DEFAULT_INIT_PACKET_SIZE - TDS_PACKET_HEADER_SIZE))
 			appendStringInfoChar(&str, TDS_PACKET_HEADER_STATUS_EOM);
 		else
 			appendStringInfoChar(&str, 0x00);  // Not end of message
@@ -257,7 +256,6 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 	}
 
 	return total_written;
-	#undef SSL_MAX_PACKET_SIZE
 }
 
 /*

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -185,64 +185,77 @@ SslWrite(BIO * h, const char *buf, int size)
 	return res;
 }
 
-/*
- * TdsSshHandShakeWrite - Tds secure write function, similar to my_sock_write.
- * During the initial handshake add the 8 bytes header to the final data which
- * is sent to client
- */
 static int
 SslHandShakeWrite(BIO * h, const char *buf, int size)
 {
-	StringInfoData str;
-	char		tmp[2];
-	uint16_t	tsize;
-	int			res = 0;
+	#define SSL_MAX_PACKET_SIZE 4096
+	StringInfoData	str;
+	char			tmp[2];
+	uint16_t		tsize;
+	int				res = 0;
+	int				total_written = 0;
 
 	/* Nothing to write */
 	if (size < 0)
 		return size;
 
-	initStringInfo(&str);
-	appendStringInfoChar(&str, TDS_PRELOGIN);
-	appendStringInfoChar(&str, TDS_PACKET_HEADER_STATUS_EOM);
-	tsize = pg_hton16(size + TDS_PACKET_HEADER_SIZE);
-	memcpy(&tmp, (char *) &tsize, 2);
-
-	appendStringInfoChar(&str, tmp[0]);
-	appendStringInfoChar(&str, tmp[1]);
-	appendStringInfoChar(&str, 0x00);
-	appendStringInfoChar(&str, 0x00);
-	appendStringInfoChar(&str, 0x00);
-	appendStringInfoChar(&str, 0x00);
-
-	appendBinaryStringInfo(&str, buf, size);
-	buf = str.data;
-	size += TDS_PACKET_HEADER_SIZE;
-
-	/* Write the complete data */
-	while (res < size)
+	/* Process data in chunks of SSL_MAX_PACKET_SIZE */
+	while (size > 0)
 	{
-		int			tmp_res = 0;
+		int chunk_size = (size > (SSL_MAX_PACKET_SIZE - TDS_PACKET_HEADER_SIZE)) ?
+							(SSL_MAX_PACKET_SIZE - TDS_PACKET_HEADER_SIZE) :
+							size;
 
-		if ((tmp_res = SslWrite(h, &buf[res], size - res)) <= 0)
-			return tmp_res;
-		res += tmp_res;
+		initStringInfo(&str);
+		appendStringInfoChar(&str, TDS_PRELOGIN);
+
+		/* Set EOM flag only for the last packet */
+		if (size <= (SSL_MAX_PACKET_SIZE - TDS_PACKET_HEADER_SIZE))
+			appendStringInfoChar(&str, TDS_PACKET_HEADER_STATUS_EOM);
+		else
+			appendStringInfoChar(&str, 0x00);  // Not end of message
+
+		tsize = pg_hton16(chunk_size + TDS_PACKET_HEADER_SIZE);
+		memcpy(&tmp, (char *) &tsize, 2);
+
+		appendStringInfoChar(&str, tmp[0]);
+		appendStringInfoChar(&str, tmp[1]);
+		appendStringInfoChar(&str, 0x00);
+		appendStringInfoChar(&str, 0x00);
+		appendStringInfoChar(&str, 0x00);
+		appendStringInfoChar(&str, 0x00);
+
+		appendBinaryStringInfo(&str, buf + total_written, chunk_size);
+
+		/* Write the current chunk */
+		res = 0;
+		while (res < tsize)
+		{
+			int tmp_res = SslWrite(h, str.data + res, (tsize - res));
+			if (tmp_res <= 0)
+				return tmp_res;
+			res += tmp_res;
+		}
+
+		/*
+		 * Below assertion should not be failed in ideal case. If it gets failed
+		 * then it means that we wrote TDS HEADER and buf on the wire without any
+		 * error above but number of bytes written is still less than
+		 * TDS_PACKET_HEADER_SIZE which is unexpected in any case.
+		 */
+		Assert(res >= TDS_PACKET_HEADER_SIZE);
+
+		total_written += chunk_size;
+		size -= chunk_size;
+		pfree(str.data);
 	}
 
 	/*
-	 * Below assertion should not be failed in ideal case. If it gets failed
-	 * then it means that we wrote TDS HEADER and buf on the wire without any
-	 * error above but number of bytes written is still less than
-	 * TDS_PACKET_HEADER_SIZE which is unexpected in any case.
+	 * We are returning size here because we are asked to write "size" number of bytes 
+	 * and callee does not know anything about TDS packet header.
 	 */
-	Assert(res >= TDS_PACKET_HEADER_SIZE);
-
-	/*
-	 * We are returning (res - TDS_PACKET_HEADER_SIZE) here because we are
-	 * asked to write "size" number of bytes and callee does not know anything
-	 * about TDS packet header.
-	 */
-	return (res - TDS_PACKET_HEADER_SIZE);
+	return size;
+	#undef SSL_MAX_PACKET_SIZE
 }
 
 /*

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -256,10 +256,6 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 		pfree(str.data);
 	}
 
-	/*
-	 * We are returning size here because we are asked to write "size" number of bytes 
-	 * and callee does not know anything about TDS packet header.
-	 */
 	return total_written;
 	#undef SSL_MAX_PACKET_SIZE
 }

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -235,7 +235,7 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 
 		/* Write the current chunk */
 		res = 0;
-		while (res < chunk_size)
+		while (res < (chunk_size + TDS_PACKET_HEADER_SIZE))
 		{
 			int tmp_res = SslWrite(h, str.data + res, (chunk_size + TDS_PACKET_HEADER_SIZE - res));
 			if (tmp_res <= 0)

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -185,15 +185,21 @@ SslWrite(BIO * h, const char *buf, int size)
 	return res;
 }
 
+/*
+ * TdsSshHandShakeWrite - Tds secure write function, similar to my_sock_write.
+ * During the initial handshake add the 8 bytes header to the final data which
+ * is sent to client
+ */
 static int
 SslHandShakeWrite(BIO * h, const char *buf, int size)
 {
 	#define SSL_MAX_PACKET_SIZE 4096
 	StringInfoData	str;
-	char			tmp[2];
-	uint16_t		tsize;
-	int				res = 0;
-	int				total_written = 0;
+	char		tmp[2];
+	uint16_t	tsize;
+	int		res = 0;
+	int		total_written = 0;
+	int		packet_id = 0;
 
 	/* Nothing to write */
 	if (size < 0)
@@ -222,16 +228,16 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 		appendStringInfoChar(&str, tmp[1]);
 		appendStringInfoChar(&str, 0x00);
 		appendStringInfoChar(&str, 0x00);
-		appendStringInfoChar(&str, 0x00);
+		appendStringInfoChar(&str, packet_id++);
 		appendStringInfoChar(&str, 0x00);
 
 		appendBinaryStringInfo(&str, buf + total_written, chunk_size);
 
 		/* Write the current chunk */
 		res = 0;
-		while (res < tsize)
+		while (res < chunk_size)
 		{
-			int tmp_res = SslWrite(h, str.data + res, (tsize - res));
+			int tmp_res = SslWrite(h, str.data + res, (chunk_size + TDS_PACKET_HEADER_SIZE - res));
 			if (tmp_res <= 0)
 				return tmp_res;
 			res += tmp_res;
@@ -254,7 +260,7 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 	 * We are returning size here because we are asked to write "size" number of bytes 
 	 * and callee does not know anything about TDS packet header.
 	 */
-	return size;
+	return total_written;
 	#undef SSL_MAX_PACKET_SIZE
 }
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdssecure.c
@@ -200,12 +200,16 @@ SslHandShakeWrite(BIO * h, const char *buf, int size)
 	int		total_written = 0;
 	int		packet_id = 0;
 
-	/* Nothing to write */
-	if (size < 0)
+	/*
+	 * No data to write — uncommon during TLS handshake as records carry data.
+	 * In BIO-based writes (e.g. BIO_write_all), size <= 0 will raise an error.
+	 * Return early to avoid sending an empty or invalid TDS packet.
+	 */
+	if (size <= 0)
 		return size;
 
 	/* Process data in chunks of TDS_DEFAULT_INIT_PACKET_SIZE */
-	while (size > 0 || (size == packet_id)) /* Special handling when the size of first packet is 0 */
+	while (size > 0)
 	{
 		int chunk_size = (size > (TDS_DEFAULT_INIT_PACKET_SIZE - TDS_PACKET_HEADER_SIZE)) ?
 							(TDS_DEFAULT_INIT_PACKET_SIZE - TDS_PACKET_HEADER_SIZE) :


### PR DESCRIPTION
### Description

During SSL handshake, when server_hello message exceeds the TDS packet size limit of 4096 bytes, the connection fails as the max allowed packets size is 4096 while doing SSL handshake. 

This commit make changes to split server_hello messages into chunks of of 4096 bytes. Mandatory TDS header (8 byes) are included in the each chunk.

Task: BABEL-5787
Authored-by: Sumit Jaiswal (sumiji@amazon.com)
Co-Authored-by: Dipesh Dhameliya (dddhamel@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).