### PR TITLE
Add test cases to verify permission denied for updating system catalogs

### DIFF
--- a/test/JDBC/expected/BABEL-3040.out
+++ b/test/JDBC/expected/BABEL-3040.out
@@ -1,0 +1,227 @@
+-- psql user=jdbc_user password=12345678
+-- setup
+drop user if exists psql_user;
+GO
+
+create user psql_user with password '12345678' createdb;
+GO
+
+-- psql user=jdbc_user password=12345678
+-- Verify sys catalog can be altered wiht super user
+drop table sys.babelfish_sysdatabases;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied: "babelfish_sysdatabases" is a system catalog
+    Server SQLState: 42501)~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_sysdatabases set name = name;
+GO
+~~ROW COUNT: 3~~
+
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_authid_login_ext;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied: "babelfish_authid_login_ext" is a system catalog
+    Server SQLState: 42501)~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_authid_login_ext set is_disabled = is_disabled;
+GO
+~~ROW COUNT: 5~~
+
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_authid_user_ext;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied: "babelfish_authid_user_ext" is a system catalog
+    Server SQLState: 42501)~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_authid_user_ext set database_name = database_name;
+GO
+~~ROW COUNT: 24~~
+
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_configurations;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied: "babelfish_configurations" is a system catalog
+    Server SQLState: 42501)~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_configurations set value = value;
+GO
+~~ROW COUNT: 7~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_db_seq set last_value = last_value;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: cannot change sequence "babelfish_db_seq"
+    Server SQLState: 42809)~~
+
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_helpcollation
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied: "babelfish_helpcollation" is a system catalog
+    Server SQLState: 42501)~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_helpcollation set name = name;
+GO
+~~ROW COUNT: 141~~
+
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_namespace_ext
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied: "babelfish_namespace_ext" is a system catalog
+    Server SQLState: 42501)~~
+
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_namespace_ext set orig_name = orig_name;
+GO
+~~ROW COUNT: 6~~
+
+
+
+-- psql user=psql_user password=12345678
+-- Verify sys catalogs cannot be altered with non super user
+drop table sys.babelfish_sysdatabases;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must be owner of table babelfish_sysdatabases
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_sysdatabases set name = name;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table babelfish_sysdatabases
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_authid_login_ext set;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: syntax error at or near "set"
+  Position: 43
+    Server SQLState: 42601)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_authid_login_ext set is_disabled = is_disabled;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table babelfish_authid_login_ext
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_authid_user_ext;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must be owner of table babelfish_authid_user_ext
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_authid_user_ext set database_name = database_name;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table babelfish_authid_user_ext
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_configurations;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must be owner of table babelfish_configurations
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_configurations set value = value;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table babelfish_configurations
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_db_seq set last_value = last_value;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for sequence babelfish_db_seq
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_helpcollation
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must be owner of table babelfish_helpcollation
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_helpcollation set name = name;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table babelfish_helpcollation
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_namespace_ext
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: must be owner of table babelfish_namespace_ext
+    Server SQLState: 42501)~~
+
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_namespace_ext set orig_name = orig_name;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied for table babelfish_namespace_ext
+    Server SQLState: 42501)~~
+

--- a/test/JDBC/input/BABEL-3040.mix
+++ b/test/JDBC/input/BABEL-3040.mix
@@ -1,0 +1,114 @@
+-- psql user=jdbc_user password=12345678
+-- setup
+drop user if exists psql_user;
+GO
+
+create user psql_user with password '12345678' createdb;
+GO
+
+-- Verify sys catalog can be altered wiht super user
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_sysdatabases;
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_sysdatabases set name = name;
+GO
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_authid_login_ext;
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_authid_login_ext set is_disabled = is_disabled;
+GO
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_authid_user_ext;
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_authid_user_ext set database_name = database_name;
+GO
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_configurations;
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_configurations set value = value;
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_db_seq set last_value = last_value;
+GO
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_helpcollation
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_helpcollation set name = name;
+GO
+
+-- psql user=jdbc_user password=12345678
+drop table sys.babelfish_namespace_ext
+GO
+
+-- psql user=jdbc_user password=12345678
+update sys.babelfish_namespace_ext set orig_name = orig_name;
+GO
+
+
+-- Verify sys catalogs cannot be altered with non super user
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_sysdatabases;
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_sysdatabases set name = name;
+GO
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_authid_login_ext set;
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_authid_login_ext set is_disabled = is_disabled;
+GO
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_authid_user_ext;
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_authid_user_ext set database_name = database_name;
+GO
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_configurations;
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_configurations set value = value;
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_db_seq set last_value = last_value;
+GO
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_helpcollation
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_helpcollation set name = name;
+GO
+
+-- psql user=psql_user password=12345678
+drop table sys.babelfish_namespace_ext
+GO
+
+-- psql user=psql_user password=12345678
+update sys.babelfish_namespace_ext set orig_name = orig_name;
+GO


### PR DESCRIPTION
### Description
Modifying the Babelfish system catalogs could corrupt Babelfish instance. Only user with super user privileges can modify the system catalog. Adding tests to validate non super users shouldn't be allowed to modify Babelfish system catalogs.

### Issues Resolved
BABEL-3040

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).