### PR TITLE
Fix StringIndexOutOfBoundsException issue in JDBC test framework

### DIFF
--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -303,17 +303,17 @@ public class TestQueryFile {
 
             if(status){
                 //extra spaces for right side padding
-                summaryLogger.info((testMethodName + ":" + "                                                     ").substring(0, maxlen+2) + "Passed! (" + exec_time + "/" + sla_val + "ms OK)" + testStats);
+                summaryLogger.info(testMethodName + ":" + " ".repeat(maxlen + 2 - (testMethodName.length()+1)) + "Passed! (" + exec_time + "/" + sla_val + "ms OK)" + testStats);
                 passed++;
             }
             else if(exec_time <= sla_val){
                 //extra spaces for right side padding
-                summaryLogger.info((testMethodName + ":" + "                                                     ").substring(0, maxlen+2) + "Failed! (" + exec_time + "/" + sla_val + "ms OK)" + testStats);
+                summaryLogger.info(testMethodName + ":" + " ".repeat(maxlen + 2 - (testMethodName.length()+1)) + "Failed! (" + exec_time + "/" + sla_val + "ms OK)" + testStats);
                 failed++;
             }
             else{
                 //extra spaces for right side padding
-                summaryLogger.info((testMethodName + ":" + "                                                     ").substring(0, maxlen+2) + "Failed! (" + exec_time + "/" + sla_val + "ms TIME OUT)" + testStats);
+                summaryLogger.info(testMethodName + ":" + " ".repeat(maxlen + 2 - (testMethodName.length()+1)) + "Failed! (" + exec_time + "/" + sla_val + "ms TIME OUT)" + testStats);
                 failed++;
             }
         }


### PR DESCRIPTION
### Description
Currently whenever two tests with testfile name length difference greater than 51, JDBC is throwing StringIndexOutOfBounds Exception. Example added below. This is happening due to the hardcoded spaces added in logSummary() function. This PR will add dynamic number of spaces based on max test file name and current test file name. Added below the test run summary after this fix.

Before fix:
```
Started test suite. Now running tests...
RUNNING sp_proc
RUNNING test_conv_string_to_datetimeoffset-before-16_3-or-15_7-or-14_12-vu-prepare
All tests executed successfully!
###########################################################################
################################  SUMMARY  ################################
###########################################################################
[ERROR] Tests run: 4, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 1.246 s <<< FAILURE! - in com.sqlsamples.TestQueryFile
[ERROR] com.sqlsamples.TestQueryFile.TestQueryBatch(String)[3]  Time elapsed: 0.193 s  <<< ERROR!
java.lang.Throwable: test_conv_string_to_datetimeoffset-before-16_3-or-15_7-or-14_12-vu-prepare FAILED! Output diff can be found in '/workplace/rohitbgt/rohit/babelfish_extensions/test/JDBC/Info/16-05-2024T08:51:45.399/16-05-2024T08:51:45.399.diff'

[ERROR] com.sqlsamples.TestQueryFile  Time elapsed: 1.246 s  <<< ERROR!
java.lang.StringIndexOutOfBoundsException: begin 0, end 76, length 61
        at com.sqlsamples.TestQueryFile.logSummary(TestQueryFile.java:281)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   TestQueryFile.TestQueryBatch(String)[3] » Throwable test_conv_string_to_dateti...
[ERROR]   TestQueryFile.logSummary:281 » StringIndexOutOfBounds begin 0, end 76, length ...
[INFO] 
[ERROR] Tests run: 4, Failures: 0, Errors: 2, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.853 s
[INFO] Finished at: 2024-05-16T08:51:46Z
[INFO] ------------------------------------------------------------------------
```

After fix:
```
tarted test suite. Now running tests...
RUNNING sp_proc
RUNNING test_conv_string_to_datetimeoffset-before-16_3-or-15_7-or-14_12-vu-prepare
All tests executed successfully!
###########################################################################
################################  SUMMARY  ################################
###########################################################################
sp_proc:                                                                    Passed! (339/40000ms OK)
test_conv_string_to_datetimeoffset-before-16_3-or-15_7-or-14_12-vu-prepare: Failed! (107/40000ms OK)
###########################################################################
TOTAL TESTS:    2
TESTS PASSED:   1
TESTS FAILED:   1
###########################################################################
Output diff can be found in '/workplace/rohitbgt/rohit/babelfish_extensions/test/JDBC/Info/16-05-2024T08:52:40.274/16-05-2024T08:52:40.274.diff'
[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.263 s <<< FAILURE! - in com.sqlsamples.TestQueryFile
[ERROR] com.sqlsamples.TestQueryFile.TestQueryBatch(String)[3]  Time elapsed: 0.191 s  <<< ERROR!
java.lang.Throwable: test_conv_string_to_datetimeoffset-before-16_3-or-15_7-or-14_12-vu-prepare FAILED! Output diff can be found in '/workplace/rohitbgt/rohit/babelfish_extensions/test/JDBC/Info/16-05-2024T08:52:40.274/16-05-2024T08:52:40.274.diff'

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   TestQueryFile.TestQueryBatch(String)[3] » Throwable test_conv_string_to_dateti...
[INFO] 
[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.770 s
[INFO] Finished at: 2024-05-16T08:52:41Z
[INFO] ------------------------------------------------------------------------
```

Authored-by: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved
NO JIRA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).