### PR TITLE
Fix assertion error for Partition Table creation with Computed Columns

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_partition.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_partition.c
@@ -300,7 +300,7 @@ bbf_create_partition_tables(CreateStmt *stmt)
 		/* Execute the CREATE PARTITION statment. */
 		standard_ProcessUtility(wrapper,
 					"(CREATE PARTITION)",
-					false,
+					true,
 					PROCESS_UTILITY_SUBCOMMAND,
 					NULL,
 					NULL,
@@ -826,7 +826,7 @@ rename_table_update_bbf_partitions_name(RenameStmt *stmt, Oid parentrelid)
 		/* Execute the rename statment. */
 		standard_ProcessUtility(wrapper,
 					"(RENAME PARTITION)",
-					false,
+					true,
 					PROCESS_UTILITY_SUBCOMMAND,
 					NULL,
 					NULL,

--- a/test/JDBC/expected/PARTITION-vu-cleanup.out
+++ b/test/JDBC/expected/PARTITION-vu-cleanup.out
@@ -452,3 +452,9 @@ go
 
 DROP DATABASE PartitionDb
 go
+
+DROP TABLE partition_float_real_partitioned_test;
+DROP TABLE partition_float_real_partitioned_computed_test;
+DROP PARTITION SCHEME partition_float_real_range_partition_scheme;
+DROP PARTITION FUNCTION partition_float_real_range_partition_func;
+GO

--- a/test/JDBC/expected/PARTITION-vu-prepare.out
+++ b/test/JDBC/expected/PARTITION-vu-prepare.out
@@ -1384,3 +1384,82 @@ GO
 CREATE PARTITION SCHEME PS_CollationTest_NVarChar 
 AS PARTITION PF_CollationTest_NVarChar ALL TO ([PRIMARY]);
 GO
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Create partition function for FLOAT values
+CREATE PARTITION FUNCTION partition_float_real_range_partition_func (FLOAT)
+AS RANGE RIGHT FOR VALUES 
+(
+    -1000.0,    -- Very negative values
+    -1.0,       -- Small negative values
+    0.0,        -- Zero boundary
+    1.0,        -- Small positive values
+    1000.0      -- Very positive values
+);
+GO
+
+-- Create partition scheme
+CREATE PARTITION SCHEME partition_float_real_range_partition_scheme
+AS PARTITION partition_float_real_range_partition_func ALL TO ([PRIMARY]);
+GO
+
+-- Create partitioned table without computed columns
+CREATE TABLE partition_float_real_partitioned_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+
+
+
+
+
+-- Insert test data covering all partitions
+INSERT INTO partition_float_real_partitioned_test (float_val, real_val, description)
+VALUES 
+    -- Partition 1: x <= -1000.0
+    (-5000.0, -5000.0, 'Very negative - P1'),
+    (-2000.0, -2000.0, 'Very negative - P1'),
+    (-1500.0, -1500.0, 'Very negative - P1'),
+    -- Partition 2: -1000.0 < x <= -1.0
+    (-750.0, -750.0, 'Medium negative - P2'),
+    (-500.0, -500.0, 'Medium negative - P2'),
+    (-2.5, -2.5, 'Medium negative - P2'),
+    -- Partition 3: -1.0 < x <= 0.0
+    (-0.75, -0.75, 'Small negative - P3'),
+    (-0.5, -0.5, 'Small negative - P3'),
+    (-0.25, -0.25, 'Small negative - P3'),
+    -- Partition 4: 0.0 < x <= 1.0
+    (0.25, 0.25, 'Small positive - P4'),
+    (0.5, 0.5, 'Small positive - P4'),
+    (0.75, 0.75, 'Small positive - P4'),
+    -- Partition 5: 1.0 < x <= 1000.0
+    (2.5, 2.5, 'Medium positive - P5'),
+    (500.0, 500.0, 'Medium positive - P5'),
+    (750.0, 750.0, 'Medium positive - P5'),
+    -- Partition 6: x > 1000.0
+    (1500.0, 1500.0, 'Very positive - P6'),
+    (2000.0, 2000.0, 'Very positive - P6'),
+    (5000.0, 5000.0, 'Very positive - P6');
+GO
+~~ROW COUNT: 18~~
+
+
+-- Test scientific notation values
+INSERT INTO partition_float_real_partitioned_test (float_val, real_val, description)
+VALUES 
+    (-1.23E+4, -1.23E+4, 'Scientific notation large negative'),
+    (-1.23E-4, -1.23E-4, 'Scientific notation small negative'),
+    (1.23E-4, 1.23E-4, 'Scientific notation small positive'),
+    (1.23E+4, 1.23E+4, 'Scientific notation large positive');
+GO
+~~ROW COUNT: 4~~
+

--- a/test/JDBC/expected/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/PARTITION-vu-verify.out
@@ -626,6 +626,7 @@ MoneyPartitionFunction#!#R #!#RANGE#!#4#!#1#!#0
 NCharPartitionFunction#!#R #!#RANGE#!#8#!#1#!#0
 NumericPartitionFunction#!#R #!#RANGE#!#5#!#1#!#0
 NVarCharPartitionFunction#!#R #!#RANGE#!#6#!#1#!#0
+partition_float_real_range_partition_func#!#R #!#RANGE#!#6#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTIONログインαιώνια#!#R #!#RANGE#!#4#!#1#!#0
@@ -694,6 +695,11 @@ NVarCharPartitionFunction#!#1#!#2#!#Banana
 NVarCharPartitionFunction#!#1#!#3#!#Cherry
 NVarCharPartitionFunction#!#1#!#4#!#Date
 NVarCharPartitionFunction#!#1#!#5#!#Mango
+partition_float_real_range_partition_func#!#1#!#1#!#-1000.0
+partition_float_real_range_partition_func#!#1#!#2#!#-1.0
+partition_float_real_range_partition_func#!#1#!#3#!#0.0
+partition_float_real_range_partition_func#!#1#!#4#!#1.0
+partition_float_real_range_partition_func#!#1#!#5#!#1000.0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#2#!#500
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#3#!#1000
@@ -775,6 +781,7 @@ MoneyPartitionFunction#!#money#!#1#!#8#!#19#!#4#!#<NULL>
 NCharPartitionFunction#!#nchar#!#1#!#8000#!#0#!#0#!#bbf_unicode_cp1_ci_as
 NumericPartitionFunction#!#numeric#!#1#!#17#!#38#!#38#!#<NULL>
 NVarCharPartitionFunction#!#nvarchar#!#1#!#8000#!#0#!#0#!#bbf_unicode_cp1_ci_as
+partition_float_real_range_partition_func#!#float#!#1#!#8#!#53#!#0#!#<NULL>
 PARTITION_FUNCTION  유니코드스키마👻  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTIONログインαιώνια#!#int#!#1#!#4#!#10#!#0#!#<NULL>
@@ -809,6 +816,7 @@ MoneyPartitionScheme#!#MoneyPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NCharPartitionScheme#!#NCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NumericPartitionScheme#!#NumericPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NVarCharPartitionScheme#!#NVarCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
+partition_float_real_range_partition_scheme#!#partition_float_real_range_partition_func#!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME  유니코드스키마👻  #!#PARTITION_FUNCTION  유니코드스키마👻  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME 😎$@ #123 🌍rder  #!#PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEMEログインαιώνια#!#PARTITION_FUNCTIONログインαιώνια#!#PS#!#PARTITION_SCHEME#!#0#!#0
@@ -3866,4 +3874,134 @@ Go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Collation of partition column 'partitionkey' does not match collation of corresponding parameter in partition function 'PF_CollationTest_NVarChar'.)~~
+
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Query to show data in each partition for table created without computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+
+-- Create partitioned table with computed columns
+CREATE TABLE partition_float_real_partitioned_computed_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    computed_val AS (float_val * real_val),
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+-- Insert test data
+INSERT INTO partition_float_real_partitioned_computed_test (float_val, real_val, description)
+SELECT float_val, real_val, description
+FROM partition_float_real_partitioned_test;
+GO
+~~ROW COUNT: 22~~
+
+
+-- Query to show data in each partition for table created with computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+-- Query to compare partition distribution in partition table with and without computed column
+SELECT 
+    'Base table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+UNION ALL
+SELECT 
+    'Computed table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+ORDER BY table_name, partition_number;
+GO
+~~START~~
+varchar#!#int#!#int
+Base table#!#1#!#4
+Base table#!#2#!#3
+Base table#!#3#!#4
+Base table#!#4#!#4
+Base table#!#5#!#3
+Base table#!#6#!#4
+Computed table#!#1#!#4
+Computed table#!#2#!#3
+Computed table#!#3#!#4
+Computed table#!#4#!#4
+Computed table#!#5#!#3
+Computed table#!#6#!#4
+~~END~~
 

--- a/test/JDBC/expected/db_collation/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/db_collation/PARTITION-vu-verify.out
@@ -626,6 +626,7 @@ MoneyPartitionFunction#!#R #!#RANGE#!#4#!#1#!#0
 NCharPartitionFunction#!#R #!#RANGE#!#8#!#1#!#0
 NumericPartitionFunction#!#R #!#RANGE#!#5#!#1#!#0
 NVarCharPartitionFunction#!#R #!#RANGE#!#6#!#1#!#0
+partition_float_real_range_partition_func#!#R #!#RANGE#!#6#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTIONログインαιώνια#!#R #!#RANGE#!#4#!#1#!#0
@@ -694,6 +695,11 @@ NVarCharPartitionFunction#!#1#!#2#!#Banana
 NVarCharPartitionFunction#!#1#!#3#!#Cherry
 NVarCharPartitionFunction#!#1#!#4#!#Date
 NVarCharPartitionFunction#!#1#!#5#!#Mango
+partition_float_real_range_partition_func#!#1#!#1#!#-1000.0
+partition_float_real_range_partition_func#!#1#!#2#!#-1.0
+partition_float_real_range_partition_func#!#1#!#3#!#0.0
+partition_float_real_range_partition_func#!#1#!#4#!#1.0
+partition_float_real_range_partition_func#!#1#!#5#!#1000.0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#2#!#500
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#3#!#1000
@@ -775,6 +781,7 @@ MoneyPartitionFunction#!#money#!#1#!#8#!#19#!#4#!#<NULL>
 NCharPartitionFunction#!#nchar#!#1#!#8000#!#0#!#0#!#bbf_unicode_cp1_ci_ai
 NumericPartitionFunction#!#numeric#!#1#!#17#!#38#!#38#!#<NULL>
 NVarCharPartitionFunction#!#nvarchar#!#1#!#8000#!#0#!#0#!#bbf_unicode_cp1_ci_ai
+partition_float_real_range_partition_func#!#float#!#1#!#8#!#53#!#0#!#<NULL>
 PARTITION_FUNCTION  유니코드스키마👻  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTIONログインαιώνια#!#int#!#1#!#4#!#10#!#0#!#<NULL>
@@ -809,6 +816,7 @@ MoneyPartitionScheme#!#MoneyPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NCharPartitionScheme#!#NCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NumericPartitionScheme#!#NumericPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NVarCharPartitionScheme#!#NVarCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
+partition_float_real_range_partition_scheme#!#partition_float_real_range_partition_func#!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME  유니코드스키마👻  #!#PARTITION_FUNCTION  유니코드스키마👻  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME 😎$@ #123 🌍rder  #!#PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEMEログインαιώνια#!#PARTITION_FUNCTIONログインαιώνια#!#PS#!#PARTITION_SCHEME#!#0#!#0
@@ -3866,4 +3874,134 @@ Go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Collation of partition column 'partitionkey' does not match collation of corresponding parameter in partition function 'PF_CollationTest_NVarChar'.)~~
+
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Query to show data in each partition for table created without computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+
+-- Create partitioned table with computed columns
+CREATE TABLE partition_float_real_partitioned_computed_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    computed_val AS (float_val * real_val),
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+-- Insert test data
+INSERT INTO partition_float_real_partitioned_computed_test (float_val, real_val, description)
+SELECT float_val, real_val, description
+FROM partition_float_real_partitioned_test;
+GO
+~~ROW COUNT: 22~~
+
+
+-- Query to show data in each partition for table created with computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+-- Query to compare partition distribution in partition table with and without computed column
+SELECT 
+    'Base table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+UNION ALL
+SELECT 
+    'Computed table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+ORDER BY table_name, partition_number;
+GO
+~~START~~
+varchar#!#int#!#int
+Base table#!#1#!#4
+Base table#!#2#!#3
+Base table#!#3#!#4
+Base table#!#4#!#4
+Base table#!#5#!#3
+Base table#!#6#!#4
+Computed table#!#1#!#4
+Computed table#!#2#!#3
+Computed table#!#3#!#4
+Computed table#!#4#!#4
+Computed table#!#5#!#3
+Computed table#!#6#!#4
+~~END~~
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/PARTITION-vu-verify.out
@@ -626,6 +626,7 @@ MoneyPartitionFunction#!#R #!#RANGE#!#4#!#1#!#0
 NCharPartitionFunction#!#R #!#RANGE#!#8#!#1#!#0
 NumericPartitionFunction#!#R #!#RANGE#!#5#!#1#!#0
 NVarCharPartitionFunction#!#R #!#RANGE#!#6#!#1#!#0
+partition_float_real_range_partition_func#!#R #!#RANGE#!#6#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTIONログインαιώνια#!#R #!#RANGE#!#4#!#1#!#0
@@ -694,6 +695,11 @@ NVarCharPartitionFunction#!#1#!#2#!#Banana
 NVarCharPartitionFunction#!#1#!#3#!#Cherry
 NVarCharPartitionFunction#!#1#!#4#!#Date
 NVarCharPartitionFunction#!#1#!#5#!#Mango
+partition_float_real_range_partition_func#!#1#!#1#!#-1000.0
+partition_float_real_range_partition_func#!#1#!#2#!#-1.0
+partition_float_real_range_partition_func#!#1#!#3#!#0.0
+partition_float_real_range_partition_func#!#1#!#4#!#1.0
+partition_float_real_range_partition_func#!#1#!#5#!#1000.0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#2#!#500
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#3#!#1000
@@ -775,6 +781,7 @@ MoneyPartitionFunction#!#money#!#1#!#8#!#19#!#4#!#<NULL>
 NCharPartitionFunction#!#nchar#!#1#!#8000#!#0#!#0#!#chinese_prc_ci_as
 NumericPartitionFunction#!#numeric#!#1#!#17#!#38#!#38#!#<NULL>
 NVarCharPartitionFunction#!#nvarchar#!#1#!#8000#!#0#!#0#!#chinese_prc_ci_as
+partition_float_real_range_partition_func#!#float#!#1#!#8#!#53#!#0#!#<NULL>
 PARTITION_FUNCTION  유니코드스키마👻  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTIONログインαιώνια#!#int#!#1#!#4#!#10#!#0#!#<NULL>
@@ -809,6 +816,7 @@ MoneyPartitionScheme#!#MoneyPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NCharPartitionScheme#!#NCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NumericPartitionScheme#!#NumericPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NVarCharPartitionScheme#!#NVarCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
+partition_float_real_range_partition_scheme#!#partition_float_real_range_partition_func#!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME  유니코드스키마👻  #!#PARTITION_FUNCTION  유니코드스키마👻  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME 😎$@ #123 🌍rder  #!#PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEMEログインαιώνια#!#PARTITION_FUNCTIONログインαιώνια#!#PS#!#PARTITION_SCHEME#!#0#!#0
@@ -3866,4 +3874,134 @@ Go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Collation of partition column 'partitionkey' does not match collation of corresponding parameter in partition function 'PF_CollationTest_NVarChar'.)~~
+
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Query to show data in each partition for table created without computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+
+-- Create partitioned table with computed columns
+CREATE TABLE partition_float_real_partitioned_computed_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    computed_val AS (float_val * real_val),
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+-- Insert test data
+INSERT INTO partition_float_real_partitioned_computed_test (float_val, real_val, description)
+SELECT float_val, real_val, description
+FROM partition_float_real_partitioned_test;
+GO
+~~ROW COUNT: 22~~
+
+
+-- Query to show data in each partition for table created with computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+-- Query to compare partition distribution in partition table with and without computed column
+SELECT 
+    'Base table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+UNION ALL
+SELECT 
+    'Computed table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+ORDER BY table_name, partition_number;
+GO
+~~START~~
+varchar#!#int#!#int
+Base table#!#1#!#4
+Base table#!#2#!#3
+Base table#!#3#!#4
+Base table#!#4#!#4
+Base table#!#5#!#3
+Base table#!#6#!#4
+Computed table#!#1#!#4
+Computed table#!#2#!#3
+Computed table#!#3#!#4
+Computed table#!#4#!#4
+Computed table#!#5#!#3
+Computed table#!#6#!#4
+~~END~~
 

--- a/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/PARTITION-vu-verify.out
@@ -626,6 +626,7 @@ MoneyPartitionFunction#!#R #!#RANGE#!#4#!#1#!#0
 NCharPartitionFunction#!#R #!#RANGE#!#8#!#1#!#0
 NumericPartitionFunction#!#R #!#RANGE#!#5#!#1#!#0
 NVarCharPartitionFunction#!#R #!#RANGE#!#6#!#1#!#0
+partition_float_real_range_partition_func#!#R #!#RANGE#!#6#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#R #!#RANGE#!#4#!#1#!#0
 PARTITION_FUNCTIONログインαιώνια#!#R #!#RANGE#!#4#!#1#!#0
@@ -694,6 +695,11 @@ NVarCharPartitionFunction#!#1#!#2#!#Banana
 NVarCharPartitionFunction#!#1#!#3#!#Cherry
 NVarCharPartitionFunction#!#1#!#4#!#Date
 NVarCharPartitionFunction#!#1#!#5#!#Mango
+partition_float_real_range_partition_func#!#1#!#1#!#-1000.0
+partition_float_real_range_partition_func#!#1#!#2#!#-1.0
+partition_float_real_range_partition_func#!#1#!#3#!#0.0
+partition_float_real_range_partition_func#!#1#!#4#!#1.0
+partition_float_real_range_partition_func#!#1#!#5#!#1000.0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#1#!#0
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#2#!#500
 PARTITION_FUNCTION  유니코드스키마👻  #!#1#!#3#!#1000
@@ -775,6 +781,7 @@ MoneyPartitionFunction#!#money#!#1#!#8#!#19#!#4#!#<NULL>
 NCharPartitionFunction#!#nchar#!#1#!#8000#!#0#!#0#!#bbf_unicode_cp1_ci_as
 NumericPartitionFunction#!#numeric#!#1#!#17#!#38#!#38#!#<NULL>
 NVarCharPartitionFunction#!#nvarchar#!#1#!#8000#!#0#!#0#!#bbf_unicode_cp1_ci_as
+partition_float_real_range_partition_func#!#float#!#1#!#8#!#53#!#0#!#<NULL>
 PARTITION_FUNCTION  유니코드스키마👻  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#int#!#1#!#4#!#10#!#0#!#<NULL>
 PARTITION_FUNCTIONログインαιώνια#!#int#!#1#!#4#!#10#!#0#!#<NULL>
@@ -809,6 +816,7 @@ MoneyPartitionScheme#!#MoneyPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NCharPartitionScheme#!#NCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NumericPartitionScheme#!#NumericPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
 NVarCharPartitionScheme#!#NVarCharPartitionFunction#!#PS#!#PARTITION_SCHEME#!#0#!#0
+partition_float_real_range_partition_scheme#!#partition_float_real_range_partition_func#!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME  유니코드스키마👻  #!#PARTITION_FUNCTION  유니코드스키마👻  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEME 😎$@ #123 🌍rder  #!#PARTITION_FUNCTION 😎$@ #123 🌍rder  #!#PS#!#PARTITION_SCHEME#!#0#!#0
 PARTITION_SCHEMEログインαιώνια#!#PARTITION_FUNCTIONログインαιώνια#!#PS#!#PARTITION_SCHEME#!#0#!#0
@@ -3975,4 +3983,134 @@ Go
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Collation of partition column 'partitionkey' does not match collation of corresponding parameter in partition function 'PF_CollationTest_NVarChar'.)~~
+
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Query to show data in each partition for table created without computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+
+-- Create partitioned table with computed columns
+CREATE TABLE partition_float_real_partitioned_computed_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    computed_val AS (float_val * real_val),
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+-- Insert test data
+INSERT INTO partition_float_real_partitioned_computed_test (float_val, real_val, description)
+SELECT float_val, real_val, description
+FROM partition_float_real_partitioned_test;
+GO
+~~ROW COUNT: 22~~
+
+
+-- Query to show data in each partition for table created with computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+~~START~~
+int#!#bigint#!#varchar#!#float#!#float#!#int
+1#!#0#!#x <= -1000.0#!#-12300.0#!#-1500.0#!#4
+2#!#0#!#-1000.0 < x <= -1.0#!#-750.0#!#-2.5#!#3
+3#!#0#!#-1.0 < x <= 0.0#!#-0.75#!#-1.23E-4#!#4
+4#!#0#!#0.0 < x <= 1.0#!#1.23E-4#!#0.75#!#4
+5#!#0#!#1.0 < x <= 1000.0#!#2.5#!#750.0#!#3
+6#!#0#!#x > 1000.0#!#1500.0#!#12300.0#!#4
+~~END~~
+
+
+-- Query to compare partition distribution in partition table with and without computed column
+SELECT 
+    'Base table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+UNION ALL
+SELECT 
+    'Computed table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+ORDER BY table_name, partition_number;
+GO
+~~START~~
+varchar#!#int#!#int
+Base table#!#1#!#4
+Base table#!#2#!#3
+Base table#!#3#!#4
+Base table#!#4#!#4
+Base table#!#5#!#3
+Base table#!#6#!#4
+Computed table#!#1#!#4
+Computed table#!#2#!#3
+Computed table#!#3#!#4
+Computed table#!#4#!#4
+Computed table#!#5#!#3
+Computed table#!#6#!#4
+~~END~~
 

--- a/test/JDBC/input/PARTITION-vu-cleanup.mix
+++ b/test/JDBC/input/PARTITION-vu-cleanup.mix
@@ -452,3 +452,9 @@ go
 
 DROP DATABASE PartitionDb
 go
+
+DROP TABLE partition_float_real_partitioned_test;
+DROP TABLE partition_float_real_partitioned_computed_test;
+DROP PARTITION SCHEME partition_float_real_range_partition_scheme;
+DROP PARTITION FUNCTION partition_float_real_range_partition_func;
+GO

--- a/test/JDBC/input/PARTITION-vu-prepare.mix
+++ b/test/JDBC/input/PARTITION-vu-prepare.mix
@@ -1205,3 +1205,78 @@ GO
 CREATE PARTITION SCHEME PS_CollationTest_NVarChar 
 AS PARTITION PF_CollationTest_NVarChar ALL TO ([PRIMARY]);
 GO
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Create partition function for FLOAT values
+CREATE PARTITION FUNCTION partition_float_real_range_partition_func (FLOAT)
+AS RANGE RIGHT FOR VALUES 
+(
+    -1000.0,    -- Very negative values
+    -1.0,       -- Small negative values
+    0.0,        -- Zero boundary
+    1.0,        -- Small positive values
+    1000.0      -- Very positive values
+);
+GO
+
+-- Create partition scheme
+CREATE PARTITION SCHEME partition_float_real_range_partition_scheme
+AS PARTITION partition_float_real_range_partition_func ALL TO ([PRIMARY]);
+GO
+
+-- Create partitioned table without computed columns
+CREATE TABLE partition_float_real_partitioned_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+-- Insert test data covering all partitions
+INSERT INTO partition_float_real_partitioned_test (float_val, real_val, description)
+VALUES 
+    -- Partition 1: x <= -1000.0
+    (-5000.0, -5000.0, 'Very negative - P1'),
+    (-2000.0, -2000.0, 'Very negative - P1'),
+    (-1500.0, -1500.0, 'Very negative - P1'),
+
+    -- Partition 2: -1000.0 < x <= -1.0
+    (-750.0, -750.0, 'Medium negative - P2'),
+    (-500.0, -500.0, 'Medium negative - P2'),
+    (-2.5, -2.5, 'Medium negative - P2'),
+
+    -- Partition 3: -1.0 < x <= 0.0
+    (-0.75, -0.75, 'Small negative - P3'),
+    (-0.5, -0.5, 'Small negative - P3'),
+    (-0.25, -0.25, 'Small negative - P3'),
+
+    -- Partition 4: 0.0 < x <= 1.0
+    (0.25, 0.25, 'Small positive - P4'),
+    (0.5, 0.5, 'Small positive - P4'),
+    (0.75, 0.75, 'Small positive - P4'),
+
+    -- Partition 5: 1.0 < x <= 1000.0
+    (2.5, 2.5, 'Medium positive - P5'),
+    (500.0, 500.0, 'Medium positive - P5'),
+    (750.0, 750.0, 'Medium positive - P5'),
+
+    -- Partition 6: x > 1000.0
+    (1500.0, 1500.0, 'Very positive - P6'),
+    (2000.0, 2000.0, 'Very positive - P6'),
+    (5000.0, 5000.0, 'Very positive - P6');
+GO
+
+-- Test scientific notation values
+INSERT INTO partition_float_real_partitioned_test (float_val, real_val, description)
+VALUES 
+    (-1.23E+4, -1.23E+4, 'Scientific notation large negative'),
+    (-1.23E-4, -1.23E-4, 'Scientific notation small negative'),
+    (1.23E-4, 1.23E-4, 'Scientific notation small positive'),
+    (1.23E+4, 1.23E+4, 'Scientific notation large positive');
+GO

--- a/test/JDBC/input/PARTITION-vu-verify.mix
+++ b/test/JDBC/input/PARTITION-vu-verify.mix
@@ -1779,3 +1779,95 @@ CREATE TABLE PT_DifferentCollation_NVarChar (
     Value NVARCHAR(100)
 ) ON PS_CollationTest_NVarChar(PartitionKey);
 Go
+
+USE master
+GO
+
+---------------------------------------------------------------
+--- Test Partition Tables with Computed columns
+---------------------------------------------------------------
+-- Query to show data in each partition for table created without computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+
+
+-- Create partitioned table with computed columns
+CREATE TABLE partition_float_real_partitioned_computed_test (
+    id INT IDENTITY(1,1),
+    float_val FLOAT,
+    real_val REAL,
+    computed_val AS (float_val * real_val),
+    description VARCHAR(100)
+) ON partition_float_real_range_partition_scheme(float_val);
+GO
+
+-- Insert test data
+INSERT INTO partition_float_real_partitioned_computed_test (float_val, real_val, description)
+SELECT float_val, real_val, description
+FROM partition_float_real_partitioned_test;
+GO
+
+-- Query to show data in each partition for table created with computed column
+SELECT 
+    p.partition_number,
+    p.rows,
+    CASE 
+        WHEN p.partition_number = 1 THEN 'x <= -1000.0'
+        WHEN p.partition_number = 2 THEN '-1000.0 < x <= -1.0'
+        WHEN p.partition_number = 3 THEN '-1.0 < x <= 0.0'
+        WHEN p.partition_number = 4 THEN '0.0 < x <= 1.0'
+        WHEN p.partition_number = 5 THEN '1.0 < x <= 1000.0'
+        WHEN p.partition_number = 6 THEN 'x > 1000.0'
+    END as partition_range,
+    MIN(t.float_val) as min_float_val,
+    MAX(t.float_val) as max_float_val,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number, p.rows
+ORDER BY p.partition_number;
+GO
+
+-- Query to compare partition distribution in partition table with and without computed column
+SELECT 
+    'Base table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+UNION ALL
+SELECT 
+    'Computed table' as table_name,
+    p.partition_number,
+    COUNT(*) as row_count
+FROM partition_float_real_partitioned_computed_test t
+JOIN sys.partitions p ON p.object_id = OBJECT_ID('partition_float_real_partitioned_computed_test')
+    AND p.index_id <= 1
+WHERE p.partition_number = $PARTITION.partition_float_real_range_partition_func(t.float_val)
+GROUP BY p.partition_number
+ORDER BY table_name, partition_number;
+GO


### PR DESCRIPTION
### Description

While creating partition tables with computed columns, we were getting assertion error 
because we were generating CREATE PARTITION statement once and reusing it multiple partition creation and
the generated statement was getting modified because the statement wasn't marked as read-only 
when passed to standard_ProcessUtility().

The fix involves setting the read_only parameter to 'true' in standard_ProcessUtility() 
calls for both partition creation and rename operations. This prevents modification 
of the same statement across multiple partition creations, ensuring the statement 
remains valid throughout the process.

Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)


### Issues Resolved

Task: BABEL-5797

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).