### PR TITLE
Add operator class between int and numeric to support index scan

### DIFF
--- a/contrib/babelfishpg_common/sql/integer.sql
+++ b/contrib/babelfishpg_common/sql/integer.sql
@@ -210,6 +210,26 @@ CREATE OPERATOR CLASS sys.numeric_int FOR TYPE int4
    OPERATOR 5 sys.> (numeric, int4),
    FUNCTION 1 sys.numeric_int4_cmp(numeric, int4);
 
+-- Operator class for numeric_ops to incorporate various operator between numeric and int4 for Index scan
+CREATE OPERATOR CLASS sys.numeric_int4_ops FOR TYPE numeric
+  USING btree FAMILY numeric_ops AS
+   OPERATOR 1 sys.< (numeric, int4),
+   OPERATOR 2 sys.<= (numeric, int4),
+   OPERATOR 3 sys.= (numeric, int4),
+   OPERATOR 4 sys.>= (numeric, int4),
+   OPERATOR 5 sys.> (numeric, int4),
+   FUNCTION 1 sys.numeric_int4_cmp(numeric, int4);
+
+-- Operator class for numeric_ops to incorporate various operator between int4 and numeric for Index scan
+CREATE OPERATOR CLASS sys.int4_numeric_ops FOR TYPE numeric
+  USING btree FAMILY numeric_ops AS
+   OPERATOR 1 sys.< (int4, numeric),
+   OPERATOR 2 sys.<= (int4, numeric),
+   OPERATOR 3 sys.= (int4, numeric),
+   OPERATOR 4 sys.>= (int4, numeric),
+   OPERATOR 5 sys.> (int4, numeric),
+   FUNCTION 1 sys.int4_numeric_cmp(int4, numeric);
+
 -- create support function for int2 and numeric comparison
 CREATE FUNCTION sys.int2_numeric_cmp (int2, numeric)
 RETURNS int
@@ -422,6 +442,26 @@ CREATE OPERATOR CLASS sys.numeric_int2 FOR TYPE int2
    OPERATOR 5 sys.> (numeric, int2),
    FUNCTION 1 sys.numeric_int2_cmp(numeric, int2);
 
+-- Operator class for numeric_ops to incorporate various operator between numeric and int2 for Index scan
+CREATE OPERATOR CLASS sys.numeric_int2_ops FOR TYPE numeric
+  USING btree FAMILY numeric_ops AS
+   OPERATOR 1 sys.< (numeric, int2),
+   OPERATOR 2 sys.<= (numeric, int2),
+   OPERATOR 3 sys.= (numeric, int2),
+   OPERATOR 4 sys.>= (numeric, int2),
+   OPERATOR 5 sys.> (numeric, int2),
+   FUNCTION 1 sys.numeric_int2_cmp(numeric, int2);
+
+-- Operator class for numeric_ops to incorporate various operator between int2 and numeric for Index scan
+CREATE OPERATOR CLASS sys.int2_numeric_ops FOR TYPE numeric
+  USING btree FAMILY numeric_ops AS
+   OPERATOR 1 sys.< (int2, numeric),
+   OPERATOR 2 sys.<= (int2, numeric),
+   OPERATOR 3 sys.= (int2, numeric),
+   OPERATOR 4 sys.>= (int2, numeric),
+   OPERATOR 5 sys.> (int2, numeric),
+   FUNCTION 1 sys.int2_numeric_cmp(int2, numeric);
+
 -- create support function for int8 and numeric comparison
 CREATE FUNCTION sys.int8_numeric_cmp (int8, numeric)
 RETURNS int
@@ -627,6 +667,26 @@ CREATE OPERATOR CLASS sys.int8_numeric FOR TYPE int8
 -- Opartor class for integer_ops to incorporate various operator between int and numeric for Index scan
 CREATE OPERATOR CLASS sys.numeric_int8 FOR TYPE int8
   USING btree FAMILY integer_ops AS
+   OPERATOR 1 sys.< (numeric, int8),
+   OPERATOR 2 sys.<= (numeric, int8),
+   OPERATOR 3 sys.= (numeric, int8),
+   OPERATOR 4 sys.>= (numeric, int8),
+   OPERATOR 5 sys.> (numeric, int8),
+   FUNCTION 1 sys.numeric_int8_cmp(numeric, int8);
+
+-- Operator class for numeric_ops to incorporate various operator between int8 and numeric for Index scan
+CREATE OPERATOR CLASS sys.int8_numeric_ops FOR TYPE numeric
+  USING btree FAMILY numeric_ops AS
+   OPERATOR 1 sys.< (int8, numeric),
+   OPERATOR 2 sys.<= (int8, numeric),
+   OPERATOR 3 sys.= (int8, numeric),
+   OPERATOR 4 sys.>= (int8, numeric),
+   OPERATOR 5 sys.> (int8, numeric),
+   FUNCTION 1 sys.int8_numeric_cmp(int8, numeric);
+
+-- Operator class for numeric_ops to incorporate various operator between numeric and int8 for Index scan
+CREATE OPERATOR CLASS sys.numeric_int8_ops FOR TYPE numeric
+  USING btree FAMILY numeric_ops AS
    OPERATOR 1 sys.< (numeric, int8),
    OPERATOR 2 sys.<= (numeric, int8),
    OPERATOR 3 sys.= (numeric, int8),

--- a/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--4.6.0--4.7.0.sql
@@ -4,3 +4,116 @@
 
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '4.7.0'" to load this file. \quit
+
+SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false);
+
+-- Operator class for numeric_ops to incorporate various operator between numeric and int4 for Index scan
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_opclass opc JOIN pg_opfamily opf ON opc.opcfamily = opf.oid 
+        WHERE opc.opcname = 'numeric_int4_ops' AND opc.opcnamespace = 'sys'::regnamespace
+        AND opf.opfname = 'numeric_ops') THEN
+
+        CREATE OPERATOR CLASS sys.numeric_int4_ops FOR TYPE numeric
+          USING btree FAMILY numeric_ops AS
+            OPERATOR 1 sys.< (numeric, int4),
+            OPERATOR 2 sys.<= (numeric, int4),
+            OPERATOR 3 sys.= (numeric, int4),
+            OPERATOR 4 sys.>= (numeric, int4),
+            OPERATOR 5 sys.> (numeric, int4),
+            FUNCTION 1 sys.numeric_int4_cmp(numeric, int4);
+    END IF;
+END $$;
+
+-- Operator class for numeric_ops to incorporate various operator between int4 and numeric for Index scan
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_opclass opc JOIN pg_opfamily opf ON opc.opcfamily = opf.oid 
+        WHERE opc.opcname = 'int4_numeric_ops' AND opc.opcnamespace = 'sys'::regnamespace
+        AND opf.opfname = 'numeric_ops') THEN
+
+        CREATE OPERATOR CLASS sys.int4_numeric_ops FOR TYPE numeric
+          USING btree FAMILY numeric_ops AS
+            OPERATOR 1 sys.< (int4, numeric),
+            OPERATOR 2 sys.<= (int4, numeric),
+            OPERATOR 3 sys.= (int4, numeric),
+            OPERATOR 4 sys.>= (int4, numeric),
+            OPERATOR 5 sys.> (int4, numeric),
+            FUNCTION 1 sys.int4_numeric_cmp(int4, numeric);
+    END IF;
+END $$;
+
+-- Operator class for numeric_ops to incorporate various operator between numeric and int2 for Index scan
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_opclass opc JOIN pg_opfamily opf ON opc.opcfamily = opf.oid 
+        WHERE opc.opcname = 'numeric_int2_ops' AND opc.opcnamespace = 'sys'::regnamespace
+        AND opf.opfname = 'numeric_ops') THEN
+
+        CREATE OPERATOR CLASS sys.numeric_int2_ops FOR TYPE numeric
+          USING btree FAMILY numeric_ops AS
+            OPERATOR 1 sys.< (numeric, int2),
+            OPERATOR 2 sys.<= (numeric, int2),
+            OPERATOR 3 sys.= (numeric, int2),
+            OPERATOR 4 sys.>= (numeric, int2),
+            OPERATOR 5 sys.> (numeric, int2),
+            FUNCTION 1 sys.numeric_int2_cmp(numeric, int2);
+    END IF;
+END $$;
+
+-- Operator class for numeric_ops to incorporate various operator between int2 and numeric for Index scan
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_opclass opc JOIN pg_opfamily opf ON opc.opcfamily = opf.oid 
+        WHERE opc.opcname = 'int2_numeric_ops' AND opc.opcnamespace = 'sys'::regnamespace
+        AND opf.opfname = 'numeric_ops') THEN
+
+        CREATE OPERATOR CLASS sys.int2_numeric_ops FOR TYPE numeric
+          USING btree FAMILY numeric_ops AS
+            OPERATOR 1 sys.< (int2, numeric),
+            OPERATOR 2 sys.<= (int2, numeric),
+            OPERATOR 3 sys.= (int2, numeric),
+            OPERATOR 4 sys.>= (int2, numeric),
+            OPERATOR 5 sys.> (int2, numeric),
+            FUNCTION 1 sys.int2_numeric_cmp(int2, numeric);
+    END IF;
+END $$;
+
+-- Operator class for numeric_ops to incorporate various operator int8 and numeric for Index scan
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_opclass opc JOIN pg_opfamily opf ON opc.opcfamily = opf.oid 
+        WHERE opc.opcname = 'int8_numeric_ops' AND opc.opcnamespace = 'sys'::regnamespace
+        AND opf.opfname = 'numeric_ops') THEN
+
+        CREATE OPERATOR CLASS sys.int8_numeric_ops FOR TYPE numeric
+          USING btree FAMILY numeric_ops AS
+            OPERATOR 1 sys.< (int8, numeric),
+            OPERATOR 2 sys.<= (int8, numeric),
+            OPERATOR 3 sys.= (int8, numeric),
+            OPERATOR 4 sys.>= (int8, numeric),
+            OPERATOR 5 sys.> (int8, numeric),
+            FUNCTION 1 sys.int8_numeric_cmp(int8, numeric);
+    END IF;
+END $$;
+
+-- Operator class for numeric_ops to incorporate various operator between numeric and int8 for Index scan
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_opclass opc JOIN pg_opfamily opf ON opc.opcfamily = opf.oid 
+        WHERE opc.opcname = 'numeric_int8_ops' AND opc.opcnamespace = 'sys'::regnamespace
+        AND opf.opfname = 'numeric_ops') THEN
+
+        CREATE OPERATOR CLASS sys.numeric_int8_ops FOR TYPE numeric
+          USING btree FAMILY numeric_ops AS
+            OPERATOR 1 sys.< (numeric, int8),
+            OPERATOR 2 sys.<= (numeric, int8),
+            OPERATOR 3 sys.= (numeric, int8),
+            OPERATOR 4 sys.>= (numeric, int8),
+            OPERATOR 5 sys.> (numeric, int8),
+            FUNCTION 1 sys.numeric_int8_cmp(numeric, int8);
+    END IF;
+END $$;
+
+-- Reset search_path to not affect any subsequent scripts
+SELECT set_config('search_path', trim(leading 'sys, ' from current_setting('search_path')), false);

--- a/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.10.0--4.0.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfishpg_common--3.10.0--4.0.0.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION ""babelfishpg_common"" UPDATE TO '4.0.0'" to load this file. \quit

--- a/test/JDBC/expected/babel_test_numeric_int2_oper-vu-prepare.out
+++ b/test/JDBC/expected/babel_test_numeric_int2_oper-vu-prepare.out
@@ -1,0 +1,468 @@
+-- tsql
+create table babel_test_numeric_int2_vu_prepare(a numeric(18,2));
+GO
+
+-- insert data
+INSERT INTO babel_test_numeric_int2_vu_prepare (a) SELECT cast(generate_series(1, 32767) as numeric(18,2));
+GO
+~~ROW COUNT: 32767~~
+
+
+INSERT INTO babel_test_numeric_int2_vu_prepare VALUES (NULL), (-32768.00), (32767.00);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE INDEX babel_test_numeric_int2_vu_prepare_idx on babel_test_numeric_int2_vu_prepare(a);
+GO
+
+
+-- procedures dependency on all the numeric,int2 or int2, numeric operators
+create procedure babel_test_numeric_int2_p0 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p00 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a;
+GO
+
+create procedure babel_test_numeric_int2_p1 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create procedure babel_test_numeric_int2_p2 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p3 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a;
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int2_p4 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p5 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a;
+GO
+
+create procedure babel_test_numeric_int2_p6 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p7 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a;
+GO
+
+create procedure babel_test_numeric_int2_p8 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p9 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a;
+GO
+
+create procedure babel_test_numeric_int2_p10 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p11 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a;
+GO
+
+create procedure babel_test_numeric_int2_p12 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p13 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a;
+GO
+
+create procedure babel_test_numeric_int2_p14 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+create procedure babel_test_numeric_int2_p15 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a;
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int2_p16 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p17 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a;
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int2_p18 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int2_p19 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint);
+GO
+
+-- mix of numeric op int2 and numeric op numeric
+create procedure babel_test_numeric_int2_p20 as
+select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p21 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint);
+Go
+
+create procedure babel_test_numeric_int2_p22 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a;
+Go
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create procedure babel_test_numeric_int2_p23 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int2_p24 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p25 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p26 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p27 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p28 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p29 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int2_p30 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int2_p31 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int2_p32 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint);
+GO
+
+-- view body dependency on all the numeric,int2 or int2, numeric operators
+create view babel_test_numeric_int2_v0 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint);
+GO
+
+create view babel_test_numeric_int2_v00 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a;
+GO
+
+create view babel_test_numeric_int2_v1 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create view babel_test_numeric_int2_v2 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v3 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a;
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int2_v4 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v5 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a;
+GO
+
+create view babel_test_numeric_int2_v6 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create view babel_test_numeric_int2_v7 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a;
+GO
+
+create view babel_test_numeric_int2_v8 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v9 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a;
+GO
+
+create view babel_test_numeric_int2_v10 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v11 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a;
+GO
+
+create view babel_test_numeric_int2_v12 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v13 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a;
+GO
+
+create view babel_test_numeric_int2_v14 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+create view babel_test_numeric_int2_v15 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a;
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int2_v16 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v17 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a;
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int2_v18 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int2_v19 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint);
+GO
+
+-- mix of numeric op int2 and numeric op numeric
+create view babel_test_numeric_int2_v20 as
+select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint);
+GO
+
+create view babel_test_numeric_int2_v21 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint);
+Go
+
+create view babel_test_numeric_int2_v22 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a;
+Go
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create view babel_test_numeric_int2_v23 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int2_v24 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v25 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create view babel_test_numeric_int2_v26 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v27 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v28 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v29 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int2_v30 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int2_v31 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int2_v32 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint);
+GO
+
+-- functions dependency on all the numeric,int2 or int2, numeric operators
+create function babel_test_numeric_int2_f0() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f00() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a) end;
+GO
+
+create function babel_test_numeric_int2_f1() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL) end;
+GO
+
+-- seq scan
+create function babel_test_numeric_int2_f2() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f3() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int2_f4() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f5() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a) end;
+GO
+
+create function babel_test_numeric_int2_f6() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f7() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a) end;
+GO
+
+create function babel_test_numeric_int2_f8() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f9() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a) end;
+GO
+
+create function babel_test_numeric_int2_f10() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f11() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a) end;
+GO
+
+create function babel_test_numeric_int2_f12() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f13() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a) end;
+GO
+
+create function babel_test_numeric_int2_f14() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f15() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int2_f16() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f17() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int2_f18() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int2_f19() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint)) end;
+GO
+
+-- mix of numeric op int2 and numeric op numeric
+create function babel_test_numeric_int2_f20() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f21() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f22() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a) end;
+GO
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create function babel_test_numeric_int2_f23() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint)) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int2_f24() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f25() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f26() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f27() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f28() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f29() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint)) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int2_f30() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint)) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int2_f31() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int2_f32() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint)) end;
+GO

--- a/test/JDBC/expected/babel_test_numeric_int2_oper-vu-verify.out
+++ b/test/JDBC/expected/babel_test_numeric_int2_oper-vu-verify.out
@@ -1,0 +1,1970 @@
+-- psql
+analyse master_dbo.babel_test_numeric_int2_vu_prepare;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+exec babel_test_numeric_int2_p0;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p0
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a = '1'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 165.790 ms
+~~END~~
+
+exec babel_test_numeric_int2_p00;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p00
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a = '1'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 10.897 ms
+~~END~~
+
+exec babel_test_numeric_int2_p1;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p1
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a IS NULL)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.580 ms
+~~END~~
+
+exec babel_test_numeric_int2_p2;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p2
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: (a <> '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 1.834 ms
+~~END~~
+
+exec babel_test_numeric_int2_p3;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p3
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: ('5'::smallint <> a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.879 ms
+~~END~~
+
+exec babel_test_numeric_int2_p4;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p4
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a < '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.301 ms
+~~END~~
+
+exec babel_test_numeric_int2_p5;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p5
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a < '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 5.280 ms
+~~END~~
+
+exec babel_test_numeric_int2_p6;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p6
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a < '-32768'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 14.673 ms
+~~END~~
+
+exec babel_test_numeric_int2_p7;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p7
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a < '-32768'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 3.110 ms
+~~END~~
+
+exec babel_test_numeric_int2_p8;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p8
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a <= '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.873 ms
+~~END~~
+
+exec babel_test_numeric_int2_p9;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p9
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a <= '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.856 ms
+~~END~~
+
+exec babel_test_numeric_int2_p10;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p10
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a > '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 5.163 ms
+~~END~~
+
+exec babel_test_numeric_int2_p11;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p11
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a > '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.286 ms
+~~END~~
+
+exec babel_test_numeric_int2_p12;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p12
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a >= '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int2_p13;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p13
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a >= '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
+~~END~~
+
+exec babel_test_numeric_int2_p14;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p14
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a > '32767'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
+~~END~~
+
+exec babel_test_numeric_int2_p15;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p15
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a > '32767'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int2_p16;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p16
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: (a > '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
+~~END~~
+
+exec babel_test_numeric_int2_p17;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p17
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: ('5'::smallint < a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
+~~END~~
+
+exec babel_test_numeric_int2_p18;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p18
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: ((a >= '5'::smallint) AND (a <= '10'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 6.972 ms
+~~END~~
+
+exec babel_test_numeric_int2_p19;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p19
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: ((a >= '5'::smallint) AND (a <= '32767'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.159 ms
+~~END~~
+
+exec babel_test_numeric_int2_p20;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p20
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: ((a >= '5'::smallint) AND (a <= '32763'::smallint) AND (a = '10'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 14.399 ms
+~~END~~
+
+exec babel_test_numeric_int2_p21;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p21
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: ((a > '5'::smallint) AND (a < '7'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.238 ms
+~~END~~
+
+exec babel_test_numeric_int2_p22;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p22
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: ((a > '5'::smallint) AND (a < '7'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.312 ms
+~~END~~
+
+exec babel_test_numeric_int2_p23;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p23
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: (a <> '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int2_p24;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p24
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a < '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int2_p25;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p25
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a < '-32768'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.155 ms
+~~END~~
+
+exec babel_test_numeric_int2_p26;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p26
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a <= '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
+~~END~~
+
+exec babel_test_numeric_int2_p27;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p27
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a > '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int2_p28;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p28
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a >= '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int2_p29;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p29
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: (a > '32767'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.150 ms
+~~END~~
+
+exec babel_test_numeric_int2_p30;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p30
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: (a > '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int2_p31;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p31
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+              Index Cond: ((a >= '5'::smallint) AND (a <= '10'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.159 ms
+~~END~~
+
+exec babel_test_numeric_int2_p32;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int2_p32
+  Query Text: select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+              Filter: ((a >= '5'::smallint) AND (a <= '32763'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.159 ms
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+exec babel_test_numeric_int2_p0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int2_p00;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int2_p1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int2_p2;
+GO
+~~START~~
+int
+32768
+~~END~~
+
+exec babel_test_numeric_int2_p3;
+GO
+~~START~~
+int
+32768
+~~END~~
+
+exec babel_test_numeric_int2_p4;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int2_p5;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int2_p6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int2_p7;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int2_p8;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p9;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p10;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int2_p11;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int2_p12;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p13;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p14;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int2_p15;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int2_p16;
+GO
+~~START~~
+int
+32763
+~~END~~
+
+exec babel_test_numeric_int2_p17;
+GO
+~~START~~
+int
+32763
+~~END~~
+
+exec babel_test_numeric_int2_p18;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p19;
+GO
+~~START~~
+int
+32764
+~~END~~
+
+exec babel_test_numeric_int2_p20;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int2_p21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int2_p22;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int2_p23;
+GO
+~~START~~
+int
+32768
+~~END~~
+
+exec babel_test_numeric_int2_p24;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int2_p25;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int2_p26;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p27;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int2_p28;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p29;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int2_p30;
+GO
+~~START~~
+int
+32763
+~~END~~
+
+exec babel_test_numeric_int2_p31;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int2_p32;
+GO
+~~START~~
+int
+32759
+~~END~~
+
+
+drop procedure babel_test_numeric_int2_p0;
+drop procedure babel_test_numeric_int2_p00;
+drop procedure babel_test_numeric_int2_p1;
+drop procedure babel_test_numeric_int2_p2;
+drop procedure babel_test_numeric_int2_p3;
+drop procedure babel_test_numeric_int2_p4;
+drop procedure babel_test_numeric_int2_p5;
+drop procedure babel_test_numeric_int2_p6;
+drop procedure babel_test_numeric_int2_p7;
+drop procedure babel_test_numeric_int2_p8;
+drop procedure babel_test_numeric_int2_p9;
+drop procedure babel_test_numeric_int2_p10;
+drop procedure babel_test_numeric_int2_p11;
+drop procedure babel_test_numeric_int2_p12;
+drop procedure babel_test_numeric_int2_p13;
+drop procedure babel_test_numeric_int2_p14;
+drop procedure babel_test_numeric_int2_p15;
+drop procedure babel_test_numeric_int2_p16;
+drop procedure babel_test_numeric_int2_p17;
+drop procedure babel_test_numeric_int2_p18;
+drop procedure babel_test_numeric_int2_p19;
+drop procedure babel_test_numeric_int2_p20;
+drop procedure babel_test_numeric_int2_p21;
+drop procedure babel_test_numeric_int2_p22;
+drop procedure babel_test_numeric_int2_p23;
+drop procedure babel_test_numeric_int2_p24;
+drop procedure babel_test_numeric_int2_p25;
+drop procedure babel_test_numeric_int2_p26;
+drop procedure babel_test_numeric_int2_p27;
+drop procedure babel_test_numeric_int2_p28;
+drop procedure babel_test_numeric_int2_p29;
+drop procedure babel_test_numeric_int2_p30;
+drop procedure babel_test_numeric_int2_p31;
+drop procedure babel_test_numeric_int2_p32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+select * from babel_test_numeric_int2_v0;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v0
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a = '1'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.684 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v00;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v00
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a = '1'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v1;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v1
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a IS NULL)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v2;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v2
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: (a <> '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v3;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v3
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: ('5'::smallint <> a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v4;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v4
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a < '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v5;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v5
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a < '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v6;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v6
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a < '-32768'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v7;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v7
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a < '-32768'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v8;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v8
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a <= '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v9;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v9
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a <= '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v10;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v10
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a > '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v11;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v11
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a > '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v12;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v12
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a >= '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v13;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v13
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a >= '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v14;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v14
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a > '32767'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v15;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v15
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a > '32767'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v16;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v16
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: (a > '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v17;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v17
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: ('5'::smallint < a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v18;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v18
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: ((a >= '5'::smallint) AND (a <= '10'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v19;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v19
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: ((a >= '5'::smallint) AND (a <= '32767'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v20;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v20
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: ((a >= '5'::smallint) AND (a <= '32763'::smallint) AND (a = '10'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v21;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v21
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: ((a > '5'::smallint) AND (a < '7'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v22;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v22
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: ((a > '5'::smallint) AND (a < '7'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v23;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v23
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: (a <> '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v24;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v24
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a < '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v25;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v25
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a < '-32768'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v26;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v26
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a <= '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v27;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v27
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a > '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v28;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v28
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a >= '32763'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v29;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v29
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: (a > '32767'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v30;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v30
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: (a > '5'::smallint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v31;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v31
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int2_vu_prep3ab57c4813ec254915153edde759da36 on babel_test_numeric_int2_vu_prepare
+        Index Cond: ((a >= '5'::smallint) AND (a <= '10'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int2_v32;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int2_v32
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int2_vu_prepare
+        Filter: ((a >= '5'::smallint) AND (a <= '32763'::smallint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select * from babel_test_numeric_int2_v0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int2_v00;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int2_v1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int2_v2;
+GO
+~~START~~
+int
+32768
+~~END~~
+
+select * from babel_test_numeric_int2_v3;
+GO
+~~START~~
+int
+32768
+~~END~~
+
+select * from babel_test_numeric_int2_v4;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int2_v5;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int2_v6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int2_v7;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int2_v8;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v9;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v10;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int2_v11;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int2_v12;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v13;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v14;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int2_v15;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int2_v16;
+GO
+~~START~~
+int
+32763
+~~END~~
+
+select * from babel_test_numeric_int2_v17;
+GO
+~~START~~
+int
+32763
+~~END~~
+
+select * from babel_test_numeric_int2_v18;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v19;
+GO
+~~START~~
+int
+32764
+~~END~~
+
+select * from babel_test_numeric_int2_v20;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int2_v21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int2_v22;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int2_v23;
+GO
+~~START~~
+int
+32768
+~~END~~
+
+select * from babel_test_numeric_int2_v24;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int2_v25;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int2_v26;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v27;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int2_v28;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v29;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int2_v30;
+GO
+~~START~~
+int
+32763
+~~END~~
+
+select * from babel_test_numeric_int2_v31;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int2_v32;
+GO
+~~START~~
+int
+32759
+~~END~~
+
+
+drop view babel_test_numeric_int2_v0;
+drop view babel_test_numeric_int2_v00;
+drop view babel_test_numeric_int2_v1;
+drop view babel_test_numeric_int2_v2;
+drop view babel_test_numeric_int2_v3;
+drop view babel_test_numeric_int2_v4;
+drop view babel_test_numeric_int2_v5;
+drop view babel_test_numeric_int2_v6;
+drop view babel_test_numeric_int2_v7;
+drop view babel_test_numeric_int2_v8;
+drop view babel_test_numeric_int2_v9;
+drop view babel_test_numeric_int2_v10;
+drop view babel_test_numeric_int2_v11;
+drop view babel_test_numeric_int2_v12;
+drop view babel_test_numeric_int2_v13;
+drop view babel_test_numeric_int2_v14;
+drop view babel_test_numeric_int2_v15;
+drop view babel_test_numeric_int2_v16;
+drop view babel_test_numeric_int2_v17;
+drop view babel_test_numeric_int2_v18;
+drop view babel_test_numeric_int2_v19;
+drop view babel_test_numeric_int2_v20;
+drop view babel_test_numeric_int2_v21;
+drop view babel_test_numeric_int2_v22;
+drop view babel_test_numeric_int2_v23;
+drop view babel_test_numeric_int2_v24;
+drop view babel_test_numeric_int2_v25;
+drop view babel_test_numeric_int2_v26;
+drop view babel_test_numeric_int2_v27;
+drop view babel_test_numeric_int2_v28;
+drop view babel_test_numeric_int2_v29;
+drop view babel_test_numeric_int2_v30;
+drop view babel_test_numeric_int2_v31;
+drop view babel_test_numeric_int2_v32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select babel_test_numeric_int2_f0();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int2_f00();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int2_f1();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int2_f2();
+GO
+~~START~~
+int
+32768
+~~END~~
+
+select babel_test_numeric_int2_f3();
+GO
+~~START~~
+int
+32768
+~~END~~
+
+select babel_test_numeric_int2_f4();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int2_f5();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int2_f6();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int2_f7();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int2_f8();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f9();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f10();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int2_f11();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int2_f12();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f13();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f14();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int2_f15();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int2_f16();
+GO
+~~START~~
+int
+32763
+~~END~~
+
+select babel_test_numeric_int2_f17();
+GO
+~~START~~
+int
+32763
+~~END~~
+
+select babel_test_numeric_int2_f18();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f19();
+GO
+~~START~~
+int
+32764
+~~END~~
+
+select babel_test_numeric_int2_f20();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int2_f21();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int2_f22();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int2_f23();
+GO
+~~START~~
+int
+32768
+~~END~~
+
+select babel_test_numeric_int2_f24();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int2_f25();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int2_f26();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f27();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int2_f28();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f29();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int2_f30();
+GO
+~~START~~
+int
+32763
+~~END~~
+
+select babel_test_numeric_int2_f31();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int2_f32();
+GO
+~~START~~
+int
+32759
+~~END~~
+
+
+drop function babel_test_numeric_int2_f0;
+drop function babel_test_numeric_int2_f00;
+drop function babel_test_numeric_int2_f1;
+drop function babel_test_numeric_int2_f2;
+drop function babel_test_numeric_int2_f3;
+drop function babel_test_numeric_int2_f4;
+drop function babel_test_numeric_int2_f5;
+drop function babel_test_numeric_int2_f6;
+drop function babel_test_numeric_int2_f7;
+drop function babel_test_numeric_int2_f8;
+drop function babel_test_numeric_int2_f9;
+drop function babel_test_numeric_int2_f10;
+drop function babel_test_numeric_int2_f11;
+drop function babel_test_numeric_int2_f12;
+drop function babel_test_numeric_int2_f13;
+drop function babel_test_numeric_int2_f14;
+drop function babel_test_numeric_int2_f15;
+drop function babel_test_numeric_int2_f16;
+drop function babel_test_numeric_int2_f17;
+drop function babel_test_numeric_int2_f18;
+drop function babel_test_numeric_int2_f19;
+drop function babel_test_numeric_int2_f20;
+drop function babel_test_numeric_int2_f21;
+drop function babel_test_numeric_int2_f22;
+drop function babel_test_numeric_int2_f23;
+drop function babel_test_numeric_int2_f24;
+drop function babel_test_numeric_int2_f25;
+drop function babel_test_numeric_int2_f26;
+drop function babel_test_numeric_int2_f27;
+drop function babel_test_numeric_int2_f28;
+drop function babel_test_numeric_int2_f29;
+drop function babel_test_numeric_int2_f30;
+drop function babel_test_numeric_int2_f31;
+drop function babel_test_numeric_int2_f32;
+GO
+
+drop table babel_test_numeric_int2_vu_prepare;
+GO

--- a/test/JDBC/expected/babel_test_numeric_int4_oper-vu-prepare.out
+++ b/test/JDBC/expected/babel_test_numeric_int4_oper-vu-prepare.out
@@ -1,0 +1,472 @@
+-- tsql
+create table babel_test_numeric_int4_vu_prepare(a numeric(18,2));
+GO
+
+-- insert data
+INSERT INTO babel_test_numeric_int4_vu_prepare (a) SELECT cast(generate_series(1, 100000) as numeric(18,2));
+GO
+~~ROW COUNT: 100000~~
+
+
+INSERT INTO babel_test_numeric_int4_vu_prepare VALUES (NULL), (-2147483648.00), (2147483647.00);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE INDEX babel_test_numeric_int4_vu_prepare_idx on babel_test_numeric_int4_vu_prepare(a);
+GO
+
+create procedure babel_test_numeric_int4_p0 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int);
+GO
+
+create procedure babel_test_numeric_int4_p00 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a;
+GO
+
+create procedure babel_test_numeric_int4_p1 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create procedure babel_test_numeric_int4_p2 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p3 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a;
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int4_p4 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p5 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a;
+GO
+
+create procedure babel_test_numeric_int4_p6 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create procedure babel_test_numeric_int4_p7 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a;
+GO
+
+create procedure babel_test_numeric_int4_p8 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p9 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a;
+GO
+
+create procedure babel_test_numeric_int4_p10 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p11 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a;
+GO
+
+create procedure babel_test_numeric_int4_p12 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p13 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a;
+GO
+
+create procedure babel_test_numeric_int4_p14 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+create procedure babel_test_numeric_int4_p15 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a;
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int4_p16 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p17 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a;
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int4_p18 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int4_p19 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int);
+GO
+
+-- mix of numeric op int4 and numeric op numeric
+create procedure babel_test_numeric_int4_p20 as
+select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int);
+GO
+
+create procedure babel_test_numeric_int4_p21 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int);
+Go
+
+create procedure babel_test_numeric_int4_p22 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a;
+Go
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create procedure babel_test_numeric_int4_p23 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int4_p24 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p25 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create procedure babel_test_numeric_int4_p26 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p27 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p28 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p29 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int4_p30 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int4_p31 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int4_p32 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int);
+GO
+
+-- view body dependency on all the numeric,int4 or int4, numeric operators
+GO
+
+-- tsql
+create view babel_test_numeric_int4_v0 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int);
+GO
+
+create view babel_test_numeric_int4_v00 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a;
+GO
+
+create view babel_test_numeric_int4_v1 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create view babel_test_numeric_int4_v2 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v3 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a;
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int4_v4 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v5 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a;
+GO
+
+create view babel_test_numeric_int4_v6 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create view babel_test_numeric_int4_v7 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a;
+GO
+
+create view babel_test_numeric_int4_v8 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v9 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a;
+GO
+
+create view babel_test_numeric_int4_v10 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v11 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a;
+GO
+
+create view babel_test_numeric_int4_v12 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v13 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a;
+GO
+
+create view babel_test_numeric_int4_v14 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+create view babel_test_numeric_int4_v15 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a;
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int4_v16 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v17 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a;
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int4_v18 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int4_v19 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int);
+GO
+
+-- mix of numeric op int4 and numeric op numeric
+create view babel_test_numeric_int4_v20 as
+select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int);
+GO
+
+create view babel_test_numeric_int4_v21 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int);
+Go
+
+create view babel_test_numeric_int4_v22 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a;
+Go
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create view babel_test_numeric_int4_v23 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int4_v24 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v25 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create view babel_test_numeric_int4_v26 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v27 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v28 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v29 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int4_v30 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int4_v31 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int4_v32 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int);
+GO
+
+-- functions dependency on all the numeric,int4 or int4, numeric operators
+GO
+
+-- tsql
+create function babel_test_numeric_int4_f0() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f00() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a) end;
+GO
+
+create function babel_test_numeric_int4_f1() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL) end;
+GO
+
+-- seq scan
+create function babel_test_numeric_int4_f2() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f3() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int4_f4() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f5() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a) end;
+GO
+
+create function babel_test_numeric_int4_f6() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f7() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a) end;
+GO
+
+create function babel_test_numeric_int4_f8() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f9() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a) end;
+GO
+
+create function babel_test_numeric_int4_f10() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f11() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a) end;
+GO
+
+create function babel_test_numeric_int4_f12() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f13() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a) end;
+GO
+
+create function babel_test_numeric_int4_f14() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f15() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int4_f16() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f17() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int4_f18() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int4_f19() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int)) end;
+GO
+
+-- mix of numeric op int4 and numeric op numeric
+create function babel_test_numeric_int4_f20() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f21() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f22() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a) end;
+GO
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create function babel_test_numeric_int4_f23() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int)) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int4_f24() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f25() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f26() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f27() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f28() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f29() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int)) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int4_f30() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int)) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int4_f31() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int4_f32() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int)) end;
+GO

--- a/test/JDBC/expected/babel_test_numeric_int4_oper-vu-verify.out
+++ b/test/JDBC/expected/babel_test_numeric_int4_oper-vu-verify.out
@@ -1,0 +1,1971 @@
+-- psql
+analyse master_dbo.babel_test_numeric_int4_vu_prepare;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+exec babel_test_numeric_int4_p0;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p0
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a = 1)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 164.880 ms
+~~END~~
+
+exec babel_test_numeric_int4_p00;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p00
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a = 1)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 10.567 ms
+~~END~~
+
+exec babel_test_numeric_int4_p1;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p1
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a IS NULL)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.529 ms
+~~END~~
+
+exec babel_test_numeric_int4_p2;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p2
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: (a <> 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 1.759 ms
+~~END~~
+
+exec babel_test_numeric_int4_p3;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p3
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: (5 <> a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.891 ms
+~~END~~
+
+exec babel_test_numeric_int4_p4;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p4
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a < 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.326 ms
+~~END~~
+
+exec babel_test_numeric_int4_p5;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p5
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a < 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 5.268 ms
+~~END~~
+
+exec babel_test_numeric_int4_p6;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p6
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a < '-2147483648'::integer)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 14.606 ms
+~~END~~
+
+exec babel_test_numeric_int4_p7;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p7
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a < '-2147483648'::integer)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 3.069 ms
+~~END~~
+
+exec babel_test_numeric_int4_p8;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p8
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a <= 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.870 ms
+~~END~~
+
+exec babel_test_numeric_int4_p9;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p9
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a <= 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.854 ms
+~~END~~
+
+exec babel_test_numeric_int4_p10;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p10
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a > 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 5.158 ms
+~~END~~
+
+exec babel_test_numeric_int4_p11;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p11
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a > 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.296 ms
+~~END~~
+
+exec babel_test_numeric_int4_p12;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p12
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a >= 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
+~~END~~
+
+exec babel_test_numeric_int4_p13;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p13
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a >= 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
+~~END~~
+
+exec babel_test_numeric_int4_p14;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p14
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a > 2147483647)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int4_p15;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p15
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a > 2147483647)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
+~~END~~
+
+exec babel_test_numeric_int4_p16;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p16
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: (a > 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int4_p17;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p17
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: (5 < a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int4_p18;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p18
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: ((a >= 5) AND (a <= 10))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 6.936 ms
+~~END~~
+
+exec babel_test_numeric_int4_p19;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p19
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: ((a >= 5) AND (a <= 2147483647))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.163 ms
+~~END~~
+
+exec babel_test_numeric_int4_p20;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p20
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: ((a >= 5) AND (a <= 99995) AND (a = 10))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 14.062 ms
+~~END~~
+
+exec babel_test_numeric_int4_p21;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p21
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: ((a > 5) AND (a < 7))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.223 ms
+~~END~~
+
+exec babel_test_numeric_int4_p22;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p22
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: ((a > 5) AND (a < 7))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.289 ms
+~~END~~
+
+exec babel_test_numeric_int4_p23;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p23
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: (a <> 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
+~~END~~
+
+exec babel_test_numeric_int4_p24;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p24
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a < 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
+~~END~~
+
+exec babel_test_numeric_int4_p25;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p25
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a < '-2147483648'::integer)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.146 ms
+~~END~~
+
+exec babel_test_numeric_int4_p26;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p26
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a <= 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
+~~END~~
+
+exec babel_test_numeric_int4_p27;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p27
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a > 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
+~~END~~
+
+exec babel_test_numeric_int4_p28;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p28
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a >= 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
+~~END~~
+
+exec babel_test_numeric_int4_p29;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p29
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: (a > 2147483647)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
+~~END~~
+
+exec babel_test_numeric_int4_p30;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p30
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: (a > 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
+~~END~~
+
+exec babel_test_numeric_int4_p31;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p31
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+              Index Cond: ((a >= 5) AND (a <= 10))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.160 ms
+~~END~~
+
+exec babel_test_numeric_int4_p32;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int4_p32
+  Query Text: select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+              Filter: ((a >= 5) AND (a <= 99995))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.162 ms
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+exec babel_test_numeric_int4_p0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int4_p00;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int4_p1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int4_p2;
+GO
+~~START~~
+int
+100001
+~~END~~
+
+exec babel_test_numeric_int4_p3;
+GO
+~~START~~
+int
+100001
+~~END~~
+
+exec babel_test_numeric_int4_p4;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int4_p5;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int4_p6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int4_p7;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int4_p8;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p9;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p10;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p11;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p12;
+GO
+~~START~~
+int
+7
+~~END~~
+
+exec babel_test_numeric_int4_p13;
+GO
+~~START~~
+int
+7
+~~END~~
+
+exec babel_test_numeric_int4_p14;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int4_p15;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int4_p16;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+exec babel_test_numeric_int4_p17;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+exec babel_test_numeric_int4_p18;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p19;
+GO
+~~START~~
+int
+99997
+~~END~~
+
+exec babel_test_numeric_int4_p20;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int4_p21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int4_p22;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int4_p23;
+GO
+~~START~~
+int
+100001
+~~END~~
+
+exec babel_test_numeric_int4_p24;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int4_p25;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int4_p26;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p27;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p28;
+GO
+~~START~~
+int
+7
+~~END~~
+
+exec babel_test_numeric_int4_p29;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int4_p30;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+exec babel_test_numeric_int4_p31;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int4_p32;
+GO
+~~START~~
+int
+99991
+~~END~~
+
+
+drop procedure babel_test_numeric_int4_p0;
+drop procedure babel_test_numeric_int4_p00;
+drop procedure babel_test_numeric_int4_p1;
+drop procedure babel_test_numeric_int4_p2;
+drop procedure babel_test_numeric_int4_p3;
+drop procedure babel_test_numeric_int4_p4;
+drop procedure babel_test_numeric_int4_p5;
+drop procedure babel_test_numeric_int4_p6;
+drop procedure babel_test_numeric_int4_p7;
+drop procedure babel_test_numeric_int4_p8;
+drop procedure babel_test_numeric_int4_p9;
+drop procedure babel_test_numeric_int4_p10;
+drop procedure babel_test_numeric_int4_p11;
+drop procedure babel_test_numeric_int4_p12;
+drop procedure babel_test_numeric_int4_p13;
+drop procedure babel_test_numeric_int4_p14;
+drop procedure babel_test_numeric_int4_p15;
+drop procedure babel_test_numeric_int4_p16;
+drop procedure babel_test_numeric_int4_p17;
+drop procedure babel_test_numeric_int4_p18;
+drop procedure babel_test_numeric_int4_p19;
+drop procedure babel_test_numeric_int4_p20;
+drop procedure babel_test_numeric_int4_p21;
+drop procedure babel_test_numeric_int4_p22;
+drop procedure babel_test_numeric_int4_p23;
+drop procedure babel_test_numeric_int4_p24;
+drop procedure babel_test_numeric_int4_p25;
+drop procedure babel_test_numeric_int4_p26;
+drop procedure babel_test_numeric_int4_p27;
+drop procedure babel_test_numeric_int4_p28;
+drop procedure babel_test_numeric_int4_p29;
+drop procedure babel_test_numeric_int4_p30;
+drop procedure babel_test_numeric_int4_p31;
+drop procedure babel_test_numeric_int4_p32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+select * from babel_test_numeric_int4_v0;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v0
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a = 1)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.635 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v00;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v00
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a = 1)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v1;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v1
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a IS NULL)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.077 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v2;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v2
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: (a <> 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v3;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v3
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: (5 <> a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v4;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v4
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a < 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v5;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v5
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a < 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v6;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v6
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a < '-2147483648'::integer)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v7;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v7
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a < '-2147483648'::integer)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v8;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v8
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a <= 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v9;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v9
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a <= 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v10;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v10
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a > 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v11;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v11
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a > 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v12;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v12
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a >= 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v13;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v13
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a >= 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v14;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v14
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a > 2147483647)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v15;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v15
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a > 2147483647)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v16;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v16
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: (a > 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v17;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v17
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: (5 < a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v18;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v18
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: ((a >= 5) AND (a <= 10))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v19;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v19
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: ((a >= 5) AND (a <= 2147483647))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v20;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v20
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: ((a >= 5) AND (a <= 99995) AND (a = 10))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v21;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v21
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: ((a > 5) AND (a < 7))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v22;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v22
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: ((a > 5) AND (a < 7))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v23;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v23
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: (a <> 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v24;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v24
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a < 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v25;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v25
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a < '-2147483648'::integer)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v26;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v26
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a <= 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v27;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v27
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a > 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v28;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v28
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a >= 99995)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v29;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v29
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: (a > 2147483647)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v30;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v30
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: (a > 5)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v31;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v31
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int4_vu_prep8a3751fdda5fb765df2f8e30b4f6828e on babel_test_numeric_int4_vu_prepare
+        Index Cond: ((a >= 5) AND (a <= 10))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+select * from babel_test_numeric_int4_v32;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int4_v32
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int4_vu_prepare
+        Filter: ((a >= 5) AND (a <= 99995))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select * from babel_test_numeric_int4_v0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int4_v00;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int4_v1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int4_v2;
+GO
+~~START~~
+int
+100001
+~~END~~
+
+select * from babel_test_numeric_int4_v3;
+GO
+~~START~~
+int
+100001
+~~END~~
+
+select * from babel_test_numeric_int4_v4;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int4_v5;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int4_v6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int4_v7;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int4_v8;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v9;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v10;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v11;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v12;
+GO
+~~START~~
+int
+7
+~~END~~
+
+select * from babel_test_numeric_int4_v13;
+GO
+~~START~~
+int
+7
+~~END~~
+
+select * from babel_test_numeric_int4_v14;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int4_v15;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int4_v16;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select * from babel_test_numeric_int4_v17;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select * from babel_test_numeric_int4_v18;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v19;
+GO
+~~START~~
+int
+99997
+~~END~~
+
+select * from babel_test_numeric_int4_v20;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int4_v21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int4_v22;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int4_v23;
+GO
+~~START~~
+int
+100001
+~~END~~
+
+select * from babel_test_numeric_int4_v24;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int4_v25;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int4_v26;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v27;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v28;
+GO
+~~START~~
+int
+7
+~~END~~
+
+select * from babel_test_numeric_int4_v29;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int4_v30;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select * from babel_test_numeric_int4_v31;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int4_v32;
+GO
+~~START~~
+int
+99991
+~~END~~
+
+
+drop view babel_test_numeric_int4_v0;
+drop view babel_test_numeric_int4_v00;
+drop view babel_test_numeric_int4_v1;
+drop view babel_test_numeric_int4_v2;
+drop view babel_test_numeric_int4_v3;
+drop view babel_test_numeric_int4_v4;
+drop view babel_test_numeric_int4_v5;
+drop view babel_test_numeric_int4_v6;
+drop view babel_test_numeric_int4_v7;
+drop view babel_test_numeric_int4_v8;
+drop view babel_test_numeric_int4_v9;
+drop view babel_test_numeric_int4_v10;
+drop view babel_test_numeric_int4_v11;
+drop view babel_test_numeric_int4_v12;
+drop view babel_test_numeric_int4_v13;
+drop view babel_test_numeric_int4_v14;
+drop view babel_test_numeric_int4_v15;
+drop view babel_test_numeric_int4_v16;
+drop view babel_test_numeric_int4_v17;
+drop view babel_test_numeric_int4_v18;
+drop view babel_test_numeric_int4_v19;
+drop view babel_test_numeric_int4_v20;
+drop view babel_test_numeric_int4_v21;
+drop view babel_test_numeric_int4_v22;
+drop view babel_test_numeric_int4_v23;
+drop view babel_test_numeric_int4_v24;
+drop view babel_test_numeric_int4_v25;
+drop view babel_test_numeric_int4_v26;
+drop view babel_test_numeric_int4_v27;
+drop view babel_test_numeric_int4_v28;
+drop view babel_test_numeric_int4_v29;
+drop view babel_test_numeric_int4_v30;
+drop view babel_test_numeric_int4_v31;
+drop view babel_test_numeric_int4_v32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select babel_test_numeric_int4_f0();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int4_f00();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int4_f1();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int4_f2();
+GO
+~~START~~
+int
+100001
+~~END~~
+
+select babel_test_numeric_int4_f3();
+GO
+~~START~~
+int
+100001
+~~END~~
+
+select babel_test_numeric_int4_f4();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int4_f5();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int4_f6();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int4_f7();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int4_f8();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f9();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f10();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f11();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f12();
+GO
+~~START~~
+int
+7
+~~END~~
+
+select babel_test_numeric_int4_f13();
+GO
+~~START~~
+int
+7
+~~END~~
+
+select babel_test_numeric_int4_f14();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int4_f15();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int4_f16();
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select babel_test_numeric_int4_f17();
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select babel_test_numeric_int4_f18();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f19();
+GO
+~~START~~
+int
+99997
+~~END~~
+
+select babel_test_numeric_int4_f20();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int4_f21();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int4_f22();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int4_f23();
+GO
+~~START~~
+int
+100001
+~~END~~
+
+select babel_test_numeric_int4_f24();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int4_f25();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int4_f26();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f27();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f28();
+GO
+~~START~~
+int
+7
+~~END~~
+
+select babel_test_numeric_int4_f29();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int4_f30();
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select babel_test_numeric_int4_f31();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int4_f32();
+GO
+~~START~~
+int
+99991
+~~END~~
+
+
+drop function babel_test_numeric_int4_f0;
+drop function babel_test_numeric_int4_f00;
+drop function babel_test_numeric_int4_f1;
+drop function babel_test_numeric_int4_f2;
+drop function babel_test_numeric_int4_f3;
+drop function babel_test_numeric_int4_f4;
+drop function babel_test_numeric_int4_f5;
+drop function babel_test_numeric_int4_f6;
+drop function babel_test_numeric_int4_f7;
+drop function babel_test_numeric_int4_f8;
+drop function babel_test_numeric_int4_f9;
+drop function babel_test_numeric_int4_f10;
+drop function babel_test_numeric_int4_f11;
+drop function babel_test_numeric_int4_f12;
+drop function babel_test_numeric_int4_f13;
+drop function babel_test_numeric_int4_f14;
+drop function babel_test_numeric_int4_f15;
+drop function babel_test_numeric_int4_f16;
+drop function babel_test_numeric_int4_f17;
+drop function babel_test_numeric_int4_f18;
+drop function babel_test_numeric_int4_f19;
+drop function babel_test_numeric_int4_f20;
+drop function babel_test_numeric_int4_f21;
+drop function babel_test_numeric_int4_f22;
+drop function babel_test_numeric_int4_f23;
+drop function babel_test_numeric_int4_f24;
+drop function babel_test_numeric_int4_f25;
+drop function babel_test_numeric_int4_f26;
+drop function babel_test_numeric_int4_f27;
+drop function babel_test_numeric_int4_f28;
+drop function babel_test_numeric_int4_f29;
+drop function babel_test_numeric_int4_f30;
+drop function babel_test_numeric_int4_f31;
+drop function babel_test_numeric_int4_f32;
+GO
+
+drop table babel_test_numeric_int4_vu_prepare;
+GO

--- a/test/JDBC/expected/babel_test_numeric_int8_oper-vu-prepare.out
+++ b/test/JDBC/expected/babel_test_numeric_int8_oper-vu-prepare.out
@@ -1,0 +1,469 @@
+create table babel_test_numeric_int8_vu_prepare(a numeric(18,2));
+GO
+
+-- insert data
+INSERT INTO babel_test_numeric_int8_vu_prepare (a) SELECT cast(generate_series(1, 100000) as numeric(18,2));
+GO
+~~ROW COUNT: 100000~~
+
+
+INSERT INTO babel_test_numeric_int8_vu_prepare VALUES (NULL), (-9223372036854775808.00), (9223372036854775807.00);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+CREATE INDEX babel_test_numeric_int8_vu_prepare_idx on babel_test_numeric_int8_vu_prepare(a);
+GO
+
+-- procedures dependency on all the numeric,int8 or int8, numeric operators
+create procedure babel_test_numeric_int8_p0 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p00 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a;
+GO
+
+create procedure babel_test_numeric_int8_p1 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create procedure babel_test_numeric_int8_p2 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p3 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a;
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int8_p4 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p5 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a;
+GO
+
+create procedure babel_test_numeric_int8_p6 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p7 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a;
+GO
+
+create procedure babel_test_numeric_int8_p8 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p9 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a;
+GO
+
+create procedure babel_test_numeric_int8_p10 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p11 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a;
+GO
+
+create procedure babel_test_numeric_int8_p12 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p13 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a;
+GO
+
+create procedure babel_test_numeric_int8_p14 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+create procedure babel_test_numeric_int8_p15 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a;
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int8_p16 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p17 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a;
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int8_p18 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int8_p19 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint);
+GO
+
+-- mix of numeric op int8 and numeric op numeric
+create procedure babel_test_numeric_int8_p20 as
+select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p21 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint);
+Go
+
+create procedure babel_test_numeric_int8_p22 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a;
+Go
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create procedure babel_test_numeric_int8_p23 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int8_p24 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p25 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p26 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p27 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p28 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p29 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int8_p30 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int8_p31 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int8_p32 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint);
+GO
+
+
+-- view body dependency on all the numeric,int8 or int8, numeric operators
+create view babel_test_numeric_int8_v0 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint);
+GO
+
+create view babel_test_numeric_int8_v00 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a;
+GO
+
+create view babel_test_numeric_int8_v1 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create view babel_test_numeric_int8_v2 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v3 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a;
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int8_v4 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v5 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a;
+GO
+
+create view babel_test_numeric_int8_v6 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create view babel_test_numeric_int8_v7 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a;
+GO
+
+create view babel_test_numeric_int8_v8 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v9 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a;
+GO
+
+create view babel_test_numeric_int8_v10 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v11 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a;
+GO
+
+create view babel_test_numeric_int8_v12 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v13 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a;
+GO
+
+create view babel_test_numeric_int8_v14 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+create view babel_test_numeric_int8_v15 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a;
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int8_v16 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v17 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a;
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int8_v18 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int8_v19 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint);
+GO
+
+-- mix of numeric op int8 and numeric op numeric
+create view babel_test_numeric_int8_v20 as
+select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint);
+GO
+
+create view babel_test_numeric_int8_v21 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint);
+Go
+
+create view babel_test_numeric_int8_v22 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a;
+Go
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create view babel_test_numeric_int8_v23 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int8_v24 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v25 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create view babel_test_numeric_int8_v26 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v27 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v28 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v29 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int8_v30 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int8_v31 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int8_v32 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint);
+GO
+
+-- functions dependency on all the numeric,int8 or int8, numeric operators
+create function babel_test_numeric_int8_f0() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f00() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a) end;
+GO
+
+create function babel_test_numeric_int8_f1() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL) end;
+GO
+
+-- seq scan
+create function babel_test_numeric_int8_f2() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f3() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int8_f4() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f5() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a) end;
+GO
+
+create function babel_test_numeric_int8_f6() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f7() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a) end;
+GO
+
+create function babel_test_numeric_int8_f8() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f9() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a) end;
+GO
+
+create function babel_test_numeric_int8_f10() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f11() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a) end;
+GO
+
+create function babel_test_numeric_int8_f12() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f13() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a) end;
+GO
+
+create function babel_test_numeric_int8_f14() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f15() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int8_f16() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f17() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int8_f18() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int8_f19() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint)) end;
+GO
+
+-- mix of numeric op int8 and numeric op numeric
+create function babel_test_numeric_int8_f20() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f21() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f22() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a) end;
+GO
+
+
+-- shouldn't be any regression on numeric op numeric operators
+-- seq scan
+create function babel_test_numeric_int8_f23() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint)) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int8_f24() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f25() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f26() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f27() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f28() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f29() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint)) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int8_f30() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint)) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int8_f31() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int8_f32() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint)) end;
+GO

--- a/test/JDBC/expected/babel_test_numeric_int8_oper-vu-verify.out
+++ b/test/JDBC/expected/babel_test_numeric_int8_oper-vu-verify.out
@@ -1,0 +1,1971 @@
+-- psql
+analyse master_dbo.babel_test_numeric_int8_vu_prepare;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+exec babel_test_numeric_int8_p0;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p0
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a = '1'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 164.570 ms
+~~END~~
+
+exec babel_test_numeric_int8_p00;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p00
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a = '1'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 10.521 ms
+~~END~~
+
+exec babel_test_numeric_int8_p1;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p1
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a IS NULL)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.468 ms
+~~END~~
+
+exec babel_test_numeric_int8_p2;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p2
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: (a <> '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 1.745 ms
+~~END~~
+
+exec babel_test_numeric_int8_p3;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p3
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: ('5'::bigint <> a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.869 ms
+~~END~~
+
+exec babel_test_numeric_int8_p4;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p4
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a < '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.266 ms
+~~END~~
+
+exec babel_test_numeric_int8_p5;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p5
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a < '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 5.221 ms
+~~END~~
+
+exec babel_test_numeric_int8_p6;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p6
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a < '-9223372036854775808'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 14.554 ms
+~~END~~
+
+exec babel_test_numeric_int8_p7;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p7
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a < '-9223372036854775808'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 3.036 ms
+~~END~~
+
+exec babel_test_numeric_int8_p8;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p8
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a <= '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.853 ms
+~~END~~
+
+exec babel_test_numeric_int8_p9;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p9
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a <= '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.847 ms
+~~END~~
+
+exec babel_test_numeric_int8_p10;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p10
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a > '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 5.134 ms
+~~END~~
+
+exec babel_test_numeric_int8_p11;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p11
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a > '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 4.246 ms
+~~END~~
+
+exec babel_test_numeric_int8_p12;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p12
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a >= '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int8_p13;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p13
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a >= '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
+~~END~~
+
+exec babel_test_numeric_int8_p14;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p14
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a > '9223372036854775807'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
+~~END~~
+
+exec babel_test_numeric_int8_p15;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p15
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a > '9223372036854775807'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int8_p16;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p16
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: (a > '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
+~~END~~
+
+exec babel_test_numeric_int8_p17;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p17
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: ('5'::bigint < a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int8_p18;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p18
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: ((a >= '5'::bigint) AND (a <= '10'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 6.905 ms
+~~END~~
+
+exec babel_test_numeric_int8_p19;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p19
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: ((a >= '5'::bigint) AND (a <= '9223372036854775807'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.159 ms
+~~END~~
+
+exec babel_test_numeric_int8_p20;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p20
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: ((a >= '5'::bigint) AND (a <= '99995'::bigint) AND (a = '10'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 14.009 ms
+~~END~~
+
+exec babel_test_numeric_int8_p21;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p21
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: ((a > '5'::bigint) AND (a < '7'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.217 ms
+~~END~~
+
+exec babel_test_numeric_int8_p22;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p22
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: ((a > '5'::bigint) AND (a < '7'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.276 ms
+~~END~~
+
+exec babel_test_numeric_int8_p23;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p23
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: (a <> '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
+~~END~~
+
+exec babel_test_numeric_int8_p24;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p24
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a < '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
+~~END~~
+
+exec babel_test_numeric_int8_p25;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p25
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a < '-9223372036854775808'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
+~~END~~
+
+exec babel_test_numeric_int8_p26;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p26
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a <= '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int8_p27;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p27
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a > '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.150 ms
+~~END~~
+
+exec babel_test_numeric_int8_p28;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p28
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a >= '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
+~~END~~
+
+exec babel_test_numeric_int8_p29;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p29
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: (a > '9223372036854775807'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
+~~END~~
+
+exec babel_test_numeric_int8_p30;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p30
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: (a > '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
+~~END~~
+
+exec babel_test_numeric_int8_p31;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p31
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint)
+  ->  Aggregate
+        ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+              Index Cond: ((a >= '5'::bigint) AND (a <= '10'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.158 ms
+~~END~~
+
+exec babel_test_numeric_int8_p32;
+GO
+~~START~~
+text
+Query Text: EXEC babel_test_numeric_int8_p32
+  Query Text: select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint)
+  ->  Aggregate
+        ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+              Filter: ((a >= '5'::bigint) AND (a <= '99995'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.170 ms
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+exec babel_test_numeric_int8_p0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int8_p00;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int8_p1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p2;
+GO
+~~START~~
+int
+99999
+~~END~~
+
+exec babel_test_numeric_int8_p3;
+GO
+~~START~~
+int
+99999
+~~END~~
+
+exec babel_test_numeric_int8_p4;
+GO
+~~START~~
+int
+4
+~~END~~
+
+exec babel_test_numeric_int8_p5;
+GO
+~~START~~
+int
+4
+~~END~~
+
+exec babel_test_numeric_int8_p6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p7;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p8;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int8_p9;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int8_p10;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int8_p11;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int8_p12;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int8_p13;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int8_p14;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p15;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p16;
+GO
+~~START~~
+int
+99995
+~~END~~
+
+exec babel_test_numeric_int8_p17;
+GO
+~~START~~
+int
+99995
+~~END~~
+
+exec babel_test_numeric_int8_p18;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int8_p19;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+exec babel_test_numeric_int8_p20;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int8_p21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int8_p22;
+GO
+~~START~~
+int
+1
+~~END~~
+
+exec babel_test_numeric_int8_p23;
+GO
+~~START~~
+int
+99999
+~~END~~
+
+exec babel_test_numeric_int8_p24;
+GO
+~~START~~
+int
+4
+~~END~~
+
+exec babel_test_numeric_int8_p25;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p26;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int8_p27;
+GO
+~~START~~
+int
+5
+~~END~~
+
+exec babel_test_numeric_int8_p28;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int8_p29;
+GO
+~~START~~
+int
+0
+~~END~~
+
+exec babel_test_numeric_int8_p30;
+GO
+~~START~~
+int
+99995
+~~END~~
+
+exec babel_test_numeric_int8_p31;
+GO
+~~START~~
+int
+6
+~~END~~
+
+exec babel_test_numeric_int8_p32;
+GO
+~~START~~
+int
+99991
+~~END~~
+
+
+drop procedure babel_test_numeric_int8_p0;
+drop procedure babel_test_numeric_int8_p00;
+drop procedure babel_test_numeric_int8_p1;
+drop procedure babel_test_numeric_int8_p2;
+drop procedure babel_test_numeric_int8_p3;
+drop procedure babel_test_numeric_int8_p4;
+drop procedure babel_test_numeric_int8_p5;
+drop procedure babel_test_numeric_int8_p6;
+drop procedure babel_test_numeric_int8_p7;
+drop procedure babel_test_numeric_int8_p8;
+drop procedure babel_test_numeric_int8_p9;
+drop procedure babel_test_numeric_int8_p10;
+drop procedure babel_test_numeric_int8_p11;
+drop procedure babel_test_numeric_int8_p12;
+drop procedure babel_test_numeric_int8_p13;
+drop procedure babel_test_numeric_int8_p14;
+drop procedure babel_test_numeric_int8_p15;
+drop procedure babel_test_numeric_int8_p16;
+drop procedure babel_test_numeric_int8_p17;
+drop procedure babel_test_numeric_int8_p18;
+drop procedure babel_test_numeric_int8_p19;
+drop procedure babel_test_numeric_int8_p20;
+drop procedure babel_test_numeric_int8_p21;
+drop procedure babel_test_numeric_int8_p22;
+drop procedure babel_test_numeric_int8_p23;
+drop procedure babel_test_numeric_int8_p24;
+drop procedure babel_test_numeric_int8_p25;
+drop procedure babel_test_numeric_int8_p26;
+drop procedure babel_test_numeric_int8_p27;
+drop procedure babel_test_numeric_int8_p28;
+drop procedure babel_test_numeric_int8_p29;
+drop procedure babel_test_numeric_int8_p30;
+drop procedure babel_test_numeric_int8_p31;
+drop procedure babel_test_numeric_int8_p32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+select * from babel_test_numeric_int8_v0;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v0
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a = '1'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.634 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v00;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v00
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a = '1'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.077 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v1;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v1
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a IS NULL)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v2;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v2
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: (a <> '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v3;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v3
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: ('5'::bigint <> a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v4;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v4
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a < '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v5;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v5
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a < '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v6;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v6
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a < '-9223372036854775808'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v7;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v7
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a < '-9223372036854775808'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v8;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v8
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a <= '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v9;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v9
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a <= '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v10;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v10
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a > '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v11;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v11
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a > '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v12;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v12
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a >= '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v13;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v13
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a >= '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v14;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v14
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a > '9223372036854775807'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v15;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v15
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a > '9223372036854775807'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v16;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v16
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: (a > '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v17;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v17
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: ('5'::bigint < a)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v18;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v18
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: ((a >= '5'::bigint) AND (a <= '10'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v19;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v19
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: ((a >= '5'::bigint) AND (a <= '9223372036854775807'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v20;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v20
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: ((a >= '5'::bigint) AND (a <= '99995'::bigint) AND (a = '10'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v21;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v21
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: ((a > '5'::bigint) AND (a < '7'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v22;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v22
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: ((a > '5'::bigint) AND (a < '7'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v23;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v23
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: (a <> '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v24;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v24
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a < '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v25;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v25
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a < '-9223372036854775808'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v26;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v26
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a <= '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v27;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v27
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a > '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v28;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v28
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a >= '99995'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v29;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v29
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: (a > '9223372036854775807'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v30;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v30
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: (a > '5'::bigint)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v31;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v31
+Aggregate
+  ->  Index Only Scan using babel_test_numeric_int8_vu_prep4153b0b6a46dc119c158b4738f12227b on babel_test_numeric_int8_vu_prepare
+        Index Cond: ((a >= '5'::bigint) AND (a <= '10'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
+~~END~~
+
+select * from babel_test_numeric_int8_v32;
+GO
+~~START~~
+text
+Query Text: select * from babel_test_numeric_int8_v32
+Aggregate
+  ->  Seq Scan on babel_test_numeric_int8_vu_prepare
+        Filter: ((a >= '5'::bigint) AND (a <= '99995'::bigint))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select * from babel_test_numeric_int8_v0;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int8_v00;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int8_v1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v2;
+GO
+~~START~~
+int
+99999
+~~END~~
+
+select * from babel_test_numeric_int8_v3;
+GO
+~~START~~
+int
+99999
+~~END~~
+
+select * from babel_test_numeric_int8_v4;
+GO
+~~START~~
+int
+4
+~~END~~
+
+select * from babel_test_numeric_int8_v5;
+GO
+~~START~~
+int
+4
+~~END~~
+
+select * from babel_test_numeric_int8_v6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v7;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v8;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int8_v9;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int8_v10;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int8_v11;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int8_v12;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int8_v13;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int8_v14;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v15;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v16;
+GO
+~~START~~
+int
+99995
+~~END~~
+
+select * from babel_test_numeric_int8_v17;
+GO
+~~START~~
+int
+99995
+~~END~~
+
+select * from babel_test_numeric_int8_v18;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int8_v19;
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select * from babel_test_numeric_int8_v20;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int8_v21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int8_v22;
+GO
+~~START~~
+int
+1
+~~END~~
+
+select * from babel_test_numeric_int8_v23;
+GO
+~~START~~
+int
+99999
+~~END~~
+
+select * from babel_test_numeric_int8_v24;
+GO
+~~START~~
+int
+4
+~~END~~
+
+select * from babel_test_numeric_int8_v25;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v26;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int8_v27;
+GO
+~~START~~
+int
+5
+~~END~~
+
+select * from babel_test_numeric_int8_v28;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int8_v29;
+GO
+~~START~~
+int
+0
+~~END~~
+
+select * from babel_test_numeric_int8_v30;
+GO
+~~START~~
+int
+99995
+~~END~~
+
+select * from babel_test_numeric_int8_v31;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select * from babel_test_numeric_int8_v32;
+GO
+~~START~~
+int
+99991
+~~END~~
+
+
+drop view babel_test_numeric_int8_v0;
+drop view babel_test_numeric_int8_v00;
+drop view babel_test_numeric_int8_v1;
+drop view babel_test_numeric_int8_v2;
+drop view babel_test_numeric_int8_v3;
+drop view babel_test_numeric_int8_v4;
+drop view babel_test_numeric_int8_v5;
+drop view babel_test_numeric_int8_v6;
+drop view babel_test_numeric_int8_v7;
+drop view babel_test_numeric_int8_v8;
+drop view babel_test_numeric_int8_v9;
+drop view babel_test_numeric_int8_v10;
+drop view babel_test_numeric_int8_v11;
+drop view babel_test_numeric_int8_v12;
+drop view babel_test_numeric_int8_v13;
+drop view babel_test_numeric_int8_v14;
+drop view babel_test_numeric_int8_v15;
+drop view babel_test_numeric_int8_v16;
+drop view babel_test_numeric_int8_v17;
+drop view babel_test_numeric_int8_v18;
+drop view babel_test_numeric_int8_v19;
+drop view babel_test_numeric_int8_v20;
+drop view babel_test_numeric_int8_v21;
+drop view babel_test_numeric_int8_v22;
+drop view babel_test_numeric_int8_v23;
+drop view babel_test_numeric_int8_v24;
+drop view babel_test_numeric_int8_v25;
+drop view babel_test_numeric_int8_v26;
+drop view babel_test_numeric_int8_v27;
+drop view babel_test_numeric_int8_v28;
+drop view babel_test_numeric_int8_v29;
+drop view babel_test_numeric_int8_v30;
+drop view babel_test_numeric_int8_v31;
+drop view babel_test_numeric_int8_v32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select babel_test_numeric_int8_f0();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int8_f00();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int8_f1();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f2();
+GO
+~~START~~
+int
+99999
+~~END~~
+
+select babel_test_numeric_int8_f3();
+GO
+~~START~~
+int
+99999
+~~END~~
+
+select babel_test_numeric_int8_f4();
+GO
+~~START~~
+int
+4
+~~END~~
+
+select babel_test_numeric_int8_f5();
+GO
+~~START~~
+int
+4
+~~END~~
+
+select babel_test_numeric_int8_f6();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f7();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f8();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int8_f9();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int8_f10();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int8_f11();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int8_f12();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int8_f13();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int8_f14();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f15();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f16();
+GO
+~~START~~
+int
+99995
+~~END~~
+
+select babel_test_numeric_int8_f17();
+GO
+~~START~~
+int
+99995
+~~END~~
+
+select babel_test_numeric_int8_f18();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int8_f19();
+GO
+~~START~~
+int
+99996
+~~END~~
+
+select babel_test_numeric_int8_f20();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int8_f21();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int8_f22();
+GO
+~~START~~
+int
+1
+~~END~~
+
+select babel_test_numeric_int8_f23();
+GO
+~~START~~
+int
+99999
+~~END~~
+
+select babel_test_numeric_int8_f24();
+GO
+~~START~~
+int
+4
+~~END~~
+
+select babel_test_numeric_int8_f25();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f26();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int8_f27();
+GO
+~~START~~
+int
+5
+~~END~~
+
+select babel_test_numeric_int8_f28();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int8_f29();
+GO
+~~START~~
+int
+0
+~~END~~
+
+select babel_test_numeric_int8_f30();
+GO
+~~START~~
+int
+99995
+~~END~~
+
+select babel_test_numeric_int8_f31();
+GO
+~~START~~
+int
+6
+~~END~~
+
+select babel_test_numeric_int8_f32();
+GO
+~~START~~
+int
+99991
+~~END~~
+
+
+drop function babel_test_numeric_int8_f0;
+drop function babel_test_numeric_int8_f00;
+drop function babel_test_numeric_int8_f1;
+drop function babel_test_numeric_int8_f2;
+drop function babel_test_numeric_int8_f3;
+drop function babel_test_numeric_int8_f4;
+drop function babel_test_numeric_int8_f5;
+drop function babel_test_numeric_int8_f6;
+drop function babel_test_numeric_int8_f7;
+drop function babel_test_numeric_int8_f8;
+drop function babel_test_numeric_int8_f9;
+drop function babel_test_numeric_int8_f10;
+drop function babel_test_numeric_int8_f11;
+drop function babel_test_numeric_int8_f12;
+drop function babel_test_numeric_int8_f13;
+drop function babel_test_numeric_int8_f14;
+drop function babel_test_numeric_int8_f15;
+drop function babel_test_numeric_int8_f16;
+drop function babel_test_numeric_int8_f17;
+drop function babel_test_numeric_int8_f18;
+drop function babel_test_numeric_int8_f19;
+drop function babel_test_numeric_int8_f20;
+drop function babel_test_numeric_int8_f21;
+drop function babel_test_numeric_int8_f22;
+drop function babel_test_numeric_int8_f23;
+drop function babel_test_numeric_int8_f24;
+drop function babel_test_numeric_int8_f25;
+drop function babel_test_numeric_int8_f26;
+drop function babel_test_numeric_int8_f27;
+drop function babel_test_numeric_int8_f28;
+drop function babel_test_numeric_int8_f29;
+drop function babel_test_numeric_int8_f30;
+drop function babel_test_numeric_int8_f31;
+drop function babel_test_numeric_int8_f32;
+GO
+
+drop table babel_test_numeric_int8_vu_prepare;
+GO

--- a/test/JDBC/input/babel_test_numeric_int2_oper-vu-prepare.sql
+++ b/test/JDBC/input/babel_test_numeric_int2_oper-vu-prepare.sql
@@ -1,0 +1,464 @@
+-- tsql
+create table babel_test_numeric_int2_vu_prepare(a numeric(18,2));
+GO
+
+-- insert data
+INSERT INTO babel_test_numeric_int2_vu_prepare (a) SELECT cast(generate_series(1, 32767) as numeric(18,2));
+GO
+
+INSERT INTO babel_test_numeric_int2_vu_prepare VALUES (NULL), (-32768.00), (32767.00);
+GO
+
+CREATE INDEX babel_test_numeric_int2_vu_prepare_idx on babel_test_numeric_int2_vu_prepare(a);
+GO
+
+-- procedures dependency on all the numeric,int2 or int2, numeric operators
+
+create procedure babel_test_numeric_int2_p0 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p00 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a;
+GO
+
+create procedure babel_test_numeric_int2_p1 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create procedure babel_test_numeric_int2_p2 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p3 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a;
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int2_p4 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p5 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a;
+GO
+
+create procedure babel_test_numeric_int2_p6 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p7 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a;
+GO
+
+create procedure babel_test_numeric_int2_p8 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p9 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a;
+GO
+
+create procedure babel_test_numeric_int2_p10 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p11 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a;
+GO
+
+create procedure babel_test_numeric_int2_p12 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p13 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a;
+GO
+
+create procedure babel_test_numeric_int2_p14 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+create procedure babel_test_numeric_int2_p15 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a;
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int2_p16 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p17 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a;
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int2_p18 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int2_p19 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint);
+GO
+
+-- mix of numeric op int2 and numeric op numeric
+create procedure babel_test_numeric_int2_p20 as
+select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p21 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint);
+Go
+
+create procedure babel_test_numeric_int2_p22 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a;
+Go
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create procedure babel_test_numeric_int2_p23 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int2_p24 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p25 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p26 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p27 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p28 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create procedure babel_test_numeric_int2_p29 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int2_p30 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int2_p31 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int2_p32 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint);
+GO
+
+-- view body dependency on all the numeric,int2 or int2, numeric operators
+create view babel_test_numeric_int2_v0 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint);
+GO
+
+create view babel_test_numeric_int2_v00 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a;
+GO
+
+create view babel_test_numeric_int2_v1 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create view babel_test_numeric_int2_v2 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v3 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a;
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int2_v4 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v5 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a;
+GO
+
+create view babel_test_numeric_int2_v6 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create view babel_test_numeric_int2_v7 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a;
+GO
+
+create view babel_test_numeric_int2_v8 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v9 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a;
+GO
+
+create view babel_test_numeric_int2_v10 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v11 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a;
+GO
+
+create view babel_test_numeric_int2_v12 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v13 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a;
+GO
+
+create view babel_test_numeric_int2_v14 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+create view babel_test_numeric_int2_v15 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a;
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int2_v16 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v17 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a;
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int2_v18 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int2_v19 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint);
+GO
+
+-- mix of numeric op int2 and numeric op numeric
+create view babel_test_numeric_int2_v20 as
+select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint);
+GO
+
+create view babel_test_numeric_int2_v21 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint);
+Go
+
+create view babel_test_numeric_int2_v22 as
+select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a;
+Go
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create view babel_test_numeric_int2_v23 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint);
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int2_v24 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v25 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint);
+GO
+
+create view babel_test_numeric_int2_v26 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint);
+GO
+
+create view babel_test_numeric_int2_v27 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v28 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint);
+GO
+
+create view babel_test_numeric_int2_v29 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint);
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int2_v30 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint);
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int2_v31 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int2_v32 as
+select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint);
+GO
+
+-- functions dependency on all the numeric,int2 or int2, numeric operators
+create function babel_test_numeric_int2_f0() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a = cast(1 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f00() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(1 as smallint) = a) end;
+GO
+
+create function babel_test_numeric_int2_f1() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a IS NULL) end;
+GO
+
+-- seq scan
+create function babel_test_numeric_int2_f2() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f3() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) <> a) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int2_f4() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f5() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) > a) end;
+GO
+
+create function babel_test_numeric_int2_f6() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f7() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(-32768 as smallint) > a) end;
+GO
+
+create function babel_test_numeric_int2_f8() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f9() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) >= a) end;
+GO
+
+create function babel_test_numeric_int2_f10() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f11() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) < a) end;
+GO
+
+create function babel_test_numeric_int2_f12() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f13() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(32763 as smallint) <= a) end;
+GO
+
+create function babel_test_numeric_int2_f14() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f15() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(32767 as smallint) < a) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int2_f16() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f17() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int2_f18() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int2_f19() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32767 as smallint)) end;
+GO
+
+-- mix of numeric op int2 and numeric op numeric
+create function babel_test_numeric_int2_f20() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where (a between cast(5 as smallint) and cast(32763 as smallint)) and a = cast(10 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f21() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint) and a < cast(7 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f22() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where cast(5 as smallint) < a and cast(7 as smallint) > a) end;
+GO
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create function babel_test_numeric_int2_f23() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <> cast(5 as smallint)) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int2_f24() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f25() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a < cast(-32768 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f26() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a <= cast(5 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f27() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f28() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a >= cast(32763 as smallint)) end;
+GO
+
+create function babel_test_numeric_int2_f29() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(32767 as smallint)) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int2_f30() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a > cast(5 as smallint)) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int2_f31() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(10 as smallint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int2_f32() returns int as
+begin return (select count(*) from babel_test_numeric_int2_vu_prepare where a between cast(5 as smallint) and cast(32763 as smallint)) end;
+GO

--- a/test/JDBC/input/babel_test_numeric_int2_oper-vu-verify.mix
+++ b/test/JDBC/input/babel_test_numeric_int2_oper-vu-verify.mix
@@ -1,0 +1,497 @@
+-- psql
+analyse master_dbo.babel_test_numeric_int2_vu_prepare;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+exec babel_test_numeric_int2_p0;
+GO
+exec babel_test_numeric_int2_p00;
+GO
+exec babel_test_numeric_int2_p1;
+GO
+exec babel_test_numeric_int2_p2;
+GO
+exec babel_test_numeric_int2_p3;
+GO
+exec babel_test_numeric_int2_p4;
+GO
+exec babel_test_numeric_int2_p5;
+GO
+exec babel_test_numeric_int2_p6;
+GO
+exec babel_test_numeric_int2_p7;
+GO
+exec babel_test_numeric_int2_p8;
+GO
+exec babel_test_numeric_int2_p9;
+GO
+exec babel_test_numeric_int2_p10;
+GO
+exec babel_test_numeric_int2_p11;
+GO
+exec babel_test_numeric_int2_p12;
+GO
+exec babel_test_numeric_int2_p13;
+GO
+exec babel_test_numeric_int2_p14;
+GO
+exec babel_test_numeric_int2_p15;
+GO
+exec babel_test_numeric_int2_p16;
+GO
+exec babel_test_numeric_int2_p17;
+GO
+exec babel_test_numeric_int2_p18;
+GO
+exec babel_test_numeric_int2_p19;
+GO
+exec babel_test_numeric_int2_p20;
+GO
+exec babel_test_numeric_int2_p21;
+GO
+exec babel_test_numeric_int2_p22;
+GO
+exec babel_test_numeric_int2_p23;
+GO
+exec babel_test_numeric_int2_p24;
+GO
+exec babel_test_numeric_int2_p25;
+GO
+exec babel_test_numeric_int2_p26;
+GO
+exec babel_test_numeric_int2_p27;
+GO
+exec babel_test_numeric_int2_p28;
+GO
+exec babel_test_numeric_int2_p29;
+GO
+exec babel_test_numeric_int2_p30;
+GO
+exec babel_test_numeric_int2_p31;
+GO
+exec babel_test_numeric_int2_p32;
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+exec babel_test_numeric_int2_p0;
+GO
+exec babel_test_numeric_int2_p00;
+GO
+exec babel_test_numeric_int2_p1;
+GO
+exec babel_test_numeric_int2_p2;
+GO
+exec babel_test_numeric_int2_p3;
+GO
+exec babel_test_numeric_int2_p4;
+GO
+exec babel_test_numeric_int2_p5;
+GO
+exec babel_test_numeric_int2_p6;
+GO
+exec babel_test_numeric_int2_p7;
+GO
+exec babel_test_numeric_int2_p8;
+GO
+exec babel_test_numeric_int2_p9;
+GO
+exec babel_test_numeric_int2_p10;
+GO
+exec babel_test_numeric_int2_p11;
+GO
+exec babel_test_numeric_int2_p12;
+GO
+exec babel_test_numeric_int2_p13;
+GO
+exec babel_test_numeric_int2_p14;
+GO
+exec babel_test_numeric_int2_p15;
+GO
+exec babel_test_numeric_int2_p16;
+GO
+exec babel_test_numeric_int2_p17;
+GO
+exec babel_test_numeric_int2_p18;
+GO
+exec babel_test_numeric_int2_p19;
+GO
+exec babel_test_numeric_int2_p20;
+GO
+exec babel_test_numeric_int2_p21;
+GO
+exec babel_test_numeric_int2_p22;
+GO
+exec babel_test_numeric_int2_p23;
+GO
+exec babel_test_numeric_int2_p24;
+GO
+exec babel_test_numeric_int2_p25;
+GO
+exec babel_test_numeric_int2_p26;
+GO
+exec babel_test_numeric_int2_p27;
+GO
+exec babel_test_numeric_int2_p28;
+GO
+exec babel_test_numeric_int2_p29;
+GO
+exec babel_test_numeric_int2_p30;
+GO
+exec babel_test_numeric_int2_p31;
+GO
+exec babel_test_numeric_int2_p32;
+GO
+
+drop procedure babel_test_numeric_int2_p0;
+drop procedure babel_test_numeric_int2_p00;
+drop procedure babel_test_numeric_int2_p1;
+drop procedure babel_test_numeric_int2_p2;
+drop procedure babel_test_numeric_int2_p3;
+drop procedure babel_test_numeric_int2_p4;
+drop procedure babel_test_numeric_int2_p5;
+drop procedure babel_test_numeric_int2_p6;
+drop procedure babel_test_numeric_int2_p7;
+drop procedure babel_test_numeric_int2_p8;
+drop procedure babel_test_numeric_int2_p9;
+drop procedure babel_test_numeric_int2_p10;
+drop procedure babel_test_numeric_int2_p11;
+drop procedure babel_test_numeric_int2_p12;
+drop procedure babel_test_numeric_int2_p13;
+drop procedure babel_test_numeric_int2_p14;
+drop procedure babel_test_numeric_int2_p15;
+drop procedure babel_test_numeric_int2_p16;
+drop procedure babel_test_numeric_int2_p17;
+drop procedure babel_test_numeric_int2_p18;
+drop procedure babel_test_numeric_int2_p19;
+drop procedure babel_test_numeric_int2_p20;
+drop procedure babel_test_numeric_int2_p21;
+drop procedure babel_test_numeric_int2_p22;
+drop procedure babel_test_numeric_int2_p23;
+drop procedure babel_test_numeric_int2_p24;
+drop procedure babel_test_numeric_int2_p25;
+drop procedure babel_test_numeric_int2_p26;
+drop procedure babel_test_numeric_int2_p27;
+drop procedure babel_test_numeric_int2_p28;
+drop procedure babel_test_numeric_int2_p29;
+drop procedure babel_test_numeric_int2_p30;
+drop procedure babel_test_numeric_int2_p31;
+drop procedure babel_test_numeric_int2_p32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+select * from babel_test_numeric_int2_v0;
+GO
+select * from babel_test_numeric_int2_v00;
+GO
+select * from babel_test_numeric_int2_v1;
+GO
+select * from babel_test_numeric_int2_v2;
+GO
+select * from babel_test_numeric_int2_v3;
+GO
+select * from babel_test_numeric_int2_v4;
+GO
+select * from babel_test_numeric_int2_v5;
+GO
+select * from babel_test_numeric_int2_v6;
+GO
+select * from babel_test_numeric_int2_v7;
+GO
+select * from babel_test_numeric_int2_v8;
+GO
+select * from babel_test_numeric_int2_v9;
+GO
+select * from babel_test_numeric_int2_v10;
+GO
+select * from babel_test_numeric_int2_v11;
+GO
+select * from babel_test_numeric_int2_v12;
+GO
+select * from babel_test_numeric_int2_v13;
+GO
+select * from babel_test_numeric_int2_v14;
+GO
+select * from babel_test_numeric_int2_v15;
+GO
+select * from babel_test_numeric_int2_v16;
+GO
+select * from babel_test_numeric_int2_v17;
+GO
+select * from babel_test_numeric_int2_v18;
+GO
+select * from babel_test_numeric_int2_v19;
+GO
+select * from babel_test_numeric_int2_v20;
+GO
+select * from babel_test_numeric_int2_v21;
+GO
+select * from babel_test_numeric_int2_v22;
+GO
+select * from babel_test_numeric_int2_v23;
+GO
+select * from babel_test_numeric_int2_v24;
+GO
+select * from babel_test_numeric_int2_v25;
+GO
+select * from babel_test_numeric_int2_v26;
+GO
+select * from babel_test_numeric_int2_v27;
+GO
+select * from babel_test_numeric_int2_v28;
+GO
+select * from babel_test_numeric_int2_v29;
+GO
+select * from babel_test_numeric_int2_v30;
+GO
+select * from babel_test_numeric_int2_v31;
+GO
+select * from babel_test_numeric_int2_v32;
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select * from babel_test_numeric_int2_v0;
+GO
+select * from babel_test_numeric_int2_v00;
+GO
+select * from babel_test_numeric_int2_v1;
+GO
+select * from babel_test_numeric_int2_v2;
+GO
+select * from babel_test_numeric_int2_v3;
+GO
+select * from babel_test_numeric_int2_v4;
+GO
+select * from babel_test_numeric_int2_v5;
+GO
+select * from babel_test_numeric_int2_v6;
+GO
+select * from babel_test_numeric_int2_v7;
+GO
+select * from babel_test_numeric_int2_v8;
+GO
+select * from babel_test_numeric_int2_v9;
+GO
+select * from babel_test_numeric_int2_v10;
+GO
+select * from babel_test_numeric_int2_v11;
+GO
+select * from babel_test_numeric_int2_v12;
+GO
+select * from babel_test_numeric_int2_v13;
+GO
+select * from babel_test_numeric_int2_v14;
+GO
+select * from babel_test_numeric_int2_v15;
+GO
+select * from babel_test_numeric_int2_v16;
+GO
+select * from babel_test_numeric_int2_v17;
+GO
+select * from babel_test_numeric_int2_v18;
+GO
+select * from babel_test_numeric_int2_v19;
+GO
+select * from babel_test_numeric_int2_v20;
+GO
+select * from babel_test_numeric_int2_v21;
+GO
+select * from babel_test_numeric_int2_v22;
+GO
+select * from babel_test_numeric_int2_v23;
+GO
+select * from babel_test_numeric_int2_v24;
+GO
+select * from babel_test_numeric_int2_v25;
+GO
+select * from babel_test_numeric_int2_v26;
+GO
+select * from babel_test_numeric_int2_v27;
+GO
+select * from babel_test_numeric_int2_v28;
+GO
+select * from babel_test_numeric_int2_v29;
+GO
+select * from babel_test_numeric_int2_v30;
+GO
+select * from babel_test_numeric_int2_v31;
+GO
+select * from babel_test_numeric_int2_v32;
+GO
+
+drop view babel_test_numeric_int2_v0;
+drop view babel_test_numeric_int2_v00;
+drop view babel_test_numeric_int2_v1;
+drop view babel_test_numeric_int2_v2;
+drop view babel_test_numeric_int2_v3;
+drop view babel_test_numeric_int2_v4;
+drop view babel_test_numeric_int2_v5;
+drop view babel_test_numeric_int2_v6;
+drop view babel_test_numeric_int2_v7;
+drop view babel_test_numeric_int2_v8;
+drop view babel_test_numeric_int2_v9;
+drop view babel_test_numeric_int2_v10;
+drop view babel_test_numeric_int2_v11;
+drop view babel_test_numeric_int2_v12;
+drop view babel_test_numeric_int2_v13;
+drop view babel_test_numeric_int2_v14;
+drop view babel_test_numeric_int2_v15;
+drop view babel_test_numeric_int2_v16;
+drop view babel_test_numeric_int2_v17;
+drop view babel_test_numeric_int2_v18;
+drop view babel_test_numeric_int2_v19;
+drop view babel_test_numeric_int2_v20;
+drop view babel_test_numeric_int2_v21;
+drop view babel_test_numeric_int2_v22;
+drop view babel_test_numeric_int2_v23;
+drop view babel_test_numeric_int2_v24;
+drop view babel_test_numeric_int2_v25;
+drop view babel_test_numeric_int2_v26;
+drop view babel_test_numeric_int2_v27;
+drop view babel_test_numeric_int2_v28;
+drop view babel_test_numeric_int2_v29;
+drop view babel_test_numeric_int2_v30;
+drop view babel_test_numeric_int2_v31;
+drop view babel_test_numeric_int2_v32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select babel_test_numeric_int2_f0();
+GO
+select babel_test_numeric_int2_f00();
+GO
+select babel_test_numeric_int2_f1();
+GO
+select babel_test_numeric_int2_f2();
+GO
+select babel_test_numeric_int2_f3();
+GO
+select babel_test_numeric_int2_f4();
+GO
+select babel_test_numeric_int2_f5();
+GO
+select babel_test_numeric_int2_f6();
+GO
+select babel_test_numeric_int2_f7();
+GO
+select babel_test_numeric_int2_f8();
+GO
+select babel_test_numeric_int2_f9();
+GO
+select babel_test_numeric_int2_f10();
+GO
+select babel_test_numeric_int2_f11();
+GO
+select babel_test_numeric_int2_f12();
+GO
+select babel_test_numeric_int2_f13();
+GO
+select babel_test_numeric_int2_f14();
+GO
+select babel_test_numeric_int2_f15();
+GO
+select babel_test_numeric_int2_f16();
+GO
+select babel_test_numeric_int2_f17();
+GO
+select babel_test_numeric_int2_f18();
+GO
+select babel_test_numeric_int2_f19();
+GO
+select babel_test_numeric_int2_f20();
+GO
+select babel_test_numeric_int2_f21();
+GO
+select babel_test_numeric_int2_f22();
+GO
+select babel_test_numeric_int2_f23();
+GO
+select babel_test_numeric_int2_f24();
+GO
+select babel_test_numeric_int2_f25();
+GO
+select babel_test_numeric_int2_f26();
+GO
+select babel_test_numeric_int2_f27();
+GO
+select babel_test_numeric_int2_f28();
+GO
+select babel_test_numeric_int2_f29();
+GO
+select babel_test_numeric_int2_f30();
+GO
+select babel_test_numeric_int2_f31();
+GO
+select babel_test_numeric_int2_f32();
+GO
+
+drop function babel_test_numeric_int2_f0;
+drop function babel_test_numeric_int2_f00;
+drop function babel_test_numeric_int2_f1;
+drop function babel_test_numeric_int2_f2;
+drop function babel_test_numeric_int2_f3;
+drop function babel_test_numeric_int2_f4;
+drop function babel_test_numeric_int2_f5;
+drop function babel_test_numeric_int2_f6;
+drop function babel_test_numeric_int2_f7;
+drop function babel_test_numeric_int2_f8;
+drop function babel_test_numeric_int2_f9;
+drop function babel_test_numeric_int2_f10;
+drop function babel_test_numeric_int2_f11;
+drop function babel_test_numeric_int2_f12;
+drop function babel_test_numeric_int2_f13;
+drop function babel_test_numeric_int2_f14;
+drop function babel_test_numeric_int2_f15;
+drop function babel_test_numeric_int2_f16;
+drop function babel_test_numeric_int2_f17;
+drop function babel_test_numeric_int2_f18;
+drop function babel_test_numeric_int2_f19;
+drop function babel_test_numeric_int2_f20;
+drop function babel_test_numeric_int2_f21;
+drop function babel_test_numeric_int2_f22;
+drop function babel_test_numeric_int2_f23;
+drop function babel_test_numeric_int2_f24;
+drop function babel_test_numeric_int2_f25;
+drop function babel_test_numeric_int2_f26;
+drop function babel_test_numeric_int2_f27;
+drop function babel_test_numeric_int2_f28;
+drop function babel_test_numeric_int2_f29;
+drop function babel_test_numeric_int2_f30;
+drop function babel_test_numeric_int2_f31;
+drop function babel_test_numeric_int2_f32;
+GO
+
+drop table babel_test_numeric_int2_vu_prepare;
+GO

--- a/test/JDBC/input/babel_test_numeric_int4_oper-vu-prepare.sql
+++ b/test/JDBC/input/babel_test_numeric_int4_oper-vu-prepare.sql
@@ -1,0 +1,468 @@
+-- tsql
+create table babel_test_numeric_int4_vu_prepare(a numeric(18,2));
+GO
+
+-- insert data
+INSERT INTO babel_test_numeric_int4_vu_prepare (a) SELECT cast(generate_series(1, 100000) as numeric(18,2));
+GO
+
+INSERT INTO babel_test_numeric_int4_vu_prepare VALUES (NULL), (-2147483648.00), (2147483647.00);
+GO
+
+CREATE INDEX babel_test_numeric_int4_vu_prepare_idx on babel_test_numeric_int4_vu_prepare(a);
+GO
+
+create procedure babel_test_numeric_int4_p0 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int);
+GO
+
+create procedure babel_test_numeric_int4_p00 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a;
+GO
+
+create procedure babel_test_numeric_int4_p1 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create procedure babel_test_numeric_int4_p2 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p3 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a;
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int4_p4 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p5 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a;
+GO
+
+create procedure babel_test_numeric_int4_p6 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create procedure babel_test_numeric_int4_p7 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a;
+GO
+
+create procedure babel_test_numeric_int4_p8 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p9 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a;
+GO
+
+create procedure babel_test_numeric_int4_p10 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p11 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a;
+GO
+
+create procedure babel_test_numeric_int4_p12 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p13 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a;
+GO
+
+create procedure babel_test_numeric_int4_p14 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+create procedure babel_test_numeric_int4_p15 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a;
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int4_p16 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p17 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a;
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int4_p18 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int4_p19 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int);
+GO
+
+-- mix of numeric op int4 and numeric op numeric
+create procedure babel_test_numeric_int4_p20 as
+select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int);
+GO
+
+create procedure babel_test_numeric_int4_p21 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int);
+Go
+
+create procedure babel_test_numeric_int4_p22 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a;
+Go
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create procedure babel_test_numeric_int4_p23 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int4_p24 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p25 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create procedure babel_test_numeric_int4_p26 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create procedure babel_test_numeric_int4_p27 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p28 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create procedure babel_test_numeric_int4_p29 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int4_p30 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int4_p31 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int4_p32 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int);
+GO
+
+-- view body dependency on all the numeric,int4 or int4, numeric operators
+GO
+
+-- tsql
+create view babel_test_numeric_int4_v0 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int);
+GO
+
+create view babel_test_numeric_int4_v00 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a;
+GO
+
+create view babel_test_numeric_int4_v1 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create view babel_test_numeric_int4_v2 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v3 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a;
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int4_v4 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v5 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a;
+GO
+
+create view babel_test_numeric_int4_v6 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create view babel_test_numeric_int4_v7 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a;
+GO
+
+create view babel_test_numeric_int4_v8 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v9 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a;
+GO
+
+create view babel_test_numeric_int4_v10 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v11 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a;
+GO
+
+create view babel_test_numeric_int4_v12 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v13 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a;
+GO
+
+create view babel_test_numeric_int4_v14 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+create view babel_test_numeric_int4_v15 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a;
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int4_v16 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v17 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a;
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int4_v18 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int4_v19 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int);
+GO
+
+-- mix of numeric op int4 and numeric op numeric
+create view babel_test_numeric_int4_v20 as
+select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int);
+GO
+
+create view babel_test_numeric_int4_v21 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int);
+Go
+
+create view babel_test_numeric_int4_v22 as
+select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a;
+Go
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create view babel_test_numeric_int4_v23 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int);
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int4_v24 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v25 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int);
+GO
+
+create view babel_test_numeric_int4_v26 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int);
+GO
+
+create view babel_test_numeric_int4_v27 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v28 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int);
+GO
+
+create view babel_test_numeric_int4_v29 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int);
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int4_v30 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int);
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int4_v31 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int4_v32 as
+select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int);
+GO
+
+-- functions dependency on all the numeric,int4 or int4, numeric operators
+GO
+
+-- tsql
+create function babel_test_numeric_int4_f0() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a = cast(1 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f00() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(1 as int) = a) end;
+GO
+
+create function babel_test_numeric_int4_f1() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a IS NULL) end;
+GO
+
+-- seq scan
+create function babel_test_numeric_int4_f2() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f3() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) <> a) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int4_f4() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f5() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) > a) end;
+GO
+
+create function babel_test_numeric_int4_f6() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f7() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(-2147483648 as int) > a) end;
+GO
+
+create function babel_test_numeric_int4_f8() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f9() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) >= a) end;
+GO
+
+create function babel_test_numeric_int4_f10() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f11() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) < a) end;
+GO
+
+create function babel_test_numeric_int4_f12() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f13() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(99995 as int) <= a) end;
+GO
+
+create function babel_test_numeric_int4_f14() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f15() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(2147483647 as int) < a) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int4_f16() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f17() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int4_f18() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int4_f19() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(2147483647 as int)) end;
+GO
+
+-- mix of numeric op int4 and numeric op numeric
+create function babel_test_numeric_int4_f20() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where (a between cast(5 as int) and cast(99995 as int)) and a = cast(10 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f21() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int) and a < cast(7 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f22() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where cast(5 as int) < a and cast(7 as int) > a) end;
+GO
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create function babel_test_numeric_int4_f23() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <> cast(5 as int)) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int4_f24() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f25() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a < cast(-2147483648 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f26() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a <= cast(5 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f27() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f28() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a >= cast(99995 as int)) end;
+GO
+
+create function babel_test_numeric_int4_f29() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(2147483647 as int)) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int4_f30() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a > cast(5 as int)) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int4_f31() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(10 as int)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int4_f32() returns int as
+begin return (select count(*) from babel_test_numeric_int4_vu_prepare where a between cast(5 as int) and cast(99995 as int)) end;
+GO

--- a/test/JDBC/input/babel_test_numeric_int4_oper-vu-verify.mix
+++ b/test/JDBC/input/babel_test_numeric_int4_oper-vu-verify.mix
@@ -1,0 +1,498 @@
+-- psql
+analyse master_dbo.babel_test_numeric_int4_vu_prepare;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+exec babel_test_numeric_int4_p0;
+GO
+exec babel_test_numeric_int4_p00;
+GO
+exec babel_test_numeric_int4_p1;
+GO
+exec babel_test_numeric_int4_p2;
+GO
+exec babel_test_numeric_int4_p3;
+GO
+exec babel_test_numeric_int4_p4;
+GO
+exec babel_test_numeric_int4_p5;
+GO
+exec babel_test_numeric_int4_p6;
+GO
+exec babel_test_numeric_int4_p7;
+GO
+exec babel_test_numeric_int4_p8;
+GO
+exec babel_test_numeric_int4_p9;
+GO
+exec babel_test_numeric_int4_p10;
+GO
+exec babel_test_numeric_int4_p11;
+GO
+exec babel_test_numeric_int4_p12;
+GO
+exec babel_test_numeric_int4_p13;
+GO
+exec babel_test_numeric_int4_p14;
+GO
+exec babel_test_numeric_int4_p15;
+GO
+exec babel_test_numeric_int4_p16;
+GO
+exec babel_test_numeric_int4_p17;
+GO
+exec babel_test_numeric_int4_p18;
+GO
+exec babel_test_numeric_int4_p19;
+GO
+exec babel_test_numeric_int4_p20;
+GO
+exec babel_test_numeric_int4_p21;
+GO
+exec babel_test_numeric_int4_p22;
+GO
+exec babel_test_numeric_int4_p23;
+GO
+exec babel_test_numeric_int4_p24;
+GO
+exec babel_test_numeric_int4_p25;
+GO
+exec babel_test_numeric_int4_p26;
+GO
+exec babel_test_numeric_int4_p27;
+GO
+exec babel_test_numeric_int4_p28;
+GO
+exec babel_test_numeric_int4_p29;
+GO
+exec babel_test_numeric_int4_p30;
+GO
+exec babel_test_numeric_int4_p31;
+GO
+exec babel_test_numeric_int4_p32;
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+exec babel_test_numeric_int4_p0;
+GO
+exec babel_test_numeric_int4_p00;
+GO
+exec babel_test_numeric_int4_p1;
+GO
+exec babel_test_numeric_int4_p2;
+GO
+exec babel_test_numeric_int4_p3;
+GO
+exec babel_test_numeric_int4_p4;
+GO
+exec babel_test_numeric_int4_p5;
+GO
+exec babel_test_numeric_int4_p6;
+GO
+exec babel_test_numeric_int4_p7;
+GO
+exec babel_test_numeric_int4_p8;
+GO
+exec babel_test_numeric_int4_p9;
+GO
+exec babel_test_numeric_int4_p10;
+GO
+exec babel_test_numeric_int4_p11;
+GO
+exec babel_test_numeric_int4_p12;
+GO
+exec babel_test_numeric_int4_p13;
+GO
+exec babel_test_numeric_int4_p14;
+GO
+exec babel_test_numeric_int4_p15;
+GO
+exec babel_test_numeric_int4_p16;
+GO
+exec babel_test_numeric_int4_p17;
+GO
+exec babel_test_numeric_int4_p18;
+GO
+exec babel_test_numeric_int4_p19;
+GO
+exec babel_test_numeric_int4_p20;
+GO
+exec babel_test_numeric_int4_p21;
+GO
+exec babel_test_numeric_int4_p22;
+GO
+exec babel_test_numeric_int4_p23;
+GO
+exec babel_test_numeric_int4_p24;
+GO
+exec babel_test_numeric_int4_p25;
+GO
+exec babel_test_numeric_int4_p26;
+GO
+exec babel_test_numeric_int4_p27;
+GO
+exec babel_test_numeric_int4_p28;
+GO
+exec babel_test_numeric_int4_p29;
+GO
+exec babel_test_numeric_int4_p30;
+GO
+exec babel_test_numeric_int4_p31;
+GO
+exec babel_test_numeric_int4_p32;
+GO
+
+drop procedure babel_test_numeric_int4_p0;
+drop procedure babel_test_numeric_int4_p00;
+drop procedure babel_test_numeric_int4_p1;
+drop procedure babel_test_numeric_int4_p2;
+drop procedure babel_test_numeric_int4_p3;
+drop procedure babel_test_numeric_int4_p4;
+drop procedure babel_test_numeric_int4_p5;
+drop procedure babel_test_numeric_int4_p6;
+drop procedure babel_test_numeric_int4_p7;
+drop procedure babel_test_numeric_int4_p8;
+drop procedure babel_test_numeric_int4_p9;
+drop procedure babel_test_numeric_int4_p10;
+drop procedure babel_test_numeric_int4_p11;
+drop procedure babel_test_numeric_int4_p12;
+drop procedure babel_test_numeric_int4_p13;
+drop procedure babel_test_numeric_int4_p14;
+drop procedure babel_test_numeric_int4_p15;
+drop procedure babel_test_numeric_int4_p16;
+drop procedure babel_test_numeric_int4_p17;
+drop procedure babel_test_numeric_int4_p18;
+drop procedure babel_test_numeric_int4_p19;
+drop procedure babel_test_numeric_int4_p20;
+drop procedure babel_test_numeric_int4_p21;
+drop procedure babel_test_numeric_int4_p22;
+drop procedure babel_test_numeric_int4_p23;
+drop procedure babel_test_numeric_int4_p24;
+drop procedure babel_test_numeric_int4_p25;
+drop procedure babel_test_numeric_int4_p26;
+drop procedure babel_test_numeric_int4_p27;
+drop procedure babel_test_numeric_int4_p28;
+drop procedure babel_test_numeric_int4_p29;
+drop procedure babel_test_numeric_int4_p30;
+drop procedure babel_test_numeric_int4_p31;
+drop procedure babel_test_numeric_int4_p32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+select * from babel_test_numeric_int4_v0;
+GO
+select * from babel_test_numeric_int4_v00;
+GO
+select * from babel_test_numeric_int4_v1;
+GO
+select * from babel_test_numeric_int4_v2;
+GO
+select * from babel_test_numeric_int4_v3;
+GO
+select * from babel_test_numeric_int4_v4;
+GO
+select * from babel_test_numeric_int4_v5;
+GO
+select * from babel_test_numeric_int4_v6;
+GO
+select * from babel_test_numeric_int4_v7;
+GO
+select * from babel_test_numeric_int4_v8;
+GO
+select * from babel_test_numeric_int4_v9;
+GO
+select * from babel_test_numeric_int4_v10;
+GO
+select * from babel_test_numeric_int4_v11;
+GO
+select * from babel_test_numeric_int4_v12;
+GO
+select * from babel_test_numeric_int4_v13;
+GO
+select * from babel_test_numeric_int4_v14;
+GO
+select * from babel_test_numeric_int4_v15;
+GO
+select * from babel_test_numeric_int4_v16;
+GO
+select * from babel_test_numeric_int4_v17;
+GO
+select * from babel_test_numeric_int4_v18;
+GO
+select * from babel_test_numeric_int4_v19;
+GO
+select * from babel_test_numeric_int4_v20;
+GO
+select * from babel_test_numeric_int4_v21;
+GO
+select * from babel_test_numeric_int4_v22;
+GO
+select * from babel_test_numeric_int4_v23;
+GO
+select * from babel_test_numeric_int4_v24;
+GO
+select * from babel_test_numeric_int4_v25;
+GO
+select * from babel_test_numeric_int4_v26;
+GO
+select * from babel_test_numeric_int4_v27;
+GO
+select * from babel_test_numeric_int4_v28;
+GO
+select * from babel_test_numeric_int4_v29;
+GO
+select * from babel_test_numeric_int4_v30;
+GO
+select * from babel_test_numeric_int4_v31;
+GO
+select * from babel_test_numeric_int4_v32;
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select * from babel_test_numeric_int4_v0;
+GO
+select * from babel_test_numeric_int4_v00;
+GO
+select * from babel_test_numeric_int4_v1;
+GO
+select * from babel_test_numeric_int4_v2;
+GO
+select * from babel_test_numeric_int4_v3;
+GO
+select * from babel_test_numeric_int4_v4;
+GO
+select * from babel_test_numeric_int4_v5;
+GO
+select * from babel_test_numeric_int4_v6;
+GO
+select * from babel_test_numeric_int4_v7;
+GO
+select * from babel_test_numeric_int4_v8;
+GO
+select * from babel_test_numeric_int4_v9;
+GO
+select * from babel_test_numeric_int4_v10;
+GO
+select * from babel_test_numeric_int4_v11;
+GO
+select * from babel_test_numeric_int4_v12;
+GO
+select * from babel_test_numeric_int4_v13;
+GO
+select * from babel_test_numeric_int4_v14;
+GO
+select * from babel_test_numeric_int4_v15;
+GO
+select * from babel_test_numeric_int4_v16;
+GO
+select * from babel_test_numeric_int4_v17;
+GO
+select * from babel_test_numeric_int4_v18;
+GO
+select * from babel_test_numeric_int4_v19;
+GO
+select * from babel_test_numeric_int4_v20;
+GO
+select * from babel_test_numeric_int4_v21;
+GO
+select * from babel_test_numeric_int4_v22;
+GO
+select * from babel_test_numeric_int4_v23;
+GO
+select * from babel_test_numeric_int4_v24;
+GO
+select * from babel_test_numeric_int4_v25;
+GO
+select * from babel_test_numeric_int4_v26;
+GO
+select * from babel_test_numeric_int4_v27;
+GO
+select * from babel_test_numeric_int4_v28;
+GO
+select * from babel_test_numeric_int4_v29;
+GO
+select * from babel_test_numeric_int4_v30;
+GO
+select * from babel_test_numeric_int4_v31;
+GO
+select * from babel_test_numeric_int4_v32;
+GO
+
+drop view babel_test_numeric_int4_v0;
+drop view babel_test_numeric_int4_v00;
+drop view babel_test_numeric_int4_v1;
+drop view babel_test_numeric_int4_v2;
+drop view babel_test_numeric_int4_v3;
+drop view babel_test_numeric_int4_v4;
+drop view babel_test_numeric_int4_v5;
+drop view babel_test_numeric_int4_v6;
+drop view babel_test_numeric_int4_v7;
+drop view babel_test_numeric_int4_v8;
+drop view babel_test_numeric_int4_v9;
+drop view babel_test_numeric_int4_v10;
+drop view babel_test_numeric_int4_v11;
+drop view babel_test_numeric_int4_v12;
+drop view babel_test_numeric_int4_v13;
+drop view babel_test_numeric_int4_v14;
+drop view babel_test_numeric_int4_v15;
+drop view babel_test_numeric_int4_v16;
+drop view babel_test_numeric_int4_v17;
+drop view babel_test_numeric_int4_v18;
+drop view babel_test_numeric_int4_v19;
+drop view babel_test_numeric_int4_v20;
+drop view babel_test_numeric_int4_v21;
+drop view babel_test_numeric_int4_v22;
+drop view babel_test_numeric_int4_v23;
+drop view babel_test_numeric_int4_v24;
+drop view babel_test_numeric_int4_v25;
+drop view babel_test_numeric_int4_v26;
+drop view babel_test_numeric_int4_v27;
+drop view babel_test_numeric_int4_v28;
+drop view babel_test_numeric_int4_v29;
+drop view babel_test_numeric_int4_v30;
+drop view babel_test_numeric_int4_v31;
+drop view babel_test_numeric_int4_v32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select babel_test_numeric_int4_f0();
+GO
+select babel_test_numeric_int4_f00();
+GO
+select babel_test_numeric_int4_f1();
+GO
+select babel_test_numeric_int4_f2();
+GO
+select babel_test_numeric_int4_f3();
+GO
+select babel_test_numeric_int4_f4();
+GO
+select babel_test_numeric_int4_f5();
+GO
+select babel_test_numeric_int4_f6();
+GO
+select babel_test_numeric_int4_f7();
+GO
+select babel_test_numeric_int4_f8();
+GO
+select babel_test_numeric_int4_f9();
+GO
+select babel_test_numeric_int4_f10();
+GO
+select babel_test_numeric_int4_f11();
+GO
+select babel_test_numeric_int4_f12();
+GO
+select babel_test_numeric_int4_f13();
+GO
+select babel_test_numeric_int4_f14();
+GO
+select babel_test_numeric_int4_f15();
+GO
+select babel_test_numeric_int4_f16();
+GO
+select babel_test_numeric_int4_f17();
+GO
+select babel_test_numeric_int4_f18();
+GO
+select babel_test_numeric_int4_f19();
+GO
+select babel_test_numeric_int4_f20();
+GO
+select babel_test_numeric_int4_f21();
+GO
+select babel_test_numeric_int4_f22();
+GO
+select babel_test_numeric_int4_f23();
+GO
+select babel_test_numeric_int4_f24();
+GO
+select babel_test_numeric_int4_f25();
+GO
+select babel_test_numeric_int4_f26();
+GO
+select babel_test_numeric_int4_f27();
+GO
+select babel_test_numeric_int4_f28();
+GO
+select babel_test_numeric_int4_f29();
+GO
+select babel_test_numeric_int4_f30();
+GO
+select babel_test_numeric_int4_f31();
+GO
+select babel_test_numeric_int4_f32();
+GO
+
+drop function babel_test_numeric_int4_f0;
+drop function babel_test_numeric_int4_f00;
+drop function babel_test_numeric_int4_f1;
+drop function babel_test_numeric_int4_f2;
+drop function babel_test_numeric_int4_f3;
+drop function babel_test_numeric_int4_f4;
+drop function babel_test_numeric_int4_f5;
+drop function babel_test_numeric_int4_f6;
+drop function babel_test_numeric_int4_f7;
+drop function babel_test_numeric_int4_f8;
+drop function babel_test_numeric_int4_f9;
+drop function babel_test_numeric_int4_f10;
+drop function babel_test_numeric_int4_f11;
+drop function babel_test_numeric_int4_f12;
+drop function babel_test_numeric_int4_f13;
+drop function babel_test_numeric_int4_f14;
+drop function babel_test_numeric_int4_f15;
+drop function babel_test_numeric_int4_f16;
+drop function babel_test_numeric_int4_f17;
+drop function babel_test_numeric_int4_f18;
+drop function babel_test_numeric_int4_f19;
+drop function babel_test_numeric_int4_f20;
+drop function babel_test_numeric_int4_f21;
+drop function babel_test_numeric_int4_f22;
+drop function babel_test_numeric_int4_f23;
+drop function babel_test_numeric_int4_f24;
+drop function babel_test_numeric_int4_f25;
+drop function babel_test_numeric_int4_f26;
+drop function babel_test_numeric_int4_f27;
+drop function babel_test_numeric_int4_f28;
+drop function babel_test_numeric_int4_f29;
+drop function babel_test_numeric_int4_f30;
+drop function babel_test_numeric_int4_f31;
+drop function babel_test_numeric_int4_f32;
+GO
+
+drop table babel_test_numeric_int4_vu_prepare;
+GO

--- a/test/JDBC/input/babel_test_numeric_int8_oper-vu-prepare.sql
+++ b/test/JDBC/input/babel_test_numeric_int8_oper-vu-prepare.sql
@@ -1,0 +1,463 @@
+create table babel_test_numeric_int8_vu_prepare(a numeric(18,2));
+GO
+
+-- insert data
+INSERT INTO babel_test_numeric_int8_vu_prepare (a) SELECT cast(generate_series(1, 100000) as numeric(18,2));
+GO
+
+INSERT INTO babel_test_numeric_int8_vu_prepare VALUES (NULL), (-9223372036854775808.00), (9223372036854775807.00);
+GO
+
+CREATE INDEX babel_test_numeric_int8_vu_prepare_idx on babel_test_numeric_int8_vu_prepare(a);
+GO
+
+-- procedures dependency on all the numeric,int8 or int8, numeric operators
+create procedure babel_test_numeric_int8_p0 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p00 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a;
+GO
+
+create procedure babel_test_numeric_int8_p1 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create procedure babel_test_numeric_int8_p2 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p3 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a;
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int8_p4 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p5 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a;
+GO
+
+create procedure babel_test_numeric_int8_p6 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p7 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a;
+GO
+
+create procedure babel_test_numeric_int8_p8 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p9 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a;
+GO
+
+create procedure babel_test_numeric_int8_p10 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p11 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a;
+GO
+
+create procedure babel_test_numeric_int8_p12 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p13 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a;
+GO
+
+create procedure babel_test_numeric_int8_p14 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+create procedure babel_test_numeric_int8_p15 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a;
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int8_p16 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p17 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a;
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int8_p18 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int8_p19 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint);
+GO
+
+-- mix of numeric op int8 and numeric op numeric
+create procedure babel_test_numeric_int8_p20 as
+select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p21 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint);
+Go
+
+create procedure babel_test_numeric_int8_p22 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a;
+Go
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create procedure babel_test_numeric_int8_p23 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+-- index scan on < and >
+create procedure babel_test_numeric_int8_p24 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p25 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p26 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p27 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p28 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create procedure babel_test_numeric_int8_p29 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+-- seq scan on < and >
+create procedure babel_test_numeric_int8_p30 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+-- index scan for BETWEEN
+create procedure babel_test_numeric_int8_p31 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create procedure babel_test_numeric_int8_p32 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint);
+GO
+
+-- view body dependency on all the numeric,int8 or int8, numeric operators
+
+create view babel_test_numeric_int8_v0 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint);
+GO
+
+create view babel_test_numeric_int8_v00 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a;
+GO
+
+create view babel_test_numeric_int8_v1 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL;
+GO
+
+-- seq scan
+create view babel_test_numeric_int8_v2 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v3 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a;
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int8_v4 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v5 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a;
+GO
+
+create view babel_test_numeric_int8_v6 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create view babel_test_numeric_int8_v7 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a;
+GO
+
+create view babel_test_numeric_int8_v8 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v9 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a;
+GO
+
+create view babel_test_numeric_int8_v10 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v11 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a;
+GO
+
+create view babel_test_numeric_int8_v12 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v13 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a;
+GO
+
+create view babel_test_numeric_int8_v14 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+create view babel_test_numeric_int8_v15 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a;
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int8_v16 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v17 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a;
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int8_v18 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int8_v19 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint);
+GO
+
+-- mix of numeric op int8 and numeric op numeric
+create view babel_test_numeric_int8_v20 as
+select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint);
+GO
+
+create view babel_test_numeric_int8_v21 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint);
+Go
+
+create view babel_test_numeric_int8_v22 as
+select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a;
+Go
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create view babel_test_numeric_int8_v23 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint);
+GO
+
+-- index scan on < and >
+create view babel_test_numeric_int8_v24 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v25 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint);
+GO
+
+create view babel_test_numeric_int8_v26 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint);
+GO
+
+create view babel_test_numeric_int8_v27 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v28 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint);
+GO
+
+create view babel_test_numeric_int8_v29 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint);
+go
+
+-- seq scan on < and >
+create view babel_test_numeric_int8_v30 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint);
+GO
+
+-- index scan for BETWEEN
+create view babel_test_numeric_int8_v31 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint);
+GO
+
+-- seq scan for BETWEEN
+create view babel_test_numeric_int8_v32 as
+select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint);
+GO
+
+-- functions dependency on all the numeric,int8 or int8, numeric operators
+create function babel_test_numeric_int8_f0() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a = cast(1 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f00() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(1 as bigint) = a) end;
+GO
+
+create function babel_test_numeric_int8_f1() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a IS NULL) end;
+GO
+
+-- seq scan
+create function babel_test_numeric_int8_f2() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f3() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) <> a) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int8_f4() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f5() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) > a) end;
+GO
+
+create function babel_test_numeric_int8_f6() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f7() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(-9223372036854775808 as bigint) > a) end;
+GO
+
+create function babel_test_numeric_int8_f8() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f9() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) >= a) end;
+GO
+
+create function babel_test_numeric_int8_f10() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f11() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) < a) end;
+GO
+
+create function babel_test_numeric_int8_f12() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f13() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(99995 as bigint) <= a) end;
+GO
+
+create function babel_test_numeric_int8_f14() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f15() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(9223372036854775807 as bigint) < a) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int8_f16() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f17() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int8_f18() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int8_f19() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(9223372036854775807 as bigint)) end;
+GO
+
+-- mix of numeric op int8 and numeric op numeric
+create function babel_test_numeric_int8_f20() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where (a between cast(5 as bigint) and cast(99995 as bigint)) and a = cast(10 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f21() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint) and a < cast(7 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f22() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where cast(5 as bigint) < a and cast(7 as bigint) > a) end;
+GO
+
+-- shouldn't be any regression on numeric op numeric operators
+
+-- seq scan
+create function babel_test_numeric_int8_f23() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <> cast(5 as bigint)) end;
+GO
+
+-- index scan on < and >
+create function babel_test_numeric_int8_f24() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f25() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a < cast(-9223372036854775808 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f26() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a <= cast(5 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f27() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f28() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a >= cast(99995 as bigint)) end;
+GO
+
+create function babel_test_numeric_int8_f29() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(9223372036854775807 as bigint)) end;
+GO
+
+-- seq scan on < and >
+create function babel_test_numeric_int8_f30() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a > cast(5 as bigint)) end;
+GO
+
+-- index scan for BETWEEN
+create function babel_test_numeric_int8_f31() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(10 as bigint)) end;
+GO
+
+-- seq scan for BETWEEN
+create function babel_test_numeric_int8_f32() returns int as
+begin return (select count(*) from babel_test_numeric_int8_vu_prepare where a between cast(5 as bigint) and cast(99995 as bigint)) end;
+GO

--- a/test/JDBC/input/babel_test_numeric_int8_oper-vu-verify.mix
+++ b/test/JDBC/input/babel_test_numeric_int8_oper-vu-verify.mix
@@ -1,0 +1,498 @@
+-- psql
+analyse master_dbo.babel_test_numeric_int8_vu_prepare;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+exec babel_test_numeric_int8_p0;
+GO
+exec babel_test_numeric_int8_p00;
+GO
+exec babel_test_numeric_int8_p1;
+GO
+exec babel_test_numeric_int8_p2;
+GO
+exec babel_test_numeric_int8_p3;
+GO
+exec babel_test_numeric_int8_p4;
+GO
+exec babel_test_numeric_int8_p5;
+GO
+exec babel_test_numeric_int8_p6;
+GO
+exec babel_test_numeric_int8_p7;
+GO
+exec babel_test_numeric_int8_p8;
+GO
+exec babel_test_numeric_int8_p9;
+GO
+exec babel_test_numeric_int8_p10;
+GO
+exec babel_test_numeric_int8_p11;
+GO
+exec babel_test_numeric_int8_p12;
+GO
+exec babel_test_numeric_int8_p13;
+GO
+exec babel_test_numeric_int8_p14;
+GO
+exec babel_test_numeric_int8_p15;
+GO
+exec babel_test_numeric_int8_p16;
+GO
+exec babel_test_numeric_int8_p17;
+GO
+exec babel_test_numeric_int8_p18;
+GO
+exec babel_test_numeric_int8_p19;
+GO
+exec babel_test_numeric_int8_p20;
+GO
+exec babel_test_numeric_int8_p21;
+GO
+exec babel_test_numeric_int8_p22;
+GO
+exec babel_test_numeric_int8_p23;
+GO
+exec babel_test_numeric_int8_p24;
+GO
+exec babel_test_numeric_int8_p25;
+GO
+exec babel_test_numeric_int8_p26;
+GO
+exec babel_test_numeric_int8_p27;
+GO
+exec babel_test_numeric_int8_p28;
+GO
+exec babel_test_numeric_int8_p29;
+GO
+exec babel_test_numeric_int8_p30;
+GO
+exec babel_test_numeric_int8_p31;
+GO
+exec babel_test_numeric_int8_p32;
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+exec babel_test_numeric_int8_p0;
+GO
+exec babel_test_numeric_int8_p00;
+GO
+exec babel_test_numeric_int8_p1;
+GO
+exec babel_test_numeric_int8_p2;
+GO
+exec babel_test_numeric_int8_p3;
+GO
+exec babel_test_numeric_int8_p4;
+GO
+exec babel_test_numeric_int8_p5;
+GO
+exec babel_test_numeric_int8_p6;
+GO
+exec babel_test_numeric_int8_p7;
+GO
+exec babel_test_numeric_int8_p8;
+GO
+exec babel_test_numeric_int8_p9;
+GO
+exec babel_test_numeric_int8_p10;
+GO
+exec babel_test_numeric_int8_p11;
+GO
+exec babel_test_numeric_int8_p12;
+GO
+exec babel_test_numeric_int8_p13;
+GO
+exec babel_test_numeric_int8_p14;
+GO
+exec babel_test_numeric_int8_p15;
+GO
+exec babel_test_numeric_int8_p16;
+GO
+exec babel_test_numeric_int8_p17;
+GO
+exec babel_test_numeric_int8_p18;
+GO
+exec babel_test_numeric_int8_p19;
+GO
+exec babel_test_numeric_int8_p20;
+GO
+exec babel_test_numeric_int8_p21;
+GO
+exec babel_test_numeric_int8_p22;
+GO
+exec babel_test_numeric_int8_p23;
+GO
+exec babel_test_numeric_int8_p24;
+GO
+exec babel_test_numeric_int8_p25;
+GO
+exec babel_test_numeric_int8_p26;
+GO
+exec babel_test_numeric_int8_p27;
+GO
+exec babel_test_numeric_int8_p28;
+GO
+exec babel_test_numeric_int8_p29;
+GO
+exec babel_test_numeric_int8_p30;
+GO
+exec babel_test_numeric_int8_p31;
+GO
+exec babel_test_numeric_int8_p32;
+GO
+
+drop procedure babel_test_numeric_int8_p0;
+drop procedure babel_test_numeric_int8_p00;
+drop procedure babel_test_numeric_int8_p1;
+drop procedure babel_test_numeric_int8_p2;
+drop procedure babel_test_numeric_int8_p3;
+drop procedure babel_test_numeric_int8_p4;
+drop procedure babel_test_numeric_int8_p5;
+drop procedure babel_test_numeric_int8_p6;
+drop procedure babel_test_numeric_int8_p7;
+drop procedure babel_test_numeric_int8_p8;
+drop procedure babel_test_numeric_int8_p9;
+drop procedure babel_test_numeric_int8_p10;
+drop procedure babel_test_numeric_int8_p11;
+drop procedure babel_test_numeric_int8_p12;
+drop procedure babel_test_numeric_int8_p13;
+drop procedure babel_test_numeric_int8_p14;
+drop procedure babel_test_numeric_int8_p15;
+drop procedure babel_test_numeric_int8_p16;
+drop procedure babel_test_numeric_int8_p17;
+drop procedure babel_test_numeric_int8_p18;
+drop procedure babel_test_numeric_int8_p19;
+drop procedure babel_test_numeric_int8_p20;
+drop procedure babel_test_numeric_int8_p21;
+drop procedure babel_test_numeric_int8_p22;
+drop procedure babel_test_numeric_int8_p23;
+drop procedure babel_test_numeric_int8_p24;
+drop procedure babel_test_numeric_int8_p25;
+drop procedure babel_test_numeric_int8_p26;
+drop procedure babel_test_numeric_int8_p27;
+drop procedure babel_test_numeric_int8_p28;
+drop procedure babel_test_numeric_int8_p29;
+drop procedure babel_test_numeric_int8_p30;
+drop procedure babel_test_numeric_int8_p31;
+drop procedure babel_test_numeric_int8_p32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+select * from babel_test_numeric_int8_v0;
+GO
+select * from babel_test_numeric_int8_v00;
+GO
+select * from babel_test_numeric_int8_v1;
+GO
+select * from babel_test_numeric_int8_v2;
+GO
+select * from babel_test_numeric_int8_v3;
+GO
+select * from babel_test_numeric_int8_v4;
+GO
+select * from babel_test_numeric_int8_v5;
+GO
+select * from babel_test_numeric_int8_v6;
+GO
+select * from babel_test_numeric_int8_v7;
+GO
+select * from babel_test_numeric_int8_v8;
+GO
+select * from babel_test_numeric_int8_v9;
+GO
+select * from babel_test_numeric_int8_v10;
+GO
+select * from babel_test_numeric_int8_v11;
+GO
+select * from babel_test_numeric_int8_v12;
+GO
+select * from babel_test_numeric_int8_v13;
+GO
+select * from babel_test_numeric_int8_v14;
+GO
+select * from babel_test_numeric_int8_v15;
+GO
+select * from babel_test_numeric_int8_v16;
+GO
+select * from babel_test_numeric_int8_v17;
+GO
+select * from babel_test_numeric_int8_v18;
+GO
+select * from babel_test_numeric_int8_v19;
+GO
+select * from babel_test_numeric_int8_v20;
+GO
+select * from babel_test_numeric_int8_v21;
+GO
+select * from babel_test_numeric_int8_v22;
+GO
+select * from babel_test_numeric_int8_v23;
+GO
+select * from babel_test_numeric_int8_v24;
+GO
+select * from babel_test_numeric_int8_v25;
+GO
+select * from babel_test_numeric_int8_v26;
+GO
+select * from babel_test_numeric_int8_v27;
+GO
+select * from babel_test_numeric_int8_v28;
+GO
+select * from babel_test_numeric_int8_v29;
+GO
+select * from babel_test_numeric_int8_v30;
+GO
+select * from babel_test_numeric_int8_v31;
+GO
+select * from babel_test_numeric_int8_v32;
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select * from babel_test_numeric_int8_v0;
+GO
+select * from babel_test_numeric_int8_v00;
+GO
+select * from babel_test_numeric_int8_v1;
+GO
+select * from babel_test_numeric_int8_v2;
+GO
+select * from babel_test_numeric_int8_v3;
+GO
+select * from babel_test_numeric_int8_v4;
+GO
+select * from babel_test_numeric_int8_v5;
+GO
+select * from babel_test_numeric_int8_v6;
+GO
+select * from babel_test_numeric_int8_v7;
+GO
+select * from babel_test_numeric_int8_v8;
+GO
+select * from babel_test_numeric_int8_v9;
+GO
+select * from babel_test_numeric_int8_v10;
+GO
+select * from babel_test_numeric_int8_v11;
+GO
+select * from babel_test_numeric_int8_v12;
+GO
+select * from babel_test_numeric_int8_v13;
+GO
+select * from babel_test_numeric_int8_v14;
+GO
+select * from babel_test_numeric_int8_v15;
+GO
+select * from babel_test_numeric_int8_v16;
+GO
+select * from babel_test_numeric_int8_v17;
+GO
+select * from babel_test_numeric_int8_v18;
+GO
+select * from babel_test_numeric_int8_v19;
+GO
+select * from babel_test_numeric_int8_v20;
+GO
+select * from babel_test_numeric_int8_v21;
+GO
+select * from babel_test_numeric_int8_v22;
+GO
+select * from babel_test_numeric_int8_v23;
+GO
+select * from babel_test_numeric_int8_v24;
+GO
+select * from babel_test_numeric_int8_v25;
+GO
+select * from babel_test_numeric_int8_v26;
+GO
+select * from babel_test_numeric_int8_v27;
+GO
+select * from babel_test_numeric_int8_v28;
+GO
+select * from babel_test_numeric_int8_v29;
+GO
+select * from babel_test_numeric_int8_v30;
+GO
+select * from babel_test_numeric_int8_v31;
+GO
+select * from babel_test_numeric_int8_v32;
+GO
+
+drop view babel_test_numeric_int8_v0;
+drop view babel_test_numeric_int8_v00;
+drop view babel_test_numeric_int8_v1;
+drop view babel_test_numeric_int8_v2;
+drop view babel_test_numeric_int8_v3;
+drop view babel_test_numeric_int8_v4;
+drop view babel_test_numeric_int8_v5;
+drop view babel_test_numeric_int8_v6;
+drop view babel_test_numeric_int8_v7;
+drop view babel_test_numeric_int8_v8;
+drop view babel_test_numeric_int8_v9;
+drop view babel_test_numeric_int8_v10;
+drop view babel_test_numeric_int8_v11;
+drop view babel_test_numeric_int8_v12;
+drop view babel_test_numeric_int8_v13;
+drop view babel_test_numeric_int8_v14;
+drop view babel_test_numeric_int8_v15;
+drop view babel_test_numeric_int8_v16;
+drop view babel_test_numeric_int8_v17;
+drop view babel_test_numeric_int8_v18;
+drop view babel_test_numeric_int8_v19;
+drop view babel_test_numeric_int8_v20;
+drop view babel_test_numeric_int8_v21;
+drop view babel_test_numeric_int8_v22;
+drop view babel_test_numeric_int8_v23;
+drop view babel_test_numeric_int8_v24;
+drop view babel_test_numeric_int8_v25;
+drop view babel_test_numeric_int8_v26;
+drop view babel_test_numeric_int8_v27;
+drop view babel_test_numeric_int8_v28;
+drop view babel_test_numeric_int8_v29;
+drop view babel_test_numeric_int8_v30;
+drop view babel_test_numeric_int8_v31;
+drop view babel_test_numeric_int8_v32;
+GO
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+
+SET BABELFISH_SHOWPLAN_ALL off
+GO
+
+select babel_test_numeric_int8_f0();
+GO
+select babel_test_numeric_int8_f00();
+GO
+select babel_test_numeric_int8_f1();
+GO
+select babel_test_numeric_int8_f2();
+GO
+select babel_test_numeric_int8_f3();
+GO
+select babel_test_numeric_int8_f4();
+GO
+select babel_test_numeric_int8_f5();
+GO
+select babel_test_numeric_int8_f6();
+GO
+select babel_test_numeric_int8_f7();
+GO
+select babel_test_numeric_int8_f8();
+GO
+select babel_test_numeric_int8_f9();
+GO
+select babel_test_numeric_int8_f10();
+GO
+select babel_test_numeric_int8_f11();
+GO
+select babel_test_numeric_int8_f12();
+GO
+select babel_test_numeric_int8_f13();
+GO
+select babel_test_numeric_int8_f14();
+GO
+select babel_test_numeric_int8_f15();
+GO
+select babel_test_numeric_int8_f16();
+GO
+select babel_test_numeric_int8_f17();
+GO
+select babel_test_numeric_int8_f18();
+GO
+select babel_test_numeric_int8_f19();
+GO
+select babel_test_numeric_int8_f20();
+GO
+select babel_test_numeric_int8_f21();
+GO
+select babel_test_numeric_int8_f22();
+GO
+select babel_test_numeric_int8_f23();
+GO
+select babel_test_numeric_int8_f24();
+GO
+select babel_test_numeric_int8_f25();
+GO
+select babel_test_numeric_int8_f26();
+GO
+select babel_test_numeric_int8_f27();
+GO
+select babel_test_numeric_int8_f28();
+GO
+select babel_test_numeric_int8_f29();
+GO
+select babel_test_numeric_int8_f30();
+GO
+select babel_test_numeric_int8_f31();
+GO
+select babel_test_numeric_int8_f32();
+GO
+
+drop function babel_test_numeric_int8_f0;
+drop function babel_test_numeric_int8_f00;
+drop function babel_test_numeric_int8_f1;
+drop function babel_test_numeric_int8_f2;
+drop function babel_test_numeric_int8_f3;
+drop function babel_test_numeric_int8_f4;
+drop function babel_test_numeric_int8_f5;
+drop function babel_test_numeric_int8_f6;
+drop function babel_test_numeric_int8_f7;
+drop function babel_test_numeric_int8_f8;
+drop function babel_test_numeric_int8_f9;
+drop function babel_test_numeric_int8_f10;
+drop function babel_test_numeric_int8_f11;
+drop function babel_test_numeric_int8_f12;
+drop function babel_test_numeric_int8_f13;
+drop function babel_test_numeric_int8_f14;
+drop function babel_test_numeric_int8_f15;
+drop function babel_test_numeric_int8_f16;
+drop function babel_test_numeric_int8_f17;
+drop function babel_test_numeric_int8_f18;
+drop function babel_test_numeric_int8_f19;
+drop function babel_test_numeric_int8_f20;
+drop function babel_test_numeric_int8_f21;
+drop function babel_test_numeric_int8_f22;
+drop function babel_test_numeric_int8_f23;
+drop function babel_test_numeric_int8_f24;
+drop function babel_test_numeric_int8_f25;
+drop function babel_test_numeric_int8_f26;
+drop function babel_test_numeric_int8_f27;
+drop function babel_test_numeric_int8_f28;
+drop function babel_test_numeric_int8_f29;
+drop function babel_test_numeric_int8_f30;
+drop function babel_test_numeric_int8_f31;
+drop function babel_test_numeric_int8_f32;
+GO
+
+drop table babel_test_numeric_int8_vu_prepare;
+GO

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -566,3 +566,7 @@ round_return_type_test
 alter-view
 test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 babel_varbinary
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper
+

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -566,3 +566,7 @@ round_return_type_test
 alter-view
 test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 babel_varbinary
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper
+

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -577,3 +577,6 @@ BABEL-5467
 round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_17_5_or_16_9
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -592,3 +592,6 @@ BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_17_5_or_16_9
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -597,3 +597,6 @@ round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 test_like_index
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -604,3 +604,6 @@ round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 test_like_index
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -617,3 +617,6 @@ alter-view
 test_conv_int_to_varbinary_binary
 babel_varbinary
 test_like_index
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -619,3 +619,6 @@ alter-view
 test_conv_int_to_varbinary_binary
 babel_varbinary
 test_like_index
+babel_test_numeric_int2_oper
+babel_test_numeric_int4_oper
+babel_test_numeric_int8_oper


### PR DESCRIPTION
### Description

Earlier, index scan would not be chosen by the optimizer when filtering between
int and numeric types if the index was created on a numeric column. While index
scans worked when the index was on an integer column (due to existing operator 
class as part of int operator family), the reverse case wasn't supported.

This commit fixes this issue by adding a new operator class as part of the numeric 
operator family which allows the optimizer to utilize indexes on numeric columns when 
filtering with integer values, improving query performance in these scenarios.

This changes also requires engine changes (https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/578)
in order to dump these Babelfish defined operator class correctly during pg_upgrade.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Issues Resolved

Task: BABEL-5648

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).