### PR TITLE
Accept alias-referenced source columns syntax in unpivot

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -2210,6 +2210,42 @@ get_unpivot_source_alias(Node *table_ref) {
 }
 
 /*
+ * Helper function to determine if UNPIVOT source table needs an alias generated
+ *
+ * source_cols: list of column references (ResTarget nodes) from UNPIVOT IN clause
+ *
+ * Returns: true if all column references are unqualified (need alias),
+ *          false if any column has alias or table/schema qualification
+ *
+ * Note: For unqualified columns (col1, col2), we generate a table alias to properly
+ * reference columns. For qualified columns (table.col1), we use references as-is.
+ * Function also validates that all source columns are valid ColumnRef nodes.
+ */
+static bool
+needs_unpivot_source_alias(List *source_cols)
+{
+    ListCell *lc;
+    
+    /* Check if all columns are unqualified */
+    foreach(lc, source_cols)
+    {
+        ResTarget *res;
+        ColumnRef *cref;
+
+        res = (ResTarget *) lfirst(lc);
+		Assert(IsA(res->val, ColumnRef));
+        cref = (ColumnRef *) res->val;
+
+        /* If any column is qualified, don't generate alias */
+        if (list_length(cref->fields) > 1)
+            return false;
+    }
+    
+    /* All columns are unqualified, need alias */
+    return true;
+}
+
+/*
  * Create an NVARCHAR constant with proper typmod
  *
  * str: input string to be cast as NVARCHAR
@@ -2276,6 +2312,7 @@ tsql_unpivot_transformation(List *components, int location)
 
     List *unpivot_info;
     List *source_cols;
+    List *col_names = NIL;
     List *values_list = NIL;
     List *value_pair;
     List *result_info;
@@ -2289,9 +2326,7 @@ tsql_unpivot_transformation(List *components, int location)
     SelectStmt *values_subquery;
     JoinExpr *n;
     RangeSubselect *rarg;
-    ListCell *lc;
-    ColumnRef *col_ref;
-    
+    ListCell *outer_lc, *inner_lc;    
     /* Extract components */
     Assert(components != NULL && list_length(components) == 3);
     table_ref = (Node *)linitial(components);
@@ -2318,26 +2353,45 @@ tsql_unpivot_transformation(List *components, int location)
     n->isNatural = false;
 
     /* Set up left side with alias if not present */
-    source_alias = get_unpivot_source_alias(table_ref);
+    source_alias = needs_unpivot_source_alias(source_cols) ? get_unpivot_source_alias(table_ref) : NULL;
 
     n->larg = table_ref;
     
     /* Build VALUES list from unpivot source columns */
-    foreach(lc, source_cols)
-    {	
-        /* 
-         * TODO [BABEL-5677]: Handle aliased unpivot source columns syntax
-         * Ex: `unpivot (a for b in (c_alias.q1, c_alias.q2))`
-         * solution: lfirst needs to be "llast" if aliases are used in values list
-         */
-        String *col_name = (String *)lfirst(lc);
+    foreach(outer_lc, source_cols)
+    {
+        ResTarget *res = (ResTarget *)lfirst(outer_lc);
+        ColumnRef *cref = (ColumnRef *)res->val;
+        char *col_name = strVal(llast(cref->fields));
 
-        /* Create ColumnRef with pair (source table alias, column name) */
-        col_ref = makeNode(ColumnRef);
-        col_ref->fields = list_make2(makeString(source_alias), col_name);
-        
-        /* Create pair (ColumnRef, column name) and append to VALUES list */
-        value_pair = list_make2(col_ref, make_nvarchar_const(strVal(col_name), location));
+        /* Check for duplicates in already processed columns */
+        foreach(inner_lc, col_names)
+        {
+            char *existing_name = strVal((String *)lfirst(inner_lc));
+            if (strcmp(col_name, existing_name) == 0)
+            {
+                ereport(ERROR,
+                       (errcode(ERRCODE_SYNTAX_ERROR),
+                        errmsg("The column \"%s\" is specified multiple times in the column list of the UNPIVOT operator",
+                               col_name)));
+            }
+        }
+
+        /* Append seen column names into a list for duplicate-check and unpivot-metadata */
+        col_names = lappend(col_names, makeString(col_name));
+
+        if (list_length(cref->fields) == 1 && source_alias)
+        {
+            /* Create new ColumnRef with source alias for unqualified columns */
+            ColumnRef *new_cref = makeNode(ColumnRef);
+            new_cref->fields = list_make2(makeString(source_alias), makeString(col_name));
+            value_pair = list_make2(new_cref, make_nvarchar_const(col_name, location));
+        }
+        else
+        {
+            /* Use original parsed ColumnRef as is */
+            value_pair = list_make2(cref, make_nvarchar_const(col_name, location));
+        }
         values_list = lappend(values_list, value_pair);
     }
     
@@ -2371,7 +2425,7 @@ tsql_unpivot_transformation(List *components, int location)
                              makeString(source_alias));
 
     /* Append the unpivot source columns and transformed node */
-    result_info = lappend(result_info, source_cols);
+    result_info = lappend(result_info, col_names);
     result_info = lappend(result_info, n);
 
     return (Node *) result_info;

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -2233,7 +2233,7 @@ needs_unpivot_source_alias(List *source_cols)
         ColumnRef *cref;
 
         res = (ResTarget *) lfirst(lc);
-		Assert(IsA(res->val, ColumnRef));
+        Assert(IsA(res->val, ColumnRef));
         cref = (ColumnRef *) res->val;
 
         /* If any column is qualified, don't generate alias */

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
@@ -58,6 +58,7 @@ static Node * buildTsqlMultiLineTvfNode(int create_loc, bool replace, List *func
 static Node *tsql_pivot_select_transformation(List *target_list, List *from_clause, List *pivot_clause, Alias *alias_clause, SelectStmt *pivot_sl);
 static Node *tsql_unpivot_transformation(List *components, int location);
 static Node *make_nvarchar_const(const char *str, int location);
+static bool needs_unpivot_source_alias(List *source_cols);
 static char *generate_unpivot_source_table_alias(const char *base);
 static char *get_unpivot_source_alias(Node *table_ref);
 

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -1905,7 +1905,7 @@ joined_table:
 		;
 
 tsql_unpivot_clause:
-            '(' columnref FOR columnref IN_P '(' columnList ')' ')'
+            '(' columnref FOR columnref IN_P '(' target_list ')' ')'
                 {
 					$$ = (Node *)list_make3($2, $4, $7);
                 }

--- a/test/JDBC/expected/unpivot-vu-cleanup.out
+++ b/test/JDBC/expected/unpivot-vu-cleanup.out
@@ -15,6 +15,8 @@ DROP TABLE product_info;
 GO
 DROP TABLE sales_data;
 GO
+DROP TABLE revenue_data;
+GO
 DROP TABLE product_sales;
 GO
 DROP TABLE product_performance;

--- a/test/JDBC/expected/unpivot-vu-prepare.out
+++ b/test/JDBC/expected/unpivot-vu-prepare.out
@@ -195,6 +195,21 @@ GO
 ~~ROW COUNT: 3~~
 
 
+CREATE TABLE revenue_data (
+    id INT,
+    q1_sales INT,
+    q2_sales INT
+);
+GO
+
+INSERT INTO revenue_data VALUES
+    (1, 100, 150),
+    (2, 200, 250),
+    (3, NULL, 350);
+GO
+~~ROW COUNT: 3~~
+
+
 CREATE TABLE product_sales (
     product_id INT,
     product_desc VARCHAR(25),

--- a/test/JDBC/expected/unpivot-vu-verify.out
+++ b/test/JDBC/expected/unpivot-vu-verify.out
@@ -1538,7 +1538,7 @@ int#!#numeric#!#nvarchar
 ~~END~~
 
 
--- BABEL-5762 - Aliased column names in unpivot source list
+-- Aliased column names in unpivot source list
     -- valid syntax
 SELECT customer_id, turnover, quarter FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (c.q1, c.q2, c.q3, c.q4)) AS unpvt;

--- a/test/JDBC/expected/unpivot-vu-verify.out
+++ b/test/JDBC/expected/unpivot-vu-verify.out
@@ -1538,17 +1538,156 @@ int#!#numeric#!#nvarchar
 ~~END~~
 
 
-
--- KNOWN ISSUES
-    -- BABEL-5677 - Support more variations of UNPIVOT Syntax
-        -- Aliased column names in unpivot source list
+-- BABEL-5762 - Aliased column names in unpivot source list
+    -- valid syntax
 SELECT customer_id, turnover, quarter FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (c.q1, c.q2, c.q3, c.q4)) AS unpvt;
 GO
+~~START~~
+int#!#int#!#nvarchar
+3#!#0#!#q2
+3#!#400#!#q3
+3#!#150#!#q4
+1#!#100#!#q1
+1#!#200#!#q2
+1#!#100#!#q3
+1#!#400#!#q4
+2#!#150#!#q1
+2#!#250#!#q2
+2#!#200#!#q3
+~~END~~
+
+
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data 
+UNPIVOT ( sales_amount FOR quarter IN 
+                 (quarterly_data.q1_sales, q2_sales, q4_sales, q3_sales)) AS unpvt;
+GO
+~~START~~
+int#!#varchar#!#numeric#!#nvarchar
+1#!#Product A#!#0.50#!#q1_sales
+1#!#Product A#!#150.75#!#q2_sales
+1#!#Product A#!#175.50#!#q4_sales
+1#!#Product A#!#200.25#!#q3_sales
+2#!#Product B#!#200.00#!#q1_sales
+2#!#Product B#!#300.00#!#q2_sales
+2#!#Product B#!#0.00#!#q3_sales
+3#!#Product C#!#175.25#!#q1_sales
+3#!#Product C#!#225.75#!#q2_sales
+3#!#Product C#!#250.00#!#q4_sales
+~~END~~
+
+
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data 
+UNPIVOT ( sales_amount FOR quarter IN 
+                 (sales.quarterly_data.q1_sales, q2_sales, q3_sales, q4_sales)) AS unpvt;
+GO
+~~START~~
+int#!#varchar#!#numeric#!#nvarchar
+1#!#Product A#!#0.50#!#q1_sales
+1#!#Product A#!#150.75#!#q2_sales
+1#!#Product A#!#200.25#!#q3_sales
+1#!#Product A#!#175.50#!#q4_sales
+2#!#Product B#!#200.00#!#q1_sales
+2#!#Product B#!#300.00#!#q2_sales
+2#!#Product B#!#0.00#!#q3_sales
+3#!#Product C#!#175.25#!#q1_sales
+3#!#Product C#!#225.75#!#q2_sales
+3#!#Product C#!#250.00#!#q4_sales
+~~END~~
+
+
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data c_ALIAS 
+UNPIVOT ( sales_amount FOR quarter IN 
+                  (c_ALIAS.q1_sales, q2_sales, q4_sales, q3_sales)) AS unpvt;
+GO
+~~START~~
+int#!#varchar#!#numeric#!#nvarchar
+1#!#Product A#!#0.50#!#q1_sales
+1#!#Product A#!#150.75#!#q2_sales
+1#!#Product A#!#175.50#!#q4_sales
+1#!#Product A#!#200.25#!#q3_sales
+2#!#Product B#!#200.00#!#q1_sales
+2#!#Product B#!#300.00#!#q2_sales
+2#!#Product B#!#0.00#!#q3_sales
+3#!#Product C#!#175.25#!#q1_sales
+3#!#Product C#!#225.75#!#q2_sales
+3#!#Product C#!#250.00#!#q4_sales
+~~END~~
+
+
+
+SELECT amount, quarter
+FROM (sales_data s JOIN revenue_data r ON s.product_id = r.id)
+UNPIVOT ( amount FOR quarter IN (s.q1_sales, r.q2_sales)) AS unpvt;
+GO
+~~START~~
+int#!#nvarchar
+100#!#q1_sales
+150#!#q2_sales
+200#!#q1_sales
+250#!#q2_sales
+350#!#q2_sales
+~~END~~
+
+
+
+        -- invalid syntax
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data c_ALIAS 
+UNPIVOT ( sales_amount FOR quarter IN 
+                  (sales.quarterly_data.q1_sales, q2_sales, q4_sales, q3_sales)) AS unpvt;
+GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near ".")~~
+~~ERROR (Message: invalid reference to FROM-clause entry for table "quarterly_data")~~
 
+
+SELECT amount, quarter
+FROM (sales_data s JOIN revenue_data r ON s.product_id = r.id)
+UNPIVOT ( amount FOR quarter IN (s.q1_sales, r.q1_sales)) AS unpvt;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The column "q1_sales" is specified multiple times in the column list of the UNPIVOT operator)~~
+
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (CAST(q1 AS DECIMAL(10,2)))) AS unpvt;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '(' at line 2 and character position 31)~~
+
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (q2 AS [Q2 Sales])) AS unpvt;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'AS' at line 2 and character position 30)~~
+
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (MAX(q3))) AS unpvt;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '(' at line 2 and character position 30)~~
+
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (CONVERT(numeric(10,2), q4))) AS unpvt;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'CONVERT' at line 2 and character position 27)~~
+
+
+-- KNOWN ISSUES
+    -- BABEL-5677 - Support more variations of UNPIVOT Syntax
         -- Extra columns in result set when `SELECT alias.*`
 SELECT unpvt.* FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;

--- a/test/JDBC/input/unpivot-vu-cleanup.sql
+++ b/test/JDBC/input/unpivot-vu-cleanup.sql
@@ -15,6 +15,8 @@ DROP TABLE product_info;
 GO
 DROP TABLE sales_data;
 GO
+DROP TABLE revenue_data;
+GO
 DROP TABLE product_sales;
 GO
 DROP TABLE product_performance;

--- a/test/JDBC/input/unpivot-vu-prepare.sql
+++ b/test/JDBC/input/unpivot-vu-prepare.sql
@@ -185,6 +185,19 @@ INSERT INTO sales_data VALUES
     (3, NULL, 350, 'Central', 'East');
 GO
 
+CREATE TABLE revenue_data (
+    id INT,
+    q1_sales INT,
+    q2_sales INT
+);
+GO
+
+INSERT INTO revenue_data VALUES
+    (1, 100, 150),
+    (2, 200, 250),
+    (3, NULL, 350);
+GO
+
 CREATE TABLE product_sales (
     product_id INT,
     product_desc VARCHAR(25),

--- a/test/JDBC/input/unpivot-vu-verify.sql
+++ b/test/JDBC/input/unpivot-vu-verify.sql
@@ -843,7 +843,7 @@ UNPIVOT (
 ) AS [Global_分析];
 GO
 
--- BABEL-5762 - Aliased column names in unpivot source list
+-- Aliased column names in unpivot source list
     -- valid syntax
 SELECT customer_id, turnover, quarter FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (c.q1, c.q2, c.q3, c.q4)) AS unpvt;

--- a/test/JDBC/input/unpivot-vu-verify.sql
+++ b/test/JDBC/input/unpivot-vu-verify.sql
@@ -843,13 +843,67 @@ UNPIVOT (
 ) AS [Global_分析];
 GO
 
-
--- KNOWN ISSUES
-    -- BABEL-5677 - Support more variations of UNPIVOT Syntax
-        -- Aliased column names in unpivot source list
+-- BABEL-5762 - Aliased column names in unpivot source list
+    -- valid syntax
 SELECT customer_id, turnover, quarter FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (c.q1, c.q2, c.q3, c.q4)) AS unpvt;
 GO
+
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data 
+UNPIVOT ( sales_amount FOR quarter IN 
+                 (quarterly_data.q1_sales, q2_sales, q4_sales, q3_sales)) AS unpvt;
+GO
+
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data 
+UNPIVOT ( sales_amount FOR quarter IN 
+                 (sales.quarterly_data.q1_sales, q2_sales, q3_sales, q4_sales)) AS unpvt;
+GO
+
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data c_ALIAS 
+UNPIVOT ( sales_amount FOR quarter IN 
+                  (c_ALIAS.q1_sales, q2_sales, q4_sales, q3_sales)) AS unpvt;
+GO
+
+
+SELECT amount, quarter
+FROM (sales_data s JOIN revenue_data r ON s.product_id = r.id)
+UNPIVOT ( amount FOR quarter IN (s.q1_sales, r.q2_sales)) AS unpvt;
+GO
+
+
+        -- invalid syntax
+SELECT product_id, product_name, sales_amount, quarter 
+FROM sales.quarterly_data c_ALIAS 
+UNPIVOT ( sales_amount FOR quarter IN 
+                  (sales.quarterly_data.q1_sales, q2_sales, q4_sales, q3_sales)) AS unpvt;
+GO
+
+SELECT amount, quarter
+FROM (sales_data s JOIN revenue_data r ON s.product_id = r.id)
+UNPIVOT ( amount FOR quarter IN (s.q1_sales, r.q1_sales)) AS unpvt;
+GO
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (CAST(q1 AS DECIMAL(10,2)))) AS unpvt;
+GO
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (q2 AS [Q2 Sales])) AS unpvt;
+GO
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (MAX(q3))) AS unpvt;
+GO
+
+SELECT * FROM customer_turnover UNPIVOT (
+    amount FOR quarter IN (CONVERT(numeric(10,2), q4))) AS unpvt;
+GO
+
+-- KNOWN ISSUES
+    -- BABEL-5677 - Support more variations of UNPIVOT Syntax
         -- Extra columns in result set when `SELECT alias.*`
 SELECT unpvt.* FROM customer_turnover c 
 UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;


### PR DESCRIPTION
Added support for alias-referenced and table and schema qualified column references in UNPIVOT IN clause.

### Description
Currently, Babelfish's UNPIVOT implementation only supports simple column references (like col1, col2) in the IN clause. With this change, it now supports qualified column references including:

- Table qualified references (table_name.col)
- Schema and table qualified references (schema_name.table_name.col)
- Alias qualified references (table_alias.col)

This enhancement improves SQL Server compatibility by allowing the same column reference patterns in UNPIVOT that are permitted in standard SQL Server. The implementation conditionally determines when to generate a table alias based on the column references provided in the SQL input, preserving the original references when they're already qualified.

The code also adds validation to detect duplicate columns in the UNPIVOT source list and provides appropriate error messages consistent with SQL Server's behavior.

Changes:
1. Modified the parser rule for unpivot IN clause to `target_list` to accept qualified names like table_name.col, schema_name.table_name.col and src_alias.col.
2. Also added logic to preserve original parsed column references when qualified and generate source alias only when all columns are unqualified. This determination is performed in the new function `needs_unpivot_source_alias`.
3. Added related test cases.


### Issues Resolved

BABEL-5762

### Test Scenarios Covered ###
* **Use case based -**
Table alias qualified: `... UNPIVOT (val FOR col IN (alias.q1, alias.q2))`
Table name qualified: `... UNPIVOT (val FOR col IN (table.q1, table.q2))`
Schema and table qualified: `... UNPIVOT (val FOR col IN (schema.table.q1))`
JOIN table references: `... UNPIVOT (val FOR col IN (t1.q1, t2.q2))`


* **Negative test cases -**
Duplicate column names in UNPIVOT list
```
 SELECT amount, quarter
 FROM (sales_data s JOIN revenue_data r ON s.product_id = r.id)
 UNPIVOT ( amount FOR quarter IN (s.q1_sales, r.q1_sales)) AS unpvt;
 GO
```
Invalid table/alias references
```
UNPIVOT ( amount FOR quarter IN (CAST( q1 AS DECIMAL(10,2) )) ) AS unpvt;

UNPIVOT ( amount FOR quarter IN (q2 AS [Q2 Sales]) ) AS unpvt;

UNPIVOT ( amount FOR quarter IN (MAX(q3)) ) AS unpvt;

UNPIVOT ( amount FOR quarter IN (CONVERT(numeric(10,2), q4)) ) AS unpvt;
```
Mixed naming patterns that violate SQL Server rules
```
SELECT product_id, product_name, sales_amount, quarter 
FROM sales.quarterly_data c_ALIAS 
UNPIVOT ( sales_amount FOR quarter IN 
                          (sales.quarterly_data.q1_sales, q2_sales, q4_sales, q3_sales) ) AS unpvt;
```


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).