### PR TITLE
Support empty string handling for date and time datatypes

### DIFF
--- a/test/JDBC/expected/babel_datetime.out
+++ b/test/JDBC/expected/babel_datetime.out
@@ -126,6 +126,13 @@ datetime
 
 
 -- Test date
+select CAST(CAST('' AS date) AS datetime)
+go
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+
 select CAST(CAST('1999-12-31' AS date) AS datetime)
 go
 ~~START~~
@@ -151,6 +158,13 @@ datetime
 
 
 -- Test time
+select CAST(CAST('' AS time) AS datetime)
+go
+~~START~~
+datetime
+1900-01-01 00:00:00.0
+~~END~~
+
 select CAST(CAST('00:00:00.000' AS time) AS datetime)
 go
 ~~START~~

--- a/test/JDBC/expected/babel_datetime2.out
+++ b/test/JDBC/expected/babel_datetime2.out
@@ -262,6 +262,13 @@ datetime2
 
 -- Test type cast to/from other time formats
 -- Test date
+select CAST(CAST('' AS date) AS datetime2);
+go
+~~START~~
+datetime2
+1900-01-01 00:00:00.0000000
+~~END~~
+
 select CAST(CAST('1999-12-31' AS date) AS datetime2);
 go
 ~~START~~
@@ -292,6 +299,13 @@ datetime2
 
 
 -- Test time
+select CAST(CAST('' AS time) AS datetime2);
+go
+~~START~~
+datetime2
+1900-01-01 00:00:00.0000000
+~~END~~
+
 select CAST(CAST('00:00:00.000' AS time) AS datetime2);
 go
 ~~START~~

--- a/test/JDBC/expected/babel_datetimeoffset.out
+++ b/test/JDBC/expected/babel_datetimeoffset.out
@@ -406,6 +406,13 @@ datetime2
 
 
 -- Test date
+select CAST(CAST('' AS date) AS datetimeoffset);
+go
+~~START~~
+datetimeoffset
+1900-01-01 00:00:00.0000000 +00:00
+~~END~~
+
 select CAST(CAST('1999-12-31' AS date) AS datetimeoffset);
 go
 ~~START~~
@@ -450,6 +457,13 @@ go
 
 
 -- Test time
+select CAST(CAST('' AS time) AS datetimeoffset);
+go
+~~START~~
+datetimeoffset
+1900-01-01 00:00:00.0000000 +00:00
+~~END~~
+
 select CAST(CAST('23:59:59.999' AS time) AS datetimeoffset);
 go
 ~~START~~

--- a/test/JDBC/expected/babel_format_standard_date_time.out
+++ b/test/JDBC/expected/babel_format_standard_date_time.out
@@ -1,5 +1,9 @@
 --DATE standard formatting
 CREATE TABLE date_testing(d DATE);
+INSERT INTO date_testing VALUES('');
+go
+~~ROW COUNT: 1~~
+
 INSERT INTO date_testing VALUES('1753-1-1');
 go
 ~~ROW COUNT: 1~~
@@ -17,6 +21,7 @@ select * from date_testing;
 go
 ~~START~~
 date
+1900-01-01
 1753-01-01
 9999-12-31
 1992-05-23
@@ -26,6 +31,7 @@ select FORMAT(d, 'd','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+1/1/1900
 1/1/1753
 12/31/9999
 5/23/1992
@@ -35,6 +41,7 @@ select FORMAT(d, 'D','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+Monday, January 1, 1900
 Monday, January 1, 1753
 Friday, December 31, 9999
 Saturday, May 23, 1992
@@ -44,6 +51,7 @@ select FORMAT(d, 'f','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+Monday, January 1, 1900 12:00 AM
 Monday, January 1, 1753 12:00 AM
 Friday, December 31, 9999 12:00 AM
 Saturday, May 23, 1992 12:00 AM
@@ -53,6 +61,7 @@ select FORMAT(d, 'F','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+Monday, January 1, 1900 12:00:00 AM
 Monday, January 1, 1753 12:00:00 AM
 Friday, December 31, 9999 12:00:00 AM
 Saturday, May 23, 1992 12:00:00 AM
@@ -62,6 +71,7 @@ select FORMAT(d, 'g','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+1/1/1900 12:00 AM
 1/1/1753 12:00 AM
 12/31/9999 12:00 AM
 5/23/1992 12:00 AM
@@ -71,6 +81,7 @@ select FORMAT(d, 'G','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+1/1/1900 12:00:00 AM
 1/1/1753 12:00:00 AM
 12/31/9999 12:00:00 AM
 5/23/1992 12:00:00 AM
@@ -80,6 +91,7 @@ select FORMAT(d, 'R','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+Mon, 01 Jan 1900 00:00:00 GMT
 Mon, 01 Jan 1753 00:00:00 GMT
 Fri, 31 Dec 9999 00:00:00 GMT
 Sat, 23 May 1992 00:00:00 GMT
@@ -89,6 +101,7 @@ select FORMAT(d, 'r','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+Mon, 01 Jan 1900 00:00:00 GMT
 Mon, 01 Jan 1753 00:00:00 GMT
 Fri, 31 Dec 9999 00:00:00 GMT
 Sat, 23 May 1992 00:00:00 GMT
@@ -98,6 +111,7 @@ select FORMAT(d, 's','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+1900-01-01T00:00:00
 1753-01-01T00:00:00
 9999-12-31T00:00:00
 1992-05-23T00:00:00
@@ -110,6 +124,7 @@ nvarchar
 12:00 AM
 12:00 AM
 12:00 AM
+12:00 AM
 ~~END~~
 
 select FORMAT(d, 'T','en-us') from date_testing;
@@ -119,12 +134,14 @@ nvarchar
 12:00:00 AM
 12:00:00 AM
 12:00:00 AM
+12:00:00 AM
 ~~END~~
 
 select FORMAT(d, 'u','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+1900-01-01 00:00:00Z
 1753-01-01 00:00:00Z
 9999-12-31 00:00:00Z
 1992-05-23 00:00:00Z
@@ -134,6 +151,7 @@ select FORMAT(d, 'U','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+Monday, January 1, 1900 12:00:00 AM
 Monday, January 1, 1753 12:00:00 AM
 Friday, December 31, 9999 12:00:00 AM
 Saturday, May 23, 1992 12:00:00 AM
@@ -143,6 +161,7 @@ select FORMAT(d, 'Y','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+January 1900
 January 1753
 December 9999
 May 1992
@@ -152,6 +171,7 @@ select FORMAT(d, 'y','en-us') from date_testing;
 GO
 ~~START~~
 nvarchar
+January 1900
 January 1753
 December 9999
 May 1992
@@ -827,6 +847,7 @@ June 2079
 
 --TIME standard formatting
 create table time_testing ( ti TIME );
+INSERT INTO time_testing VALUES('');
 INSERT INTO time_testing VALUES('00:00:00.12345');
 INSERT INTO time_testing VALUES('3:53:59');
 INSERT INTO time_testing VALUES('15:5:45.0000');
@@ -841,8 +862,11 @@ go
 
 ~~ROW COUNT: 1~~
 
+~~ROW COUNT: 1~~
+
 ~~START~~
 time
+00:00:00.0000000
 00:00:00.1234500
 03:53:59.0000000
 15:05:45.0000000
@@ -853,6 +877,7 @@ select FORMAT(ti, 'c','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+00:00:00
 00:00:00.123450
 03:53:59
 15:05:45
@@ -867,12 +892,14 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 'D','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+<NULL>
 <NULL>
 <NULL>
 <NULL>
@@ -887,6 +914,7 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 'F','en-us') from time_testing;
@@ -897,12 +925,14 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 'g','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+00:00:00
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Format g is not supported currently! Please try again with another format)~~
@@ -911,6 +941,7 @@ select FORMAT(ti, 'R','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+<NULL>
 <NULL>
 <NULL>
 <NULL>
@@ -925,6 +956,7 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 's','en-us') from time_testing;
@@ -935,12 +967,14 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 't','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+00:00:00
 00:00:00.123450
 03:53:59
 15:05:45
@@ -951,6 +985,7 @@ select FORMAT(ti, 'T','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+00:00:00
 00:00:00.123450
 03:53:59
 15:05:45
@@ -965,12 +1000,14 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 'U','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+<NULL>
 <NULL>
 <NULL>
 <NULL>
@@ -985,12 +1022,14 @@ nvarchar
 <NULL>
 <NULL>
 <NULL>
+<NULL>
 ~~END~~
 
 select FORMAT(ti, 'y','en-us') from time_testing;
 GO
 ~~START~~
 nvarchar
+<NULL>
 <NULL>
 <NULL>
 <NULL>

--- a/test/JDBC/expected/babel_smalldatetime.out
+++ b/test/JDBC/expected/babel_smalldatetime.out
@@ -112,8 +112,10 @@ smalldatetime
 
 -- Test type cast to/from other time formats
 -- Cast to smalldatetime
+select CAST(CAST('' AS time) AS smalldatetime);
 select CAST(CAST('00:00:00.234' AS time) AS smalldatetime);
 select CAST(CAST('01:02:03.456' AS time) AS smalldatetime);
+select CAST(CAST('' AS date) AS smalldatetime);
 select CAST(CAST('2020-03-15' AS date) AS smalldatetime);
 select CAST(CAST('2020-03-15' AS datetime) AS smalldatetime);
 select CAST(CAST('2010-07-08 23:59:29.998' AS datetime) AS smalldatetime);
@@ -129,7 +131,17 @@ smalldatetime
 
 ~~START~~
 smalldatetime
+1900-01-01 00:00:00.0
+~~END~~
+
+~~START~~
+smalldatetime
 1900-01-01 01:02:00.0
+~~END~~
+
+~~START~~
+smalldatetime
+1900-01-01 00:00:00.0
 ~~END~~
 
 ~~START~~

--- a/test/JDBC/input/babel_datetime.sql
+++ b/test/JDBC/input/babel_datetime.sql
@@ -52,6 +52,8 @@ select CAST(CAST('2079-06-06 23:59:29.992343' AS datetime2) AS datetime)
 go
 
 -- Test date
+select CAST(CAST('' AS date) AS datetime)
+go
 select CAST(CAST('1999-12-31' AS date) AS datetime)
 go
 select CAST(CAST('2000-01-01 23:59:59.999' AS datetime) AS date)
@@ -61,6 +63,8 @@ select CAST(CAST('1752-12-31' AS date) AS datetime)
 go
 
 -- Test time
+select CAST(CAST('' AS time) AS datetime)
+go
 select CAST(CAST('00:00:00.000' AS time) AS datetime)
 go
 select CAST(CAST('23:59:59.999' AS time) AS datetime)

--- a/test/JDBC/input/babel_datetime2.sql
+++ b/test/JDBC/input/babel_datetime2.sql
@@ -82,6 +82,8 @@ go
 
 -- Test type cast to/from other time formats
 -- Test date
+select CAST(CAST('' AS date) AS datetime2);
+go
 select CAST(CAST('1999-12-31' AS date) AS datetime2);
 go
 select CAST(CAST('2000-01-01 23:59:59.99932' AS datetime2) AS date);
@@ -92,6 +94,8 @@ select CAST(CAST('2000-12-31' AS date) AS datetime2(2));
 go
 
 -- Test time
+select CAST(CAST('' AS time) AS datetime2);
+go
 select CAST(CAST('00:00:00.000' AS time) AS datetime2);
 go
 select CAST(CAST('23:59:59.999' AS time) AS datetime2);

--- a/test/JDBC/input/babel_datetimeoffset.sql
+++ b/test/JDBC/input/babel_datetimeoffset.sql
@@ -137,6 +137,8 @@ select CAST(CAST('1900-05-06 13:59:29.998 -8:00' AS datetimeoffset) AS datetime2
 go
 
 -- Test date
+select CAST(CAST('' AS date) AS datetimeoffset);
+go
 select CAST(CAST('1999-12-31' AS date) AS datetimeoffset);
 go
 select CAST(CAST('0001-12-31' AS date) AS datetimeoffset);
@@ -152,6 +154,8 @@ select CAST(CAST('12000-01-01' AS date) AS datetimeoffset);
 go
 
 -- Test time
+select CAST(CAST('' AS time) AS datetimeoffset);
+go
 select CAST(CAST('23:59:59.999' AS time) AS datetimeoffset);
 go
 select CAST(CAST('00:30:31' AS time) AS datetimeoffset);

--- a/test/JDBC/input/babel_format_standard_date_time.sql
+++ b/test/JDBC/input/babel_format_standard_date_time.sql
@@ -1,5 +1,7 @@
 --DATE standard formatting
 CREATE TABLE date_testing(d DATE);
+INSERT INTO date_testing VALUES('');
+go
 INSERT INTO date_testing VALUES('1753-1-1');
 go
 INSERT INTO date_testing VALUES('9999-12-31');
@@ -175,6 +177,7 @@ GO
 
 --TIME standard formatting
 create table time_testing ( ti TIME );
+INSERT INTO time_testing VALUES('');
 INSERT INTO time_testing VALUES('00:00:00.12345');
 INSERT INTO time_testing VALUES('3:53:59');
 INSERT INTO time_testing VALUES('15:5:45.0000');

--- a/test/JDBC/input/babel_smalldatetime.sql
+++ b/test/JDBC/input/babel_smalldatetime.sql
@@ -31,8 +31,10 @@ go
 
 -- Test type cast to/from other time formats
 -- Cast to smalldatetime
+select CAST(CAST('' AS time) AS smalldatetime);
 select CAST(CAST('00:00:00.234' AS time) AS smalldatetime);
 select CAST(CAST('01:02:03.456' AS time) AS smalldatetime);
+select CAST(CAST('' AS date) AS smalldatetime);
 select CAST(CAST('2020-03-15' AS date) AS smalldatetime);
 select CAST(CAST('2020-03-15' AS datetime) AS smalldatetime);
 select CAST(CAST('2010-07-08 23:59:29.998' AS datetime) AS smalldatetime);


### PR DESCRIPTION
### Overview
Add TSQL-compatible handling of empty string ('') for date and time types, defaulting to '1900-01-01' for date and time, similar to datetime, datetime2, datetimeoffset, smalldatetime.

Task: BABEL-3433

### Description

In SQL Server, when an empty string ('') is cast to `date` or `time` datatype, it should be return a default value - '1900-01-01' for date and '00:00:00.0000000' for time. Currently, Babelfish raises a syntax error for these cases. This change improves TSQL compatibility by matching SQL Server's behavior for empty string handling in date and time datatypes, while maintaining existing behavior for non-empty inputs.

```
1> create table bug(dt date null, tm time(3) null);
2> insert into bug values ('', '');
go
Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
invalid input syntax for type date: ""
Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
invalid input syntax for type time: ""
```
 
### Changes:
- Modified `date_in()` and `time_in()` functions in PostgreSQL engine to check for empty input string before ParseDateTime() and if in _**TSQL dialect**_, prepare date and time default values adjusting their time struct and converting to respective return type Datums (by calling `date2j` and `tm2time` respectively). 
  - This approach mirrors the empty string handling logic in the babelfish_common package for **datetime**, **datetime2**, **datetimeoffset**, and **smalldatetime** datatypes through the use of `initializeToDefaultDatetime()`.
- Added comprehensive test coverage in the Babelfish JDBC test suite to verify empty string handling across different scenarios including direct casts, table insert operation, type conversions, and formatting functions.


### Issues Resolved

BABEL-3433: Support for empty input string handling in date and time datatypes


### Test Scenarios Covered ### [TBD]
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).