### PR TITLE
Fix AM/PM and timezone parsing for DATETIMEOFFSET

### DIFF
--- a/contrib/babelfishpg_common/src/datetime.c
+++ b/contrib/babelfishpg_common/src/datetime.c
@@ -290,6 +290,10 @@ clean_input_str(char *str, bool *contains_extra_spaces, DateTimeContext context)
 				(context != DATE_TIME && (str[i] == '.' || str[i] == '/' 
 				|| str[i] == '+' || str[i] == '-')))
 		{
+			/* For datetimeoffset, preserve space before timezone indicator (+/-) */
+			if (context == DATE_TIME_OFFSET && (str[i] == '+' || str[i] == '-') && num_colons > 0)
+				result[j++] = ' ';
+
 			result[j] = str[i];
 			j++;
 		}

--- a/test/JDBC/expected/babel_datetimeoffset.out
+++ b/test/JDBC/expected/babel_datetimeoffset.out
@@ -330,6 +330,43 @@ datetimeoffset
 ~~END~~
 
 
+-- Test AM/PM notation
+select CAST('2025-05-20 02:30:20.123456 PM -07:00' as DATETIMEOFFSET);
+go
+~~START~~
+datetimeoffset
+2025-05-20 14:30:20.1234560 -07:00
+~~END~~
+
+select CAST('2025-05-20 02:30:20.123456 PM-07:0' as DATETIMEOFFSET);
+go
+~~START~~
+datetimeoffset
+2025-05-20 14:30:20.1234560 -07:00
+~~END~~
+
+select CAST('2025-05- 20    02:30:20.123456     PM    -07:00' as DATETIMEOFFSET(4));
+go
+~~START~~
+datetimeoffset
+2025-05-20 14:30:20.1235 -07:00
+~~END~~
+
+select CAST('2025-05-20 02:30:20.123456 AM +07:59' as DATETIMEOFFSET);
+go
+~~START~~
+datetimeoffset
+2025-05-20 02:30:20.1234560 +07:59
+~~END~~
+
+    -- out of range
+select CAST('2025-05-20 02:30:20.123456 AM +07:79' as DATETIMEOFFSET);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: time zone displacement out of range: "2025-05-20 02:30:20.123456 AM +07:79")~~
+
+
 -- Test type cast to/from other time formats
 -- Test datetime/dateime2
 select CAST(CAST('2020-03-15 23:59:29.99' AS datetime) AS datetimeoffset);

--- a/test/JDBC/input/babel_datetimeoffset.sql
+++ b/test/JDBC/input/babel_datetimeoffset.sql
@@ -110,6 +110,19 @@ go
 select CAST('2079-06-06 23:59:29.123456 -9:30' AS datetimeoffset(7));
 go
 
+-- Test AM/PM notation
+select CAST('2025-05-20 02:30:20.123456 PM -07:00' as DATETIMEOFFSET);
+go
+select CAST('2025-05-20 02:30:20.123456 PM-07:0' as DATETIMEOFFSET);
+go
+select CAST('2025-05- 20    02:30:20.123456     PM    -07:00' as DATETIMEOFFSET(4));
+go
+select CAST('2025-05-20 02:30:20.123456 AM +07:59' as DATETIMEOFFSET);
+go
+    -- out of range
+select CAST('2025-05-20 02:30:20.123456 AM +07:79' as DATETIMEOFFSET);
+go
+
 -- Test type cast to/from other time formats
 -- Test datetime/dateime2
 select CAST(CAST('2020-03-15 23:59:29.99' AS datetime) AS datetimeoffset);


### PR DESCRIPTION
### Description

**ISSUE:**
The `clean_input_str()` function - responsible for parsing date strings, while removing leading spaces, incorrectly removes the space between AM/PM and timezone indicators (e.g., converting "PM -07:00" to "PM-07:00"), causing the subsequent date parser function `ParseDateTime` to fail to recognize the components completely.

**CHANGES:**
Modified the space-handling logic in `clean_input_str()` to preserve spaces before timezone indicators in datetimeoffset context, provided that the time information has already been seen (after encountering colons in the input string). This ensures the timezone offset remains properly separated from the preceding time information, allowing `ParseDateTime` to correctly parse both components.

### Issues Resolved
BABEL-5832

### Test Scenarios Covered ###
* **Use case based -**
```
1> select CAST('2025-05-20 02:30:20.123456 PM -07:00' as DATETIMEOFFSET);
2> go
datetimeoffset                               
---------------------------------------------
           2025-05-20 14:30:20.1234560 -07:00

(1 rows affected)
```

* **Boundary conditions -**
```
1> select CAST('2025-05-20 02:30:20.123456 AM +07:59' as DATETIMEOFFSET);
2> go
datetimeoffset                               
---------------------------------------------
           2025-05-20 02:30:20.1234560 +07:59

(1 rows affected)
```


* **Arbitrary inputs -**
```
1> select CAST('2025-05-20 02:30:20.123456 PM-07:0' as DATETIMEOFFSET);
2> go
datetimeoffset                               
---------------------------------------------
           2025-05-20 14:30:20.1234560 -07:00

(1 rows affected)

1> select CAST('2025-05- 20    02:30:20.123456     PM    -07:00' as DATETIMEOFFSET(4));
2> go
datetimeoffset                               
---------------------------------------------
              2025-05-20 14:30:20.1235 -07:00

(1 rows affected)
```


* **Negative test cases -**
```
1> select CAST('2025-05-20 02:30:20.123456 AM +07:79' as DATETIMEOFFSET);
2> go
Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
time zone displacement out of range: "2025-05-20 02:30:20.123456 AM +07:79"
```

* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).