### PR TITLE
Enable cross database tests for partition function/scheme 

### DIFF
--- a/test/JDBC/expected/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/PARTITION-vu-verify.out
@@ -1258,31 +1258,16 @@ PS_CollationTest_VarChar#!#PF_CollationTest_VarChar#!#PS#!#PARTITION_SCHEME#!#0#
 ~~END~~
 
 
-
--- psql
-
+-- tsql database=partitiondb
 ------------------------------------------------------------
 --- all user can use the metadata of the partition scheme 
 --- to create table if they permission to create table
 ------------------------------------------------------------
--- grant create permission to user on schema so that it can create table
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'GRANT CREATE ON SCHEMA ' || quote_ident(schema_name) || ' TO partitiondb_partition_u1';
-END$$;
+-- add user as a member of db_ddladmin, so that it gets create permission
+ALTER ROLE db_ddladmin ADD MEMBER partition_u1
 GO
 
--- tsql     user=partition_l1 password=12345678
-USE PartitionDb;
-GO
-
+-- tsql     user=partition_l1 password=12345678 database=partitiondb
 SELECT CURRENT_USER
 GO
 ~~START~~
@@ -1291,32 +1276,15 @@ partition_u1
 ~~END~~
 
 
-/** CREATE PERMISSION GRANTED VIA PG PORT MAY NOT TAKE EFFECT ON TSQL OBJECTS **/
-/** NOT A RECOMMENDED WAY **/
 CREATE TABLE PartitionDb_TestPartitionTable (
     Id INT,
     Value sys.varchar(20)
 ) ON PartitionDb_PartitionScheme(Id);
 GO
-~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: must be owner of table partitiondb_testpartitiontable)~~
-
-
--- psql
-
--- revoke create permission from user on schema
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'REVOKE CREATE ON SCHEMA ' || quote_ident(schema_name) || ' FROM partitiondb_partition_u1';
-END$$;
+-- tsql database=partitiondb
+-- remove user from member of db_ddladmin
+ALTER ROLE db_ddladmin DROP MEMBER partition_u1
 GO
 
 -- tsql

--- a/test/JDBC/expected/db_collation/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/db_collation/PARTITION-vu-verify.out
@@ -1258,31 +1258,16 @@ PS_CollationTest_VarChar#!#PF_CollationTest_VarChar#!#PS#!#PARTITION_SCHEME#!#0#
 ~~END~~
 
 
-
--- psql
-
+-- tsql database=partitiondb
 ------------------------------------------------------------
 --- all user can use the metadata of the partition scheme 
 --- to create table if they permission to create table
 ------------------------------------------------------------
--- grant create permission to user on schema so that it can create table
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'GRANT CREATE ON SCHEMA ' || quote_ident(schema_name) || ' TO partitiondb_partition_u1';
-END$$;
+-- add user as a member of db_ddladmin, so that it gets create permission
+ALTER ROLE db_ddladmin ADD MEMBER partition_u1
 GO
 
--- tsql     user=partition_l1 password=12345678
-USE PartitionDb;
-GO
-
+-- tsql     user=partition_l1 password=12345678 database=partitiondb
 SELECT CURRENT_USER
 GO
 ~~START~~
@@ -1291,32 +1276,15 @@ partition_u1
 ~~END~~
 
 
-/** CREATE PERMISSION GRANTED VIA PG PORT MAY NOT TAKE EFFECT ON TSQL OBJECTS **/
-/** NOT A RECOMMENDED WAY **/
 CREATE TABLE PartitionDb_TestPartitionTable (
     Id INT,
     Value sys.varchar(20)
 ) ON PartitionDb_PartitionScheme(Id);
 GO
-~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: must be owner of table partitiondb_testpartitiontable)~~
-
-
--- psql
-
--- revoke create permission from user on schema
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'REVOKE CREATE ON SCHEMA ' || quote_ident(schema_name) || ' FROM partitiondb_partition_u1';
-END$$;
+-- tsql database=partitiondb
+-- remove user from member of db_ddladmin
+ALTER ROLE db_ddladmin DROP MEMBER partition_u1
 GO
 
 -- tsql

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
@@ -1258,31 +1258,16 @@ PS_CollationTest_VarChar#!#PF_CollationTest_VarChar#!#PS#!#PARTITION_SCHEME#!#0#
 ~~END~~
 
 
-
--- psql
-
+-- tsql database=partitiondb
 ------------------------------------------------------------
 --- all user can use the metadata of the partition scheme 
 --- to create table if they permission to create table
 ------------------------------------------------------------
--- grant create permission to user on schema so that it can create table
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'GRANT CREATE ON SCHEMA ' || quote_ident(schema_name) || ' TO partitiondb_partition_u1';
-END$$;
+-- add user as a member of db_ddladmin, so that it gets create permission
+ALTER ROLE db_ddladmin ADD MEMBER partition_u1
 GO
 
--- tsql     user=partition_l1 password=12345678
-USE PartitionDb;
-GO
-
+-- tsql     user=partition_l1 password=12345678 database=partitiondb
 SELECT CURRENT_USER
 GO
 ~~START~~
@@ -1291,32 +1276,15 @@ partition_u1
 ~~END~~
 
 
-/** CREATE PERMISSION GRANTED VIA PG PORT MAY NOT TAKE EFFECT ON TSQL OBJECTS **/
-/** NOT A RECOMMENDED WAY **/
 CREATE TABLE PartitionDb_TestPartitionTable (
     Id INT,
     Value sys.varchar(20)
 ) ON PartitionDb_PartitionScheme(Id);
 GO
-~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: must be owner of table partitiondb_testpartitiontable)~~
-
-
--- psql
-
--- revoke create permission from user on schema
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'REVOKE CREATE ON SCHEMA ' || quote_ident(schema_name) || ' FROM partitiondb_partition_u1';
-END$$;
+-- tsql database=partitiondb
+-- remove user from member of db_ddladmin
+ALTER ROLE db_ddladmin DROP MEMBER partition_u1
 GO
 
 -- tsql

--- a/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
@@ -1258,31 +1258,16 @@ PS_CollationTest_VarChar#!#PF_CollationTest_VarChar#!#PS#!#PARTITION_SCHEME#!#0#
 ~~END~~
 
 
-
--- psql
-
+-- tsql database=partitiondb
 ------------------------------------------------------------
 --- all user can use the metadata of the partition scheme 
 --- to create table if they permission to create table
 ------------------------------------------------------------
--- grant create permission to user on schema so that it can create table
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'GRANT CREATE ON SCHEMA ' || quote_ident(schema_name) || ' TO partitiondb_partition_u1';
-END$$;
+-- add user as a member of db_ddladmin, so that it gets create permission
+ALTER ROLE db_ddladmin ADD MEMBER partition_u1
 GO
 
--- tsql     user=partition_l1 password=12345678
-USE PartitionDb;
-GO
-
+-- tsql     user=partition_l1 password=12345678 database=partitiondb
 SELECT CURRENT_USER
 GO
 ~~START~~
@@ -1291,32 +1276,15 @@ partition_u1
 ~~END~~
 
 
-/** CREATE PERMISSION GRANTED VIA PG PORT MAY NOT TAKE EFFECT ON TSQL OBJECTS **/
-/** NOT A RECOMMENDED WAY **/
 CREATE TABLE PartitionDb_TestPartitionTable (
     Id INT,
     Value sys.varchar(20)
 ) ON PartitionDb_PartitionScheme(Id);
 GO
-~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: must be owner of table partitiondb_testpartitiontable)~~
-
-
--- psql
-
--- revoke create permission from user on schema
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-    EXECUTE 'REVOKE CREATE ON SCHEMA ' || quote_ident(schema_name) || ' FROM partitiondb_partition_u1';
-END$$;
+-- tsql database=partitiondb
+-- remove user from member of db_ddladmin
+ALTER ROLE db_ddladmin DROP MEMBER partition_u1
 GO
 
 -- tsql

--- a/test/JDBC/input/PARTITION-vu-verify.mix
+++ b/test/JDBC/input/PARTITION-vu-verify.mix
@@ -600,52 +600,24 @@ go
 --- all user can use the metadata of the partition scheme 
 --- to create table if they permission to create table
 ------------------------------------------------------------
-
--- grant create permission to user on schema so that it can create table
--- psql
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-
-    EXECUTE 'GRANT CREATE ON SCHEMA ' || quote_ident(schema_name) || ' TO partitiondb_partition_u1';
-END$$;
+-- tsql database=partitiondb
+-- add user as a member of db_ddladmin, so that it gets create permission
+ALTER ROLE db_ddladmin ADD MEMBER partition_u1
 GO
 
--- tsql     user=partition_l1 password=12345678
-USE PartitionDb;
-GO
-
+-- tsql     user=partition_l1 password=12345678 database=partitiondb
 SELECT CURRENT_USER
 GO
 
-/** CREATE PERMISSION GRANTED VIA PG PORT MAY NOT TAKE EFFECT ON TSQL OBJECTS **/
-/** NOT A RECOMMENDED WAY **/
 CREATE TABLE PartitionDb_TestPartitionTable (
     Id INT,
     Value sys.varchar(20)
 ) ON PartitionDb_PartitionScheme(Id);
 GO
 
--- revoke create permission from user on schema
--- psql
-DO $$
-DECLARE
-    schema_name TEXT;
-BEGIN
-    IF current_setting('babelfishpg_tsql.migration_mode') = 'multi-db' THEN
-        schema_name := 'partitiondb_dbo';
-    ELSE
-        schema_name := 'dbo';
-    END IF;
-
-    EXECUTE 'REVOKE CREATE ON SCHEMA ' || quote_ident(schema_name) || ' FROM partitiondb_partition_u1';
-END$$;
+-- tsql database=partitiondb
+-- remove user from member of db_ddladmin
+ALTER ROLE db_ddladmin DROP MEMBER partition_u1
 GO
 
 -----------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

This commit enables cross database tests for partition function/scheme to validate that any user can use the metadata of the partition function/scheme to create table if they have permission to create, which was disabled in https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/d35674ff5db34f2f06d380e7e866fc52846a800f as the previous tests was using PSQL endpoint to grant create permission on user which has been blocked recently.


Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)


### Issues Resolved

Task : BABEL-5681





### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).