### PR TITLE
Check array not empty before accessing leading digits in Numeric

### DIFF
--- a/contrib/babelfishpg_common/src/numeric.c
+++ b/contrib/babelfishpg_common/src/numeric.c
@@ -1018,7 +1018,7 @@ tsql_numeric_get_typmod(Numeric num)
 			10,
 			1,
 		};
-		int			leading_digits = NUMERIC_DIGITS(num)[0];
+		int			leading_digits = NUMERIC_NDIGITS(num) != 0 ? NUMERIC_DIGITS(num)[0] : 0;
 
 		precision = weight * DEC_DIGITS + scale;
 

--- a/contrib/babelfishpg_common/src/numeric.c
+++ b/contrib/babelfishpg_common/src/numeric.c
@@ -1010,7 +1010,17 @@ tsql_numeric_get_typmod(Numeric num)
 	int32_t		weight = NUMERIC_WEIGHT(num);
 	int32_t		precision;
 
-	if (weight >= 0)
+	/*
+	 * We can identify a zero by the fact that there are no digits at all. In
+	 * case of zero both precision and scale will be evaluated to zero, so we
+	 * will set (precision,scale) to T-SQL default (18,0).
+	 */
+	if (NUMERIC_NDIGITS(num) == 0)
+	{
+		precision = 18;
+		scale = 0;
+	}
+	else if (weight >= 0)
 	{
 		static const int32 timescales[DEC_DIGITS] = {
 			1000,
@@ -1018,7 +1028,7 @@ tsql_numeric_get_typmod(Numeric num)
 			10,
 			1,
 		};
-		int			leading_digits = NUMERIC_NDIGITS(num) != 0 ? NUMERIC_DIGITS(num)[0] : 0;
+		int			leading_digits = NUMERIC_DIGITS(num)[0];
 
 		precision = weight * DEC_DIGITS + scale;
 


### PR DESCRIPTION
### Description

Before fetching the leading digits from numeric added check if the numeric array is empty or not as it leads to invalid read when the numeric is zero.

### Issues Resolved
BABEL-4631


### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).