### PR TITLE
Use Index Scan for EXACT and PREFIX pattern matches for LIKE for Const node inside CollateExpr

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -339,7 +339,7 @@ static Node *
 optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_info_t coll_info_of_inputcollid, bool is_constraint)
 {
 	Node	   *leftop = copyObject(linitial(op->args));
-	Node	   *rightop = (Node *) lsecond(op->args);
+	Node	   *rightop = copyObject(lsecond(op->args));
 	Oid			ltypeId = exprType(leftop);
 	Oid			rtypeId = exprType(rightop);
 	char	   *op_str;
@@ -884,15 +884,7 @@ convert_node_to_funcexpr_for_like(Node *node, Oid inputcollid)
 					if (con->constisnull)
 						return new_node;
 
-					#ifdef USE_ICU
-						if (U_ICU_VERSION_MAJOR_NUM == pltsql_remove_accent_map_icu_major_version && U_ICU_VERSION_MINOR_NUM == pltsql_remove_accent_map_icu_min_version)
-						{
-							con->constvalue = DirectFunctionCall1(remove_accents_internal_using_cache, con->constvalue);
-							con->constcollid = InvalidOid;
-							return (Node *) con;
-						}
-					#endif
-					con->constvalue = DirectFunctionCall1(remove_accents_internal, con->constvalue);
+					con->constvalue = OidFunctionCall1(remove_accents_internal_oid, con->constvalue);
 					con->constcollid = InvalidOid;
 					return (Node *) con;
 				}
@@ -949,15 +941,8 @@ convert_node_to_funcexpr_for_like(Node *node, Oid inputcollid)
 						constnode = (Const *) new_node;
 						if (constnode->constisnull)
 							return new_node;
-						#ifdef USE_ICU
-							if (U_ICU_VERSION_MAJOR_NUM == pltsql_remove_accent_map_icu_major_version && U_ICU_VERSION_MINOR_NUM == pltsql_remove_accent_map_icu_min_version)
-							{
-								constnode->constvalue = DirectFunctionCall1(remove_accents_internal_using_cache, constnode->constvalue);
-								constnode->constcollid = InvalidOid;
-								return (Node *) constnode;
-							}
-						#endif
-						constnode->constvalue = DirectFunctionCall1(remove_accents_internal, constnode->constvalue);
+
+						constnode->constvalue = OidFunctionCall1(remove_accents_internal_oid, constnode->constvalue);
 						constnode->constcollid = InvalidOid;
 						return (Node *) constnode;
 					}

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -386,6 +386,20 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 		op->opfuncid = like_entry.ilike_opfuncid;
 	}
 	
+	op->inputcollid = tsql_get_oid_from_collidx(collidx_of_cs_as);
+
+
+	/* Remove CollateExpr as the op->inputcollid has already been set */
+	if (IsA(rightop, CollateExpr))
+	{
+		lsecond(op->args) = rightop = (Node*)((CollateExpr*) rightop)->arg;
+	}
+
+	if (IsA(leftop, CollateExpr))
+	{
+		linitial(op->args) = leftop = (Node*)((CollateExpr*) leftop)->arg;
+	}
+
 	/* 
 	 * This is needed to process CI_AI for Const nodes
 	 * Because after we call coerce_to_target_type for type conversion in transform_likenode_for_AI,
@@ -401,7 +415,6 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 			rightop = (Node *) lsecond(op->args);
 		}
 	}
-	op->inputcollid = tsql_get_oid_from_collidx(collidx_of_cs_as);
 
 	/* 
 	 * no constant prefix found in pattern, or pattern is not constant 
@@ -870,7 +883,17 @@ convert_node_to_funcexpr_for_like(Node *node, Oid inputcollid)
 					con = (Const *) new_node;
 					if (con->constisnull)
 						return new_node;
+
+					#ifdef USE_ICU
+						if (U_ICU_VERSION_MAJOR_NUM == pltsql_remove_accent_map_icu_major_version && U_ICU_VERSION_MINOR_NUM == pltsql_remove_accent_map_icu_min_version)
+						{
+							con->constvalue = DirectFunctionCall1(remove_accents_internal_using_cache, con->constvalue);
+							con->constcollid = InvalidOid;
+							return (Node *) con;
+						}
+					#endif
 					con->constvalue = DirectFunctionCall1(remove_accents_internal, con->constvalue);
+					con->constcollid = InvalidOid;
 					return (Node *) con;
 				}
 				else
@@ -887,7 +910,6 @@ convert_node_to_funcexpr_for_like(Node *node, Oid inputcollid)
 		case T_CaseExpr:
 		case T_RelabelType:
 		case T_CoerceViaIO:
-		case T_CollateExpr:
 			{
 				new_node = coerce_to_target_type(NULL, (Node *) node, exprType(node),
 													TEXTOID, -1,
@@ -901,6 +923,67 @@ convert_node_to_funcexpr_for_like(Node *node, Oid inputcollid)
 								errmsg("Could not type cast the input argument of LIKE operator to desired data type")));
 				}
 				newFuncExpr->args = list_make1(new_node);
+				break;
+			}
+		case T_CollateExpr:
+			{
+				CollateExpr *collateexpr = (CollateExpr*) node;
+				if (IsA(collateexpr->arg, Const))
+				{
+					Const *constnode = (Const*) (collateexpr->arg);
+					constnode->constcollid = collateexpr->collOid;
+					new_node = coerce_to_target_type(NULL, (Node *) constnode, exprType((Node *)constnode),
+													TEXTOID, -1,
+													COERCION_EXPLICIT,
+													COERCE_EXPLICIT_CAST,
+													exprLocation(node));
+					if (unlikely(new_node == NULL))
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_INTERNAL_ERROR),
+									errmsg("Could not type cast the input argument of LIKE operator to desired data type")));
+					}
+
+					if (IsA(new_node, Const))
+					{
+						constnode = (Const *) new_node;
+						if (constnode->constisnull)
+							return new_node;
+						#ifdef USE_ICU
+							if (U_ICU_VERSION_MAJOR_NUM == pltsql_remove_accent_map_icu_major_version && U_ICU_VERSION_MINOR_NUM == pltsql_remove_accent_map_icu_min_version)
+							{
+								constnode->constvalue = DirectFunctionCall1(remove_accents_internal_using_cache, constnode->constvalue);
+								constnode->constcollid = InvalidOid;
+								return (Node *) constnode;
+							}
+						#endif
+						constnode->constvalue = DirectFunctionCall1(remove_accents_internal, constnode->constvalue);
+						constnode->constcollid = InvalidOid;
+						return (Node *) constnode;
+					}
+					else
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_INTERNAL_ERROR),
+								errmsg("Could not convert Const node to desired node type")));
+					}
+				}
+				else
+				{
+					new_node = coerce_to_target_type(NULL, (Node *) node, exprType(node),
+													TEXTOID, -1,
+													COERCION_EXPLICIT,
+													COERCE_EXPLICIT_CAST,
+													exprLocation(node));
+					if (unlikely(new_node == NULL))
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_INTERNAL_ERROR),
+									errmsg("Could not type cast the input argument of LIKE operator to desired data type")));
+					}
+					newFuncExpr->args = list_make1(new_node);
+					break;
+				}
 				break;
 			}
 		case T_SubLink:
@@ -1111,9 +1194,14 @@ pltsql_predicate_transformer(Node *expr, bool is_constraint)
 			}
 			else if (IsA(qual, OpExpr))
 			{
-				qual = transform_likenode(qual, is_constraint);
-				new_predicates = lappend(new_predicates,
-										 expression_tree_mutator(qual, pgtsql_expression_tree_mutator, NULL));
+				Node *ret = transform_likenode(qual, is_constraint);
+				if (qual == ret)
+					/* If it's not a like Opexpr, then walk through args */
+					new_predicates = lappend(new_predicates,
+						expression_tree_mutator(qual, pgtsql_expression_tree_mutator, NULL));
+				else 
+					/* Singleton predicate */
+					new_predicates = lappend(new_predicates, ret);
 			}
 			else
 				new_predicates = lappend(new_predicates, qual);

--- a/test/JDBC/expected/babel_collection.out
+++ b/test/JDBC/expected/babel_collection.out
@@ -191,7 +191,7 @@ Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 6.623 ms
+Babelfish T-SQL Batch Parsing Time: 0.154 ms
 ~~END~~
 
 
@@ -209,7 +209,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
 ~~END~~
 
 
@@ -227,7 +227,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.133 ms
 ~~END~~
 
 
@@ -243,7 +243,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.132 ms
 ~~END~~
 
 
@@ -259,7 +259,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.130 ms
 ~~END~~
 
 
@@ -278,7 +278,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.149 ms
+Babelfish T-SQL Batch Parsing Time: 0.135 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -295,7 +295,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -312,7 +312,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.147 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -329,7 +329,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.990 ms
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
 ~~END~~
 
 
@@ -345,7 +345,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.201 ms
+Babelfish T-SQL Batch Parsing Time: 0.134 ms
 ~~END~~
 
 
@@ -361,7 +361,7 @@ Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.208 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 
@@ -381,7 +381,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.148 ms
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
 ~~END~~
 
 
@@ -399,7 +399,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.133 ms
 ~~END~~
 
 
@@ -531,7 +531,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.124 ms
+Babelfish T-SQL Batch Parsing Time: 0.122 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -572,7 +572,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.120 ms
+Babelfish T-SQL Batch Parsing Time: 0.118 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -596,7 +596,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.166 ms
+Babelfish T-SQL Batch Parsing Time: 0.118 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -618,12 +618,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE French_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE french_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.151 ms
+Babelfish T-SQL Batch Parsing Time: 0.135 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -644,12 +644,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE Chinese_PRC_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text COLLATE chinese_prc_ci_as) AND ((c1)::text < 'jo?'::text COLLATE chinese_prc_ci_as))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE chinese_prc_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE chinese_prc_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.135 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/babel_collection.out
+++ b/test/JDBC/expected/db_collation/babel_collection.out
@@ -190,7 +190,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=3 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 6.300 ms
+Babelfish T-SQL Batch Parsing Time: 0.170 ms
 ~~END~~
 
 
@@ -206,7 +206,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.147 ms
 ~~END~~
 
 
@@ -222,7 +222,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.130 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -238,7 +238,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.127 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -254,7 +254,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..31.16 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -271,7 +271,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.146 ms
+Babelfish T-SQL Batch Parsing Time: 0.151 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -286,7 +286,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.152 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -301,7 +301,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.159 ms
 ~~END~~
 
 
@@ -318,7 +318,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.990 ms
+Babelfish T-SQL Batch Parsing Time: 0.152 ms
 ~~END~~
 
 
@@ -334,7 +334,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..37.81 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.183 ms
 ~~END~~
 
 
@@ -350,7 +350,7 @@ Bitmap Heap Scan on testing4  (cost=11.49..37.74 rows=361 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.200 ms
+Babelfish T-SQL Batch Parsing Time: 0.151 ms
 ~~END~~
 
 
@@ -368,7 +368,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.210 ms
+Babelfish T-SQL Batch Parsing Time: 0.138 ms
 ~~END~~
 
 
@@ -384,7 +384,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.182 ms
+Babelfish T-SQL Batch Parsing Time: 0.131 ms
 ~~END~~
 
 
@@ -515,7 +515,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.119 ms
+Babelfish T-SQL Batch Parsing Time: 0.132 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -556,7 +556,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.118 ms
+Babelfish T-SQL Batch Parsing Time: 0.128 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -580,7 +580,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.118 ms
+Babelfish T-SQL Batch Parsing Time: 0.129 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -602,12 +602,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE French_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE french_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.166 ms
+Babelfish T-SQL Batch Parsing Time: 0.145 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -628,12 +628,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE Chinese_PRC_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text COLLATE chinese_prc_ci_as) AND ((c1)::text < 'jo?'::text COLLATE chinese_prc_ci_as))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE chinese_prc_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE chinese_prc_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.147 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/db_collation/test_constraint_like-vu-prepare.out
@@ -236,7 +236,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -245,7 +245,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -254,7 +254,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -280,7 +280,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -288,7 +288,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -323,7 +323,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -331,7 +331,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -388,7 +388,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -396,7 +396,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -405,7 +405,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_constraint_like-vu-verify.out
@@ -521,7 +521,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -530,7 +530,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -539,7 +539,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -565,7 +565,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -573,7 +573,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -608,7 +608,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -616,7 +616,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -673,7 +673,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -681,7 +681,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -690,7 +690,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_like_index-vu-verify.out
@@ -177,6 +177,144 @@ Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_csas_col2 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col2 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csas_col 
@@ -194,7 +332,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_v_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -215,7 +353,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_v_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -295,6 +433,76 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
+        Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304
+              Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -448,6 +656,144 @@ Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_cias_col2 >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col2 < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_cias_col 
@@ -465,7 +811,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_v_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -486,7 +832,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -566,6 +912,76 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
+        Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133
+              Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -716,6 +1132,141 @@ Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csai_col 
@@ -834,6 +1385,77 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -984,6 +1606,141 @@ Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) < 'ciai999?'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) < 'ciai999?'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_ciai_col 
@@ -1095,6 +1852,79 @@ text
 Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
@@ -1251,6 +2081,139 @@ Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f871246
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col2 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col2 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csas_col 
@@ -1259,6 +2222,7 @@ WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'c
 GO
 ~~START~~
 char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1266,9 +2230,9 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
-Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0 loops=1)
-  Filter: ((test_like_index_vu_prepare_c_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
-  Rows Removed by Filter: 1000
+Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Rows Removed by Filter: 999
 ~~END~~
 
 
@@ -1288,7 +2252,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_c_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1366,6 +2330,74 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -1514,6 +2546,139 @@ Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6c
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col2 >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col2 < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_cias_col 
@@ -1522,6 +2687,7 @@ WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'c
 GO
 ~~START~~
 char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1529,9 +2695,9 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0 loops=1)
-  Filter: ((test_like_index_vu_prepare_c_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-  Rows Removed by Filter: 1000
+Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Rows Removed by Filter: 999
 ~~END~~
 
 
@@ -1551,7 +2717,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1629,6 +2795,74 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -1773,6 +3007,135 @@ Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csai_col 
@@ -1889,6 +3252,75 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -2033,6 +3465,135 @@ Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) < 'ciai999?'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) < 'ciai999?'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_ciai_col 
@@ -2144,6 +3705,77 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
@@ -2304,6 +3936,144 @@ Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col2 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csas_col 
@@ -2321,7 +4091,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2342,7 +4112,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_nv_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2422,6 +4192,76 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
+        Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48
+              Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -2576,6 +4416,144 @@ Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b79
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col2 < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_cias_col 
@@ -2593,7 +4571,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2614,7 +4592,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2694,6 +4672,76 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
+        Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9
+              Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -2844,6 +4892,141 @@ Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_i
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csai_col 
@@ -2962,6 +5145,77 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -3112,6 +5366,141 @@ Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_i
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) < 'ciai999?'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) < 'ciai999?'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_ciai_col 
@@ -3224,6 +5613,79 @@ text
 Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
@@ -3379,6 +5841,139 @@ Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col2 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csas_col 
@@ -3396,7 +5991,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3417,7 +6012,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_t_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3495,6 +6090,74 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -3643,6 +6306,139 @@ Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col2 >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col2 < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_cias_col 
@@ -3660,7 +6456,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3681,7 +6477,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3759,6 +6555,74 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -3909,6 +6773,141 @@ Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csai_col 
@@ -4027,6 +7026,77 @@ Nested Loop
         Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
               Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_csai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -4177,6 +7247,141 @@ Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) < 'ciai999?'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) < 'ciai999?'::nvarchar))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_ciai_col 
@@ -4289,6 +7494,79 @@ text
 Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_common_idx_ai
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar))

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
@@ -468,9 +468,8 @@ Select * from testing4 where c3 LIKE (select c3 from testing4 where c3 NOT LIKE'
 GO
 ~~START~~
 varchar#!#char#!#nvarchar
-~~ERROR (Code: 512)~~
-
-~~ERROR (Message: more than one row returned by a subquery used as an expression)~~
+abcD#!#AbcD                #!#ABCd
+~~END~~
 
 with p1 as (select c1 from testing4 where c1 LIKE '__Ć_'),
 p2 as (select c3 from testing4 where c3 LIKE 'äƀ__')

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
@@ -191,7 +191,7 @@ Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 6.932 ms
+Babelfish T-SQL Batch Parsing Time: 0.170 ms
 ~~END~~
 
 
@@ -209,7 +209,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.195 ms
 ~~END~~
 
 
@@ -227,7 +227,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.150 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 
@@ -243,7 +243,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.162 ms
 ~~END~~
 
 
@@ -259,7 +259,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.195 ms
 ~~END~~
 
 
@@ -295,7 +295,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -312,7 +312,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.145 ms
 ~~END~~
 
 
@@ -329,7 +329,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 1.047 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 
@@ -345,7 +345,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.132 ms
+Babelfish T-SQL Batch Parsing Time: 0.196 ms
 ~~END~~
 
 
@@ -361,7 +361,7 @@ Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -381,7 +381,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
 ~~END~~
 
 
@@ -399,7 +399,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.129 ms
+Babelfish T-SQL Batch Parsing Time: 0.133 ms
 ~~END~~
 
 
@@ -468,8 +468,9 @@ Select * from testing4 where c3 LIKE (select c3 from testing4 where c3 NOT LIKE'
 GO
 ~~START~~
 varchar#!#char#!#nvarchar
-abcD#!#AbcD                #!#ABCd
-~~END~~
+~~ERROR (Code: 512)~~
+
+~~ERROR (Message: more than one row returned by a subquery used as an expression)~~
 
 with p1 as (select c1 from testing4 where c1 LIKE '__Ć_'),
 p2 as (select c3 from testing4 where c3 LIKE 'äƀ__')
@@ -529,7 +530,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.119 ms
+Babelfish T-SQL Batch Parsing Time: 0.121 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -570,7 +571,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.117 ms
+Babelfish T-SQL Batch Parsing Time: 0.135 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -594,7 +595,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.119 ms
+Babelfish T-SQL Batch Parsing Time: 0.118 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -616,12 +617,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE French_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE french_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -642,12 +643,12 @@ GO
 text
 Query Text: SELECT * FROM testing5 where c1 COLLATE Chinese_PRC_CI_AS like 'jo%'
 Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text) AND ((c1)::text < 'jo?'::text))
+  Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND (c1 >= 'jo'::"varchar") AND (c1 < 'jo?'::"varchar"))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
@@ -236,7 +236,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -245,7 +245,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -254,7 +254,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -280,7 +280,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -288,7 +288,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -323,7 +323,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -331,7 +331,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -388,7 +388,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -396,7 +396,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -405,7 +405,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
@@ -521,7 +521,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -530,7 +530,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -539,7 +539,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -565,7 +565,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -573,7 +573,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -608,7 +608,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -616,7 +616,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -673,7 +673,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -681,7 +681,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -690,7 +690,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_like_index-vu-verify.out
@@ -177,6 +177,144 @@ Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_csas_col2 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col2 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csas_col 
@@ -194,7 +332,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_v_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -215,7 +353,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_v_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -295,6 +433,76 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
+        Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304
+              Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -448,6 +656,144 @@ Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_cias_col2 >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col2 < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_cias_col 
@@ -465,7 +811,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_v_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -486,7 +832,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -566,6 +912,76 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
+        Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133
+              Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -716,6 +1132,141 @@ Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csai_col 
@@ -834,6 +1385,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -984,6 +1606,141 @@ Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_ciai_col 
@@ -1101,6 +1858,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1251,6 +2079,139 @@ Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f871246
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col2 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col2 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csas_col 
@@ -1259,6 +2220,7 @@ WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'c
 GO
 ~~START~~
 char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1266,9 +2228,9 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
-Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0 loops=1)
-  Filter: ((test_like_index_vu_prepare_c_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
-  Rows Removed by Filter: 1000
+Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Rows Removed by Filter: 999
 ~~END~~
 
 
@@ -1288,7 +2250,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_c_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1366,6 +2328,74 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -1514,6 +2544,139 @@ Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6c
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col2 >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col2 < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_cias_col 
@@ -1522,6 +2685,7 @@ WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'c
 GO
 ~~START~~
 char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1529,9 +2693,9 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0 loops=1)
-  Filter: ((test_like_index_vu_prepare_c_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-  Rows Removed by Filter: 1000
+Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Rows Removed by Filter: 999
 ~~END~~
 
 
@@ -1551,7 +2715,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1629,6 +2793,74 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -1773,6 +3005,135 @@ Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csai_col 
@@ -1889,6 +3250,75 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -2033,6 +3463,135 @@ Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_ciai_col 
@@ -2150,6 +3709,75 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -2304,6 +3932,144 @@ Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col2 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csas_col 
@@ -2321,7 +4087,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2342,7 +4108,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_nv_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2422,6 +4188,76 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
+        Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48
+              Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -2576,6 +4412,144 @@ Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b79
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col2 < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_cias_col 
@@ -2593,7 +4567,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2614,7 +4588,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2694,6 +4668,76 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
+        Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9
+              Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -2844,6 +4888,141 @@ Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_i
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csai_col 
@@ -2962,6 +5141,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -3112,6 +5362,141 @@ Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_i
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_ciai_col 
@@ -3230,6 +5615,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -3379,6 +5835,139 @@ Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col2 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csas_col 
@@ -3396,7 +5985,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_csas_col)::text = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3417,7 +6006,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_csas_col)::text >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND ((test_like_index_vu_prepare_t_csas_col)::text < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3495,6 +6084,74 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -3643,6 +6300,139 @@ Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col2 >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col2 < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_cias_col 
@@ -3660,7 +6450,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3681,7 +6471,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3759,6 +6549,74 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_ci_as))
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -3909,6 +6767,141 @@ Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csai_col 
@@ -4027,6 +7020,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_csai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -4177,6 +7241,141 @@ Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_ciai_col 
@@ -4295,6 +7494,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE chinese_prc_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 

--- a/test/JDBC/expected/parallel_query/babel_collection.out
+++ b/test/JDBC/expected/parallel_query/babel_collection.out
@@ -194,7 +194,7 @@ Gather  (cost=4.17..11.28 rows=3 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 6.545 ms
+Babelfish T-SQL Batch Parsing Time: 0.175 ms
 ~~END~~
 
 
@@ -215,7 +215,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.205 ms
+Babelfish T-SQL Batch Parsing Time: 0.136 ms
 ~~END~~
 
 
@@ -236,7 +236,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.160 ms
+Babelfish T-SQL Batch Parsing Time: 0.132 ms
 ~~END~~
 
 
@@ -254,7 +254,7 @@ Gather  (cost=11.40..24.02 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.142 ms
 ~~END~~
 
 
@@ -272,7 +272,7 @@ Gather  (cost=11.41..24.03 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.186 ms
 ~~END~~
 
 
@@ -294,7 +294,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.141 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -314,7 +314,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -334,7 +334,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.210 ms
 ~~END~~
 
 
@@ -353,7 +353,7 @@ Gather  (cost=11.56..24.18 rows=647 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.976 ms
+Babelfish T-SQL Batch Parsing Time: 0.206 ms
 ~~END~~
 
 
@@ -371,7 +371,7 @@ Gather  (cost=11.56..25.23 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.173 ms
 ~~END~~
 
 
@@ -389,7 +389,7 @@ Gather  (cost=11.55..25.22 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.148 ms
 ~~END~~
 
 
@@ -412,7 +412,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.144 ms
 ~~END~~
 
 
@@ -433,7 +433,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.131 ms
+Babelfish T-SQL Batch Parsing Time: 0.194 ms
 ~~END~~
 
 
@@ -568,7 +568,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.145 ms
+Babelfish T-SQL Batch Parsing Time: 0.139 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -612,7 +612,7 @@ Gather  (cost=10000000000.00..10000000027.00 rows=7 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.126 ms
+Babelfish T-SQL Batch Parsing Time: 0.124 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -639,7 +639,7 @@ Gather  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.123 ms
+Babelfish T-SQL Batch Parsing Time: 0.121 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -664,12 +664,12 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
   ->  Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND ((c1)::text >= 'jo'::text COLLATE french_ci_as) AND ((c1)::text < 'jo?'::text COLLATE french_ci_as))
+        Filter: (((c1)::text ~~* 'jo%'::text COLLATE french_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE french_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE french_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -693,12 +693,12 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
   ->  Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
-        Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND ((c1)::text >= 'jo'::text COLLATE chinese_prc_ci_as) AND ((c1)::text < 'jo?'::text COLLATE chinese_prc_ci_as))
+        Filter: (((c1)::text ~~* 'jo%'::text COLLATE chinese_prc_cs_as) AND (c1 >= 'jo'::"varchar" COLLATE chinese_prc_ci_as) AND (c1 < 'jo?'::"varchar" COLLATE chinese_prc_ci_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.137 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/parallel_query/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_index-vu-verify.out
@@ -199,6 +199,166 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col2 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col2 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csas_col 
@@ -219,7 +379,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_v_csas_col)::text = 'cs1'::text)
+        Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar")
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -243,7 +403,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=0 loops=3)
-        Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_v_csas_col)::text < 'cs999?'::text))
+        Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar") AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar"))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -329,6 +489,88 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
+        Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304
+              Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas t1
@@ -506,6 +748,166 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col2 >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col2 < 'ci999?'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 < 'ci999?'::"varchar"))
+        Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_cias_col 
@@ -526,7 +928,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_v_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -550,7 +952,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=0 loops=3)
-        Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -630,6 +1032,87 @@ text
 Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
+        Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133
+              Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -810,6 +1293,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csai_col 
@@ -940,6 +1580,89 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai t1
@@ -1114,6 +1837,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_ciai_col 
@@ -1243,6 +2123,89 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai t1
@@ -1419,6 +2382,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col2 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col2 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csas_col 
@@ -1427,6 +2547,7 @@ WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'c
 GO
 ~~START~~
 char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1434,11 +2555,11 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
-Gather (actual rows=0 loops=1)
+Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0 loops=5)
-        Filter: ((test_like_index_vu_prepare_c_csas_col)::text = 'cs1'::text)
+        Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar)
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -1462,7 +2583,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0 loops=5)
-        Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_c_csas_col)::text < 'cs999?'::text))
+        Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -1546,6 +2667,86 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas t1
@@ -1720,6 +2921,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar))
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar))
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col2 >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col2 < 'ci999?'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 < 'ci999?'::bpchar))
+        Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_cias_col 
@@ -1728,6 +3086,7 @@ WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'c
 GO
 ~~START~~
 char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1735,11 +3094,11 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Gather (actual rows=0 loops=1)
+Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0 loops=5)
-        Filter: ((test_like_index_vu_prepare_c_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -1763,7 +3122,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0 loops=5)
-        Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -1841,6 +3200,85 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar))
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -2017,6 +3455,159 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csai_col 
@@ -2145,6 +3736,87 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai t1
@@ -2315,6 +3987,159 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_ciai_col 
@@ -2444,6 +4269,87 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 4
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai t1
@@ -2622,6 +4528,166 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col2 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csas_col 
@@ -2642,7 +4708,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text = 'cs1'::text)
+        Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar)
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -2666,7 +4732,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=0 loops=3)
-        Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_nv_csas_col)::text < 'cs999?'::text))
+        Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -2752,6 +4818,88 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
+        Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48
+              Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas t1
@@ -2930,6 +5078,166 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+        Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+              Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col2 < 'ci999?'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 < 'ci999?'::nvarchar))
+        Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_cias_col 
@@ -2950,7 +5258,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -2974,7 +5282,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=0 loops=3)
-        Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -3054,6 +5362,87 @@ text
 Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
+        Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9
+              Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -3234,6 +5623,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csai_col 
@@ -3364,6 +5910,89 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai t1
@@ -3538,6 +6167,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_ciai_col 
@@ -3668,6 +6454,89 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai t1
@@ -3843,6 +6712,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col2 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csas_col 
@@ -3863,7 +6889,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_t_csas_col)::text = 'cs1'::text)
+        Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text)
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -3887,7 +6913,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_t_csas_col)::text < 'cs999?'::text))
+        Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col >= 'cs999'::text) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -3971,6 +6997,86 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas t1
@@ -4145,6 +7251,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text))
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text))
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+        Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col2 >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col2 < 'ci999?'::text) AND (test_like_index_vu_prepare_t_cias_col3 >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col3 < 'ci999?'::text))
+        Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_cias_col 
@@ -4165,7 +7428,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=0 loops=3)
-        Filter: ((test_like_index_vu_prepare_t_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -4189,7 +7452,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=0 loops=3)
-        Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -4267,6 +7530,85 @@ text
 Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text))
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -4447,6 +7789,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csai_col 
@@ -4577,6 +8076,89 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_csai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai t1
@@ -4751,6 +8333,163 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Gather (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_ciai_col 
@@ -4881,6 +8620,89 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai t1
+  ->  Materialize
+        ->  Gather
+              Workers Planned: 2
+              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai t1

--- a/test/JDBC/expected/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like-vu-prepare.out
@@ -236,7 +236,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -245,7 +245,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -254,7 +254,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -280,7 +280,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -288,7 +288,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -323,7 +323,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -331,7 +331,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -388,7 +388,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -396,7 +396,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -405,7 +405,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like-vu-verify.out
@@ -521,7 +521,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -530,7 +530,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -539,7 +539,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((('abc'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (('A%'::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -565,7 +565,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('ABC'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -573,7 +573,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -608,7 +608,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -616,7 +616,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -673,7 +673,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('abc'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -681,7 +681,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(('a%'::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -690,7 +690,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_ci_as) COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 

--- a/test/JDBC/expected/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/test_like_index-vu-verify.out
@@ -177,6 +177,144 @@ Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+varchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_csas_col2 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col2 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csas_col 
@@ -194,7 +332,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_v_csas_col)::text = 'cs1'::text)
+  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar")
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -215,7 +353,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_v_csas_col)::text < 'cs999?'::text))
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar") AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar"))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -295,6 +433,76 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
+        Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304
+              Index Cond: ((test_like_index_vu_prepare_v_csas_col >= 'cs999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col < 'cs999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -448,6 +656,144 @@ Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+varchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_v_cias_col2 >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col2 < 'ci999?'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 < 'ci999?'::"varchar"))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_cias_col 
@@ -465,7 +811,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_v_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -486,7 +832,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -560,6 +906,79 @@ text
 Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
+        Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133
+              Index Cond: ((test_like_index_vu_prepare_v_cias_col >= 'ci999'::"varchar") AND (test_like_index_vu_prepare_v_cias_col < 'ci999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -716,6 +1135,141 @@ Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+varchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csai_col 
@@ -834,6 +1388,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -984,6 +1609,141 @@ Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+varchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_ciai_col 
@@ -1101,6 +1861,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_v_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_v_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1251,6 +2082,139 @@ Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f871246
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+char
+cs999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_csas_col2 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col2 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csas_col 
@@ -1259,6 +2223,7 @@ WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'c
 GO
 ~~START~~
 char
+cs1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1266,9 +2231,9 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_csas_col 
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
-Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0 loops=1)
-  Filter: ((test_like_index_vu_prepare_c_csas_col)::text = 'cs1'::text)
-  Rows Removed by Filter: 1000
+Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar)
+  Rows Removed by Filter: 999
 ~~END~~
 
 
@@ -1288,7 +2253,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_c_csas_col)::text < 'cs999?'::text))
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1366,6 +2331,74 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
+        Index Cond: ((test_like_index_vu_prepare_c_csas_col >= 'cs999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col < 'cs999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -1514,6 +2547,139 @@ Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6c
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar))
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar))
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+char
+ci999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_c_cias_col2 >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col2 < 'ci999?'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 < 'ci999?'::bpchar))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_cias_col 
@@ -1522,6 +2688,7 @@ WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'c
 GO
 ~~START~~
 char
+ci1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
 ~~END~~
 
 ~~START~~
@@ -1529,9 +2696,9 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_cias_col 
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0 loops=1)
-  Filter: ((test_like_index_vu_prepare_c_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-  Rows Removed by Filter: 1000
+Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Rows Removed by Filter: 999
 ~~END~~
 
 
@@ -1551,7 +2718,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1623,6 +2790,77 @@ text
 Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
+        Index Cond: ((test_like_index_vu_prepare_c_cias_col >= 'ci999'::bpchar) AND (test_like_index_vu_prepare_c_cias_col < 'ci999?'::bpchar))
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -1773,6 +3011,135 @@ Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+char
+csai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csai_col 
@@ -1889,6 +3256,75 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -2033,6 +3469,135 @@ Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+char
+ciai999                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_ciai_col 
@@ -2150,6 +3715,75 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -2304,6 +3938,144 @@ Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+nvarchar
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col2 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csas_col 
@@ -2321,7 +4093,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text = 'cs1'::text)
+  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2342,7 +4114,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_nv_csas_col)::text < 'cs999?'::text))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2422,6 +4194,76 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
+        Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csas t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48
+              Index Cond: ((test_like_index_vu_prepare_nv_csas_col >= 'cs999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col < 'cs999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -2576,6 +4418,144 @@ Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b79
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 (actual rows=1 loops=1)
+        Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+nvarchar
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col2 < 'ci999?'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 < 'ci999?'::nvarchar))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_cias_col 
@@ -2593,7 +4573,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2614,7 +4594,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2688,6 +4668,79 @@ text
 Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
+        Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_cias t1
+        Recheck Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9
+              Index Cond: ((test_like_index_vu_prepare_nv_cias_col >= 'ci999'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col < 'ci999?'::nvarchar))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -2844,6 +4897,141 @@ Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_i
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+nvarchar
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csai_col 
@@ -2962,6 +5150,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_csai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_csai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -3112,6 +5371,141 @@ Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_i
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+nvarchar
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_ciai_col 
@@ -3230,6 +5624,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
+        Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_nv_ciai t1
+        Recheck Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_nv_ciai_idx
+              Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -3379,6 +5844,139 @@ Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+cs999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as
+Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col2 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csas_col 
@@ -3396,7 +5994,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_csas_col)::text = 'cs1'::text)
+  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3417,7 +6015,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_csas_col)::text >= 'cs999'::text) AND ((test_like_index_vu_prepare_t_csas_col)::text < 'cs999?'::text))
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col >= 'cs999'::text) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3495,6 +6093,74 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col >= 'cs999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col < 'cs999?'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -3643,6 +6309,139 @@ Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text))
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Fetches: 1
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text))
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+  Heap Fetches: 1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+ci999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as
+Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: ((test_like_index_vu_prepare_t_cias_col2 >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col2 < 'ci999?'::text) AND (test_like_index_vu_prepare_t_cias_col3 >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col3 < 'ci999?'::text))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_cias_col 
@@ -3660,7 +6459,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: ((test_like_index_vu_prepare_t_cias_col)::text = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3681,7 +6480,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col)::text < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col >= 'ci999'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3753,6 +6552,77 @@ text
 Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%'
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
+        Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
+              Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
+        Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+  ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as
+Nested Loop
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
+        Index Cond: ((test_like_index_vu_prepare_t_cias_col >= 'ci999'::text) AND (test_like_index_vu_prepare_t_cias_col < 'ci999?'::text))
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_common t2
         Recheck Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
@@ -3909,6 +6779,141 @@ Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+csai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csai_col 
@@ -4027,6 +7032,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_csai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_csai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col) >= 'csai999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) < 'csai999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -4177,6 +7253,141 @@ Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_in
 ~~END~~
 
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+  Heap Blocks: exact=1
+  ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx (actual rows=1 loops=1)
+        Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai1
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+ciai999
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_ciai_col 
@@ -4295,6 +7506,77 @@ Nested Loop
         Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77
               Index Cond: ((test_like_index_vu_prepare_t_common_col >= 'common999'::"varchar") AND (test_like_index_vu_prepare_t_common_col < 'common999?'::"varchar"))
+  ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
+~~END~~
+
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
+        Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
+  ->  Materialize
+        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+~~END~~
+
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Bitmap Heap Scan on test_like_index_vu_prepare_t_ciai t1
+        Recheck Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai999%'::text COLLATE bbf_unicode_cp1_cs_as)
+        ->  Bitmap Index Scan on test_like_index_vu_prepare_t_ciai_idx
+              Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) >= 'ciai999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) < 'ciai999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+~~END~~
+
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
+GO
+~~START~~
+text
+Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai
+Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common999%'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) >= 'common999'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) < 'common999?'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 

--- a/test/JDBC/input/test_like_index-vu-verify.mix
+++ b/test/JDBC/input/test_like_index-vu-verify.mix
@@ -60,6 +60,46 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col_no_idx 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col2 
+FROM test_like_index_vu_prepare_v_csas 
+WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csas_col 
@@ -100,6 +140,29 @@ GO
 SELECT test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csas_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -153,6 +216,46 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col_no_idx 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col2 
+FROM test_like_index_vu_prepare_v_cias 
+WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_cias_col 
@@ -193,6 +296,29 @@ GO
 SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_v_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -246,6 +372,46 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col_no_idx 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col2 
+FROM test_like_index_vu_prepare_v_csai 
+WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_csai_col 
@@ -286,6 +452,29 @@ GO
 SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -339,6 +528,46 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col2 
+FROM test_like_index_vu_prepare_v_ciai 
+WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_v_ciai_col 
@@ -378,6 +607,29 @@ GO
 SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -433,6 +685,46 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col_no_idx 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col2 
+FROM test_like_index_vu_prepare_c_csas 
+WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csas_col 
@@ -473,6 +765,29 @@ GO
 SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_c_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -526,6 +841,46 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col_no_idx 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col2 
+FROM test_like_index_vu_prepare_c_cias 
+WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_cias_col 
@@ -566,6 +921,29 @@ GO
 SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_c_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -619,6 +997,46 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col_no_idx 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col2 
+FROM test_like_index_vu_prepare_c_csai 
+WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_csai_col 
@@ -659,6 +1077,29 @@ GO
 SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -712,6 +1153,46 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col2 
+FROM test_like_index_vu_prepare_c_ciai 
+WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_c_ciai_col 
@@ -753,6 +1234,29 @@ GO
 SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -807,6 +1311,46 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col2 
+FROM test_like_index_vu_prepare_nv_csas 
+WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csas_col 
@@ -847,6 +1391,29 @@ GO
 SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_nv_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -901,6 +1468,46 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col_no_idx 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col2 
+FROM test_like_index_vu_prepare_nv_cias 
+WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_cias_col 
@@ -941,6 +1548,29 @@ GO
 SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_nv_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -994,6 +1624,46 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col2 
+FROM test_like_index_vu_prepare_nv_csai 
+WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_csai_col 
@@ -1034,6 +1704,29 @@ GO
 SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -1087,6 +1780,46 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col2 
+FROM test_like_index_vu_prepare_nv_ciai 
+WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_nv_ciai_col 
@@ -1127,6 +1860,29 @@ GO
 SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -1181,6 +1937,46 @@ WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%'
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col_no_idx 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col2 
+FROM test_like_index_vu_prepare_t_csas 
+WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs999%' 
+AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csas_col 
@@ -1221,6 +2017,29 @@ GO
 SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs999%' COLLATE latin1_general_cs_as;
+GO
+
+SELECT test_like_index_vu_prepare_t_csas_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -1274,6 +2093,46 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col_no_idx 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col2 
+FROM test_like_index_vu_prepare_t_cias 
+WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci999%' 
+AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_cias_col 
@@ -1314,6 +2173,29 @@ GO
 SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci999%' COLLATE latin1_general_ci_as;
+GO
+
+SELECT test_like_index_vu_prepare_t_cias_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_as;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -1367,6 +2249,46 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col_no_idx 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col2 
+FROM test_like_index_vu_prepare_t_csai 
+WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai999%' 
+AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_csai_col 
@@ -1407,6 +2329,29 @@ GO
 SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai999%' COLLATE latin1_general_cs_ai;
+GO
+
+SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_cs_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;
@@ -1460,6 +2405,46 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%';
 GO
 
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col_no_idx 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+-- Composite Index Scans
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col2 
+FROM test_like_index_vu_prepare_t_ciai 
+WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai999%' 
+AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
 -- No Index Usage (collation override)
 -- Exact match
 SELECT test_like_index_vu_prepare_t_ciai_col 
@@ -1500,6 +2485,29 @@ GO
 SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
 FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%';
+GO
+
+-- CollateExpr(Const) as right operand
+-- Exact match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai;
+GO
+
+-- Prefix match
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai999%' COLLATE latin1_general_ci_ai;
+GO
+
+SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_prepare_t_common_col
+FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
+ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common999%' COLLATE latin1_general_ci_ai;
 GO
 
 SET BABELFISH_SHOWPLAN_ALL OFF;


### PR DESCRIPTION
### Description

With this commit: https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/e119968d7ffe59a49f2326d5fc421b1442d9c40c, babelfish now use Index Scans for the following cases:

-- CASE 1
```
SELECT COL FROM TAB WHERE COL LIKE 'ab'
```

-- CASE 2
```
SELECT COL FROM TAB WHERE COL LIKE 'a%'
```

However if there is a Collate clause with the right operand :
-- CASE 1
```
SELECT COL FROM TAB WHERE COL LIKE 'ab' COLLATE DATABASE_DEFAULT
```

-- CASE 2
```
SELECT COL FROM TAB WHERE COL LIKE 'a%' COLLATE DATABASE_DEFAULT
```
babelfish does NOT use Index Scan.

This commit enables Index scan for such cases. We do this by removing CollateExpr on both operands as those are redundant and the OpExpr (LIKE) operator is already aware of the collation it needs to use. 


### Issues Resolved

BABEL-5077
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).