### PR TITLE
Optimize the antlr g4 definition to get better performance

### DIFF
--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5266,26 +5266,15 @@ collation
     ;
 
 full_column_name
-// standard
-    : column_name=id                                     // column
-    | column=id DOT geospatial_col          // column.geospatial
-    | tablename=id DOT column_name=id                      // table.column_name
-    | table=id DOT column=id DOT geospatial_col          // table.column.geospatial
+    : column_name=id                                    // column
+    | column=id DOT geospatial_col                      // column.geospatial
+    | tablename=id DOT column_name=id                   // table.column_name
+    | table=id DOT column=id DOT geospatial_col         // table.column.geospatial
     | schema=id DOT tablename=id DOT column_name=id                      // schema.tablename.column_name
     | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
     | server=id DOT schema=id DOT tablename=id DOT column_name=id               // server.schema.tablename.column_name
-// geospatial_col
-// standard partial with missing IDs
-//    | DOT column_name=id
-//    | DOT DOT column_name=id
-//    | DOT DOT DOT column_name=id
-    | DOT tablename=id DOT column_name=id
-//    | DOT DOT tablename=id DOT column_name=id
-//    | DOT schema=id DOT tablename=id DOT column_name=id
-// geospatial_col partial with missing IDs
-//    | DOT table=id DOT column=id DOT geospatial_col                      // .t.c.g
-//    | DOT DOT column=id DOT geospatial_col                               // ..c.g
-//    | DOT column=id DOT geospatial_col                               // .c.g
+    | DOT tablename=id DOT column_name=id                                       // .tablename.column_name
+    | DOT DOT tablename=id DOT column_name=id                                   // ..tablename.column_name
     ;
 
 column_name_list_with_order

--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5274,8 +5274,6 @@ full_column_name
     | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
     | server=id DOT schema=id DOT tablename=id DOT column_name=id               // server.schema.tablename.column_name
     | DOT tablename=id DOT column_name=id                                       // .tablename.column_name
-    | DOT table=id DOT column=id DOT geospatial_col                             // .tablename.column_name.geospatial
-    | DOT DOT column=id DOT geospatial_col                                      // ..column.geospatial
     | DOT DOT tablename=id DOT column_name=id                                   // ..tablename.column_name
     ;
 

--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5266,8 +5266,13 @@ collation
     ;
     
 full_column_name
-    : ((schema=id? DOT)? table=id? DOT)? column=id DOT geospatial_col
-    | (((server=id? DOT)? schema=id? DOT)? tablename=id? DOT)? column_name=id
+    : column_name=id                                     // column
+    | tablename=id DOT column_name=id                      // table.column_name
+    | schema=id DOT tablename=id DOT column_name=id                      // schema.tablename.column_name
+    | server=id DOT schema=id DOT tablename=id DOT column_name=id               // server.schema.tablename.column_name
+    | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
+    | table=id DOT column=id DOT geospatial_col          // table.column.geospatial
+    | column=id DOT geospatial_col          // table.column.geospatial
     ;
 
 column_name_list_with_order

--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5268,24 +5268,24 @@ collation
 full_column_name
 // standard
     : column_name=id                                     // column
+    | column=id DOT geospatial_col          // column.geospatial
     | tablename=id DOT column_name=id                      // table.column_name
+    | table=id DOT column=id DOT geospatial_col          // table.column.geospatial
     | schema=id DOT tablename=id DOT column_name=id                      // schema.tablename.column_name
+    | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
     | server=id DOT schema=id DOT tablename=id DOT column_name=id               // server.schema.tablename.column_name
 // geospatial_col
-    | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
-    | table=id DOT column=id DOT geospatial_col          // table.column.geospatial
-    | column=id DOT geospatial_col          // table.column.geospatial
 // standard partial with missing IDs
-    | DOT column_name=id
-    | DOT DOT column_name=id
-    | DOT DOT DOT column_name=id
+//    | DOT column_name=id
+//    | DOT DOT column_name=id
+//    | DOT DOT DOT column_name=id
     | DOT tablename=id DOT column_name=id
-    | DOT DOT tablename=id DOT column_name=id
-    | DOT schema=id DOT tablename=id DOT column_name=id
+//    | DOT DOT tablename=id DOT column_name=id
+//    | DOT schema=id DOT tablename=id DOT column_name=id
 // geospatial_col partial with missing IDs
-    | DOT table=id DOT column=id DOT geospatial_col                      // .t.c.g
-    | DOT DOT column=id DOT geospatial_col                               // ..c.g
-    | DOT column=id DOT geospatial_col                               // .c.g
+//    | DOT table=id DOT column=id DOT geospatial_col                      // .t.c.g
+//    | DOT DOT column=id DOT geospatial_col                               // ..c.g
+//    | DOT column=id DOT geospatial_col                               // .c.g
     ;
 
 column_name_list_with_order

--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5264,15 +5264,28 @@ external_name
 collation
     : COLLATE id
     ;
-    
+
 full_column_name
+// standard
     : column_name=id                                     // column
     | tablename=id DOT column_name=id                      // table.column_name
     | schema=id DOT tablename=id DOT column_name=id                      // schema.tablename.column_name
     | server=id DOT schema=id DOT tablename=id DOT column_name=id               // server.schema.tablename.column_name
+// geospatial_col
     | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
     | table=id DOT column=id DOT geospatial_col          // table.column.geospatial
     | column=id DOT geospatial_col          // table.column.geospatial
+// standard partial with missing IDs
+    | DOT column_name=id
+    | DOT DOT column_name=id
+    | DOT DOT DOT column_name=id
+    | DOT tablename=id DOT column_name=id
+    | DOT DOT tablename=id DOT column_name=id
+    | DOT schema=id DOT tablename=id DOT column_name=id
+// geospatial_col partial with missing IDs
+    | DOT table=id DOT column=id DOT geospatial_col                      // .t.c.g
+    | DOT DOT column=id DOT geospatial_col                               // ..c.g
+    | DOT column=id DOT geospatial_col                               // .c.g
     ;
 
 column_name_list_with_order

--- a/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
+++ b/contrib/babelfishpg_tsql/antlr/TSqlParser.g4
@@ -5274,6 +5274,8 @@ full_column_name
     | schema=id DOT table=id DOT column=id DOT geospatial_col   // schema.table.column.geospatial
     | server=id DOT schema=id DOT tablename=id DOT column_name=id               // server.schema.tablename.column_name
     | DOT tablename=id DOT column_name=id                                       // .tablename.column_name
+    | DOT table=id DOT column=id DOT geospatial_col                             // .tablename.column_name.geospatial
+    | DOT DOT column=id DOT geospatial_col                                      // ..column.geospatial
     | DOT DOT tablename=id DOT column_name=id                                   // ..tablename.column_name
     ;
 

--- a/test/JDBC/expected/BABEL-2724.out
+++ b/test/JDBC/expected/BABEL-2724.out
@@ -36,7 +36,7 @@ select .a from t2724;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near ".")~~
+~~ERROR (Message: syntax error near 'from' at line 2 and character position 10)~~
 
 
 -- valid error
@@ -44,7 +44,7 @@ select ..a from t2724;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near "..")~~
+~~ERROR (Message: syntax error near 'from' at line 2 and character position 11)~~
 
 
 -- valid error
@@ -52,7 +52,7 @@ select dbo..a from t2724;
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near "..")~~
+~~ERROR (Message: syntax error near 'from' at line 2 and character position 14)~~
 
 
 -- special case on insert-column. DOT and qualifier is totally ignored

--- a/test/JDBC/expected/BABEL-5548.out
+++ b/test/JDBC/expected/BABEL-5548.out
@@ -1,0 +1,55 @@
+use master;
+go
+
+create table t5548(a int);
+insert into t5548 values (1);
+go
+~~ROW COUNT: 1~~
+
+
+select .a from t5548
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'from' at line 1 and character position 10)~~
+
+
+select dbo..a from t5548
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'from' at line 1 and character position 14)~~
+
+
+select ...a from .t5548
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'from' at line 1 and character position 12)~~
+
+
+select .t5548.a from t5548;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select ..t5548.a from t5548;
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select .dbo.t5548.a from t5548;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '.' at line 1 and character position 17)~~
+
+
+drop table t5548;
+go

--- a/test/JDBC/expected/BABEL-5548.out
+++ b/test/JDBC/expected/BABEL-5548.out
@@ -121,7 +121,7 @@ select .TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFun
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near ".")~~
+~~ERROR (Message: syntax error near '.' at line 1 and character position 53)~~
 
 
 select dbo.TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp

--- a/test/JDBC/expected/BABEL-5548.out
+++ b/test/JDBC/expected/BABEL-5548.out
@@ -82,6 +82,58 @@ GO
 ~~ERROR (Message: Remote procedure/function reference with 4-part object name is not currently supported in Babelfish)~~
 
 
+CREATE TABLE TestSpatialFunction_YourTableTemp ( ID INT PRIMARY KEY, PointColumn geometry ); 
+GO
+
+INSERT INTO TestSpatialFunction_YourTableTemp (ID, PointColumn) VALUES (1, geometry::Point(3.0, 4.0, 4326)), (2, geometry::Point(5.0, 6.0, 4326)), (3, geometry::Point(3.0, 4.0, 0));
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+~~START~~
+int
+4326
+4326
+0
+~~END~~
+
+
+select PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+~~START~~
+int
+4326
+4326
+0
+~~END~~
+
+
+select .PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "pointcolumn")~~
+
+
+select .TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near ".")~~
+
+
+select dbo.TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The multi-part identifier "dbo.TestSpatialFunction_YourTableTemp.PointColumn.STSrid" could not be bound.)~~
+
+
+drop table TestSpatialFunction_YourTableTemp
+GO
+
 drop table GEOSPATIALPOINTEMPTYdt
 GO
 

--- a/test/JDBC/expected/BABEL-5548.out
+++ b/test/JDBC/expected/BABEL-5548.out
@@ -21,11 +21,18 @@ go
 ~~ERROR (Message: syntax error near 'from' at line 1 and character position 14)~~
 
 
-select ...a from .t5548
+select ...a from t5548
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: syntax error near 'from' at line 1 and character position 12)~~
+
+
+select ..a from t5548
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'from' at line 1 and character position 11)~~
 
 
 select .t5548.a from t5548;
@@ -50,6 +57,33 @@ GO
 
 ~~ERROR (Message: syntax error near '.' at line 1 and character position 17)~~
 
+
+CREATE TABLE GEOSPATIALPOINTEMPTYdt (geom geometry, geog geography);
+GO
+
+select .GEOSPATIALPOINTEMPTYdt.geom.STAsText() from GEOSPATIALPOINTEMPTYdt
+GO
+~~START~~
+text
+~~END~~
+
+
+select ..geom.STAsText() from GEOSPATIALPOINTEMPTYdt
+GO
+~~START~~
+text
+~~END~~
+
+
+select dbo.GEOSPATIALPOINTEMPTYdt.geom.STAsText() from GEOSPATIALPOINTEMPTYdt
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Remote procedure/function reference with 4-part object name is not currently supported in Babelfish)~~
+
+
+drop table GEOSPATIALPOINTEMPTYdt
+GO
 
 drop table t5548;
 go

--- a/test/JDBC/expected/float_exponent-vu-verify.out
+++ b/test/JDBC/expected/float_exponent-vu-verify.out
@@ -215,7 +215,7 @@ select .e
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near ".")~~
+~~ERROR (Message: syntax error near '<EOF>' at line 3 and character position 0)~~
 
 
 -- not a number

--- a/test/JDBC/expected/fts-contains-vu-verify.out
+++ b/test/JDBC/expected/fts-contains-vu-verify.out
@@ -3442,14 +3442,14 @@ select * from test_special_char_t t where contains(t..name, 'one');
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near "..")~~
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 36)~~
 
 
 select t..name from test_special_char_t t where contains(t.name, 'one');
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near "..")~~
+~~ERROR (Message: syntax error near 'from' at line 1 and character position 15)~~
 
 
 select t.name from test_special_char_t where contains(t.name, 'one');
@@ -3484,7 +3484,7 @@ select t.name from test_special_char_t t where contains(.name, 'one');
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error at or near ".")~~
+~~ERROR (Message: syntax error near 'where' at line 1 and character position 41)~~
 
 
 select t.name from test_special_char_t t where contains(t., 'one');

--- a/test/JDBC/expected/sys-suser_sname-vu-verify.out
+++ b/test/JDBC/expected/sys-suser_sname-vu-verify.out
@@ -18,7 +18,7 @@ SELECT SYS.SUSER_SNAME(0x0P)
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: syntax error near '0x0' at line 1 and character position 23)~~
+~~ERROR (Message: syntax error near '.' at line 1 and character position 10)~~
 
 
 DECLARE @id SYS.VARBINARY(85)

--- a/test/JDBC/input/BABEL-5548.sql
+++ b/test/JDBC/input/BABEL-5548.sql
@@ -11,8 +11,11 @@ go
 select dbo..a from t5548
 go
 
-select ...a from .t5548
+select ...a from t5548
 GO
+
+select ..a from t5548
+go
 
 select .t5548.a from t5548;
 GO
@@ -21,6 +24,21 @@ select ..t5548.a from t5548;
 go
 
 select .dbo.t5548.a from t5548;
+GO
+
+CREATE TABLE GEOSPATIALPOINTEMPTYdt (geom geometry, geog geography);
+GO
+
+select .GEOSPATIALPOINTEMPTYdt.geom.STAsText() from GEOSPATIALPOINTEMPTYdt
+GO
+
+select ..geom.STAsText() from GEOSPATIALPOINTEMPTYdt
+GO
+
+select dbo.GEOSPATIALPOINTEMPTYdt.geom.STAsText() from GEOSPATIALPOINTEMPTYdt
+GO
+
+drop table GEOSPATIALPOINTEMPTYdt
 GO
 
 drop table t5548;

--- a/test/JDBC/input/BABEL-5548.sql
+++ b/test/JDBC/input/BABEL-5548.sql
@@ -1,0 +1,27 @@
+use master;
+go
+
+create table t5548(a int);
+insert into t5548 values (1);
+go
+
+select .a from t5548
+go
+
+select dbo..a from t5548
+go
+
+select ...a from .t5548
+GO
+
+select .t5548.a from t5548;
+GO
+
+select ..t5548.a from t5548;
+go
+
+select .dbo.t5548.a from t5548;
+GO
+
+drop table t5548;
+go

--- a/test/JDBC/input/BABEL-5548.sql
+++ b/test/JDBC/input/BABEL-5548.sql
@@ -38,6 +38,30 @@ GO
 select dbo.GEOSPATIALPOINTEMPTYdt.geom.STAsText() from GEOSPATIALPOINTEMPTYdt
 GO
 
+CREATE TABLE TestSpatialFunction_YourTableTemp ( ID INT PRIMARY KEY, PointColumn geometry ); 
+GO
+
+INSERT INTO TestSpatialFunction_YourTableTemp (ID, PointColumn) VALUES (1, geometry::Point(3.0, 4.0, 4326)), (2, geometry::Point(5.0, 6.0, 4326)), (3, geometry::Point(3.0, 4.0, 0));
+GO
+
+SELECT TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+
+select PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+
+select .PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+
+select .TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+
+select dbo.TestSpatialFunction_YourTableTemp.PointColumn.STSrid from TestSpatialFunction_YourTableTemp
+GO
+
+drop table TestSpatialFunction_YourTableTemp
+GO
+
 drop table GEOSPATIALPOINTEMPTYdt
 GO
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,9 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-float_exponent-vu-prepare
-float_exponent-vu-verify
-float_exponent-vu-cleanup
+all
 
 # TODO
 ignore#!#charindex_and_replace_CIAI_collations

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,9 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+float_exponent-vu-prepare
+float_exponent-vu-verify
+float_exponent-vu-cleanup
 
 # TODO
 ignore#!#charindex_and_replace_CIAI_collations


### PR DESCRIPTION
Rewrite the antlr rule for column_name, skip the nested ()? structure, rewrite it into a clean antlr rule options, it'll save 30 ~ 40% of the time in some extreme cases.

Meanwhile, such rewrite will ignore those column text like '..a.b', 'a..b' or '.a..b' previously regard as valid by antlr parser, after this change, those column text will be invalid from antlr parser, it'll change the error message for such column texts. But this commit will not change the behavior for such column text, because previously, it was regard as invalid by gram.y parser.

Task: BABEL-5548



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).