### PR TITLE
Fix invalid read in tsql_round_var function

### DIFF
--- a/contrib/babelfishpg_common/src/numeric.c
+++ b/contrib/babelfishpg_common/src/numeric.c
@@ -804,7 +804,7 @@ tsql_round_var(NumericVar *var, int rscale)
 	di = (var->weight + 1) * DEC_DIGITS + rscale;
 
 	/* checking numeric overflow for TSQL */
-	if (rscale < 0)
+	if (rscale < 0 && var->ndigits > 0)
 	{
 		int			integral_digits = di - DEC_DIGITS;
 		int			leading_digits = digits[0];

--- a/test/JDBC/expected/round_return_type_test-vu-verify.out
+++ b/test/JDBC/expected/round_return_type_test-vu-verify.out
@@ -449,4 +449,11 @@ go
 ~~ERROR (Message: The function round is found but cannot be used. Possibly due to datatype mismatch and implicit casting is not allowed.)~~
 
 
+select round(0.0, -1)
+go
+~~START~~
+numeric
+0
+~~END~~
+
 

--- a/test/JDBC/input/round_return_type_test-vu-verify.sql
+++ b/test/JDBC/input/round_return_type_test-vu-verify.sql
@@ -215,4 +215,6 @@ DECLARE @inputString geography = geography::STGeomFromText('POINT(-122.34900 47.
 select round(@inputString, 1)
 go
 
+select round(0.0, -1)
+go
 


### PR DESCRIPTION
### Description

To detect for overflow and underflow we need to determine total integral digits which in-turn uses leading digits in the digits array. But digits array will be empty in case of 0 numeric values which leads to invalid read. 
When the rscale is negative and numeric value is 0 we can skip checking for numeric overflow as the base-NBASE digits will be empty for 0.


### Issues Resolved
BABEL-5546

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).