### PR TITLE
Handle more variations of A_Star (*) in targetList for unpivot

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -88,6 +88,16 @@
 #include "bbf_parallel_query.h"
 
 #define TDS_NUMERIC_MAX_PRECISION	38
+
+/* Constants for UNPIVOT info list structure */
+#define UNPIVOT_TAG_INDEX           0  /* "UNPIVOT" string tag */
+#define UNPIVOT_ALIAS_INDEX         1  /* Alias name for the unpivot operation */
+#define UNPIVOT_DIMENSION_COL_INDEX 2  /* Dimension column name */
+#define UNPIVOT_MEASURE_COL_INDEX   3  /* Measure column name */
+#define UNPIVOT_SOURCE_ALIAS_INDEX  4  /* Source table alias */
+#define UNPIVOT_SOURCE_COLS_INDEX   5  /* List of source columns */
+#define UNPIVOT_NODE_INDEX          6  /* Transformed node (JoinExpr) */
+
 extern bool babelfish_dump_restore;
 extern char *babelfish_dump_restore_min_oid;
 extern bool pltsql_quoted_identifier;
@@ -5560,8 +5570,10 @@ transform_unpivot_clause_recursive(Node **node_ptr, List **measure_cols, List **
     JoinExpr *join;
     List *unpivot_info;
     char *measure_col;
+    char *unpivot_alias;
     Node *transformed_node;
     List *cols;
+    List *alias_cols_pair;
     bool found_unpivot;
 
     found_unpivot = false;
@@ -5583,18 +5595,22 @@ transform_unpivot_clause_recursive(Node **node_ptr, List **measure_cols, List **
             IsA(linitial(unpivot_info), String) &&
             strcmp(strVal(linitial(unpivot_info)), "UNPIVOT") == 0)
         {
-            measure_col = strVal(list_nth(unpivot_info,3));
-            transformed_node = list_nth(unpivot_info, 6);
+            measure_col = strVal(list_nth(unpivot_info, UNPIVOT_MEASURE_COL_INDEX));
+            unpivot_alias = strVal(list_nth(unpivot_info, UNPIVOT_ALIAS_INDEX));
+            transformed_node = list_nth(unpivot_info, UNPIVOT_NODE_INDEX);
 
             /* Add this measure column to the list */
             *measure_cols = lappend(*measure_cols, makeString(measure_col));
 
             /* Get source columns */
             cols = (List *)list_nth(unpivot_info, 5);
+            /* Create pair of (unpivot_alias, source_cols) */
+            alias_cols_pair = list_make2(makeString(unpivot_alias), 
+                                         copyObject(cols));
             if (*unpivot_src_cols == NIL)
-                *unpivot_src_cols = copyObject(cols);
+                *unpivot_src_cols = list_make1(alias_cols_pair);
             else
-                *unpivot_src_cols = list_concat(*unpivot_src_cols, copyObject(cols));
+                *unpivot_src_cols = lappend(*unpivot_src_cols, alias_cols_pair);
 
             /* Replace UNPIVOT info with transformed node */
             *node_ptr = transformed_node;
@@ -5622,23 +5638,92 @@ filter_star_targetlist_for_unpivot(ParseState *pstate, SelectStmt *stmt, List **
 {
     Query *temp_query;
     List *result_targetlist;
+    List *columns_to_filter;
     ListCell *lc;
-    
-    /* 
-     * Return if not 'SELECT *'
-     *
-     * TODO [BABEL-5677]: Handle aliased unpivot source columns syntax
-     * Does not check: `SELECT unpivot_alias.* ...`
-     * Validate against more variations of targetlist
-     */
-    if (stmt->targetList == NIL || 
-        !IsA(((ResTarget *)linitial(stmt->targetList))->val, ColumnRef) ||
-        !IsA(linitial(((ColumnRef *)((ResTarget *)linitial(stmt->targetList))->val)->fields), A_Star))
-    {
+    bool has_star;
+
+    /* Return if no * in target list */
+    if (stmt->targetList == NIL)
         return stmt->targetList;
-    }
 
     result_targetlist = NIL;
+    columns_to_filter = NIL;
+    has_star = false;
+
+    /* Check for * patterns */
+    foreach(lc, stmt->targetList)
+    {
+        Node *last;
+        ColumnRef *cref;
+        ResTarget *rt = (ResTarget *)lfirst(lc);
+
+        if (!IsA(rt->val, ColumnRef))
+            continue;
+
+        cref = (ColumnRef *)rt->val;
+        last = llast(cref->fields);
+
+        /* 
+         * Only process star expressions (table.* or *) for filtering out 
+         * unpivot source columns from result targetlist.
+         * Other targetlist items are left unmodified and processed normally
+         */
+        if (IsA(last, A_Star))
+        {
+            has_star = true;
+
+            /* Build list of columns to filter based on star type */
+            if (list_length(cref->fields) == 1)
+            {
+                /* For plain SELECT *, collect columns from all unpivots */
+                ListCell *info_lc;
+                foreach(info_lc, *source_cols)
+                {
+                    ListCell *col_lc;
+                    List *info = (List *) lfirst(info_lc);
+                    List *unpivot_col_list = (List *) lsecond(info);
+
+                    /* Add each column to filter list */
+                    foreach(col_lc, unpivot_col_list)
+                        columns_to_filter = lappend(columns_to_filter, lfirst(col_lc));
+                }
+            }
+            else if (list_length(cref->fields) == 2)
+            {
+                /* For alias.*, only filter if it's an unpivot alias */
+                ListCell *info_lc;
+                char *alias = strVal(linitial(cref->fields));
+                bool found_match = false;
+
+                /* Find matching unpivot alias */
+                foreach(info_lc, *source_cols)
+                {
+                    List *info = (List *) lfirst(info_lc);
+
+                    if (strcmp(alias, strVal(linitial(info))) == 0)
+                    {
+                        /* Found matching unpivot - collect its columns */
+                        ListCell *col_lc;
+                        List *unpivot_col_list = (List *) lsecond(info);
+
+                        foreach(col_lc, unpivot_col_list)
+                            columns_to_filter = lappend(columns_to_filter, lfirst(col_lc));
+
+                        found_match = true;
+                        break;
+                    }
+                }
+
+                /* If not an unpivot alias, skip filtering */
+                if (!found_match)
+                    continue;
+            }
+        }
+    }
+
+    /* If no star or no columns to filter, return original target list */
+    if (!has_star || columns_to_filter == NIL)
+        return stmt->targetList;
 
     /* Analyze to expand * */
     temp_query = parse_sub_analyze((Node *)copyObject(stmt), 
@@ -5658,13 +5743,12 @@ filter_star_targetlist_for_unpivot(ParseState *pstate, SelectStmt *stmt, List **
         te = (TargetEntry *)lfirst(lc);
         skip_column = false;
 
-        /* Check if this column is in source_cols */
-        foreach(source_lc, *source_cols) {
+        /* Check if column should be excluded */
+        foreach(source_lc, columns_to_filter)
+        {
             source_col = (String *)lfirst(source_lc);
             if (strcmp(te->resname, strVal(source_col)) == 0) {
                 skip_column = true;
-                /* Remove the matched source column to avoid duplicate removal */
-                *source_cols = foreach_delete_current(*source_cols, source_lc);
                 break;
             }
         }
@@ -5676,7 +5760,10 @@ filter_star_targetlist_for_unpivot(ParseState *pstate, SelectStmt *stmt, List **
             result_targetlist = lappend(result_targetlist, rt);
         }
     }
-    
+
+    /* Free the temporary filter list */
+    list_free(columns_to_filter);
+
     return result_targetlist;
 }
 

--- a/test/JDBC/expected/unpivot-vu-cleanup.out
+++ b/test/JDBC/expected/unpivot-vu-cleanup.out
@@ -2,6 +2,9 @@
 DROP VIEW sales.sales_analysis_view;
 GO
 
+DROP VIEW sales.quarterly_view;
+GO
+
 -- Drop tables
 DROP TABLE customer_quarterly_sales;
 GO

--- a/test/JDBC/expected/unpivot-vu-prepare.out
+++ b/test/JDBC/expected/unpivot-vu-prepare.out
@@ -296,6 +296,11 @@ GO
 ~~ROW COUNT: 3~~
 
 
+CREATE VIEW sales.quarterly_view AS
+SELECT customer_id, q1 AS q1_sales, q2, q3, q4 
+FROM customer_turnover;
+GO
+
 CREATE TABLE customer_history (
     customer_id INT, 
     q1 INT,  

--- a/test/JDBC/expected/unpivot-vu-verify.out
+++ b/test/JDBC/expected/unpivot-vu-verify.out
@@ -98,6 +98,87 @@ int#!#varchar#!#char#!#int#!#nvarchar
 ~~END~~
 
 
+SELECT unpvt.* FROM customer_turnover 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
+GO
+~~START~~
+int#!#varchar#!#char#!#int#!#nvarchar
+3#!#Cust C#!#R#!#0#!#q2
+3#!#Cust C#!#R#!#400#!#q3
+3#!#Cust C#!#R#!#150#!#q4
+1#!#Cust A#!#R#!#100#!#q1
+1#!#Cust A#!#R#!#200#!#q2
+1#!#Cust A#!#R#!#100#!#q3
+1#!#Cust A#!#R#!#400#!#q4
+2#!#Cust B#!#P#!#150#!#q1
+2#!#Cust B#!#P#!#250#!#q2
+2#!#Cust B#!#P#!#200#!#q3
+~~END~~
+
+
+SELECT unpvt.* 
+FROM (customer_turnover c JOIN product_sales p ON p.product_id = c.customer_id) 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
+GO
+~~START~~
+int#!#varchar#!#char#!#int#!#varchar#!#int#!#numeric#!#int#!#numeric#!#int#!#nvarchar
+3#!#Cust C#!#R#!#3#!#XYZ#!#0#!#0.00#!#<NULL>#!#<NULL>#!#0#!#q2
+3#!#Cust C#!#R#!#3#!#XYZ#!#0#!#0.00#!#<NULL>#!#<NULL>#!#400#!#q3
+3#!#Cust C#!#R#!#3#!#XYZ#!#0#!#0.00#!#<NULL>#!#<NULL>#!#150#!#q4
+1#!#Cust A#!#R#!#1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#100#!#q1
+1#!#Cust A#!#R#!#1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#200#!#q2
+1#!#Cust A#!#R#!#1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#100#!#q3
+1#!#Cust A#!#R#!#1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#400#!#q4
+2#!#Cust B#!#P#!#2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#150#!#q1
+2#!#Cust B#!#P#!#2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#250#!#q2
+2#!#Cust B#!#P#!#2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#200#!#q3
+~~END~~
+
+
+SELECT 
+    p.*, 
+    unpvt.* 
+FROM customer_turnover 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt 
+JOIN product_sales p ON p.product_id = unpvt.customer_id;
+GO
+~~START~~
+int#!#varchar#!#int#!#numeric#!#int#!#numeric#!#int#!#varchar#!#char#!#int#!#nvarchar
+3#!#XYZ#!#0#!#0.00#!#<NULL>#!#<NULL>#!#3#!#Cust C#!#R#!#0#!#q2
+3#!#XYZ#!#0#!#0.00#!#<NULL>#!#<NULL>#!#3#!#Cust C#!#R#!#400#!#q3
+3#!#XYZ#!#0#!#0.00#!#<NULL>#!#<NULL>#!#3#!#Cust C#!#R#!#150#!#q4
+1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#1#!#Cust A#!#R#!#100#!#q1
+1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#1#!#Cust A#!#R#!#200#!#q2
+1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#1#!#Cust A#!#R#!#100#!#q3
+1#!#ABC#!#100#!#1000.00#!#150#!#1500.00#!#1#!#Cust A#!#R#!#400#!#q4
+2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#2#!#Cust B#!#P#!#150#!#q1
+2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#2#!#Cust B#!#P#!#250#!#q2
+2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#2#!#Cust B#!#P#!#200#!#q3
+~~END~~
+
+
+SELECT 
+    p.*, 
+    u1.*, 
+    u2.* 
+FROM customer_turnover t1 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS u1 
+JOIN product_sales p 
+    ON p.product_id = u1.customer_id 
+    AND p.revenue_q1 > 1000.00 
+JOIN revenue_data t2 
+UNPIVOT (revenue FOR quarter2 IN (q1_sales, q2_sales)) AS u2 
+    ON u1.customer_id = u2.id
+    AND u1.quarter = SUBSTRING(u2.quarter2, 1, 2)
+    AND turnover > 100;
+GO
+~~START~~
+int#!#varchar#!#int#!#numeric#!#int#!#numeric#!#int#!#varchar#!#char#!#int#!#nvarchar#!#int#!#int#!#nvarchar
+2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#2#!#Cust B#!#P#!#150#!#q1#!#2#!#200#!#q1_sales
+2#!#PQR#!#80#!#1600.00#!#90#!#1800.00#!#2#!#Cust B#!#P#!#250#!#q2#!#2#!#250#!#q2_sales
+~~END~~
+
+
     -- Mixed join and unpivoted columns
 SELECT c.customer_name, u.turnover, u.quarter 
 FROM customer_info c 
@@ -989,6 +1070,23 @@ int#!#varchar#!#numeric#!#nvarchar#!#varchar
 ~~END~~
 
 
+SELECT * FROM sales.quarterly_view 
+UNPIVOT (turnover FOR quarter IN (q1_sales, q2, q3, q4)) AS unpvt;
+GO
+~~START~~
+int#!#int#!#nvarchar
+3#!#0#!#q2
+3#!#400#!#q3
+3#!#150#!#q4
+1#!#100#!#q1_sales
+1#!#200#!#q2
+1#!#100#!#q3
+1#!#400#!#q4
+2#!#150#!#q1_sales
+2#!#250#!#q2
+2#!#200#!#q3
+~~END~~
+
 
 -- SUBQURIES
     -- 1. IN/EXISTS
@@ -1068,16 +1166,16 @@ AS
 RETURN ( SELECT product_id, q1_sales, q2_sales  FROM sales_data );
 GO
 
-SELECT product_id, quarter, sales FROM dbo.GetSalesData()
+SELECT * FROM dbo.GetSalesData()
 UNPIVOT ( sales FOR quarter IN (q1_sales, q2_sales)) AS unpvt;
 GO
 ~~START~~
-int#!#nvarchar#!#int
-1#!#q1_sales#!#100
-1#!#q2_sales#!#150
-2#!#q1_sales#!#200
-2#!#q2_sales#!#250
-3#!#q2_sales#!#350
+int#!#int#!#nvarchar
+1#!#100#!#q1_sales
+1#!#150#!#q2_sales
+2#!#200#!#q1_sales
+2#!#250#!#q2_sales
+3#!#350#!#q2_sales
 ~~END~~
 
 
@@ -1688,24 +1786,6 @@ GO
 
 -- KNOWN ISSUES
     -- BABEL-5677 - Support more variations of UNPIVOT Syntax
-        -- Extra columns in result set when `SELECT alias.*`
-SELECT unpvt.* FROM customer_turnover c 
-UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
-GO
-~~START~~
-int#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#nvarchar
-3#!#Cust C#!#R#!#<NULL>#!#0#!#400#!#150#!#0#!#q2
-3#!#Cust C#!#R#!#<NULL>#!#0#!#400#!#150#!#400#!#q3
-3#!#Cust C#!#R#!#<NULL>#!#0#!#400#!#150#!#150#!#q4
-1#!#Cust A#!#R#!#100#!#200#!#100#!#400#!#100#!#q1
-1#!#Cust A#!#R#!#100#!#200#!#100#!#400#!#200#!#q2
-1#!#Cust A#!#R#!#100#!#200#!#100#!#400#!#100#!#q3
-1#!#Cust A#!#R#!#100#!#200#!#100#!#400#!#400#!#q4
-2#!#Cust B#!#P#!#150#!#250#!#200#!#<NULL>#!#150#!#q1
-2#!#Cust B#!#P#!#150#!#250#!#200#!#<NULL>#!#250#!#q2
-2#!#Cust B#!#P#!#150#!#250#!#200#!#<NULL>#!#200#!#q3
-~~END~~
-
         -- Uppercase column names in unpivot source list
 SELECT [ID_番号], [Amount_金額], [Quarter_四半期]
 FROM [Global_データ_Sales]

--- a/test/JDBC/input/unpivot-vu-cleanup.sql
+++ b/test/JDBC/input/unpivot-vu-cleanup.sql
@@ -2,6 +2,9 @@
 DROP VIEW sales.sales_analysis_view;
 GO
 
+DROP VIEW sales.quarterly_view;
+GO
+
 -- Drop tables
 DROP TABLE customer_quarterly_sales;
 GO

--- a/test/JDBC/input/unpivot-vu-prepare.sql
+++ b/test/JDBC/input/unpivot-vu-prepare.sql
@@ -274,6 +274,11 @@ INSERT INTO sales.quarterly_data VALUES
 (3, 'Product C', 175.25, 225.75, NULL, 250.00);
 GO
 
+CREATE VIEW sales.quarterly_view AS
+SELECT customer_id, q1 AS q1_sales, q2, q3, q4 
+FROM customer_turnover;
+GO
+
 CREATE TABLE customer_history (
     customer_id INT, 
     q1 INT,  

--- a/test/JDBC/input/unpivot-vu-verify.sql
+++ b/test/JDBC/input/unpivot-vu-verify.sql
@@ -28,6 +28,39 @@ SELECT * FROM customer_turnover
 UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
 GO
 
+SELECT unpvt.* FROM customer_turnover 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
+GO
+
+SELECT unpvt.* 
+FROM (customer_turnover c JOIN product_sales p ON p.product_id = c.customer_id) 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
+GO
+
+SELECT 
+    p.*, 
+    unpvt.* 
+FROM customer_turnover 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt 
+JOIN product_sales p ON p.product_id = unpvt.customer_id;
+GO
+
+SELECT 
+    p.*, 
+    u1.*, 
+    u2.* 
+FROM customer_turnover t1 
+UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS u1 
+JOIN product_sales p 
+    ON p.product_id = u1.customer_id 
+    AND p.revenue_q1 > 1000.00 
+JOIN revenue_data t2 
+UNPIVOT (revenue FOR quarter2 IN (q1_sales, q2_sales)) AS u2 
+    ON u1.customer_id = u2.id
+    AND u1.quarter = SUBSTRING(u2.quarter2, 1, 2)
+    AND turnover > 100;
+GO
+
     -- Mixed join and unpivoted columns
 SELECT c.customer_name, u.turnover, u.quarter 
 FROM customer_info c 
@@ -514,6 +547,9 @@ GO
 SELECT * FROM sales.sales_analysis_view;
 GO
 
+SELECT * FROM sales.quarterly_view 
+UNPIVOT (turnover FOR quarter IN (q1_sales, q2, q3, q4)) AS unpvt;
+GO
 
 -- SUBQURIES
     -- 1. IN/EXISTS
@@ -568,7 +604,7 @@ AS
 RETURN ( SELECT product_id, q1_sales, q2_sales  FROM sales_data );
 GO
 
-SELECT product_id, quarter, sales FROM dbo.GetSalesData()
+SELECT * FROM dbo.GetSalesData()
 UNPIVOT ( sales FOR quarter IN (q1_sales, q2_sales)) AS unpvt;
 GO
 
@@ -904,10 +940,6 @@ GO
 
 -- KNOWN ISSUES
     -- BABEL-5677 - Support more variations of UNPIVOT Syntax
-        -- Extra columns in result set when `SELECT alias.*`
-SELECT unpvt.* FROM customer_turnover c 
-UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
-GO
         -- Uppercase column names in unpivot source list
 SELECT [ID_番号], [Amount_金額], [Quarter_四半期]
 FROM [Global_データ_Sales]


### PR DESCRIPTION
**_Cherry-picked from 5_X_**
### Description

Currently, Babelfish's UNPIVOT implementation only filters source columns for simple SELECT * queries. With this change, it now properly handles all variations of star (*) references in the target list:
* Plain `SELECT *`
* Qualified `SELECT unpivot_alias.*`
* Multiple star references `SELECT unpivot1.*, unpivot2.*, table.*`

This enhancement improves SQL Server compatibility by correctly filtering out UNPIVOT source columns from the result set based on the specific star reference used. The implementation tracks source columns per UNPIVOT alias and filters them only when appropriate.

#### Changes:
1. Modified the source column tracking to maintain pairs of (unpivot_alias, source_columns)
2. Enhanced star pattern detection to handle both qualified and unqualified references
3. Added selective filtering based on the star reference type:
 * For `SELECT *`: Filter source columns from all UNPIVOTs
 * For `alias.*`: Only filter if it matches an UNPIVOT alias (by appending related source columns to columns_to_filter list)

### Issues Resolved

Task: BABEL-5763 (parent: BABEL-5677)

### Test Scenarios Covered ###
* **Use case based -**
```
SELECT * FROM customer_turnover 
UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
GO

SELECT unpvt.* FROM customer_turnover 
UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
GO

SELECT unpvt.* 
FROM (customer_turnover c JOIN product_sales p ON p.product_id = c.customer_id) 
UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt;
GO

SELECT 
    p.*, 
    unpvt.* 
FROM customer_turnover 
UNPIVOT (turnover FOR quarter IN (q1, q2, q3, q4)) AS unpvt 
JOIN product_sales p ON p.product_id = unpvt.customer_id;

```


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).