### PR TITLE
Fix loading of data for TEXT column (NULL allowed) if primary key is defined using non-default collation from PG endpoint for logical database

### DIFF
--- a/contrib/babelfishpg_common/src/collation.c
+++ b/contrib/babelfishpg_common/src/collation.c
@@ -26,7 +26,7 @@
 #define DATABASE_DEFAULT "database_default"
 #define CATALOG_DEFAULT "catalog_default"
 
-collation_callbacks collation_callbacks_var = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+collation_callbacks collation_callbacks_var = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 /* Cached values derived from server_collation_name */
 static int	server_collation_collidx = NOT_FOUND;
@@ -35,6 +35,8 @@ static bool db_collation_is_CI = true;
 
 static Oid database_collation_oid = InvalidOid;
 static int database_collation_collidx = NOT_FOUND;
+
+static bool is_logical_db_name_set = false;
 
 /*
  * Below two vars are defined to store the value of the babelfishpg_tsql.server_collation_name
@@ -1249,6 +1251,14 @@ BABELFISH_CLUSTER_COLLATION_OID()
 													 * database or server_collation_oid */
 		return db_coll;
 	}
+	
+	/* 
+	 * If logical db collation is required from PG, we can return the server level collation
+	 * this is decided by is_logical_db_name_set, which is set if psql_logical_babelfish_db_name is set
+	 */
+	if (is_logical_db_name_set)
+		return get_database_or_server_collation_oid_internal(false);
+
 	return DEFAULT_COLLATION_OID;
 }
 
@@ -1647,6 +1657,7 @@ get_collation_callbacks(void)
 		collation_callbacks_var.translate_bbf_collation_to_tsql_collation = &translate_bbf_collation_to_tsql_collation;
 		collation_callbacks_var.translate_tsql_collation_to_bbf_collation = &translate_tsql_collation_to_bbf_collation;
 		collation_callbacks_var.set_db_collation = &set_db_collation;
+		collation_callbacks_var.set_logical_db_name_cache = &set_logical_db_name_cache;
 	}
 	return &collation_callbacks_var;
 }
@@ -1749,4 +1760,17 @@ set_db_collation(Oid db_coll)
 	database_collation_oid = db_coll;
 	database_collation_collidx = find_any_collation((lookup_collation_table(database_collation_oid).collname), false);
 	db_collation_is_CI = collation_is_CI(database_collation_oid);
+}
+
+/* 
+ * Set the cache for logical database name
+ * this is decided by "psql_logical_babelfish_db_name" GUC
+ */
+void
+set_logical_db_name_cache(const char* dbname)
+{
+	if (dbname)
+		is_logical_db_name_set = true;
+	else
+		is_logical_db_name_set = false;
 }

--- a/contrib/babelfishpg_common/src/collation.h
+++ b/contrib/babelfishpg_common/src/collation.h
@@ -121,6 +121,8 @@ typedef struct collation_callbacks
 
 	void		(*set_db_collation) (Oid db_coll);
 
+	void		(*set_logical_db_name_cache) (const char *dbname);
+
 } collation_callbacks;
 
 extern int	find_cs_as_collation(int collidx);
@@ -152,6 +154,7 @@ extern bool has_ilike_node(Node *expr);
 extern bool has_like_node(Node *expr);
 extern Oid	babelfish_define_type_default_collation(Oid typeNamespace);
 extern void	set_db_collation(Oid db_coll);
+extern void set_logical_db_name_cache(const char *dbname);
 
 extern collation_callbacks *get_collation_callbacks(void);
 

--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -25,6 +25,7 @@
 #include <unicode/usearch.h>
 #endif
 
+#include "miscadmin.h"
 #include "pltsql.h"
 #include "src/collation.h"
 #include "catalog.h"
@@ -2247,4 +2248,22 @@ patindex_ai_collations(PG_FUNCTION_ARGS)
 	pfree(pattern);
 
 	PG_RETURN_INT32(result);
+}
+
+
+void
+assign_psql_logical_babelfish_db_name(const char *newval, void *extra)
+{
+	/* 
+	 * No need to tell babelfishpg_common that logical db name has been set if it is TDS connection
+	 * because the psql_logical_babelfish_db_name is to be used for PG dialect only
+	 */
+	if (!IS_TDS_CONN())
+	{
+		/* Initialise collation callbacks */
+		init_and_check_collation_callbacks();
+
+		/* let babelfishpg_common know that psql_logical_babelfish_db_name has been updated */
+		(*collation_callbacks_ptr->set_logical_db_name_cache) (newval);
+	}
 }

--- a/contrib/babelfishpg_tsql/src/collation.h
+++ b/contrib/babelfishpg_tsql/src/collation.h
@@ -90,6 +90,8 @@ typedef struct collation_callbacks
 
 	void		(*set_db_collation) (Oid db_coll);
 
+	void		(*set_logical_db_name_cache) (const char *dbname);
+
 } collation_callbacks;
 
 extern collation_callbacks *collation_callbacks_ptr;

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -825,7 +825,7 @@ define_custom_variables(void)
 							   NULL,
 							   PGC_USERSET,
 							   GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL | GUC_NO_RESET_ALL | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-							   NULL, NULL, NULL);
+							   NULL, assign_psql_logical_babelfish_db_name, NULL);
 
 	DefineCustomIntVariable("babelfishpg_tsql.datefirst",
 							gettext_noop("Sets the first day of the week to a number from 1 through 7."),

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -45,4 +45,6 @@ void		pltsql_revert_guc(int nest_level);
 extern int	pltsql_new_scope_identity_nest_level(void);
 extern void pltsql_revert_last_scope_identity(int nest_level);
 extern void pltsql_remove_current_query_env(void);
+
+extern void assign_psql_logical_babelfish_db_name(const char *newval, void *extra);
 #endif

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -6080,8 +6080,15 @@ default_collation_for_builtin_type(Type typ, bool handle_pg_type)
 	 * Special handling for PG datatypes such as TEXT because Babelfish does not define sys.TEXT.
 	 * This is required as Babelfish currently does not handle collation of String Const node correctly.
 	 * TODO: Fix the handling of the collation for String Const node.
+	 * 
+	 * When pltsql_psql_logical_babelfish_db_name is set, 
+	 * return CLUSTER_COLLATION_OID() -- this API will handle whether to return babelfish server/database level
+	 * collation or DEFAULT_COLLTAION_OID based on dialect for TEXT (e.g: string literals) as well
+	 * Otherwise, during collation resolution in merge_collation_state, CLUSTER_COLLATION_OID() will return
+	 * babelfish server/db level collation as pltsql_psql_logical_babelfish_db_name is set but current collation would
+	 * be DEFAULT_COLLATION_OID which would throw collation conflict
 	 */
-	if (handle_pg_type && oid == DEFAULT_COLLATION_OID)
+	if ((handle_pg_type || pltsql_psql_logical_babelfish_db_name) && oid == DEFAULT_COLLATION_OID)
 	{
 		oid = CLUSTER_COLLATION_OID();
 	}

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/psql_logical_babelfish_db.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/psql_logical_babelfish_db.out
@@ -311,6 +311,994 @@ go
 drop database logical_database_db1
 go
 
+-- reset the GUC to default, else it may cause incorrect result/unexpected behaviour
+select set_config('psql_logical_babelfish_db_name', NULL, false);
+GO
+~~START~~
+text
+
+~~END~~
+
+
+-- BABEL-5077
+CREATE DATABASE dms_db_babel_5077;
+GO
+
+USE dms_db_babel_5077;
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t1(dms_db_babel_5077_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t1_col2 [varchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t1(dms_db_babel_5077_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t2(dms_db_babel_5077_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t2_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t2(dms_db_babel_5077_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_t3(dms_db_babel_5077_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t3(dms_db_babel_5077_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- varchar, varchar
+CREATE TABLE dms_db_babel_5077_t4(dms_db_babel_5077_t4_col1 [varchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t4_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t4(dms_db_babel_5077_t4_col2) VALUES ('estonian_varchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_t5(dms_db_babel_5077_t5_col1 text NULL, dms_db_babel_5077_t5_col2 [varchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t5(dms_db_babel_5077_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_t6(dms_db_babel_5077_t6_col1 text NULL, dms_db_babel_5077_t6_col2 [varchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_t7(dms_db_babel_5077_t7_col1 text NULL, dms_db_babel_5077_t7_col2 [varchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_t7(dms_db_babel_5077_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t1_col2 [nvarchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t2_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- nvarchar, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col1 [nvarchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t4_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col2) VALUES ('estonian_nvarchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col1 text NULL, dms_db_babel_5077_nv_t5_col2 [nvarchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col1 text NULL, dms_db_babel_5077_nv_t6_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col1 text NULL, dms_db_babel_5077_nv_t7_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+-- psql
+SET psql_logical_babelfish_db_name = 'dms_db_babel_5077';
+GO
+
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
+dms_db_babel_5077
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'collation' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'NULL' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col2 = 'chinese' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'collation' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'NULL' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col2 = 'estonian' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'collation' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'NULL' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col2 = 'chinese_text' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'collation' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'NULL' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col2 = 'estonian_varchar' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_varchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'collation' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'NULL' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col2 = 'default' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'collation' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'NULL' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'collation' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'NULL' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'collation' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'NULL' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col2 = 'chinese' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'collation' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'NULL' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col2 = 'estonian' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'collation' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'NULL' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col2 = 'chinese_text' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'collation' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'NULL' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_nvarchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'collation' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'NULL' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col2 = 'default' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'collation' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'NULL' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'collation' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'NULL' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE MASTER;
+GO
+
+DROP DATABASE dms_db_babel_5077;
+GO
+
+-- create database with a non-default collation
+CREATE DATABASE dms_db_babel_5077 COLLATE latin1_general_ci_ai;
+GO
+
+USE dms_db_babel_5077;
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t1(dms_db_babel_5077_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t1_col2 [varchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t1(dms_db_babel_5077_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t2(dms_db_babel_5077_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t2_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t2(dms_db_babel_5077_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_t3(dms_db_babel_5077_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t3(dms_db_babel_5077_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- varchar, varchar
+CREATE TABLE dms_db_babel_5077_t4(dms_db_babel_5077_t4_col1 [varchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t4_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t4(dms_db_babel_5077_t4_col2) VALUES ('estonian_varchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_t5(dms_db_babel_5077_t5_col1 text NULL, dms_db_babel_5077_t5_col2 [varchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t5(dms_db_babel_5077_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_t6(dms_db_babel_5077_t6_col1 text NULL, dms_db_babel_5077_t6_col2 [varchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_t7(dms_db_babel_5077_t7_col1 text NULL, dms_db_babel_5077_t7_col2 [varchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_t7(dms_db_babel_5077_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t1_col2 [nvarchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t2_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- nvarchar, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col1 [nvarchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t4_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col2) VALUES ('estonian_nvarchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col1 text NULL, dms_db_babel_5077_nv_t5_col2 [nvarchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col1 text NULL, dms_db_babel_5077_nv_t6_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col1 text NULL, dms_db_babel_5077_nv_t7_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- psql
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
+
+~~END~~
+
+
+SET psql_logical_babelfish_db_name = 'dms_db_babel_5077';
+GO
+
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
+dms_db_babel_5077
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'collation' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'NULL' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col2 = 'chinese' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'collation' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'NULL' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col2 = 'estonian' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'collation' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'NULL' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col2 = 'chinese_text' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'collation' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'NULL' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col2 = 'estonian_varchar' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_varchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'collation' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'NULL' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col2 = 'default' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'collation' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'NULL' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'collation' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'NULL' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'collation' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'NULL' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col2 = 'chinese' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'collation' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'NULL' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col2 = 'estonian' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'collation' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'NULL' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col2 = 'chinese_text' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'collation' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'NULL' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_nvarchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'collation' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'NULL' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col2 = 'default' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'collation' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'NULL' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'collation' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'NULL' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+DROP DATABASE dms_db_babel_5077;
+GO
+
+
 -- psql
 -- Cleanup
 -- Need to terminate active session before cleaning up the login
@@ -328,6 +1316,14 @@ SELECT pg_sleep(1);
 GO
 ~~START~~
 void
+
+~~END~~
+
+
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
 
 ~~END~~
 

--- a/test/JDBC/expected/psql_logical_babelfish_db.out
+++ b/test/JDBC/expected/psql_logical_babelfish_db.out
@@ -311,6 +311,994 @@ go
 drop database logical_database_db1
 go
 
+-- reset the GUC to default, else it may cause incorrect result/unexpected behaviour
+select set_config('psql_logical_babelfish_db_name', NULL, false);
+GO
+~~START~~
+text
+
+~~END~~
+
+
+-- BABEL-5077
+CREATE DATABASE dms_db_babel_5077;
+GO
+
+USE dms_db_babel_5077;
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t1(dms_db_babel_5077_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t1_col2 [varchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t1(dms_db_babel_5077_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t2(dms_db_babel_5077_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t2_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t2(dms_db_babel_5077_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_t3(dms_db_babel_5077_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t3(dms_db_babel_5077_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- varchar, varchar
+CREATE TABLE dms_db_babel_5077_t4(dms_db_babel_5077_t4_col1 [varchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t4_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t4(dms_db_babel_5077_t4_col2) VALUES ('estonian_varchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_t5(dms_db_babel_5077_t5_col1 text NULL, dms_db_babel_5077_t5_col2 [varchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t5(dms_db_babel_5077_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_t6(dms_db_babel_5077_t6_col1 text NULL, dms_db_babel_5077_t6_col2 [varchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_t7(dms_db_babel_5077_t7_col1 text NULL, dms_db_babel_5077_t7_col2 [varchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_t7(dms_db_babel_5077_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t1_col2 [nvarchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t2_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- nvarchar, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col1 [nvarchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t4_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col2) VALUES ('estonian_nvarchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col1 text NULL, dms_db_babel_5077_nv_t5_col2 [nvarchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col1 text NULL, dms_db_babel_5077_nv_t6_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col1 text NULL, dms_db_babel_5077_nv_t7_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+-- psql
+SET psql_logical_babelfish_db_name = 'dms_db_babel_5077';
+GO
+
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
+dms_db_babel_5077
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'collation' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'NULL' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col2 = 'chinese' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'collation' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'NULL' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col2 = 'estonian' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'collation' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'NULL' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col2 = 'chinese_text' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'collation' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'NULL' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col2 = 'estonian_varchar' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_varchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'collation' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'NULL' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col2 = 'default' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'collation' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'NULL' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'collation' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'NULL' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'collation' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'NULL' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col2 = 'chinese' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'collation' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'NULL' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col2 = 'estonian' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'collation' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'NULL' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col2 = 'chinese_text' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'collation' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'NULL' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_nvarchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'collation' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'NULL' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col2 = 'default' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'collation' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'NULL' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'collation' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'NULL' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE MASTER;
+GO
+
+DROP DATABASE dms_db_babel_5077;
+GO
+
+-- create database with a non-default collation
+CREATE DATABASE dms_db_babel_5077 COLLATE latin1_general_ci_ai;
+GO
+
+USE dms_db_babel_5077;
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t1(dms_db_babel_5077_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t1_col2 [varchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t1(dms_db_babel_5077_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t2(dms_db_babel_5077_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t2_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t2(dms_db_babel_5077_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_t3(dms_db_babel_5077_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t3(dms_db_babel_5077_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- varchar, varchar
+CREATE TABLE dms_db_babel_5077_t4(dms_db_babel_5077_t4_col1 [varchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t4_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t4(dms_db_babel_5077_t4_col2) VALUES ('estonian_varchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, varchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_t5(dms_db_babel_5077_t5_col1 text NULL, dms_db_babel_5077_t5_col2 [varchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t5(dms_db_babel_5077_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_t6(dms_db_babel_5077_t6_col1 text NULL, dms_db_babel_5077_t6_col2 [varchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_t7(dms_db_babel_5077_t7_col1 text NULL, dms_db_babel_5077_t7_col2 [varchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_t7(dms_db_babel_5077_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t1_col2 [nvarchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col2) VALUES ('chinese');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t2_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col2) VALUES ('estonian');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col2) VALUES ('chinese_text');
+GO
+~~ROW COUNT: 1~~
+
+
+-- nvarchar, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col1 [nvarchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t4_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col2) VALUES ('estonian_nvarchar');
+GO
+~~ROW COUNT: 1~~
+
+
+-- text, nvarchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col1 text NULL, dms_db_babel_5077_nv_t5_col2 [nvarchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col2) VALUES ('default');
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col1 text NULL, dms_db_babel_5077_nv_t6_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col1 text NULL, dms_db_babel_5077_nv_t7_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col2) VALUES ('unicode_cs_as');
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- psql
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
+
+~~END~~
+
+
+SET psql_logical_babelfish_db_name = 'dms_db_babel_5077';
+GO
+
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
+dms_db_babel_5077
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'collation' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'NULL' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col2 = 'chinese' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'collation' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'NULL' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col2 = 'estonian' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'collation' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'NULL' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col2 = 'chinese_text' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'collation' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'NULL' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col2 = 'estonian_varchar' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_varchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'collation' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'NULL' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col2 = 'default' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'collation' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'NULL' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'collation' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'NULL' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'collation' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'NULL' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col2 = 'chinese' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#chinese
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'collation' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'NULL' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col2 = 'estonian' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#estonian
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'collation' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'NULL' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col2 = 'chinese_text' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3;
+GO
+~~START~~
+text#!#text
+NULL#!#chinese_text
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'collation' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'NULL' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4;
+GO
+~~START~~
+"sys"."varchar"#!#"sys"."varchar"
+NULL#!#estonian_nvarchar
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'collation' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'NULL' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col2 = 'default' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#default
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'collation' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'NULL' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'collation' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'NULL' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7;
+GO
+~~START~~
+text#!#"sys"."varchar"
+NULL#!#unicode_cs_as
+~~END~~
+
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
+-- tsql
+USE master;
+GO
+
+DROP DATABASE dms_db_babel_5077;
+GO
+
+
 -- psql
 -- Cleanup
 -- Need to terminate active session before cleaning up the login
@@ -328,6 +1316,14 @@ SELECT pg_sleep(1);
 GO
 ~~START~~
 void
+
+~~END~~
+
+
+SHOW psql_logical_babelfish_db_name;
+GO
+~~START~~
+text
 
 ~~END~~
 

--- a/test/JDBC/input/psql_logical_babelfish_db.mix
+++ b/test/JDBC/input/psql_logical_babelfish_db.mix
@@ -120,6 +120,600 @@ go
 drop database logical_database_db1
 go
 
+-- reset the GUC to default, else it may cause incorrect result/unexpected behaviour
+select set_config('psql_logical_babelfish_db_name', NULL, false);
+GO
+
+-- BABEL-5077
+CREATE DATABASE dms_db_babel_5077;
+GO
+
+USE dms_db_babel_5077;
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t1(dms_db_babel_5077_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t1_col2 [varchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t1(dms_db_babel_5077_t1_col2) VALUES ('chinese');
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t2(dms_db_babel_5077_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t2_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t2(dms_db_babel_5077_t2_col2) VALUES ('estonian');
+GO
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_t3(dms_db_babel_5077_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t3(dms_db_babel_5077_t3_col2) VALUES ('chinese_text');
+GO
+
+-- varchar, varchar
+CREATE TABLE dms_db_babel_5077_t4(dms_db_babel_5077_t4_col1 [varchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t4_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t4(dms_db_babel_5077_t4_col2) VALUES ('estonian_varchar');
+GO
+
+-- text, varchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_t5(dms_db_babel_5077_t5_col1 text NULL, dms_db_babel_5077_t5_col2 [varchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t5(dms_db_babel_5077_t5_col2) VALUES ('default');
+GO
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_t6(dms_db_babel_5077_t6_col1 text NULL, dms_db_babel_5077_t6_col2 [varchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2) VALUES ('unicode_cs_as');
+GO
+
+CREATE TABLE dms_db_babel_5077_t7(dms_db_babel_5077_t7_col1 text NULL, dms_db_babel_5077_t7_col2 [varchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_t7(dms_db_babel_5077_t7_col2) VALUES ('unicode_cs_as');
+GO
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t1_col2 [nvarchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col2) VALUES ('chinese');
+GO
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t2_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col2) VALUES ('estonian');
+GO
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col2) VALUES ('chinese_text');
+GO
+
+-- nvarchar, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col1 [nvarchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t4_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col2) VALUES ('estonian_nvarchar');
+GO
+
+-- text, nvarchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col1 text NULL, dms_db_babel_5077_nv_t5_col2 [nvarchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col2) VALUES ('default');
+GO
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col1 text NULL, dms_db_babel_5077_nv_t6_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2) VALUES ('unicode_cs_as');
+GO
+
+CREATE TABLE dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col1 text NULL, dms_db_babel_5077_nv_t7_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col2) VALUES ('unicode_cs_as');
+GO
+
+-- psql
+SET psql_logical_babelfish_db_name = 'dms_db_babel_5077';
+GO
+
+SHOW psql_logical_babelfish_db_name;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'collation' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'NULL' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col2 = 'chinese' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t1;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'collation' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'NULL' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col2 = 'estonian' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t2;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'collation' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'NULL' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col2 = 'chinese_text' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t3;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'collation' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'NULL' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col2 = 'estonian_varchar' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t4;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'collation' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'NULL' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col2 = 'default' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t5;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'collation' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'NULL' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t6;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'collation' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'NULL' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t7;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'collation' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'NULL' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col2 = 'chinese' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'collation' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'NULL' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col2 = 'estonian' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'collation' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'NULL' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col2 = 'chinese_text' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'collation' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'NULL' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'collation' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'NULL' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col2 = 'default' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'collation' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'NULL' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'collation' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'NULL' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7;
+GO
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+USE MASTER;
+GO
+
+DROP DATABASE dms_db_babel_5077;
+GO
+
+-- create database with a non-default collation
+CREATE DATABASE dms_db_babel_5077 COLLATE latin1_general_ci_ai;
+GO
+
+USE dms_db_babel_5077;
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t1(dms_db_babel_5077_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t1_col2 [varchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t1(dms_db_babel_5077_t1_col2) VALUES ('chinese');
+GO
+
+-- text, varchar
+CREATE TABLE dms_db_babel_5077_t2(dms_db_babel_5077_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t2_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t2(dms_db_babel_5077_t2_col2) VALUES ('estonian');
+GO
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_t3(dms_db_babel_5077_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t3(dms_db_babel_5077_t3_col2) VALUES ('chinese_text');
+GO
+
+-- varchar, varchar
+CREATE TABLE dms_db_babel_5077_t4(dms_db_babel_5077_t4_col1 [varchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_t4_col2 [varchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t4(dms_db_babel_5077_t4_col2) VALUES ('estonian_varchar');
+GO
+
+-- text, varchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_t5(dms_db_babel_5077_t5_col1 text NULL, dms_db_babel_5077_t5_col2 [varchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_t5(dms_db_babel_5077_t5_col2) VALUES ('default');
+GO
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_t6(dms_db_babel_5077_t6_col1 text NULL, dms_db_babel_5077_t6_col2 [varchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2) VALUES ('unicode_cs_as');
+GO
+
+CREATE TABLE dms_db_babel_5077_t7(dms_db_babel_5077_t7_col1 text NULL, dms_db_babel_5077_t7_col2 [varchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_t6(dms_db_babel_5077_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_t7(dms_db_babel_5077_t7_col2) VALUES ('unicode_cs_as');
+GO
+
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t1_col2 [nvarchar](44) COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t1(dms_db_babel_5077_nv_t1_col2) VALUES ('chinese');
+GO
+
+-- text, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col1 text COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t2_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t2(dms_db_babel_5077_nv_t2_col2) VALUES ('estonian');
+GO
+
+-- text, text
+CREATE TABLE dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col1 text COLLATE Chinese_PRC_CS_AS NULL, dms_db_babel_5077_nv_t3_col2 text COLLATE Chinese_PRC_CS_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t3(dms_db_babel_5077_nv_t3_col2) VALUES ('chinese_text');
+GO
+
+-- nvarchar, nvarchar
+CREATE TABLE dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col1 [nvarchar](44) COLLATE Estonian_CS_AS NULL, dms_db_babel_5077_nv_t4_col2 [nvarchar](44) COLLATE Estonian_CI_AS NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t4(dms_db_babel_5077_nv_t4_col2) VALUES ('estonian_nvarchar');
+GO
+
+-- text, nvarchar : DATABASE_DEFAULT_COLLATION
+CREATE TABLE dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col1 text NULL, dms_db_babel_5077_nv_t5_col2 [nvarchar](44) NOT NULL);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t5(dms_db_babel_5077_nv_t5_col2) VALUES ('default');
+GO
+
+-- FOREIGN_KEY_CONSTRAINT
+CREATE TABLE dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col1 text NULL, dms_db_babel_5077_nv_t6_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS primary key);
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2) VALUES ('unicode_cs_as');
+GO
+
+CREATE TABLE dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col1 text NULL, dms_db_babel_5077_nv_t7_col2 [nvarchar](44) collate BBF_Unicode_General_CS_AS references dms_db_babel_5077_nv_t6(dms_db_babel_5077_nv_t6_col2));
+GO
+
+INSERT INTO dms_db_babel_5077_nv_t7(dms_db_babel_5077_nv_t7_col2) VALUES ('unicode_cs_as');
+GO
+
+
+-- psql
+SHOW psql_logical_babelfish_db_name;
+GO
+
+SET psql_logical_babelfish_db_name = 'dms_db_babel_5077';
+GO
+
+SHOW psql_logical_babelfish_db_name;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'collation' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col1 = 'NULL' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t1 SET dms_db_babel_5077_t1_col2 = 'chinese' where dms_db_babel_5077_t1_col2 = 'chinese';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t1;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'collation' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col1 = 'NULL' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t2 SET dms_db_babel_5077_t2_col2 = 'estonian' where dms_db_babel_5077_t2_col2 = 'estonian';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t2;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'collation' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col1 = 'NULL' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t3 SET dms_db_babel_5077_t3_col2 = 'chinese_text' where dms_db_babel_5077_t3_col2 = 'chinese_text';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t3;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'collation' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col1 = 'NULL' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t4 SET dms_db_babel_5077_t4_col2 = 'estonian_varchar' where dms_db_babel_5077_t4_col2 = 'estonian_varchar';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t4;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'collation' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col1 = 'NULL' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t5 SET dms_db_babel_5077_t5_col2 = 'default' where dms_db_babel_5077_t5_col2 = 'default';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t5;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'collation' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col1 = 'NULL' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t6 SET dms_db_babel_5077_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_t6_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t6;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'collation' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col1 = 'NULL' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_t7 SET dms_db_babel_5077_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_t7_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_t7;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'collation' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col1 = 'NULL' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1 SET dms_db_babel_5077_nv_t1_col2 = 'chinese' where dms_db_babel_5077_nv_t1_col2 = 'chinese';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t1;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'collation' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col1 = 'NULL' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2 SET dms_db_babel_5077_nv_t2_col2 = 'estonian' where dms_db_babel_5077_nv_t2_col2 = 'estonian';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t2;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'collation' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col1 = 'NULL' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3 SET dms_db_babel_5077_nv_t3_col2 = 'chinese_text' where dms_db_babel_5077_nv_t3_col2 = 'chinese_text';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t3;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'collation' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col1 = 'NULL' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4 SET dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar' where dms_db_babel_5077_nv_t4_col2 = 'estonian_nvarchar';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t4;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'collation' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col1 = 'NULL' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5 SET dms_db_babel_5077_nv_t5_col2 = 'default' where dms_db_babel_5077_nv_t5_col2 = 'default';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t5;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'collation' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col1 = 'NULL' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6 SET dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t6_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t6;
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'collation' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col1 = 'NULL' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+
+UPDATE dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7 SET dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as' where dms_db_babel_5077_nv_t7_col2 = 'unicode_cs_as';
+GO
+
+SELECT * FROM dms_db_babel_5077_dbo.dms_db_babel_5077_nv_t7;
+GO
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- Wait to sync with another session
+SELECT pg_sleep(1);
+GO
+
+-- tsql
+USE master;
+GO
+
+DROP DATABASE dms_db_babel_5077;
+GO
+
+
 -- psql
 -- Cleanup
 -- Need to terminate active session before cleaning up the login
@@ -129,6 +723,9 @@ GO
 
 -- Wait to sync with another session
 SELECT pg_sleep(1);
+GO
+
+SHOW psql_logical_babelfish_db_name;
 GO
 
 -- tsql

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -15,3 +15,4 @@ ignore#!#test_search_path
 ignore#!#alter-mvu-test-vu-prepare
 ignore#!#alter-mvu-test-vu-verify
 ignore#!#alter-mvu-test-vu-cleanup
+ignore#!#psql_logical_babelfish_db


### PR DESCRIPTION
### Description
If the babelfish table has a column whose type is anything other than text/ntext (eg: varchar, nvarchar etc) and the collation of the column is NOT same as babelfish database/server level collation and if the query is executed from PSQL endpoint, it will throw error saying it can not decide which collation to use.

If the same query is executed from TDS endpoint, it runs successfully.

This is because when the query is executed from PSQL endpoint -- the collation of varchar is server level collation. During resolution of collation at the parent node, the collation of left and right operand does NOT match and none of their collation matches with CLUSTER_COLLATION_OID (this returns DEFAULT_COLLATION_OID as the dialect is PG)

The query is working from TDS endpoint -- the collation of varchar is database level collation. During resolution of collation at the parent node, the collation of left and right operand does NOT match and collation of right operand matches with CLUSTER_COLLATION_OID (this returns database level collation as the dialect is TSQL)

This commit handles the case when the connection is from PG endpoint and psql_logical_babelfish_db_name GUC is set -- the case for logical/TSQL database. If both the aforementioned conditions are met, we will return babelfish server level collation irrespective of dialect (initially it was only for TDS connection).


### Issues Resolved

BABEL-5077
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).