### PR TITLE
Allow parallelism for pltsql return expression after community commit 556f7b7

### DIFF
--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1366,6 +1366,15 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		/* In case of RO functions we want the caller to handle errors. */
 		if (ro_func)
 		{
+			if (IsInParallelMode())
+			{
+				/*
+				 * If this xact has started any unfinished parallel operation, clean up
+				 * its workers and exit parallel mode.  Don't warn about leaked resources.
+				 */
+				AtEOXact_Parallel(false);
+				ExitParallelMode();
+			}
 			/* Cleanup SPI connections if they exist. */
 			AtEOXact_SPI(false);
 			PG_RE_THROW();

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -729,7 +729,7 @@ exec_stmt_push_result(PLtsql_execstate *estate,
 	if (estate->insert_exec)
 		return exec_stmt_insert_execute_select(estate, stmt->query);
 
-	exec_run_select(estate, stmt->query, 0, &portal);
+	exec_run_select(estate, stmt->query, &portal);
 
 	receiver = CreateDestReceiver(DestRemote);
 	SetRemoteDestReceiverParams(receiver, portal);
@@ -3042,7 +3042,7 @@ exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *query)
 		exec_init_tuple_store(estate);
 
 	Assert(query != NULL);
-	exec_run_select(estate, query, 0, &portal);
+	exec_run_select(estate, query, &portal);
 
 	/* Use eval_mcontext for tuple conversion work */
 	oldcontext = MemoryContextSwitchTo(get_eval_mcontext(estate));

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -378,7 +378,7 @@ static Datum exec_eval_expr(PLtsql_execstate *estate,
 							Oid *rettype,
 							int32 *rettypmod);
 static int	exec_run_select(PLtsql_execstate *estate,
-							PLtsql_expr *expr, long maxtuples, Portal *portalP);
+							PLtsql_expr *expr, Portal *portalP);
 static int	exec_for_query(PLtsql_execstate *estate, PLtsql_stmt_forq *stmt,
 						   Portal portal, bool prefetch_ok);
 static ParamListInfo setup_param_list(PLtsql_execstate *estate,
@@ -2359,7 +2359,7 @@ exec_stmt_perform(PLtsql_execstate *estate, PLtsql_stmt_perform *stmt)
 {
 	PLtsql_expr *expr = stmt->expr;
 
-	(void) exec_run_select(estate, expr, 0, NULL);
+	(void) exec_run_select(estate, expr, NULL);
 	exec_set_found(estate, (estate->eval_processed != 0));
 	exec_eval_cleanup(estate);
 
@@ -3039,7 +3039,7 @@ exec_stmt_fors(PLtsql_execstate *estate, PLtsql_stmt_fors *stmt)
 	/*
 	 * Open the implicit cursor for the statement using exec_run_select
 	 */
-	exec_run_select(estate, stmt->query, 0, &portal);
+	exec_run_select(estate, stmt->query, &portal);
 
 	/*
 	 * Execute the loop
@@ -3848,7 +3848,7 @@ exec_stmt_return_query(PLtsql_execstate *estate,
 	if (stmt->query != NULL)
 	{
 		/* static query */
-		exec_run_select(estate, stmt->query, 0, &portal);
+		exec_run_select(estate, stmt->query, &portal);
 	}
 	else
 	{
@@ -6300,7 +6300,7 @@ exec_assign_expr(PLtsql_execstate *estate, PLtsql_datum *target,
 		append_explain_info(NULL, strinfo->data);
 
 		increment_explain_indent();
-		rc = exec_run_select(estate, expr, 0, NULL);
+		rc = exec_run_select(estate, expr, NULL);
 		decrement_explain_indent();
 
 		if (rc != SPI_OK_SELECT)
@@ -7237,7 +7237,7 @@ exec_eval_expr(PLtsql_execstate *estate,
 	/*
 	 * Else do it the hard way via exec_run_select
 	 */
-	rc = exec_run_select(estate, expr, 2, NULL);
+	rc = exec_run_select(estate, expr, NULL);
 	if (rc != SPI_OK_SELECT)
 		ereport(ERROR,
 				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
@@ -7294,7 +7294,7 @@ exec_eval_expr(PLtsql_execstate *estate,
  */
 static int
 exec_run_select(PLtsql_execstate *estate,
-				PLtsql_expr *expr, long maxtuples, Portal *portalP)
+				PLtsql_expr *expr, Portal *portalP)
 {
 	ParamListInfo paramLI;
 	int			rc;
@@ -7349,7 +7349,7 @@ exec_run_select(PLtsql_execstate *estate,
 	 * Execute the query
 	 */
 	rc = SPI_execute_plan_with_paramlist(expr->plan, paramLI,
-										 estate->readonly_func, maxtuples);
+										 estate->readonly_func, 0);
 	if (rc != SPI_OK_SELECT)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),

--- a/test/JDBC/expected/BABEL_5599.out
+++ b/test/JDBC/expected/BABEL_5599.out
@@ -1,0 +1,1095 @@
+create table test_tab (a int)
+GO
+
+------------------------------------------------------------------------
+-- statement terminating error through parallel worker testing starts --
+------------------------------------------------------------------------
+GO
+
+create table setup_tab1(a bigint)
+GO
+
+insert into setup_tab1 values(99999999999999999)
+GO
+~~ROW COUNT: 1~~
+
+
+-- simple function whose return expression will throw an error
+CREATE FUNCTION stmt_terminating_err()
+RETURNS int
+AS
+BEGIN
+    RETURN (SELECT CAST(a AS INT) FROM setup_tab1);  -- This will cause integer out of range error
+END
+GO
+
+-- simple proc whose return expression will throw an error
+CREATE PROCEDURE stmt_terminating_err_proc
+AS
+BEGIN
+    RETURN (SELECT CAST(a AS INT) FROM setup_tab1)
+END
+GO
+
+-- simple proc whose expression evaluation will throw an error
+CREATE PROCEDURE stmt_terminating_err_proc_with_txn
+AS
+BEGIN
+    DECLARE @result int
+    BEGIN TRANSACTION
+        SELECT @result = CAST(a AS INT) FROM setup_tab1
+    COMMIT TRANSACTION
+    RETURN (@result)
+END
+GO
+
+-- Variant 1: Without explicit transaction
+CREATE FUNCTION call_error_function_no_txn()
+RETURNS int
+AS
+BEGIN
+    RETURN (SELECT dbo.stmt_terminating_err()) -- Direct call without transaction
+END
+GO
+
+-- Cannot have begin txn inside func
+CREATE FUNCTION call_error_function_with_txn()
+RETURNS int
+AS
+BEGIN
+    DECLARE @result int
+    
+    BEGIN TRANSACTION
+        SET @result = dbo.stmt_terminating_err()  -- Call within transaction
+    COMMIT TRANSACTION
+    
+    RETURN @result
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid use of a side-effecting operator 'COMMIT TRANSACTION' within a function.)~~
+
+
+-- variant 2: inner procedure that calls the error function
+CREATE PROCEDURE call_error_function_no_txn_proc
+AS
+BEGIN
+    RETURN (SELECT dbo.stmt_terminating_err())
+END
+GO
+
+-- Variant 3: With explicit transaction
+CREATE PROCEDURE call_error_function_with_txn_proc
+AS
+BEGIN
+    BEGIN TRANSACTION;
+        DECLARE @result int;
+        SET @result = dbo.stmt_terminating_err();
+    COMMIT TRANSACTION;
+    RETURN @result;
+END
+GO
+
+-- simple function call without explicit txn
+insert into test_tab values (1)
+select stmt_terminating_err()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- simple function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select stmt_terminating_err()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call without explicit txn
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call through proc without explicit txn
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call through proc within explicit txn at batch level
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call without batch level explicit txn
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call within batch levle explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc without explicit txn
+insert into test_tab values (1)
+exec stmt_terminating_err_proc;
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec stmt_terminating_err_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) without batch level explicit txn
+insert into test_tab values (1)
+exec stmt_terminating_err_proc_with_txn;
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) with batch level explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec stmt_terminating_err_proc_with_txn
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 8115)~~
+
+~~ERROR (Message: integer out of range)~~
+
+~~ROW COUNT: 1~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+1
+~~END~~
+
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- cleanup
+DROP PROCEDURE call_error_function_with_txn_proc
+GO
+
+DROP PROCEDURE call_error_function_no_txn_proc
+GO
+
+DROP FUNCTION call_error_function_no_txn()
+GO
+
+DROP PROCEDURE stmt_terminating_err_proc_with_txn
+GO
+
+DROP PROCEDURE stmt_terminating_err_proc
+GO
+
+DROP FUNCTION stmt_terminating_err()
+GO
+
+drop table setup_tab1
+GO
+
+
+
+----------------------------------------------
+-- statement terminating error testing ends --
+----------------------------------------------
+---------------------------------------------------------------
+-- txn aborting error through parallel worker testing starts --
+---------------------------------------------------------------
+GO
+
+
+create table setup_tab2(a varchar(10))
+GO
+
+insert into setup_tab2 values ('abc')
+GO
+~~ROW COUNT: 1~~
+
+
+-- simple function whose return expression will throw an error
+CREATE FUNCTION txn_abort_err()
+RETURNS int
+AS
+BEGIN
+    RETURN (select cast( a as int) from setup_tab2);  -- This will cause integer out of range error
+END
+GO
+
+-- simple proc whose return expression will throw an error
+CREATE PROCEDURE txn_abort_err_proc
+AS
+BEGIN
+    RETURN ( select cast( a as int) from setup_tab2)
+END
+GO
+
+-- simple proc whose expression evaluation will throw an error
+CREATE PROCEDURE txn_abort_err_proc_with_txn
+AS
+BEGIN
+    DECLARE @result int
+    BEGIN TRANSACTION
+        select @result = cast( a as int) from setup_tab2
+    COMMIT TRANSACTION
+    RETURN (@result)
+END
+GO
+
+-- Variant 1: Without explicit transaction
+CREATE FUNCTION call_error_function_no_txn()
+RETURNS int
+AS
+BEGIN
+    RETURN (SELECT dbo.txn_abort_err()) -- Direct call without transaction
+END
+GO
+
+-- Cannot have begin txn inside func
+CREATE FUNCTION call_error_function_with_txn()
+RETURNS int
+AS
+BEGIN
+    DECLARE @result int
+    
+    BEGIN TRANSACTION
+        SET @result = dbo.txn_abort_err()  -- Call within transaction
+    COMMIT TRANSACTION
+    
+    RETURN @result
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid use of a side-effecting operator 'COMMIT TRANSACTION' within a function.)~~
+
+
+-- variant 2: inner procedure that calls the error function
+CREATE PROCEDURE call_error_function_no_txn_proc
+AS
+BEGIN
+    RETURN (SELECT dbo.txn_abort_err())
+END
+GO
+
+-- Variant 3: With explicit transaction
+CREATE PROCEDURE call_error_function_with_txn_proc
+AS
+BEGIN
+    BEGIN TRANSACTION;
+        DECLARE @result int;
+        SET @result = dbo.txn_abort_err();
+    COMMIT TRANSACTION;
+    RETURN @result;
+END
+GO
+
+-- simple function call without explicit txn
+insert into test_tab values (1)
+select txn_abort_err()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- simple function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select txn_abort_err()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call without explicit txn
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call through proc without explicit txn
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function call through proc within explicit txn at batch level
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call without batch level explicit txn
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call within batch levle explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc without explicit txn
+insert into test_tab values (1)
+exec txn_abort_err_proc;
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec txn_abort_err_proc
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) without batch level explicit txn
+insert into test_tab values (1)
+exec txn_abort_err_proc_with_txn;
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) with batch level explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec txn_abort_err_proc_with_txn
+insert into test_tab values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "abc")~~
+
+
+select @@trancount
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+rollback tran
+GO
+~~ERROR (Code: 3903)~~
+
+~~ERROR (Message: ROLLBACK can only be used in transaction blocks)~~
+
+
+select * from test_tab;
+GO
+~~START~~
+int
+~~END~~
+
+
+truncate table test_tab
+GO
+
+-- cleanup
+DROP PROCEDURE call_error_function_with_txn_proc
+GO
+
+DROP PROCEDURE call_error_function_no_txn_proc
+GO
+
+DROP FUNCTION call_error_function_no_txn()
+GO
+
+DROP PROCEDURE txn_abort_err_proc_with_txn
+GO
+
+DROP PROCEDURE txn_abort_err_proc
+GO
+
+DROP FUNCTION txn_abort_err()
+GO
+
+drop table setup_tab2
+GO
+
+
+-------------------------------------------------------------
+-- txn aborting error through parallel worker testing ends --
+-------------------------------------------------------------
+drop table test_tab
+GO

--- a/test/JDBC/input/BABEL_5599.sql
+++ b/test/JDBC/input/BABEL_5599.sql
@@ -1,0 +1,647 @@
+create table test_tab (a int)
+GO
+
+------------------------------------------------------------------------
+-- statement terminating error through parallel worker testing starts --
+------------------------------------------------------------------------
+GO
+
+create table setup_tab1(a bigint)
+GO
+
+insert into setup_tab1 values(99999999999999999)
+GO
+
+-- simple function whose return expression will throw an error
+CREATE FUNCTION stmt_terminating_err()
+RETURNS int
+AS
+BEGIN
+    RETURN (SELECT CAST(a AS INT) FROM setup_tab1);  -- This will cause integer out of range error
+END
+GO
+
+-- simple proc whose return expression will throw an error
+CREATE PROCEDURE stmt_terminating_err_proc
+AS
+BEGIN
+    RETURN (SELECT CAST(a AS INT) FROM setup_tab1)
+END
+GO
+
+-- simple proc whose expression evaluation will throw an error
+CREATE PROCEDURE stmt_terminating_err_proc_with_txn
+AS
+BEGIN
+    DECLARE @result int
+    BEGIN TRANSACTION
+        SELECT @result = CAST(a AS INT) FROM setup_tab1
+    COMMIT TRANSACTION
+    RETURN (@result)
+END
+GO
+
+-- Variant 1: Without explicit transaction
+CREATE FUNCTION call_error_function_no_txn()
+RETURNS int
+AS
+BEGIN
+    RETURN (SELECT dbo.stmt_terminating_err()) -- Direct call without transaction
+END
+GO
+
+-- Cannot have begin txn inside func
+CREATE FUNCTION call_error_function_with_txn()
+RETURNS int
+AS
+BEGIN
+    DECLARE @result int
+    
+    BEGIN TRANSACTION
+        SET @result = dbo.stmt_terminating_err()  -- Call within transaction
+    COMMIT TRANSACTION
+    
+    RETURN @result
+END
+GO
+
+-- variant 2: inner procedure that calls the error function
+CREATE PROCEDURE call_error_function_no_txn_proc
+AS
+BEGIN
+    RETURN (SELECT dbo.stmt_terminating_err())
+END
+GO
+
+-- Variant 3: With explicit transaction
+CREATE PROCEDURE call_error_function_with_txn_proc
+AS
+BEGIN
+    BEGIN TRANSACTION;
+        DECLARE @result int;
+        SET @result = dbo.stmt_terminating_err();
+    COMMIT TRANSACTION;
+    RETURN @result;
+END
+GO
+
+-- simple function call without explicit txn
+insert into test_tab values (1)
+select stmt_terminating_err()
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- simple function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select stmt_terminating_err()
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call without explicit txn
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call through proc without explicit txn
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call through proc within explicit txn at batch level
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call without batch level explicit txn
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call within batch levle explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc without explicit txn
+insert into test_tab values (1)
+exec stmt_terminating_err_proc;
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec stmt_terminating_err_proc
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) without batch level explicit txn
+insert into test_tab values (1)
+exec stmt_terminating_err_proc_with_txn;
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) with batch level explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec stmt_terminating_err_proc_with_txn
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- cleanup
+DROP PROCEDURE call_error_function_with_txn_proc
+GO
+
+DROP PROCEDURE call_error_function_no_txn_proc
+GO
+
+DROP FUNCTION call_error_function_no_txn()
+GO
+
+DROP PROCEDURE stmt_terminating_err_proc_with_txn
+GO
+
+DROP PROCEDURE stmt_terminating_err_proc
+GO
+
+DROP FUNCTION stmt_terminating_err()
+GO
+
+drop table setup_tab1
+GO
+
+----------------------------------------------
+-- statement terminating error testing ends --
+----------------------------------------------
+
+
+---------------------------------------------------------------
+-- txn aborting error through parallel worker testing starts --
+---------------------------------------------------------------
+GO
+
+
+create table setup_tab2(a varchar(10))
+GO
+
+insert into setup_tab2 values ('abc')
+GO
+
+-- simple function whose return expression will throw an error
+CREATE FUNCTION txn_abort_err()
+RETURNS int
+AS
+BEGIN
+    RETURN (select cast( a as int) from setup_tab2);  -- This will cause integer out of range error
+END
+GO
+
+-- simple proc whose return expression will throw an error
+CREATE PROCEDURE txn_abort_err_proc
+AS
+BEGIN
+    RETURN ( select cast( a as int) from setup_tab2)
+END
+GO
+
+-- simple proc whose expression evaluation will throw an error
+CREATE PROCEDURE txn_abort_err_proc_with_txn
+AS
+BEGIN
+    DECLARE @result int
+    BEGIN TRANSACTION
+        select @result = cast( a as int) from setup_tab2
+    COMMIT TRANSACTION
+    RETURN (@result)
+END
+GO
+
+-- Variant 1: Without explicit transaction
+CREATE FUNCTION call_error_function_no_txn()
+RETURNS int
+AS
+BEGIN
+    RETURN (SELECT dbo.txn_abort_err()) -- Direct call without transaction
+END
+GO
+
+-- Cannot have begin txn inside func
+CREATE FUNCTION call_error_function_with_txn()
+RETURNS int
+AS
+BEGIN
+    DECLARE @result int
+    
+    BEGIN TRANSACTION
+        SET @result = dbo.txn_abort_err()  -- Call within transaction
+    COMMIT TRANSACTION
+    
+    RETURN @result
+END
+GO
+
+-- variant 2: inner procedure that calls the error function
+CREATE PROCEDURE call_error_function_no_txn_proc
+AS
+BEGIN
+    RETURN (SELECT dbo.txn_abort_err())
+END
+GO
+
+-- Variant 3: With explicit transaction
+CREATE PROCEDURE call_error_function_with_txn_proc
+AS
+BEGIN
+    BEGIN TRANSACTION;
+        DECLARE @result int;
+        SET @result = dbo.txn_abort_err();
+    COMMIT TRANSACTION;
+    RETURN @result;
+END
+GO
+
+-- simple function call without explicit txn
+insert into test_tab values (1)
+select txn_abort_err()
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- simple function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select txn_abort_err()
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call without explicit txn
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+select call_error_function_no_txn()
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call through proc without explicit txn
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function call through proc within explicit txn at batch level
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_no_txn_proc
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call without batch level explicit txn
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- nested function through proc (that starts explicit txn during execution) call within batch levle explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec call_error_function_with_txn_proc
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc without explicit txn
+insert into test_tab values (1)
+exec txn_abort_err_proc;
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc within explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec txn_abort_err_proc
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) without batch level explicit txn
+insert into test_tab values (1)
+exec txn_abort_err_proc_with_txn;
+insert into test_tab values (1)
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- exec proc (with explicit txn within body) with batch level explicit txn
+begin tran
+GO
+insert into test_tab values (1)
+exec txn_abort_err_proc_with_txn
+insert into test_tab values (1)
+GO
+
+select @@trancount
+GO
+
+select * from test_tab;
+GO
+
+rollback tran
+GO
+
+select * from test_tab;
+GO
+
+truncate table test_tab
+GO
+
+-- cleanup
+DROP PROCEDURE call_error_function_with_txn_proc
+GO
+
+DROP PROCEDURE call_error_function_no_txn_proc
+GO
+
+DROP FUNCTION call_error_function_no_txn()
+GO
+
+DROP PROCEDURE txn_abort_err_proc_with_txn
+GO
+
+DROP PROCEDURE txn_abort_err_proc
+GO
+
+DROP FUNCTION txn_abort_err()
+GO
+
+drop table setup_tab2
+GO
+
+-------------------------------------------------------------
+-- txn aborting error through parallel worker testing ends --
+-------------------------------------------------------------
+
+drop table test_tab
+GO


### PR DESCRIPTION
With the commit 556f7b7, we unintentionally blocked parallelism to evaluate plpgsql return expression because maxtuples = 2 is being passed to exec_run_select(...) from exec_eval_expr(...) to evaluate the return expression of the plpgsql function.

Idea to fix this issue to pass maxtuples = 0. It is safe to do it because number of processed rows is anyway being checked later in exec_eval_expr(...). But with this, there is not real caller remained which calls exec_run_select(...) with maxtuple != 0 so updated definition of exec_run_select(...) to remove maxtuples argument.

This commit also fixes parallel context leak in case of statement terminating error originating from PLTSQL function body. This is important because subsequent resetting search_path or table variable cleanup operations may end up error.

Task: BABEL-5599

(cherry picked from commit b3f148486f8c1660ff650d1a488bf14e377ef45b)



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).