### PR TITLE
Implement needs_fmgr_hook

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -96,9 +96,9 @@ runs:
             ( [[ "${engine_version%%.*}" == "15" ]] && version_le "$engine_version" "15.12" ) || 
             ( [[ "${engine_version%%.*}" == "16" ]] && version_le "$engine_version" "16.8" ) || 
             ( [[ "${engine_version%%.*}" == "17" ]] && version_le "$engine_version" "17.4" ) ); then
-          export CC='ccache gcc-9'
+          export "CC=ccache gcc-9" >> $GITHUB_ENV
         else
-          export CC='ccache gcc'
+          export "CC=ccache gcc" >> $GITHUB_ENV
         fi
 
         echo "${{env.SAVE_CCACHE}}"
@@ -106,13 +106,13 @@ runs:
         cd ..
         cd postgresql_modified_for_babelfish
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
-          ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3 --without-readline --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
+          ./configure CC=${{env.CC}}  --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3 --without-readline --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu --enable-tap-tests --with-gssapi
         elif [[ ${{inputs.code_coverage}} == "yes" ]]; then
-          ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3  --without-readline --enable-coverage --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          ./configure CC=${{env.CC}} --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3  --without-readline --enable-coverage --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         elif [[ ${{inputs.release_mode}} == "yes" ]]; then
-            ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3 CFLAGS="-ggdb -O2" --without-readline --with-libxml --with-uuid=ossp --with-icu
+            ./configure CC=${{env.CC}} --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3 CFLAGS="-ggdb -O2" --without-readline --with-libxml --with-uuid=ossp --with-icu
         else
-            ./configure --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3 --without-readline --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+            ./configure CC=${{env.CC}} --prefix=$HOME/${{ inputs.install_dir }}/ --with-python PYTHON=/usr/bin/python3 --without-readline --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
         fi
         make -j 4
         make install

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -1146,6 +1146,11 @@ TdsGetGenericTypmod(Node *expr)
 			break;
 	}
 
+	if (rettypmod == -1)
+		ereport(ERROR, (errcode(ERRCODE_DATA_EXCEPTION),
+						errmsg("The string size for the given CHAR/NCHAR data is not defined. "
+							"Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n)")));
+
 	return rettypmod;
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -117,6 +117,7 @@ extern Datum init_tsql_cursor_hash_tab(PG_FUNCTION_ARGS);
 extern PLtsql_execstate *get_current_tsql_estate(void);
 extern PLtsql_execstate *get_outermost_tsql_estate(int *nestlevel);
 extern void pre_check_trigger_schema(List *object, bool missing_ok);
+static bool pltsql_needs_fmgr_hook(Oid funcoid);
 static void get_language_procs(const char *langname, Oid *compiler, Oid *validator);
 static void get_func_language_oids(Oid *lang_handler, Oid *lang_validator);
 extern bool pltsql_suppress_string_truncation_error();
@@ -292,6 +293,7 @@ planner_node_transformer_hook_type prev_planner_node_transformer_hook = NULL;
 pltsql_nextval_hook_type prev_pltsql_nextval_hook = NULL;
 pltsql_resetcache_hook_type prev_pltsql_resetcache_hook = NULL;
 pltsql_setval_hook_type prev_pltsql_setval_hook = NULL;
+static needs_fmgr_hook_type prev_needs_fmgr_hook = NULL;
 
 static void
 set_procid(Oid oid)
@@ -5467,6 +5469,9 @@ _PG_init(void)
 
 	check_pltsql_support_tsql_transactions_hook = pltsql_support_tsql_transactions;
 
+	prev_needs_fmgr_hook = needs_fmgr_hook;
+	needs_fmgr_hook = pltsql_needs_fmgr_hook;
+
 	inited = true;
 }
 
@@ -5493,6 +5498,7 @@ _PG_fini(void)
 	non_tsql_proc_entry_hook = prev_non_tsql_proc_entry_hook;
 	get_func_language_oids_hook = prev_get_func_language_oids_hook;
 	tsql_has_linked_srv_permissions_hook = prev_tsql_has_linked_srv_permissions_hook;
+	needs_fmgr_hook = prev_needs_fmgr_hook;
 
 	UninstallExtendedHooks();
 }
@@ -6522,6 +6528,12 @@ pltsql_validator(PG_FUNCTION_ARGS)
 	PG_END_TRY();
 
 	PG_RETURN_VOID();
+}
+
+static bool
+pltsql_needs_fmgr_hook(Oid funcoid)
+{
+	return true;
 }
 
 /*


### PR DESCRIPTION
### Description

Implement needs_fmgr_hook to force fmgr_security_definer
for all routines. We need to force it since we change sql_dialect
before and after every function execution based on their lang.

Without this fix we are not chaning the sql_dialect for
inlinable functions and running into unexpected erros.


### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/3071


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).