### PR TITLE
Reimplement ISNUMERIC() function in C language to improve performance

### DIFF
--- a/contrib/babelfishpg_money/fixeddecimal.c
+++ b/contrib/babelfishpg_money/fixeddecimal.c
@@ -229,8 +229,8 @@ typedef struct FixedDecimalAggState
 
 static char *pg_int64tostr(char *str, int64 value);
 static char *pg_int64tostr_zeropad(char *str, int64 value, int64 padding);
-static void apply_typmod(int64 value, int32 typmod, int precision, int scale);
-static int64 scanfixeddecimal(const char *str, int *precision, int *scale);
+static bool apply_typmod(int64 value, int32 typmod, int precision, int scale, FunctionCallInfo *fcinfo);
+static int64 scanfixeddecimal(const char *str, int *precision, int *scale, FunctionCallInfo *fcinfo);
 static FixedDecimalAggState *makeFixedDecimalAggState(FunctionCallInfo fcinfo);
 static void fixeddecimal_accum(FixedDecimalAggState *state, int64 newval);
 static int64 int8fixeddecimal_internal(int64 arg, const char *typename);
@@ -445,7 +445,7 @@ fixeddecimal2str(int64 val, char *buffer,
  * scanfixeddecimal --- try to parse a string into a fixeddecimal.
  */
 static int64
-scanfixeddecimal(const char *str, int *precision, int *scale)
+scanfixeddecimal(const char *str, int *precision, int *scale, FunctionCallInfo *fcinfo)
 {
 	const char *ptr = str;
 	int64		integralpart = 0;
@@ -454,6 +454,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 	int			vprecision = 0;
 	int			vscale = 0;
 	bool		has_seen_sign = false;
+	Node		*escontext = (*fcinfo)->context;
 
 	/*
 	 * Do our own scan, rather than relying on sscanf which might be broken
@@ -500,7 +501,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 		 */
 		if ((*ptr >= 'a' && *ptr <= 'z') || (*ptr >= 'A' && *ptr <= 'Z'))
 		{
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("invalid characters found: cannot cast value \"%s\" to money",
 							str)));
@@ -520,7 +521,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 	{
 		if (has_seen_sign)
 		{
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("invalid characters found: cannot cast value \"%s\" to money",
 							str)));
@@ -539,7 +540,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 			vprecision++;
 			if ((tmp / 10) != integralpart) /* underflow? */
 			{
-				ereport(ERROR,
+				ereturn(escontext, (Datum) 0,
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 						 errmsg("value \"%s\" is out of range for type fixeddecimal",
 								str)));
@@ -559,7 +560,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 		{
 			if (has_seen_sign)
 			{
-				ereport(ERROR,
+				ereturn(escontext, (Datum) 0,
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 						 errmsg("invalid characters found: cannot cast value \"%s\" to money",
 								str)));
@@ -583,7 +584,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 			vprecision++;
 			if ((tmp / 10) != integralpart) /* overflow? */
 			{
-				ereport(ERROR,
+				ereturn(escontext, (Datum) 0,
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 						 errmsg("value \"%s\" is out of range for type fixeddecimal",
 								str)));
@@ -628,7 +629,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 		ptr++;
 
 	if (*ptr != '\0')
-		ereport(ERROR,
+		ereturn(escontext, (Datum) 0,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("value \"%s\" is out of range for type fixeddecimal", str)));
 
@@ -644,13 +645,13 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 		int64		multiplier = FIXEDDECIMAL_MULTIPLIER;
 
 		if (__builtin_mul_overflow(integralpart, multiplier, &value))
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%s\" is out of range for type fixeddecimal",
 							str)));
 
 		if (__builtin_sub_overflow(value, fractionalpart, &value))
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%s\" is out of range for type fixeddecimal",
 							str)));
@@ -661,7 +662,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 		if (value != 0 && (!SAMESIGN(value, integralpart) ||
 						   !SAMESIGN(value - fractionalpart, value) ||
 						   !SAMESIGN(value - fractionalpart, value)))
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%s\" is out of range for type fixeddecimal",
 							str)));
@@ -676,13 +677,13 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 
 #ifdef HAVE_BUILTIN_OVERFLOW
 		if (__builtin_mul_overflow(integralpart, FIXEDDECIMAL_MULTIPLIER, &value))
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%s\" is out of range for type fixeddecimal",
 							str)));
 
 		if (__builtin_add_overflow(value, fractionalpart, &value))
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%s\" is out of range for type fixeddecimal",
 							str)));
@@ -692,7 +693,7 @@ scanfixeddecimal(const char *str, int *precision, int *scale)
 		if (value != 0 && (!SAMESIGN(value, integralpart) ||
 						   !SAMESIGN(value - fractionalpart, value) ||
 						   !SAMESIGN(value + fractionalpart, value)))
-			ereport(ERROR,
+			ereturn(escontext, (Datum) 0,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("value \"%s\" is out of range for type fixeddecimal",
 							str)));
@@ -713,23 +714,24 @@ fixeddecimalin(PG_FUNCTION_ARGS)
 	int32		typmod = PG_GETARG_INT32(2);
 	int			precision;
 	int			scale;
-	int64		result = scanfixeddecimal(str, &precision, &scale);
+	int64		result = scanfixeddecimal(str, &precision, &scale, &fcinfo);
 
-	apply_typmod(result, typmod, precision, scale);
+	apply_typmod(result, typmod, precision, scale, &fcinfo);
 
 	PG_RETURN_INT64(result);
 }
 
-static void
-apply_typmod(int64 value, int32 typmod, int precision, int scale)
+static bool
+apply_typmod(int64 value, int32 typmod, int precision, int scale, FunctionCallInfo *fcinfo)
 {
 	int			precisionlimit;
 	int			scalelimit;
 	int			maxdigits;
+	Node			*escontext = (*fcinfo)->context;
 
 	/* Do nothing if we have a default typmod (-1) */
 	if (typmod < (int32) (VARHDRSZ))
-		return;
+		return true;
 
 	typmod -= VARHDRSZ;
 	precisionlimit = (typmod >> 16) & 0xffff;
@@ -739,13 +741,13 @@ apply_typmod(int64 value, int32 typmod, int precision, int scale)
 	if (scale > scalelimit)
 
 		if (scale != FIXEDDECIMAL_SCALE)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("FIXEDDECIMAL scale must be %d",
 							FIXEDDECIMAL_SCALE)));
 
 	if (precision > maxdigits)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("FIXEDDECIMAL field overflow"),
 				 errdetail("A field with precision %d, scale %d must round to an absolute value less than %s%d.",
@@ -754,7 +756,7 @@ apply_typmod(int64 value, int32 typmod, int precision, int scale)
 						   maxdigits ? "10^" : "",
 						   maxdigits ? maxdigits : 1
 						   )));
-
+	return true;
 }
 
 Datum
@@ -3136,7 +3138,7 @@ char_to_fixeddecimal(PG_FUNCTION_ARGS)
 	char	   *str = TextDatumGetCString(PG_GETARG_DATUM(0));
 	int			precision;
 	int			scale;
-	int64		result = scanfixeddecimal(str, &precision, &scale);
+	int64		result = scanfixeddecimal(str, &precision, &scale, &fcinfo);
 
 	PG_RETURN_INT64(result);
 }

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -196,6 +196,7 @@ PG_FUNCTION_INFO_V1(datepart_internal_real);
 PG_FUNCTION_INFO_V1(datepart_internal_money);
 PG_FUNCTION_INFO_V1(datepart_internal_smallmoney);
 PG_FUNCTION_INFO_V1(replace_special_chars_fts);
+PG_FUNCTION_INFO_V1(isnumeric);
 
 void	   *string_to_tsql_varchar(const char *input_str);
 void	   *get_servername_internal(void);
@@ -2148,6 +2149,137 @@ search_partition(PG_FUNCTION_ARGS)
 
 	PG_RETURN_INT32(result);
 }
+
+/*
+ * Structure to cache metadata needed in isnumeric().
+ */
+typedef struct IsNumericIOData
+{
+	/* For numeric type */
+	FmgrInfo	numeric_inputproc;
+	Oid		numeric_typioparam;
+	
+	/* For money type */
+	FmgrInfo	money_inputproc;
+	Oid		money_typoid;
+	Oid		money_typioparam;
+} IsNumericIOData;
+
+/*
+ * isnumeric()
+ *	Returns 1 if the input value is numeric or can be 
+ *	converted to a numeric value, and 0 otherwise.
+
+ *	It directly returns 1 for known numeric types (including TSQL types).
+ *	For other types, attempts conversion to numeric and money.
+ */
+Datum
+isnumeric(PG_FUNCTION_ARGS)
+{
+	Oid		argtypeid;
+	Oid		numeric_typiofunc;
+	Oid		money_typiofunc;
+	char		*value_str;
+	bool		result = false;
+	Datum		converted;
+	ErrorSaveContext numeric_escontext = {T_ErrorSaveContext};
+	ErrorSaveContext money_escontext = {T_ErrorSaveContext};
+	IsNumericIOData *my_extra;
+
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_INT32(0);
+
+	argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+
+	/* Sanity check. */
+	if (!OidIsValid(argtypeid))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("could not determine input data type")));
+
+	/* Fast path for known numeric types. */
+	if (argtypeid != TEXTOID)
+	{
+		if ((*common_utility_plugin_ptr->is_tsql_tinyint_datatype)(argtypeid) ||
+			(*common_utility_plugin_ptr->is_tsql_money_datatype)(argtypeid) ||
+			(*common_utility_plugin_ptr->is_tsql_smallmoney_datatype)(argtypeid) ||
+			(*common_utility_plugin_ptr->is_tsql_decimal_datatype)(argtypeid) ||
+			(*common_utility_plugin_ptr->is_tsql_fixeddecimal_datatype)(argtypeid) ||
+			(argtypeid == FLOAT4OID) || (argtypeid == FLOAT8OID) || 
+			(argtypeid == NUMERICOID) || (argtypeid == INT2OID) || 
+			(argtypeid == INT4OID) || (argtypeid == INT8OID))
+			PG_RETURN_INT32(1);
+	}
+
+	/* Get or initialize the cached data. */
+	my_extra = (IsNumericIOData *) fcinfo->flinfo->fn_extra;
+	if (my_extra == NULL)
+	{
+		fcinfo->flinfo->fn_extra = MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
+								sizeof(IsNumericIOData));
+		my_extra = (IsNumericIOData *) fcinfo->flinfo->fn_extra;
+		my_extra->money_typoid = InvalidOid;
+	}
+
+	/* Initialize the cached information for the first time. */
+	if (my_extra->money_typoid == InvalidOid)
+	{
+		/* Setup for money type. */
+		my_extra->money_typoid = (*common_utility_plugin_ptr->get_tsql_datatype_oid)("money");
+		getTypeInputInfo(my_extra->money_typoid,
+						&money_typiofunc,
+						&my_extra->money_typioparam);
+		fmgr_info_cxt(money_typiofunc,
+					  &my_extra->money_inputproc,
+					  fcinfo->flinfo->fn_mcxt);
+		
+		/* Setup for numeric type. */
+		getTypeInputInfo(NUMERICOID,
+					&numeric_typiofunc,
+					&my_extra->numeric_typioparam);
+		fmgr_info_cxt(numeric_typiofunc,
+					&my_extra->numeric_inputproc,
+					fcinfo->flinfo->fn_mcxt);
+	}
+
+	/* Get the string representation from input datum. */
+	if (argtypeid == TEXTOID)
+	{
+		value_str = text_to_cstring(PG_GETARG_TEXT_P(0));
+	}
+	else
+	{
+		Oid typoutput;
+		bool typisvarlena;
+		getTypeOutputInfo(argtypeid, &typoutput, &typisvarlena);
+		value_str = OidOutputFunctionCall(typoutput, PG_GETARG_DATUM(0));
+	}
+
+	/* Try to perform the conversion to numeric. */
+	result = InputFunctionCallSafe(&my_extra->numeric_inputproc,
+								 value_str,
+								 my_extra->numeric_typioparam,
+								 -1,
+								 (Node *) &numeric_escontext,
+								 &converted);
+
+	/* If conversion to numeric fails, try to perform the conversion to money. */
+	if (!result)
+	{
+		result = InputFunctionCallSafe(&my_extra->money_inputproc,
+									 value_str,
+									 my_extra->money_typioparam,
+									 -1,
+									 (Node *) &money_escontext,
+									 &converted);
+	}
+
+	pfree(value_str);
+	PG_RETURN_INT32(result ? 1 : 0);
+}
+
+
 
 /*
  * object_id

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -32,6 +32,7 @@
 #include "executor/spi.h"
 #include "executor/spi_priv.h"
 #include "miscadmin.h"
+#include "nodes/miscnodes.h"
 #include "parser/scansup.h"
 #include "tsearch/ts_locale.h"
 #include "utils/acl.h"

--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -756,69 +756,15 @@ LANGUAGE plpgsql
 IMMUTABLE
 RETURNS NULL ON NULL INPUT;
 
-CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr ANYELEMENT) RETURNS INTEGER AS
-$BODY$
-DECLARE 
-    x NUMERIC;
-    y MONEY;
-BEGIN
-    IF (expr IS NULL) THEN
-	    RETURN 0;
-    END IF;
-    IF ($1::VARCHAR COLLATE "C" ~ '^\s*$') THEN 
-	    RETURN 0;
-    END IF;
-    IF pg_typeof(expr) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
-    'numeric'::regtype, 'float'::regtype, 'real'::regtype, 'sys.money'::regtype)
-	THEN
-		RETURN 1;
-	END IF;
-    x = $1::NUMERIC;
-    RETURN 1;
-EXCEPTION WHEN others THEN
-    BEGIN
-        y = $1::sys.MONEY;
-        RETURN 1;
-        EXCEPTION WHEN others THEN
-            RETURN 0;
-    END;
-END;
-$BODY$
-LANGUAGE plpgsql
-STABLE CALLED ON NULL INPUT;
+CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr ANYELEMENT)
+RETURNS INTEGER AS
+'babelfishpg_tsql', 'isnumeric'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr TEXT) RETURNS INTEGER AS
-$BODY$
-DECLARE 
-    x NUMERIC;
-    y MONEY;
-BEGIN
-    IF (expr IS NULL) THEN
-	    RETURN 0;
-    END IF;
-
-    -- IF ($1::VARCHAR ~ '^\s*$') THEN 
-    IF (expr COLLATE "C" ~ '^\s*$') THEN 
-	    RETURN 0;
-    END IF;
-    IF pg_typeof(expr) IN ('bigint'::regtype, 'int'::regtype, 'smallint'::regtype,'sys.tinyint'::regtype,
-    'numeric'::regtype, 'float'::regtype, 'real'::regtype, 'sys.money'::regtype)
-	THEN
-		RETURN 1;
-	END IF;
-    x = $1::NUMERIC;
-    RETURN 1;
-EXCEPTION WHEN others THEN
-    BEGIN
-        y = $1::sys.MONEY;
-        RETURN 1;
-        EXCEPTION WHEN others THEN
-            RETURN 0;
-    END;
-END;
-$BODY$
-LANGUAGE plpgsql
-STABLE CALLED ON NULL INPUT;
+CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr TEXT)
+RETURNS INTEGER AS
+'babelfishpg_tsql', 'isnumeric'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 -- Return the object ID given the object name. Can specify optional type.
 CREATE OR REPLACE FUNCTION sys.object_id(IN object_name sys.VARCHAR, IN object_type sys.VARCHAR DEFAULT NULL)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -170,6 +170,16 @@ WHERE(pg_has_role(sys.suser_id(), 'sysadmin'::TEXT, 'MEMBER')
   AND Ext.type = 'S';
 GRANT SELECT ON sys.sql_logins TO PUBLIC;
 
+CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr ANYELEMENT)
+RETURNS INTEGER AS
+'babelfishpg_tsql', 'isnumeric'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr TEXT)
+RETURNS INTEGER AS
+'babelfishpg_tsql', 'isnumeric'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/expected/BABEL-5129-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5129-vu-verify.out
@@ -115,7 +115,7 @@ SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
 GO
 ~~START~~
 int#!#int#!#int
-0#!#0#!#0
+1#!#0#!#0
 ~~END~~
 
 
@@ -126,7 +126,7 @@ SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
 GO
 ~~START~~
 int#!#int#!#int
-0#!#0#!#0
+1#!#0#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_isnumeric-vu-verify.out
+++ b/test/JDBC/expected/babel_isnumeric-vu-verify.out
@@ -229,7 +229,7 @@ select isnumeric(' ')
 GO
 ~~START~~
 int
-0
+1
 ~~END~~
 
 select isnumeric('1 .1234')
@@ -251,5 +251,474 @@ GO
 ~~START~~
 int
 0
+~~END~~
+
+
+-- Test different datatypes as local variables
+DECLARE @int_var int = 12345
+select isnumeric(@int_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @bigint_var bigint = 9223372036854775807
+select isnumeric(@bigint_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @smallint_var smallint = -32768
+select isnumeric(@smallint_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @tinyint_var tinyint = 255
+select isnumeric(@tinyint_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @bit_var bit = 1
+select isnumeric(@bit_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @decimal_var decimal(10,5) = 12345.67890
+select isnumeric(@decimal_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @numeric_var numeric(18,9) = 123456789.987654321
+select isnumeric(@numeric_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @float_var float = 1.79E+308
+select isnumeric(@float_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @real_var real = 3.40E+38
+select isnumeric(@real_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @money_var money = 922337203685477.5807
+select isnumeric(@money_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @smallmoney_var smallmoney = 214748.3647
+select isnumeric(@smallmoney_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @char_var char(20) = '12345.6789'
+select isnumeric(@char_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @varchar_var varchar(50) = '$1,234,567.89'
+select isnumeric(@varchar_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @nchar_var nchar(20) = N'12345.6789'
+select isnumeric(@nchar_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @nvarchar_var nvarchar(50) = N'-9876.54321'
+select isnumeric(@nvarchar_var)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @datetime_var datetime = '2023-01-01 12:34:56'
+select isnumeric(@datetime_var)
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DECLARE @date_var date = '2023-01-01'
+select isnumeric(@date_var)
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test text values exceeding numeric(38,0)
+select isnumeric('9999999999999999999999999999999999999999')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('10000000000000000000000000000000000000000')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('-9999999999999999999999999999999999999999')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('999999999999999999999999999999999999999.99999')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('1' + REPLICATE('0', 38))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('1' + REPLICATE('0', 100))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('0.' + REPLICATE('9', 38))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('1E+38')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('1E+100')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('1E-100')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test invalid conversions to numeric
+select isnumeric('abc')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('123abc')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('abc123')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('12.34.56')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('12,34,56')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('$123$456')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('123..456')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('++123')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('--123')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('+-123')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('123-')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('123+')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('123.456.789')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('1,23,456')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('1.2e3.4')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('1.2e')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('e1.2')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('1.2D')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+select isnumeric('€')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('¥')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric('£')
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test expressions with mixed valid/invalid inputs
+select isnumeric('123' + 'abc')
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DECLARE @valid varchar(10) = '123', @invalid varchar(10) = 'abc'
+select isnumeric(@valid + @invalid)
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+DECLARE @overflow varchar(50) = '1' + REPLICATE('0', 38)
+select isnumeric(@overflow)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test with expressions that might cause overflow
+DECLARE @big_decimal decimal(38,0) = 99999999999999999999999999999999999999
+select isnumeric(@big_decimal)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @big_float float = 1.79E+308
+select isnumeric(@big_float)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test with CAST that might cause overflow
+select isnumeric(CAST(1.79E+308 AS varchar(50)))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test with computed expressions
+select isnumeric(CAST(POWER(10, 3) AS varchar(50)))
+GO
+~~START~~
+int
+1
 ~~END~~
 

--- a/test/JDBC/expected/parallel_query/babel_isnumeric.out
+++ b/test/JDBC/expected/parallel_query/babel_isnumeric.out
@@ -412,10 +412,14 @@ text
 Query Text: SELECT count(*)
 FROM babel_isnumeric_test
 WHERE isnumeric(val) = 1
-Aggregate (actual rows=1 loops=1)
-  ->  Seq Scan on babel_isnumeric_test (actual rows=4000 loops=1)
-        Filter: (isnumeric(val) = 1)
-        Rows Removed by Filter: 2000
+Finalize Aggregate (actual rows=1 loops=1)
+  ->  Gather (actual rows=5 loops=1)
+        Workers Planned: 4
+        Workers Launched: 4
+        ->  Partial Aggregate (actual rows=1 loops=5)
+              ->  Parallel Seq Scan on babel_isnumeric_test (actual rows=800 loops=5)
+                    Filter: (isnumeric(val) = 1)
+                    Rows Removed by Filter: 400
 ~~END~~
 
 

--- a/test/JDBC/input/babel_isnumeric-vu-verify.sql
+++ b/test/JDBC/input/babel_isnumeric-vu-verify.sql
@@ -93,3 +93,197 @@ select isnumeric('+1 .1234')
 GO
 select isnumeric('$1 .1234')
 GO
+
+-- Test different datatypes as local variables
+DECLARE @int_var int = 12345
+select isnumeric(@int_var)
+GO
+
+DECLARE @bigint_var bigint = 9223372036854775807
+select isnumeric(@bigint_var)
+GO
+
+DECLARE @smallint_var smallint = -32768
+select isnumeric(@smallint_var)
+GO
+
+DECLARE @tinyint_var tinyint = 255
+select isnumeric(@tinyint_var)
+GO
+
+DECLARE @bit_var bit = 1
+select isnumeric(@bit_var)
+GO
+
+DECLARE @decimal_var decimal(10,5) = 12345.67890
+select isnumeric(@decimal_var)
+GO
+
+DECLARE @numeric_var numeric(18,9) = 123456789.987654321
+select isnumeric(@numeric_var)
+GO
+
+DECLARE @float_var float = 1.79E+308
+select isnumeric(@float_var)
+GO
+
+DECLARE @real_var real = 3.40E+38
+select isnumeric(@real_var)
+GO
+
+DECLARE @money_var money = 922337203685477.5807
+select isnumeric(@money_var)
+GO
+
+DECLARE @smallmoney_var smallmoney = 214748.3647
+select isnumeric(@smallmoney_var)
+GO
+
+DECLARE @char_var char(20) = '12345.6789'
+select isnumeric(@char_var)
+GO
+
+DECLARE @varchar_var varchar(50) = '$1,234,567.89'
+select isnumeric(@varchar_var)
+GO
+
+DECLARE @nchar_var nchar(20) = N'12345.6789'
+select isnumeric(@nchar_var)
+GO
+
+DECLARE @nvarchar_var nvarchar(50) = N'-9876.54321'
+select isnumeric(@nvarchar_var)
+GO
+
+DECLARE @datetime_var datetime = '2023-01-01 12:34:56'
+select isnumeric(@datetime_var)
+GO
+
+DECLARE @date_var date = '2023-01-01'
+select isnumeric(@date_var)
+GO
+
+-- Test text values exceeding numeric(38,0)
+select isnumeric('9999999999999999999999999999999999999999')
+GO
+
+select isnumeric('10000000000000000000000000000000000000000')
+GO
+
+select isnumeric('-9999999999999999999999999999999999999999')
+GO
+
+select isnumeric('999999999999999999999999999999999999999.99999')
+GO
+
+select isnumeric('1' + REPLICATE('0', 38))
+GO
+
+select isnumeric('1' + REPLICATE('0', 100))
+GO
+
+select isnumeric('0.' + REPLICATE('9', 38))
+GO
+
+select isnumeric('1E+38')
+GO
+
+select isnumeric('1E+100')
+GO
+
+select isnumeric('1E-100')
+GO
+
+-- Test invalid conversions to numeric
+select isnumeric('abc')
+GO
+
+select isnumeric('123abc')
+GO
+
+select isnumeric('abc123')
+GO
+
+select isnumeric('12.34.56')
+GO
+
+select isnumeric('12,34,56')
+GO
+
+select isnumeric('$123$456')
+GO
+
+select isnumeric('123..456')
+GO
+
+select isnumeric('++123')
+GO
+
+select isnumeric('--123')
+GO
+
+select isnumeric('+-123')
+GO
+
+select isnumeric('123-')
+GO
+
+select isnumeric('123+')
+GO
+
+select isnumeric('123.456.789')
+GO
+
+select isnumeric('1,23,456')
+GO
+
+select isnumeric('1.2e3.4')
+GO
+
+select isnumeric('1.2e')
+GO
+
+select isnumeric('e1.2')
+GO
+
+select isnumeric('1.2D')
+GO
+
+
+select isnumeric('€')
+GO
+
+select isnumeric('¥')
+GO
+
+select isnumeric('£')
+GO
+
+-- Test expressions with mixed valid/invalid inputs
+select isnumeric('123' + 'abc')
+GO
+
+DECLARE @valid varchar(10) = '123', @invalid varchar(10) = 'abc'
+select isnumeric(@valid + @invalid)
+GO
+
+DECLARE @overflow varchar(50) = '1' + REPLICATE('0', 38)
+select isnumeric(@overflow)
+GO
+
+-- Test with expressions that might cause overflow
+DECLARE @big_decimal decimal(38,0) = 99999999999999999999999999999999999999
+select isnumeric(@big_decimal)
+GO
+
+DECLARE @big_float float = 1.79E+308
+select isnumeric(@big_float)
+GO
+
+-- Test with CAST that might cause overflow
+select isnumeric(CAST(1.79E+308 AS varchar(50)))
+GO
+
+-- Test with computed expressions
+select isnumeric(CAST(POWER(10, 3) AS varchar(50)))
+GO

--- a/test/JDBC/input/babel_isnumeric.sql
+++ b/test/JDBC/input/babel_isnumeric.sql
@@ -1,3 +1,4 @@
+-- parallel_query_expected
 --
 -- Tests for ISNUMERIC function
 --
@@ -145,4 +146,74 @@ GO
 select isnumeric('+1 .1234')
 GO
 select isnumeric('$1 .1234')
+GO
+
+-- Create the table
+CREATE TABLE babel_isnumeric_test (
+    id int IDENTITY(1,1),
+    val varchar(100)
+);
+GO
+
+-- Insert decimal numbers
+INSERT INTO babel_isnumeric_test (val)
+SELECT CAST(RAND() as varchar(100))
+FROM generate_series(1, 1000);
+GO
+
+-- Insert integers
+INSERT INTO babel_isnumeric_test (val)
+SELECT CAST(CAST((RAND() * 1000000) as int) as varchar(100))
+FROM generate_series(1, 1000);
+GO
+
+-- Insert money format
+INSERT INTO babel_isnumeric_test (val)
+SELECT '$' + CAST(CAST((RAND() * 1000) as decimal(10,2)) as varchar(100))
+FROM generate_series(1, 1000);
+GO
+
+-- Insert alphanumeric
+INSERT INTO babel_isnumeric_test (val)
+SELECT 'abc' + CAST(CAST((RAND() * 100) as int) as varchar(100))
+FROM generate_series(1, 1000);
+GO
+
+-- Insert scientific notation
+INSERT INTO babel_isnumeric_test (val)
+SELECT '1E' + CAST(CAST((RAND() * 10) as int) as varchar(100))
+FROM generate_series(1, 1000);
+GO
+
+-- Insert plain text
+INSERT INTO babel_isnumeric_test (val)
+SELECT 'not a number'
+FROM generate_series(1, 1000);
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'off', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'off', false)
+SELECT set_config('babelfishpg_tsql.memory', 'off', false)
+GO
+SET BABELFISH_STATISTICS PROFILE ON
+GO
+
+SELECT count(*)
+FROM babel_isnumeric_test
+WHERE isnumeric(val) = 1
+GO
+
+SET BABELFISH_STATISTICS PROFILE OFF
+GO
+
+SELECT set_config('babelfishpg_tsql.explain_verbose', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_timing', 'on', false)
+SELECT set_config('babelfishpg_tsql.explain_summary', 'on', false)
+SELECT set_config('babelfishpg_tsql.memory', 'on', false)
+GO
+
+DROP TABLE babel_isnumeric_test
 GO


### PR DESCRIPTION
### Description
To improve the performance of queries with ISNUMERIC() predicates, this commit 
reimplements the ISNUMERIC() function from PL/pgSQL to C language. The new implementation 
uses InputFunctionCallSafe for safer and more efficient type checking and conversion. 


Additionally, the money data type's input function has been updated to report 
invalid input as a "soft" error for InputFunctionCallSafe, avoiding unnecessary transaction aborts. 
This commit also changes the ISNUMERIC() function attributes to IMMUTABLE and 
PARALLEL SAFE for better query optimization opportunities.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>



### Issues Resolved

Task : BABEL-5696



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).