### PR TITLE
Fixing typmod handling for COUNT(*) and COUNT_BIG(*).

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -82,9 +82,13 @@ static bool is_tsql_numeric_fixeddecimal(Oid oid);
 static bool is_tsql_bit_numeric(Oid oid);
 static bool is_tsql_int4_bit(Oid oid);
 
-#define SMALLINT_PRECISION_RADIX 5
-#define INT_PRECISION_RADIX 10
-#define BIGINT_PRECISION_RADIX 19
+#define SMALLINT_PRECISION_RADIX	5
+#define INT_PRECISION_RADIX		10
+#define BIGINT_PRECISION_RADIX		19
+
+#define DEFAULT_SMALLINT_TYPMOD		((SMALLINT_PRECISION_RADIX << 16) | 0) + VARHDRSZ
+#define DEFAULT_INT_TYPMOD		((INT_PRECISION_RADIX << 16) | 0) + VARHDRSZ
+#define DEFAULT_BIGINT_TYPMOD		((BIGINT_PRECISION_RADIX << 16) | 0) + VARHDRSZ
 
 /* Numeirc operator OID from pg_proc.dat */
 #define NUMERIC_ADD_OID 1724
@@ -1411,11 +1415,11 @@ resolve_numeric_typmod_from_exp(Plan *plan, Node *expr, bool *found)
 
 					/* handling for fixed length datatypes */
 					if (plan && var->vartype == INT4OID)
-						return ((INT_PRECISION_RADIX << 16) | 0) + VARHDRSZ;
+						return DEFAULT_INT_TYPMOD;
 					else if (plan && var->vartype == INT8OID)
-						return ((BIGINT_PRECISION_RADIX << 16) | 0) + VARHDRSZ;
+						return DEFAULT_BIGINT_TYPMOD;
 					else if (plan && var->vartype == INT2OID)
-						return ((SMALLINT_PRECISION_RADIX << 16) | 0) + VARHDRSZ;
+						return DEFAULT_SMALLINT_TYPMOD;
 
 					if (found != NULL) *found = false;
 				}
@@ -1774,8 +1778,16 @@ resolve_numeric_typmod_from_exp(Plan *plan, Node *expr, bool *found)
 
 				if (aggref->aggstar)
 				{
-					if (found != NULL) *found = false;
-					typmod = -1;
+					/* handling for COUNT(*) and COUNT_BIG(*) */
+					if (aggref->aggtype == INT4OID)
+						return DEFAULT_INT_TYPMOD;
+					else if (aggref->aggtype == INT8OID)
+						return DEFAULT_BIGINT_TYPMOD;
+					else
+					{
+						if (found != NULL) *found = false;
+						typmod = -1;
+					}
 				}
 				else
 				{

--- a/test/JDBC/expected/babel_numeric.out
+++ b/test/JDBC/expected/babel_numeric.out
@@ -486,3 +486,847 @@ drop type decimal_7_2;
 drop type numeric_18_2;
 drop type numeric_7_2;
 go
+
+CREATE TABLE agg_test_table (a NUMERIC(38, 10), b NUMERIC(38, 37));
+GO
+
+INSERT INTO agg_test_table VALUES (1.1234567890, 1.1234567890);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO agg_test_table VALUES (8.8765434567, 8.1234634);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO agg_test_table VALUES (9.5678, 1);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+4.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+4.00
+~~END~~
+
+
+SELECT COUNT(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.0000
+3.0000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.0000
+3.0000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT(*) / 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.000000
+~~END~~
+
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) / 1 FROM agg_test_table
+GO
+~~START~~
+bigint
+3
+~~END~~
+
+
+SELECT COUNT(*) FROM agg_test_table
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+GO
+~~START~~
+bigint
+3
+~~END~~
+
+
+-- FIX ME: Will be fixed by BABEL-5880.
+SELECT COUNT_BIG(NULL) * 1.00 FROM agg_test_table 
+UNION 
+SELECT 2.00 
+GO
+~~START~~
+numeric
+0.000000
+2.000000
+~~END~~
+
+
+SELECT COUNT_BIG(NULL) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+1.00000000
+2.00000000
+~~END~~
+
+
+SELECT COUNT_BIG(NULL) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+0E-8
+2.00000000
+~~END~~
+
+
+SELECT COUNT(NULL) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+0.000000
+2.000000
+~~END~~
+
+
+SELECT COUNT(NULL) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+1.00000000
+2.00000000
+~~END~~
+
+
+SELECT COUNT(NULL) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+0E-8
+2.00000000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(NULL)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+0E-8
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(NULL)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+0E-8
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(NULL)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+0.000000
+2.000000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(NULL)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+0.000000
+2.000000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(NULL) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(NULL) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+SELECT COUNT(NULL) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+SELECT COUNT(NULL) / 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+SELECT COUNT_BIG(NULL) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+0.000000
+~~END~~
+
+
+SELECT COUNT_BIG(NULL) / 1 FROM agg_test_table
+GO
+~~START~~
+bigint
+0
+~~END~~
+
+
+SELECT COUNT(NULL) FROM agg_test_table
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT COUNT_BIG(NULL) FROM agg_test_table
+GO
+~~START~~
+bigint
+0
+~~END~~
+
+
+DROP TABLE agg_test_table;
+GO
+
+CREATE TABLE agg_test_table (a MONEY, b SMALLMONEY);
+GO
+
+INSERT INTO agg_test_table VALUES (1.1234567890, 1.1234567890);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO agg_test_table VALUES (8.8765434567, 8.1234634);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO agg_test_table VALUES (9.5678, 1);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+4.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+4.00
+~~END~~
+
+
+SELECT COUNT(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.0000
+3.0000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.0000
+3.0000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT(*) / 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.000000
+~~END~~
+
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) / 1 FROM agg_test_table
+GO
+~~START~~
+bigint
+3
+~~END~~
+
+
+SELECT COUNT(*) FROM agg_test_table
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+GO
+~~START~~
+bigint
+3
+~~END~~
+
+
+DROP TABLE agg_test_table;
+GO
+
+create type numeric_18_2 from numeric(18,2);
+go
+
+create type numeric_7_2 from numeric(7,2);
+go
+
+CREATE TABLE agg_test_table (a numeric_18_2, b numeric_7_2);
+GO
+
+INSERT INTO agg_test_table VALUES (1.1234567890, 1.1234567890);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO agg_test_table VALUES (8.8765434567, 8.1234634);
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO agg_test_table VALUES (9.5678, 1);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+4.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT COUNT(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+4.00
+~~END~~
+
+
+SELECT COUNT(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.00
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.0000
+3.0000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+~~START~~
+numeric
+2.0000
+3.0000
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT(*) / 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.000000
+~~END~~
+
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+GO
+~~START~~
+numeric
+3.00
+~~END~~
+
+
+SELECT COUNT_BIG(*) / 1 FROM agg_test_table
+GO
+~~START~~
+bigint
+3
+~~END~~
+
+
+SELECT COUNT(*) FROM agg_test_table
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+GO
+~~START~~
+bigint
+3
+~~END~~
+
+
+DROP TABLE agg_test_table;
+GO
+
+DROP TYPE numeric_18_2;
+GO
+
+drop TYPE numeric_7_2;
+GO

--- a/test/JDBC/input/babel_numeric.sql
+++ b/test/JDBC/input/babel_numeric.sql
@@ -254,3 +254,437 @@ drop type decimal_7_2;
 drop type numeric_18_2;
 drop type numeric_7_2;
 go
+
+CREATE TABLE agg_test_table (a NUMERIC(38, 10), b NUMERIC(38, 37));
+GO
+
+INSERT INTO agg_test_table VALUES (1.1234567890, 1.1234567890);
+GO
+
+INSERT INTO agg_test_table VALUES (8.8765434567, 8.1234634);
+GO
+
+INSERT INTO agg_test_table VALUES (9.5678, 1);
+GO
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT(*) / 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) / 1 FROM agg_test_table
+GO
+
+SELECT COUNT(*) FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+GO
+
+-- FIX ME: Will be fixed by BABEL-5880.
+SELECT COUNT_BIG(NULL) * 1.00 FROM agg_test_table 
+UNION 
+SELECT 2.00 
+GO
+
+SELECT COUNT_BIG(NULL) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(NULL) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(NULL) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(NULL) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(NULL) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(NULL)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(NULL)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(NULL)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(NULL)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(NULL) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(NULL) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT COUNT(NULL) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT(NULL) / 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(NULL) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(NULL) / 1 FROM agg_test_table
+GO
+
+SELECT COUNT(NULL) FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(NULL) FROM agg_test_table
+GO
+
+DROP TABLE agg_test_table;
+GO
+
+CREATE TABLE agg_test_table (a MONEY, b SMALLMONEY);
+GO
+
+INSERT INTO agg_test_table VALUES (1.1234567890, 1.1234567890);
+GO
+
+INSERT INTO agg_test_table VALUES (8.8765434567, 8.1234634);
+GO
+
+INSERT INTO agg_test_table VALUES (9.5678, 1);
+GO
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT(*) / 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) / 1 FROM agg_test_table
+GO
+
+SELECT COUNT(*) FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+GO
+
+DROP TABLE agg_test_table;
+GO
+
+create type numeric_18_2 from numeric(18,2);
+go
+
+create type numeric_7_2 from numeric(7,2);
+go
+
+CREATE TABLE agg_test_table (a numeric_18_2, b numeric_7_2);
+GO
+
+INSERT INTO agg_test_table VALUES (1.1234567890, 1.1234567890);
+GO
+
+INSERT INTO agg_test_table VALUES (8.8765434567, 8.1234634);
+GO
+
+INSERT INTO agg_test_table VALUES (9.5678, 1);
+GO
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) + 1.00 FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT COUNT(*) FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*)
+    ELSE 2.00
+END * 1.00
+FROM agg_test_table
+UNION
+SELECT 2.00
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT CASE 1
+    WHEN 1 THEN COUNT_BIG(*) * 1.00
+    ELSE 2.00
+END
+FROM agg_test_table
+GO
+
+SELECT COUNT(*) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT(*) / 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) * 1.00 FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) / 1 FROM agg_test_table
+GO
+
+SELECT COUNT(*) FROM agg_test_table
+GO
+
+SELECT COUNT_BIG(*) FROM agg_test_table
+GO
+
+DROP TABLE agg_test_table;
+GO
+
+DROP TYPE numeric_18_2;
+GO
+
+drop TYPE numeric_7_2;
+GO


### PR DESCRIPTION
### 1. Issue:

Recursive calls to `resolve_numeric_typmod_from_exp`, triggered by the `is_numeric_cast` condition in `T_FuncExpr`, failed to handle `COUNT(*)` and `COUNT_BIG(*)` operations in the `T_Aggref` node.

In BBF:
```
1> select count(*) * 1.00 union select 2.00
2> go
----------------------------------------
                                1.000000
                                2.000000 
```

In TSQL:
```
1> select count(*) * 1.00 union select 2.00
2> go

----------------
            1.00
            2.00
```

### 2. Changes made to fix the issues

Added handling for `COUNT(*)` and `COUNT_BIG(*)` aggregates in `T_Aggref` node

### Issues Resolved

Task: BABEL-5886

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3768

Authored-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)
Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -** YES


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).