### PR TITLE
Add cross-db testcases for Table Valued function

### DIFF
--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-cleanup.out
@@ -48,6 +48,9 @@ GO
 DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
 GO
 
+DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_tvf1;
+GO
+
 DROP PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
 GO
 
@@ -84,10 +87,16 @@ GO
 DROP FUNCTION dbo.babel_cross_db_vu_prepare_f2;
 GO
 
+DROP FUNCTION dbo.babel_cross_db_vu_prepare_tvf2;
+GO
+
 DROP VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
 GO
 
 DROP FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2;
+GO
+
+DROP FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2;
 GO
 
 DROP TABLE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2;

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-prepare.out
@@ -102,6 +102,11 @@ CREATE FUNCTION dbo.babel_cross_db_vu_prepare_f2 (@a int)
     END;
 GO
 
+CREATE FUNCTION dbo.babel_cross_db_vu_prepare_tvf2()
+    RETURNS TABLE AS
+    RETURN select 'IT IS TVF' as col;
+GO
+
 -- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
 USE my_babel_cross_db_vu_prepare_db1;
 GO
@@ -121,8 +126,14 @@ CREATE FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2 (@a in
     END;
 GO
 
+CREATE FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2()
+    RETURNS TABLE AS
+    RETURN select 'IT IS TVF' as col;
+GO
+
 CREATE VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 AS
-    SELECT id, babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(id), name
+    SELECT id, babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(id),
+    babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2(), name
     FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2
     ORDER BY id;
 GO
@@ -148,6 +159,7 @@ GO
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1 AS
     SELECT x.id,
         my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(x.id),
+        my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2(),
         x.name AS t1_name,
         y.name AS t2_name
     FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1 x INNER JOIN
@@ -165,7 +177,8 @@ GO
 
 -- View containing cross-db function on which login babel_cross_db_vu_prepare_l1 does not have privilege
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3 AS
-    SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(id) AS id, name
+    SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(id) AS id,
+    my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_tvf2(), name
     FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1
     ORDER BY id;
 GO
@@ -200,6 +213,11 @@ CREATE FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1 (@a in
     END;
 GO
 
+CREATE FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_tvf1()
+    RETURNS TABLE AS
+    RETURN SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2();
+GO
+
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested AS
     SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
 GO
@@ -217,7 +235,8 @@ CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested AS
 GO
 
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested AS
-    SELECT babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1(1) AS id;
+    SELECT babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1(1) AS id,
+    babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_tvf1();
 GO
 
 CREATE PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
@@ -436,8 +436,8 @@ int#!#varchar
 SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
 GO
 ~~START~~
-int#!#int#!#varchar
-1#!#1#!#abc
+int#!#int#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#abc
 ~~END~~
 
 
@@ -447,6 +447,14 @@ GO
 ~~START~~
 int
 1
+~~END~~
+
+
+SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2();
+GO
+~~START~~
+varchar
+IT IS TVF
 ~~END~~
 
 
@@ -466,28 +474,35 @@ GO
 ~~ERROR (Message: permission denied for function babel_cross_db_vu_prepare_f2)~~
 
 
+SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_tvf2();
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function babel_cross_db_vu_prepare_tvf2)~~
+
+
 -- SELECT from a view in db1 which references objects in db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful
 SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
 GO
 ~~START~~
-int#!#int#!#varchar#!#varchar
-1#!#1#!#def#!#abc
+int#!#int#!#varchar#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#def#!#abc
 ~~END~~
 
 
 SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested;
 GO
 ~~START~~
-int#!#int#!#varchar#!#varchar
-1#!#1#!#def#!#abc
+int#!#int#!#varchar#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#def#!#abc
 ~~END~~
 
 
 SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested;
 GO
 ~~START~~
-int
-1
+int#!#varchar
+1#!#IT IS TVF
 ~~END~~
 
 
@@ -545,8 +560,8 @@ int#!#varchar
 ~~END~~
 
 ~~START~~
-int#!#int#!#varchar
-1#!#1#!#abc
+int#!#int#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#abc
 ~~END~~
 
 
@@ -564,8 +579,8 @@ int#!#varchar
 ~~END~~
 
 ~~START~~
-int#!#int#!#varchar#!#varchar
-1#!#1#!#def#!#abc
+int#!#int#!#varchar#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#def#!#abc
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~
@@ -586,8 +601,8 @@ int#!#varchar
 ~~END~~
 
 ~~START~~
-int#!#int#!#varchar#!#varchar
-1#!#1#!#def#!#abc
+int#!#int#!#varchar#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#def#!#abc
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~
@@ -612,8 +627,8 @@ int#!#varchar
 ~~END~~
 
 ~~START~~
-int#!#int#!#varchar#!#varchar
-1#!#1#!#def#!#abc
+int#!#int#!#varchar#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#def#!#abc
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~
@@ -638,8 +653,8 @@ int#!#varchar
 ~~END~~
 
 ~~START~~
-int#!#int#!#varchar#!#varchar
-1#!#1#!#def#!#abc
+int#!#int#!#varchar#!#varchar#!#varchar
+1#!#1#!#IT IS TVF#!#def#!#abc
 ~~END~~
 
 ~~ERROR (Code: 33557097)~~

--- a/test/JDBC/expected/BABEL-CROSS-DB.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB.out
@@ -13,6 +13,15 @@ AS
 SELECT a FROM dbo.master_t1;
 GO
 
+-- TVF
+CREATE FUNCTION myschema.cross_db_babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'Accessible' as status;
+GO
+
+
 CREATE TABLE myschema.tab1( a int);
 GO
  
@@ -41,6 +50,14 @@ CREATE DATABASE db1;
 GO
 
 USE db1;
+GO
+
+-- TVF
+CREATE FUNCTION dbo.nested_babel_5792_tvf()
+RETURNS TABLE 
+AS
+RETURN
+    SELECT master.myschema.cross_db_babel_5792_tvf()
 GO
 
 SELECT current_user;
@@ -93,6 +110,16 @@ GO
 ~~START~~
 int
 1
+~~END~~
+
+
+-- access on TVF as current user is dbo.
+-- should work
+SELECT master.myschema.cross_db_babel_5792_tvf();
+go
+~~START~~
+varchar
+Accessible
 ~~END~~
 
 
@@ -268,6 +295,28 @@ int#!#int
 USE MASTER;
 GO
 
+CREATE database db2;
+GO
+
+USE db2
+GO
+
+-- access on outer and inner TVFs as current user is dbo.
+-- should work
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+~~START~~
+varchar
+Accessible
+~~END~~
+
+
+USE master
+GO
+
+DROP database db2
+GO
+
 SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
 GO
 ~~START~~
@@ -318,8 +367,25 @@ GO
 ~~ERROR (Message: permission denied for table db1_t1)~~
 
 
+-- user has no access on TVF.
+-- should give permission denied
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function nested_babel_5792_tvf)~~
+
+
 USE db1;
 GO
+
+-- should give permission denied
+SELECT master.myschema.cross_db_babel_5792_tvf();
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function cross_db_babel_5792_tvf)~~
+
 
 EXEC master.dbo.master_p2
 GO
@@ -354,6 +420,9 @@ GO
 GRANT EXECUTE ON dbo.master_p2 TO master_janedoe;
 GO
 
+GRANT EXECUTE ON myschema.cross_db_babel_5792_tvf TO master_janedoe;
+GO
+
 USE db1;
 GO
 
@@ -361,11 +430,30 @@ GRANT SELECT ON dbo.db1_t1 TO db1_janedoe;
 GO
 
 -- tsql user=johndoe password=12345678
+USE db1;
+GO
+
+-- user has access on base TVF
+-- should work
+SELECT master.myschema.cross_db_babel_5792_tvf();
+go
+~~START~~
+varchar
+Accessible
+~~END~~
+
+
 USE MASTER;
 GO
 
-USE db1;
+-- user doesn't have access on outer TVF
+-- should give permission denied
+SELECT db1.dbo.nested_babel_5792_tvf()
 GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function nested_babel_5792_tvf)~~
+
 
 EXEC master.dbo.master_p2
 GO
@@ -392,13 +480,104 @@ GO
 -- terminate-tsql-conn user=johndoe password=12345678
 
 -- tsql
+USE master;
+GO
+
+REVOKE EXECUTE ON myschema.cross_db_babel_5792_tvf FROM master_janedoe;
+GO
+
+use db1
+GO
+
+GRANT EXECUTE ON nested_babel_5792_tvf TO db1_janedoe;
+GO
+
+-- tsql user=johndoe password=12345678
+USE MASTER;
+GO
+
+-- user doesn't have access on inner TVF but has on outer.
+-- should give permission denied
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+~~START~~
+varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for function cross_db_babel_5792_tvf)~~
+
+
+-- terminate-tsql-conn user=johndoe password=12345678
+
+-- tsql
+USE master;
+GO
+
+CREATE DATABASE db2
+GO
+
+USE db2
+GO
+
+CREATE USER db2_janedoe FOR LOGIN johndoe;
+GO
+
+USE MASTER;
+GO
+
+GRANT EXECUTE ON myschema.cross_db_babel_5792_tvf TO master_janedoe;
+GO
+
+-- tsql user=johndoe password=12345678
+USE db2
+GO
+
+select current_user;
+GO
+~~START~~
+varchar
+db2_janedoe
+~~END~~
+
+
+-- user has access on outer and inner both TVF
+-- should work
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+~~START~~
+varchar
+Accessible
+~~END~~
+
+
+-- terminate-tsql-conn user=johndoe password=12345678
+
+-- tsql
+USE db2;
+GO
+
+DROP USER db2_janedoe;
+GO
+
 USE db1;
+GO
+
+DROP database db2;
+GO
+
+REVOKE EXECUTE ON nested_babel_5792_tvf FROM db1_janedoe;
 GO
 
 REVOKE SELECT ON dbo.db1_t1 FROM db1_janedoe;
 GO
 
+DROP FUNCTION dbo.nested_babel_5792_tvf
+GO
+
 USE MASTER;
+GO
+
+REVOKE EXECUTE ON myschema.cross_db_babel_5792_tvf FROM master_janedoe;
 GO
 
 DROP DATABASE db1;
@@ -774,6 +953,9 @@ DROP DATABASE db1;
 GO
 
 DROP TABLE dbo.master_t1;
+GO
+
+DROP FUNCTION myschema.cross_db_babel_5792_tvf;
 GO
 
 DROP PROC dbo.master_p1;

--- a/test/JDBC/expected/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-cleanup.out
@@ -32,6 +32,17 @@ GO
 DROP FUNCTION babel_5448_s2.babel_5448_f
 GO
 
+DROP FUNCTION dbo.babel_5792_tvf
+GO
+DROP FUNCTION babel_5448_user_default_schema.babel_5792_tvf
+GO
+DROP FUNCTION babel_5448_s1.babel_5792_tvf, babel_5448_s1.babel_5792_f2_tvf,
+              babel_5448_s1.babel_5792_f3_tvf, babel_5448_s1.babel_5792_f4_tvf,
+              babel_5448_s1.babel_5792_f5_tvf;
+GO
+DROP FUNCTION babel_5448_s2.babel_5792_tvf
+GO
+
 DROP TABLE dbo.babel_5448_t
 GO
 DROP TABLE babel_5448_user_default_schema.babel_5448_t

--- a/test/JDBC/expected/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-prepare.out
+++ b/test/JDBC/expected/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-prepare.out
@@ -76,11 +76,28 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION dbo.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'master.dbo' as SchemaName;
+GO
+
+
 CREATE FUNCTION babel_5448_user_default_schema.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN 'master.babel_5448_user_default_schema';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_user_default_schema.babel_5792_tvf()
+RETURNS TABLE 
+AS
+RETURN
+    SELECT 'master.babel_5448_user_default_schema' as SchemaName;
 GO
 
 CREATE FUNCTION babel_5448_s1.babel_5448_f() RETURNS NVARCHAR(MAX)
@@ -90,11 +107,27 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'master.babel_5448_s1' as SchemaName;
+GO
+
 CREATE FUNCTION babel_5448_s2.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN ' |-- function in -- master.babel_5448_s2 --| ';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s2.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT ' |-- TVF in -- master.babel_5448_s2 --| ' as SchemaName;
 GO
 
 -- Test declare statement inside function
@@ -106,6 +139,19 @@ BEGIN
 END
 GO
 
+CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- master.babel_5448_s2 --| ' AS col1
+GO
+
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f2_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT id FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
+GO
+
+
 -- Test return statement inside function
 CREATE FUNCTION babel_5448_s1.babel_5448_f3() RETURNS NVARCHAR(MAX)
 AS
@@ -114,7 +160,13 @@ BEGIN
 END
 GO
 
-CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- master.babel_5448_s2 --| ' AS col1
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f3_tvf()
+RETURNS TABLE
+AS
+    RETURN (SELECT id
+    FROM babel_5448_t 
+    JOIN babel_5448_s2.babel_5448_v ON (1=1));
 GO
 
 CREATE TRIGGER dbo.babel_5448_trigger
@@ -122,6 +174,7 @@ ON dbo.babel_5448_t
 AFTER INSERT AS
     SELECT '=========== START OF TRIGGER EXECUTION ========== master.dbo'
     SELECT dbo.babel_5448_f();
+    SELECT dbo.babel_5792_tvf();
     SELECT * FROM babel_5448_t;
     SELECT '=========== END OF TRIGGER EXECUTION ========== master.dbo'
 GO
@@ -131,6 +184,7 @@ ON babel_5448_user_default_schema.babel_5448_t
 AFTER INSERT AS
     SELECT '=========== START OF TRIGGER EXECUTION ========== master.babel_5448_user_default_schema'
     SELECT babel_5448_user_default_schema.babel_5448_f();
+    SELECT babel_5448_user_default_schema.babel_5792_tvf();
     SELECT * FROM babel_5448_t;
     SELECT '=========== END OF TRIGGER EXECUTION ========== master.babel_5448_user_default_schema'
 GO
@@ -140,13 +194,14 @@ ON babel_5448_s1.babel_5448_t
 AFTER INSERT AS
     SELECT '=========== START OF TRIGGER EXECUTION ========== master.babel_5448_s1'
     SELECT babel_5448_s1.babel_5448_f();
+    SELECT babel_5448_s1.babel_5792_tvf();
     SELECT * FROM babel_5448_t;
     SELECT '=========== END OF TRIGGER EXECUTION ========== master.babel_5448_s1'
 GO
 
 CREATE PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -157,7 +212,7 @@ GO
 
 CREATE PROCEDURE babel_5448_user_default_schema.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -168,7 +223,7 @@ GO
 
 CREATE PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -178,17 +233,17 @@ AS
 GO
 
 CREATE PROC dbo.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5448_f(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_user_default_schema.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_s1.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -240,11 +295,28 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION dbo.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'babel_5448_db.dbo' as SchemaName;
+GO
+
+
 CREATE FUNCTION babel_5448_user_default_schema.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN 'babel_5448_db.babel_5448_user_default_schema';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_user_default_schema.babel_5792_tvf()
+RETURNS TABLE 
+AS
+RETURN
+    SELECT 'babel_5448_db.babel_5448_user_default_schema' as SchemaName;
 GO
 
 CREATE FUNCTION babel_5448_s1.babel_5448_f() RETURNS NVARCHAR(MAX)
@@ -254,11 +326,28 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'babel_5448_db.babel_5448_s1' as SchemaName;
+GO
+
 CREATE FUNCTION babel_5448_s2.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN ' |-- function in -- babel_5448_db.babel_5448_s2 --| ';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s2.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT ' |-- TVF in -- babel_5448_db.babel_5448_s2 --| ' as SchemaName;
+    
 GO
 
 -- Test declare statement inside function
@@ -270,6 +359,19 @@ BEGIN
 END
 GO
 
+CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- babel_5448_db.babel_5448_s2 --| ' AS col1
+GO
+
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f2_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT id FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
+GO
+
+
 -- Test return statement inside function
 CREATE FUNCTION babel_5448_s1.babel_5448_f3() RETURNS NVARCHAR(MAX)
 AS
@@ -278,8 +380,15 @@ BEGIN
 END
 GO
 
-CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- babel_5448_db.babel_5448_s2 --| ' AS col1
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f3_tvf()
+RETURNS TABLE
+AS
+    RETURN (SELECT id AS ID
+    FROM babel_5448_t 
+    JOIN babel_5448_s2.babel_5448_v ON (1=1));
 GO
+
 
 CREATE TRIGGER dbo.babel_5448_trigger
 ON dbo.babel_5448_t
@@ -310,7 +419,7 @@ GO
 
 CREATE PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -321,7 +430,7 @@ GO
 
 CREATE PROCEDURE babel_5448_user_default_schema.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -332,7 +441,7 @@ GO
 
 CREATE PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -342,17 +451,18 @@ AS
 GO
 
 CREATE PROC dbo.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5448_f(), 
+         babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_user_default_schema.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_s1.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -401,6 +511,24 @@ AS
     END
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f4_tvf() 
+RETURNS TABLE 
+AS 
+RETURN 
+    WITH table_var(id) AS 
+    (
+        SELECT id 
+        FROM (VALUES (1), (255), (256)) AS t(id)
+    )
+    SELECT 
+        CASE 
+            WHEN MAX(id) > 255 THEN 255 
+            ELSE CAST(MAX(id) AS TINYINT) 
+        END AS MaxId 
+    FROM table_var;
+GO
+
 USE babel_5448_db
 GO
 
@@ -435,6 +563,24 @@ AS
         INSERT INTO @table_var VALUES (1), (255), (256)
         RETURN (SELECT CAST(max(id) AS TINYINT) FROM @table_var);
     END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f4_tvf() 
+RETURNS TABLE 
+AS 
+RETURN 
+    WITH table_var(id) AS 
+    (
+        SELECT id 
+        FROM (VALUES (1), (255), (256)) AS t(id)
+    )
+    SELECT 
+        CASE 
+            WHEN MAX(id) > 255 THEN 255 
+            ELSE CAST(MAX(id) AS TINYINT) 
+        END AS MaxId 
+    FROM table_var;
 GO
 
 
@@ -540,7 +686,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p11
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf();')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -550,7 +696,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p11
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf()')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -565,7 +711,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p12
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf()')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -575,7 +721,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p12
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf()')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -638,6 +784,14 @@ BEGIN
 END;
 GO
 
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f5_tvf()
+RETURNS TABLE AS 
+RETURN 
+    SELECT babel_5448_plpgsql_func() AS Value;
+GO
+
 -- same as previous but temp table will be created in another database and used inside this proc
 USE babel_5448_db
 GO
@@ -656,4 +810,12 @@ CREATE FUNCTION babel_5448_s1.babel_5448_f5() RETURNS NVARCHAR(MAX) AS
 BEGIN
     return (SELECT master.dbo.babel_5448_plpgsql_func())
 END;
+GO
+
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f5_tvf()
+RETURNS TABLE AS 
+RETURN 
+    SELECT  master.dbo.babel_5448_plpgsql_func() AS Value;
 GO

--- a/test/JDBC/expected/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-verify.out
+++ b/test/JDBC/expected/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-verify.out
@@ -14,8 +14,8 @@ GO
 EXEC dbo.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-babel_5448_db.dbo#!#babel_5448_db.dbo
+nvarchar#!#varchar#!#nvarchar
+babel_5448_db.dbo#!#babel_5448_db.dbo#!#babel_5448_db.dbo
 ~~END~~
 
 ~~START~~
@@ -59,8 +59,8 @@ babel_5448_db.dbo
 EXEC babel_5448_s1.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-babel_5448_db.babel_5448_s1#!#babel_5448_db.babel_5448_s1
+nvarchar#!#varchar#!#nvarchar
+babel_5448_db.babel_5448_s1#!#babel_5448_db.babel_5448_s1#!#babel_5448_db.babel_5448_s1
 ~~END~~
 
 ~~START~~
@@ -105,7 +105,7 @@ babel_5448_db.babel_5448_s1
 -- proc in babel_5448_s1 will reference objects from dbo schema
 ALTER PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_user_default_schema.babel_5448_f(), * FROM babel_5448_user_default_schema.babel_5448_t;
+    SELECT babel_5448_user_default_schema.babel_5448_f(), babel_5448_user_default_schema.babel_5792_tvf(), * FROM babel_5448_user_default_schema.babel_5448_t;
     EXEC babel_5448_user_default_schema.babel_5448_p;
     INSERT INTO babel_5448_user_default_schema.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM babel_5448_user_default_schema.babel_5448_t WHERE length(id) > 50;
@@ -115,7 +115,7 @@ GO
 
 ALTER PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT dbo.babel_5448_f(), * FROM dbo.babel_5448_t;
+    SELECT dbo.babel_5448_f(), dbo.babel_5792_tvf(), * FROM dbo.babel_5448_t;
     EXEC dbo.babel_5448_p;
     INSERT INTO dbo.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM dbo.babel_5448_t WHERE length(id) > 50;
@@ -127,8 +127,8 @@ GO
 EXEC dbo.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-babel_5448_db.babel_5448_user_default_schema#!#babel_5448_db.babel_5448_user_default_schema
+nvarchar#!#varchar#!#nvarchar
+babel_5448_db.babel_5448_user_default_schema#!#babel_5448_db.babel_5448_user_default_schema#!#babel_5448_db.babel_5448_user_default_schema
 ~~END~~
 
 ~~START~~
@@ -171,8 +171,8 @@ babel_5448_db.babel_5448_user_default_schema
 EXEC babel_5448_s1.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-babel_5448_db.dbo#!#babel_5448_db.dbo
+nvarchar#!#varchar#!#nvarchar
+babel_5448_db.dbo#!#babel_5448_db.dbo#!#babel_5448_db.dbo
 ~~END~~
 
 ~~START~~
@@ -218,6 +218,7 @@ babel_5448_db.dbo
 ALTER PROCEDURE dbo.babel_5448_p1
 AS
     INSERT INTO babel_5448_user_default_schema.babel_5448_t SELECT babel_5448_f() FROM generate_series(1,3);
+    INSERT INTO babel_5448_user_default_schema.babel_5448_t SELECT babel_5792_tvf() FROM generate_series(1,3);
     -- trigger execution will tells use what the function resolved to
     -- and what the objects inside triggers resolved to
     DELETE FROM babel_5448_user_default_schema.babel_5448_t WHERE id != 'babel_5448_db.babel_5448_user_default_schema'
@@ -226,6 +227,7 @@ GO
 ALTER PROCEDURE babel_5448_s1.babel_5448_p1
 AS
     INSERT INTO dbo.babel_5448_t SELECT babel_5448_f() FROM generate_series(1,3);
+    INSERT INTO dbo.babel_5448_t SELECT babel_5792_tvf() FROM generate_series(1,3);
     -- trigger execution will tells use what the function resolved to
     -- and what the objects inside triggers resolved to
     DELETE FROM dbo.babel_5448_t WHERE id != 'babel_5448_db.dbo'
@@ -259,7 +261,35 @@ varchar
 
 ~~ROW COUNT: 3~~
 
+~~START~~
+varchar
+=========== START OF TRIGGER EXECUTION ========== babel_5448_db.babel_5448_user_default_schema
+~~END~~
+
+~~START~~
+nvarchar
+babel_5448_db.babel_5448_user_default_schema
+~~END~~
+
+~~START~~
+nvarchar
+babel_5448_db.babel_5448_user_default_schema
+babel_5448_db.dbo
+babel_5448_db.dbo
+babel_5448_db.dbo
+babel_5448_db.dbo
+babel_5448_db.dbo
+babel_5448_db.dbo
+~~END~~
+
+~~START~~
+varchar
+=========== END OF TRIGGER EXECUTION ========== babel_5448_db.babel_5448_user_default_schema
+~~END~~
+
 ~~ROW COUNT: 3~~
+
+~~ROW COUNT: 6~~
 
 
 EXEC babel_5448_s1.babel_5448_p1
@@ -289,11 +319,39 @@ varchar
 
 ~~ROW COUNT: 3~~
 
+~~START~~
+varchar
+=========== START OF TRIGGER EXECUTION ========== babel_5448_db.dbo
+~~END~~
+
+~~START~~
+nvarchar
+babel_5448_db.dbo
+~~END~~
+
+~~START~~
+nvarchar
+babel_5448_db.dbo
+babel_5448_db.babel_5448_s1
+babel_5448_db.babel_5448_s1
+babel_5448_db.babel_5448_s1
+babel_5448_db.babel_5448_s1
+babel_5448_db.babel_5448_s1
+babel_5448_db.babel_5448_s1
+~~END~~
+
+~~START~~
+varchar
+=========== END OF TRIGGER EXECUTION ========== babel_5448_db.dbo
+~~END~~
+
 ~~ROW COUNT: 3~~
+
+~~ROW COUNT: 6~~
 
 
 -- Test INSERT EXEC
-CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX))
+CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX), col5 NVARCHAR(MAX), col6 NVARCHAR(MAX))
 GO
 
 INSERT INTO #temp EXEC dbo.babel_5448_p2
@@ -303,8 +361,8 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-babel_5448_db.dbo#!# |-- function in -- babel_5448_db.babel_5448_s2 --| #!#babel_5448_db.dbo#!# |-- view in -- babel_5448_db.babel_5448_s2 --| 
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+babel_5448_db.dbo#!#babel_5448_db.dbo#!# |-- function in -- babel_5448_db.babel_5448_s2 --| #!# |-- TVF in -- babel_5448_db.babel_5448_s2 --| #!#babel_5448_db.dbo#!# |-- view in -- babel_5448_db.babel_5448_s2 --| 
 ~~END~~
 
 
@@ -315,8 +373,8 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-babel_5448_db.babel_5448_s1#!# |-- function in -- babel_5448_db.babel_5448_s2 --| #!#babel_5448_db.babel_5448_s1#!# |-- view in -- babel_5448_db.babel_5448_s2 --| 
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+babel_5448_db.babel_5448_s1#!# |-- function in -- babel_5448_db.babel_5448_s2 --| #!#babel_5448_db.babel_5448_s1#!# |-- TVF in -- babel_5448_db.babel_5448_s2 --| #!#babel_5448_db.babel_5448_s1#!# |-- view in -- babel_5448_db.babel_5448_s2 --| 
 ~~END~~
 
 
@@ -326,9 +384,21 @@ GO
 
 -- Test declare statement inside function
 SELECT babel_5448_s1.babel_5448_f2();
+SELECT babel_5448_s1.babel_5792_f2_tvf();
 -- Test declare statement inside function
 SELECT babel_5448_s1.babel_5448_f3();
+SELECT babel_5448_s1.babel_5792_f3_tvf();
 GO
+~~START~~
+nvarchar
+babel_5448_db.babel_5448_s1
+~~END~~
+
+~~START~~
+nvarchar
+babel_5448_db.babel_5448_s1
+~~END~~
+
 ~~START~~
 nvarchar
 babel_5448_db.babel_5448_s1
@@ -351,8 +421,8 @@ GO
 EXEC master.dbo.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-master.dbo#!#master.dbo
+nvarchar#!#varchar#!#nvarchar
+master.dbo#!#master.dbo#!#master.dbo
 ~~END~~
 
 ~~START~~
@@ -367,6 +437,11 @@ varchar
 
 ~~START~~
 nvarchar
+master.dbo
+~~END~~
+
+~~START~~
+varchar
 master.dbo
 ~~END~~
 
@@ -396,8 +471,8 @@ master.dbo
 EXEC master.babel_5448_s1.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-master.babel_5448_s1#!#master.babel_5448_s1
+nvarchar#!#varchar#!#nvarchar
+master.babel_5448_s1#!#master.babel_5448_s1#!#master.babel_5448_s1
 ~~END~~
 
 ~~START~~
@@ -412,6 +487,11 @@ varchar
 
 ~~START~~
 nvarchar
+master.babel_5448_s1
+~~END~~
+
+~~START~~
+varchar
 master.babel_5448_s1
 ~~END~~
 
@@ -444,7 +524,7 @@ GO
 
 ALTER PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_user_default_schema.babel_5448_f(), * FROM babel_5448_user_default_schema.babel_5448_t;
+    SELECT babel_5448_user_default_schema.babel_5448_f(), babel_5448_user_default_schema.babel_5792_tvf(), * FROM babel_5448_user_default_schema.babel_5448_t;
     EXEC babel_5448_user_default_schema.babel_5448_p;
     INSERT INTO babel_5448_user_default_schema.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM babel_5448_user_default_schema.babel_5448_t WHERE length(id) > 50;
@@ -454,7 +534,7 @@ GO
 
 ALTER PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT dbo.babel_5448_f(), * FROM dbo.babel_5448_t;
+    SELECT dbo.babel_5448_f(), dbo.babel_5792_tvf(), * FROM dbo.babel_5448_t;
     EXEC dbo.babel_5448_p;
     INSERT INTO dbo.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM dbo.babel_5448_t WHERE length(id) > 50;
@@ -470,8 +550,8 @@ GO
 EXEC master.dbo.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-master.babel_5448_user_default_schema#!#master.babel_5448_user_default_schema
+nvarchar#!#varchar#!#nvarchar
+master.babel_5448_user_default_schema#!#master.babel_5448_user_default_schema#!#master.babel_5448_user_default_schema
 ~~END~~
 
 ~~START~~
@@ -486,6 +566,11 @@ varchar
 
 ~~START~~
 nvarchar
+master.babel_5448_user_default_schema
+~~END~~
+
+~~START~~
+varchar
 master.babel_5448_user_default_schema
 ~~END~~
 
@@ -514,8 +599,8 @@ master.babel_5448_user_default_schema
 EXEC master.babel_5448_s1.babel_5448_p1
 GO
 ~~START~~
-nvarchar#!#nvarchar
-master.dbo#!#master.dbo
+nvarchar#!#varchar#!#nvarchar
+master.dbo#!#master.dbo#!#master.dbo
 ~~END~~
 
 ~~START~~
@@ -530,6 +615,11 @@ varchar
 
 ~~START~~
 nvarchar
+master.dbo
+~~END~~
+
+~~START~~
+varchar
 master.dbo
 ~~END~~
 
@@ -555,7 +645,7 @@ master.dbo
 
 
 -- Test INSERT EXEC
-CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX))
+CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX), col5 NVARCHAR(MAX), col6 NVARCHAR(MAX))
 GO
 
 INSERT INTO #temp EXEC master.dbo.babel_5448_p2
@@ -565,15 +655,15 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-master.dbo#!# |-- function in -- master.babel_5448_s2 --| #!#master.dbo#!# |-- view in -- master.babel_5448_s2 --| 
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+master.dbo#!#master.dbo#!# |-- function in -- master.babel_5448_s2 --| #!# |-- TVF in -- master.babel_5448_s2 --| #!#master.dbo#!# |-- view in -- master.babel_5448_s2 --| 
 ~~END~~
 
 EXEC master.babel_5448_s1.babel_5448_p2
 GO
 ~~START~~
-nvarchar#!#nvarchar#!#nvarchar#!#varchar
-master.babel_5448_s1#!# |-- function in -- master.babel_5448_s2 --| #!#master.babel_5448_s1#!# |-- view in -- master.babel_5448_s2 --| 
+nvarchar#!#nvarchar#!#varchar#!#varchar#!#nvarchar#!#varchar
+master.babel_5448_s1#!# |-- function in -- master.babel_5448_s2 --| #!#master.babel_5448_s1#!# |-- TVF in -- master.babel_5448_s2 --| #!#master.babel_5448_s1#!# |-- view in -- master.babel_5448_s2 --| 
 ~~END~~
 
 INSERT INTO #temp EXEC master.babel_5448_s1.babel_5448_p2
@@ -583,17 +673,29 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
-master.babel_5448_s1#!# |-- function in -- master.babel_5448_s2 --| #!#master.babel_5448_s1#!# |-- view in -- master.babel_5448_s2 --| 
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+master.babel_5448_s1#!# |-- function in -- master.babel_5448_s2 --| #!#master.babel_5448_s1#!# |-- TVF in -- master.babel_5448_s2 --| #!#master.babel_5448_s1#!# |-- view in -- master.babel_5448_s2 --| 
 ~~END~~
 
 
 
 -- Test declare statement inside function
 SELECT master.babel_5448_s1.babel_5448_f2();
+SELECT master.babel_5448_s1.babel_5792_f2_tvf();
 -- Test declare statement inside function
 SELECT master.babel_5448_s1.babel_5448_f3();
+SELECT master.babel_5448_s1.babel_5792_f3_tvf();
 GO
+~~START~~
+nvarchar
+master.babel_5448_s1
+~~END~~
+
+~~START~~
+nvarchar
+master.babel_5448_s1
+~~END~~
+
 ~~START~~
 nvarchar
 master.babel_5448_s1
@@ -710,6 +812,13 @@ int
 
 ~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
 
+SELECT babel_5448_s1.babel_5792_f4_tvf();
+GO
+~~START~~
+int
+255
+~~END~~
+
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 ~~START~~
@@ -826,6 +935,13 @@ int
 
 ~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
 
+SELECT babel_5448_s1.babel_5792_f4_tvf();
+GO
+~~START~~
+int
+255
+~~END~~
+
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 ~~START~~
@@ -924,10 +1040,10 @@ varchar
 ~~END~~
 
 
-SELECT master.babel_5448_s1.babel_5448_f4() FROM generate_series(1,3);
+SELECT master.babel_5448_s1.babel_5448_f4(), master.babel_5448_s1.babel_5792_f4_tvf() FROM generate_series(1,3);
 GO
 ~~START~~
-int
+int#!#int
 ~~ERROR (Code: 220)~~
 
 ~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
@@ -1040,10 +1156,10 @@ varchar
 
 BEGIN TRAN
 GO
-SELECT master.babel_5448_s1.babel_5448_f4() FROM generate_series(1,3);
+SELECT master.babel_5448_s1.babel_5448_f4(), master.babel_5448_s1.babel_5792_f4_tvf() FROM generate_series(1,3);
 GO
 ~~START~~
-int
+int#!#int
 ~~ERROR (Code: 220)~~
 
 ~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
@@ -1295,6 +1411,11 @@ babel_5448_db.babel_5448_s1
 ~~END~~
 
 ~~START~~
+nvarchar
+babel_5448_db.babel_5448_s1
+~~END~~
+
+~~START~~
 nvarchar#!#varchar
 babel_5448_db.babel_5448_s1#!# |-- view in -- babel_5448_db.babel_5448_s2 --| 
 ~~END~~
@@ -1310,6 +1431,11 @@ master.babel_5448_s1#!# |-- view in -- master.babel_5448_s2 --|
 ~~START~~
 nvarchar#!#varchar
 master.dbo#!# |-- view in -- master.babel_5448_s2 --| 
+~~END~~
+
+~~START~~
+nvarchar
+master.babel_5448_s1
 ~~END~~
 
 ~~START~~
@@ -1345,6 +1471,11 @@ babel_5448_db.babel_5448_s1
 ~~END~~
 
 ~~START~~
+nvarchar
+babel_5448_db.babel_5448_s1
+~~END~~
+
+~~START~~
 nvarchar#!#varchar
 babel_5448_db.babel_5448_s1#!# |-- view in -- babel_5448_db.babel_5448_s2 --| 
 ~~END~~
@@ -1360,6 +1491,11 @@ master.babel_5448_s1#!# |-- view in -- master.babel_5448_s2 --|
 ~~START~~
 nvarchar#!#varchar
 master.dbo#!# |-- view in -- master.babel_5448_s2 --| 
+~~END~~
+
+~~START~~
+nvarchar
+master.babel_5448_s1
 ~~END~~
 
 ~~START~~
@@ -1594,11 +1730,17 @@ master.babel_5448_s1#!#<-------- temp table --------->
 
 
 SELECT master.babel_5448_s1.babel_5448_f5();
+SELECT master.babel_5448_s1.babel_5792_f5_tvf();
 CREATE TABLE #temp_babel_5448 (id NVARCHAR(MAX));
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 ~~START~~
 nvarchar
+master.babel_5448_s1
+~~END~~
+
+~~START~~
+text
 master.babel_5448_s1
 ~~END~~
 
@@ -1645,9 +1787,15 @@ DROP TABLE #temp_babel_5448;
 GO
 
 SELECT babel_5448_s1.babel_5448_f5();
+SELECT babel_5448_s1.babel_5792_f5_tvf();
 GO
 ~~START~~
 nvarchar
+babel_5448_db.babel_5448_s1
+~~END~~
+
+~~START~~
+text
 babel_5448_db.babel_5448_s1
 ~~END~~
 

--- a/test/JDBC/input/BABEL-CROSS-DB.mix
+++ b/test/JDBC/input/BABEL-CROSS-DB.mix
@@ -14,6 +14,15 @@ AS
 SELECT a FROM dbo.master_t1;
 GO
 
+-- TVF
+CREATE FUNCTION myschema.cross_db_babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'Accessible' as status;
+GO
+
+
 CREATE TABLE myschema.tab1( a int);
 GO
  
@@ -44,6 +53,14 @@ GO
 USE db1;
 GO
 
+-- TVF
+CREATE FUNCTION dbo.nested_babel_5792_tvf()
+RETURNS TABLE 
+AS
+RETURN
+    SELECT master.myschema.cross_db_babel_5792_tvf()
+GO
+
 SELECT current_user;
 GO
 
@@ -64,6 +81,11 @@ GO
 
 EXEC master.dbo.master_p2
 GO
+
+-- access on TVF as current user is dbo.
+-- should work
+SELECT master.myschema.cross_db_babel_5792_tvf();
+go
 
 -- tab1 resolves to master.myschema.tab1
 EXEC master.myschema.proc1
@@ -159,6 +181,23 @@ GO
 USE MASTER;
 GO
 
+CREATE database db2;
+GO
+
+USE db2
+GO
+
+-- access on outer and inner TVFs as current user is dbo.
+-- should work
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+
+USE master
+GO
+
+DROP database db2
+GO
+
 SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
 GO
 
@@ -188,8 +227,17 @@ GO
 SELECT * FROM db1.dbo.db1_t1 ORDER BY a;
 GO
 
+-- user has no access on TVF.
+-- should give permission denied
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+
 USE db1;
 GO
+
+-- should give permission denied
+SELECT master.myschema.cross_db_babel_5792_tvf();
+go
 
 EXEC master.dbo.master_p2
 GO
@@ -211,6 +259,9 @@ GO
 GRANT EXECUTE ON dbo.master_p2 TO master_janedoe;
 GO
 
+GRANT EXECUTE ON myschema.cross_db_babel_5792_tvf TO master_janedoe;
+GO
+
 USE db1;
 GO
 
@@ -218,10 +269,20 @@ GRANT SELECT ON dbo.db1_t1 TO db1_janedoe;
 GO
 
 -- tsql user=johndoe password=12345678
+USE db1;
+GO
+
+-- user has access on base TVF
+-- should work
+SELECT master.myschema.cross_db_babel_5792_tvf();
+go
+
 USE MASTER;
 GO
 
-USE db1;
+-- user doesn't have access on outer TVF
+-- should give permission denied
+SELECT db1.dbo.nested_babel_5792_tvf()
 GO
 
 EXEC master.dbo.master_p2
@@ -235,13 +296,88 @@ GO
 -- terminate-tsql-conn user=johndoe password=12345678
 
 -- tsql
+USE master;
+GO
+
+REVOKE EXECUTE ON myschema.cross_db_babel_5792_tvf FROM master_janedoe;
+GO
+
+use db1
+GO
+
+GRANT EXECUTE ON nested_babel_5792_tvf TO db1_janedoe;
+GO
+
+-- tsql user=johndoe password=12345678
+USE MASTER;
+GO
+
+-- user doesn't have access on inner TVF but has on outer.
+-- should give permission denied
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+
+-- terminate-tsql-conn user=johndoe password=12345678
+
+-- tsql
+USE master;
+GO
+
+CREATE DATABASE db2
+GO
+
+USE db2
+GO
+
+CREATE USER db2_janedoe FOR LOGIN johndoe;
+GO
+
+USE MASTER;
+GO
+
+GRANT EXECUTE ON myschema.cross_db_babel_5792_tvf TO master_janedoe;
+GO
+
+-- tsql user=johndoe password=12345678
+USE db2
+GO
+
+select current_user;
+GO
+
+-- user has access on outer and inner both TVF
+-- should work
+SELECT db1.dbo.nested_babel_5792_tvf()
+GO
+
+-- terminate-tsql-conn user=johndoe password=12345678
+
+-- tsql
+USE db2;
+GO
+
+DROP USER db2_janedoe;
+GO
+
 USE db1;
+GO
+
+DROP database db2;
+GO
+
+REVOKE EXECUTE ON nested_babel_5792_tvf FROM db1_janedoe;
 GO
 
 REVOKE SELECT ON dbo.db1_t1 FROM db1_janedoe;
 GO
 
+DROP FUNCTION dbo.nested_babel_5792_tvf
+GO
+
 USE MASTER;
+GO
+
+REVOKE EXECUTE ON myschema.cross_db_babel_5792_tvf FROM master_janedoe;
 GO
 
 DROP DATABASE db1;
@@ -449,6 +585,9 @@ DROP DATABASE db1;
 GO
 
 DROP TABLE dbo.master_t1;
+GO
+
+DROP FUNCTION myschema.cross_db_babel_5792_tvf;
 GO
 
 DROP PROC dbo.master_p1;

--- a/test/JDBC/input/object_resolution/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-cleanup.mix
+++ b/test/JDBC/input/object_resolution/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-cleanup.mix
@@ -32,6 +32,17 @@ GO
 DROP FUNCTION babel_5448_s2.babel_5448_f
 GO
 
+DROP FUNCTION dbo.babel_5792_tvf
+GO
+DROP FUNCTION babel_5448_user_default_schema.babel_5792_tvf
+GO
+DROP FUNCTION babel_5448_s1.babel_5792_tvf, babel_5448_s1.babel_5792_f2_tvf,
+              babel_5448_s1.babel_5792_f3_tvf, babel_5448_s1.babel_5792_f4_tvf,
+              babel_5448_s1.babel_5792_f5_tvf;
+GO
+DROP FUNCTION babel_5448_s2.babel_5792_tvf
+GO
+
 DROP TABLE dbo.babel_5448_t
 GO
 DROP TABLE babel_5448_user_default_schema.babel_5448_t

--- a/test/JDBC/input/object_resolution/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-prepare.mix
+++ b/test/JDBC/input/object_resolution/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-prepare.mix
@@ -70,11 +70,28 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION dbo.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'master.dbo' as SchemaName;
+GO
+
+
 CREATE FUNCTION babel_5448_user_default_schema.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN 'master.babel_5448_user_default_schema';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_user_default_schema.babel_5792_tvf()
+RETURNS TABLE 
+AS
+RETURN
+    SELECT 'master.babel_5448_user_default_schema' as SchemaName;
 GO
 
 CREATE FUNCTION babel_5448_s1.babel_5448_f() RETURNS NVARCHAR(MAX)
@@ -84,11 +101,27 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'master.babel_5448_s1' as SchemaName;
+GO
+
 CREATE FUNCTION babel_5448_s2.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN ' |-- function in -- master.babel_5448_s2 --| ';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s2.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT ' |-- TVF in -- master.babel_5448_s2 --| ' as SchemaName;
 GO
 
 -- Test declare statement inside function
@@ -100,6 +133,19 @@ BEGIN
 END
 GO
 
+CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- master.babel_5448_s2 --| ' AS col1
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f2_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT id FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
+
+GO
+
+
 -- Test return statement inside function
 CREATE FUNCTION babel_5448_s1.babel_5448_f3() RETURNS NVARCHAR(MAX)
 AS
@@ -108,7 +154,13 @@ BEGIN
 END
 GO
 
-CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- master.babel_5448_s2 --| ' AS col1
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f3_tvf()
+RETURNS TABLE
+AS
+    RETURN (SELECT id
+    FROM babel_5448_t 
+    JOIN babel_5448_s2.babel_5448_v ON (1=1));
 GO
 
 CREATE TRIGGER dbo.babel_5448_trigger
@@ -116,6 +168,7 @@ ON dbo.babel_5448_t
 AFTER INSERT AS
     SELECT '=========== START OF TRIGGER EXECUTION ========== master.dbo'
     SELECT dbo.babel_5448_f();
+    SELECT dbo.babel_5792_tvf();
     SELECT * FROM babel_5448_t;
     SELECT '=========== END OF TRIGGER EXECUTION ========== master.dbo'
 GO
@@ -125,6 +178,7 @@ ON babel_5448_user_default_schema.babel_5448_t
 AFTER INSERT AS
     SELECT '=========== START OF TRIGGER EXECUTION ========== master.babel_5448_user_default_schema'
     SELECT babel_5448_user_default_schema.babel_5448_f();
+    SELECT babel_5448_user_default_schema.babel_5792_tvf();
     SELECT * FROM babel_5448_t;
     SELECT '=========== END OF TRIGGER EXECUTION ========== master.babel_5448_user_default_schema'
 GO
@@ -134,13 +188,14 @@ ON babel_5448_s1.babel_5448_t
 AFTER INSERT AS
     SELECT '=========== START OF TRIGGER EXECUTION ========== master.babel_5448_s1'
     SELECT babel_5448_s1.babel_5448_f();
+    SELECT babel_5448_s1.babel_5792_tvf();
     SELECT * FROM babel_5448_t;
     SELECT '=========== END OF TRIGGER EXECUTION ========== master.babel_5448_s1'
 GO
 
 CREATE PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -151,7 +206,7 @@ GO
 
 CREATE PROCEDURE babel_5448_user_default_schema.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -162,7 +217,7 @@ GO
 
 CREATE PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -172,17 +227,17 @@ AS
 GO
 
 CREATE PROC dbo.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5448_f(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_user_default_schema.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_s1.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -228,11 +283,28 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION dbo.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'babel_5448_db.dbo' as SchemaName;
+GO
+
+
 CREATE FUNCTION babel_5448_user_default_schema.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN 'babel_5448_db.babel_5448_user_default_schema';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_user_default_schema.babel_5792_tvf()
+RETURNS TABLE 
+AS
+RETURN
+    SELECT 'babel_5448_db.babel_5448_user_default_schema' as SchemaName;
 GO
 
 CREATE FUNCTION babel_5448_s1.babel_5448_f() RETURNS NVARCHAR(MAX)
@@ -242,11 +314,28 @@ BEGIN
 END
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT 'babel_5448_db.babel_5448_s1' as SchemaName;
+GO
+
 CREATE FUNCTION babel_5448_s2.babel_5448_f() RETURNS NVARCHAR(MAX)
 AS
 BEGIN
     RETURN ' |-- function in -- babel_5448_db.babel_5448_s2 --| ';
 END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s2.babel_5792_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT ' |-- TVF in -- babel_5448_db.babel_5448_s2 --| ' as SchemaName;
+    
 GO
 
 -- Test declare statement inside function
@@ -258,6 +347,19 @@ BEGIN
 END
 GO
 
+CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- babel_5448_db.babel_5448_s2 --| ' AS col1
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f2_tvf()
+RETURNS TABLE
+AS
+RETURN
+    SELECT id FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
+
+GO
+
+
 -- Test return statement inside function
 CREATE FUNCTION babel_5448_s1.babel_5448_f3() RETURNS NVARCHAR(MAX)
 AS
@@ -266,8 +368,15 @@ BEGIN
 END
 GO
 
-CREATE VIEW babel_5448_s2.babel_5448_v AS SELECT ' |-- view in -- babel_5448_db.babel_5448_s2 --| ' AS col1
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f3_tvf()
+RETURNS TABLE
+AS
+    RETURN (SELECT id AS ID
+    FROM babel_5448_t 
+    JOIN babel_5448_s2.babel_5448_v ON (1=1));
 GO
+
 
 CREATE TRIGGER dbo.babel_5448_trigger
 ON dbo.babel_5448_t
@@ -298,7 +407,7 @@ GO
 
 CREATE PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -309,7 +418,7 @@ GO
 
 CREATE PROCEDURE babel_5448_user_default_schema.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -320,7 +429,7 @@ GO
 
 CREATE PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT babel_5448_f(), * FROM babel_5448_t;
+    SELECT babel_5448_f(), babel_5792_tvf(), * FROM babel_5448_t;
     -- EXEC call should still resolve to dbo.babel_5448_p
     EXEC babel_5448_p;
     INSERT INTO babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
@@ -330,17 +439,18 @@ AS
 GO
 
 CREATE PROC dbo.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5448_f(), 
+         babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_user_default_schema.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
 CREATE PROC babel_5448_s1.babel_5448_p2 AS
-    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), * FROM
+    SELECT babel_5448_f(), babel_5448_s2.babel_5448_f(), babel_5792_tvf(), babel_5448_s2.babel_5792_tvf(), * FROM
         babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -389,6 +499,24 @@ AS
     END
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f4_tvf() 
+RETURNS TABLE 
+AS 
+RETURN 
+    WITH table_var(id) AS 
+    (
+        SELECT id 
+        FROM (VALUES (1), (255), (256)) AS t(id)
+    )
+    SELECT 
+        CASE 
+            WHEN MAX(id) > 255 THEN 255 
+            ELSE CAST(MAX(id) AS TINYINT) 
+        END AS MaxId 
+    FROM table_var;
+GO
+
 USE babel_5448_db
 GO
 
@@ -423,6 +551,24 @@ AS
         INSERT INTO @table_var VALUES (1), (255), (256)
         RETURN (SELECT CAST(max(id) AS TINYINT) FROM @table_var);
     END
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f4_tvf() 
+RETURNS TABLE 
+AS 
+RETURN 
+    WITH table_var(id) AS 
+    (
+        SELECT id 
+        FROM (VALUES (1), (255), (256)) AS t(id)
+    )
+    SELECT 
+        CASE 
+            WHEN MAX(id) > 255 THEN 255 
+            ELSE CAST(MAX(id) AS TINYINT) 
+        END AS MaxId 
+    FROM table_var;
 GO
 
 
@@ -528,7 +674,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p11
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf();')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -538,7 +684,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p11
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf()')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -553,7 +699,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p12
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf()')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -563,7 +709,7 @@ GO
 CREATE PROCEDURE babel_5448_s1.babel_5448_p12
 AS
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
-    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2();')
+    EXEC('SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1); SELECT babel_5448_s1.babel_5448_f2(); SELECT babel_5448_s1.babel_5792_f2_tvf()')
     SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -626,6 +772,14 @@ BEGIN
 END;
 GO
 
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f5_tvf()
+RETURNS TABLE AS 
+RETURN 
+    SELECT babel_5448_plpgsql_func() AS Value;
+
+GO
+
 -- same as previous but temp table will be created in another database and used inside this proc
 USE babel_5448_db
 GO
@@ -644,4 +798,12 @@ CREATE FUNCTION babel_5448_s1.babel_5448_f5() RETURNS NVARCHAR(MAX) AS
 BEGIN
     return (SELECT master.dbo.babel_5448_plpgsql_func())
 END;
+GO
+
+-- TVF
+CREATE FUNCTION babel_5448_s1.babel_5792_f5_tvf()
+RETURNS TABLE AS 
+RETURN 
+    SELECT  master.dbo.babel_5448_plpgsql_func() AS Value;
+
 GO

--- a/test/JDBC/input/object_resolution/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-verify.mix
+++ b/test/JDBC/input/object_resolution/BABEL_OBJECT_RESOLUTION_IN_ROUTINES-vu-verify.mix
@@ -25,7 +25,7 @@ GO
 
 ALTER PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_user_default_schema.babel_5448_f(), * FROM babel_5448_user_default_schema.babel_5448_t;
+    SELECT babel_5448_user_default_schema.babel_5448_f(), babel_5448_user_default_schema.babel_5792_tvf(), * FROM babel_5448_user_default_schema.babel_5448_t;
     EXEC babel_5448_user_default_schema.babel_5448_p;
     INSERT INTO babel_5448_user_default_schema.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM babel_5448_user_default_schema.babel_5448_t WHERE length(id) > 50;
@@ -35,7 +35,7 @@ GO
 
 ALTER PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT dbo.babel_5448_f(), * FROM dbo.babel_5448_t;
+    SELECT dbo.babel_5448_f(), dbo.babel_5792_tvf(), * FROM dbo.babel_5448_t;
     EXEC dbo.babel_5448_p;
     INSERT INTO dbo.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM dbo.babel_5448_t WHERE length(id) > 50;
@@ -58,6 +58,7 @@ GO
 ALTER PROCEDURE dbo.babel_5448_p1
 AS
     INSERT INTO babel_5448_user_default_schema.babel_5448_t SELECT babel_5448_f() FROM generate_series(1,3);
+    INSERT INTO babel_5448_user_default_schema.babel_5448_t SELECT babel_5792_tvf() FROM generate_series(1,3);
     -- trigger execution will tells use what the function resolved to
     -- and what the objects inside triggers resolved to
     DELETE FROM babel_5448_user_default_schema.babel_5448_t WHERE id != 'babel_5448_db.babel_5448_user_default_schema'
@@ -66,6 +67,7 @@ GO
 ALTER PROCEDURE babel_5448_s1.babel_5448_p1
 AS
     INSERT INTO dbo.babel_5448_t SELECT babel_5448_f() FROM generate_series(1,3);
+    INSERT INTO dbo.babel_5448_t SELECT babel_5792_tvf() FROM generate_series(1,3);
     -- trigger execution will tells use what the function resolved to
     -- and what the objects inside triggers resolved to
     DELETE FROM dbo.babel_5448_t WHERE id != 'babel_5448_db.dbo'
@@ -79,7 +81,7 @@ EXEC babel_5448_s1.babel_5448_p1
 GO
 
 -- Test INSERT EXEC
-CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX))
+CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX), col5 NVARCHAR(MAX), col6 NVARCHAR(MAX))
 GO
 
 INSERT INTO #temp EXEC dbo.babel_5448_p2
@@ -97,9 +99,11 @@ GO
 
 -- Test declare statement inside function
 SELECT babel_5448_s1.babel_5448_f2();
+SELECT babel_5448_s1.babel_5792_f2_tvf();
 
 -- Test declare statement inside function
 SELECT babel_5448_s1.babel_5448_f3();
+SELECT babel_5448_s1.babel_5792_f3_tvf();
 GO
 
 /*********************************/
@@ -126,7 +130,7 @@ GO
 
 ALTER PROCEDURE dbo.babel_5448_p1
 AS
-    SELECT babel_5448_user_default_schema.babel_5448_f(), * FROM babel_5448_user_default_schema.babel_5448_t;
+    SELECT babel_5448_user_default_schema.babel_5448_f(), babel_5448_user_default_schema.babel_5792_tvf(), * FROM babel_5448_user_default_schema.babel_5448_t;
     EXEC babel_5448_user_default_schema.babel_5448_p;
     INSERT INTO babel_5448_user_default_schema.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM babel_5448_user_default_schema.babel_5448_t WHERE length(id) > 50;
@@ -136,7 +140,7 @@ GO
 
 ALTER PROCEDURE babel_5448_s1.babel_5448_p1
 AS
-    SELECT dbo.babel_5448_f(), * FROM dbo.babel_5448_t;
+    SELECT dbo.babel_5448_f(), dbo.babel_5792_tvf(), * FROM dbo.babel_5448_t;
     EXEC dbo.babel_5448_p;
     INSERT INTO dbo.babel_5448_t VALUES ('temp inserted row to check DML and trigger executiong');
     DELETE FROM dbo.babel_5448_t WHERE length(id) > 50;
@@ -157,7 +161,7 @@ EXEC master.babel_5448_s1.babel_5448_p1
 GO
 
 -- Test INSERT EXEC
-CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX))
+CREATE TABLE #temp (col1 NVARCHAR(MAX), col2 NVARCHAR(MAX), col3 NVARCHAR(MAX), col4 NVARCHAR(MAX), col5 NVARCHAR(MAX), col6 NVARCHAR(MAX))
 GO
 
 INSERT INTO #temp EXEC master.dbo.babel_5448_p2
@@ -173,9 +177,11 @@ GO
 
 -- Test declare statement inside function
 SELECT master.babel_5448_s1.babel_5448_f2();
+SELECT master.babel_5448_s1.babel_5792_f2_tvf();
 
 -- Test declare statement inside function
 SELECT master.babel_5448_s1.babel_5448_f3();
+SELECT master.babel_5448_s1.babel_5792_f3_tvf();
 GO
 
 DROP TABLE #temp
@@ -205,6 +211,8 @@ GO
 
 SELECT babel_5448_s1.babel_5448_f4();
 GO
+SELECT babel_5448_s1.babel_5792_f4_tvf();
+GO
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 
@@ -238,6 +246,8 @@ BEGIN TRAN
 GO
 SELECT babel_5448_s1.babel_5448_f4();
 GO
+SELECT babel_5448_s1.babel_5792_f4_tvf();
+GO
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
 COMMIT
@@ -259,7 +269,7 @@ GO
 SELECT '========= END OF TRANSACTION ABORTING ERROR ===================='
 GO
 
-SELECT master.babel_5448_s1.babel_5448_f4() FROM generate_series(1,3);
+SELECT master.babel_5448_s1.babel_5448_f4(), master.babel_5448_s1.babel_5792_f4_tvf() FROM generate_series(1,3);
 GO
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
@@ -292,7 +302,7 @@ GO
 
 BEGIN TRAN
 GO
-SELECT master.babel_5448_s1.babel_5448_f4() FROM generate_series(1,3);
+SELECT master.babel_5448_s1.babel_5448_f4(), master.babel_5448_s1.babel_5792_f4_tvf() FROM generate_series(1,3);
 GO
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
 GO
@@ -468,6 +478,7 @@ EXEC master.babel_5448_s1.babel_5448_p15
 GO
 
 SELECT master.babel_5448_s1.babel_5448_f5();
+SELECT master.babel_5448_s1.babel_5792_f5_tvf();
 
 CREATE TABLE #temp_babel_5448 (id NVARCHAR(MAX));
 SELECT * FROM babel_5448_t JOIN babel_5448_s2.babel_5448_v ON (1=1);
@@ -478,4 +489,5 @@ DROP TABLE #temp_babel_5448;
 GO
 
 SELECT babel_5448_s1.babel_5448_f5();
+SELECT babel_5448_s1.babel_5792_f5_tvf();
 GO

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-cleanup.mix
@@ -48,6 +48,9 @@ GO
 DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1;
 GO
 
+DROP FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_tvf1;
+GO
+
 DROP PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested;
 GO
 
@@ -84,10 +87,16 @@ GO
 DROP FUNCTION dbo.babel_cross_db_vu_prepare_f2;
 GO
 
+DROP FUNCTION dbo.babel_cross_db_vu_prepare_tvf2;
+GO
+
 DROP VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2;
 GO
 
 DROP FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2;
+GO
+
+DROP FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2;
 GO
 
 DROP TABLE babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2;

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-prepare.mix
@@ -102,6 +102,11 @@ CREATE FUNCTION dbo.babel_cross_db_vu_prepare_f2 (@a int)
     END;
 GO
 
+CREATE FUNCTION dbo.babel_cross_db_vu_prepare_tvf2()
+    RETURNS TABLE AS
+    RETURN select 'IT IS TVF' as col;
+GO
+
 -- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
 USE my_babel_cross_db_vu_prepare_db1;
 GO
@@ -119,8 +124,14 @@ CREATE FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2 (@a in
     END;
 GO
 
+CREATE FUNCTION babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2()
+    RETURNS TABLE AS
+    RETURN select 'IT IS TVF' as col;
+GO
+
 CREATE VIEW babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 AS
-    SELECT id, babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(id), name
+    SELECT id, babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(id),
+    babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2(), name
     FROM babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_t2
     ORDER BY id;
 GO
@@ -144,6 +155,7 @@ GO
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1 AS
     SELECT x.id,
         my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(x.id),
+        my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2(),
         x.name AS t1_name,
         y.name AS t2_name
     FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1 x INNER JOIN
@@ -161,7 +173,8 @@ GO
 
 -- View containing cross-db function on which login babel_cross_db_vu_prepare_l1 does not have privilege
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v3 AS
-    SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(id) AS id, name
+    SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(id) AS id,
+    my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_tvf2(), name
     FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_t1
     ORDER BY id;
 GO
@@ -196,6 +209,11 @@ CREATE FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1 (@a in
     END;
 GO
 
+CREATE FUNCTION babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_tvf1()
+    RETURNS TABLE AS
+    RETURN SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2();
+GO
+
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1_nested AS
     SELECT * FROM babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v1;
 GO
@@ -213,7 +231,8 @@ CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v4_nested AS
 GO
 
 CREATE VIEW babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_v5_nested AS
-    SELECT babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1(1) AS id;
+    SELECT babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_f1(1) AS id,
+    babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_tvf1();
 GO
 
 CREATE PROCEDURE babel_cross_db_vu_prepare_s1.babel_cross_db_vu_prepare_p1_nested

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
@@ -272,12 +272,18 @@ GO
 SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_f2(1);
 GO
 
+SELECT my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_tvf2();
+GO
+
 -- bare SELECT table from db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
 SELECT * FROM my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_t2 ORDER BY id;
 GO
 
 -- bare SELECT function from db1, which login babel_cross_db_vu_prepare_l1 does not have privilege, should throw error
 SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_f2(1);
+GO
+
+SELECT my_babel_cross_db_vu_prepare_db1.dbo.babel_cross_db_vu_prepare_tvf2();
 GO
 
 -- SELECT from a view in db1 which references objects in db1, which login babel_cross_db_vu_prepare_l1 has privilege, should be successful


### PR DESCRIPTION
### Description
fix: correct behavior of cross-database table valued functions

Earlier, tabled valued function was not working for cross-db scenarios, with this commit we have fixed it's behaviour.

Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/583

### Issues Resolved

BABEL-5792
