### PR TITLE
[OSS-ONLY] Fix grantor to bootstrap superuser while granting login to guest user 

### DIFF
--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -460,7 +460,7 @@ drop_bbf_authid_user_ext(ObjectAccessType access,
 
 			/* Grant guest user to login if it's mapped user is being dropped. */
 			if (strlen(login) > 0)
-				grant_revoke_role_to_login(login, get_guest_role_name(get_cur_db_name()), "bbf_role_admin", true);
+				grant_revoke_role_to_login(login, get_guest_role_name(get_cur_db_name()), NULL, true);
 		}
 		CatalogTupleDelete(bbf_authid_user_ext_rel,
 						   &tuple->t_self);
@@ -1753,7 +1753,7 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, NULL, false);
 			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, "bbf_role_admin", false);
 			/* Now grant guest user to old login as it's mapped user is being removed. */
-			grant_revoke_role_to_login(old_login_name, get_guest_role_name(get_cur_db_name()), "bbf_role_admin", true);
+			grant_revoke_role_to_login(old_login_name, get_guest_role_name(get_cur_db_name()), NULL, true);
 		}
 
 		/* Revoke guest user from new login as login now has a mapped user in current database. */

--- a/test/JDBC/expected/BABEL-USER-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-USER-vu-cleanup.out
@@ -27,3 +27,24 @@ GO
 
 DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO
+
+USE babel_5890_db
+GO
+
+DROP PROC babel_role_vu_prepare_role_mapping
+GO
+
+DROP USER babel_5890_role_vu_prepare_r2;
+GO
+
+USE master
+GO
+
+DROP LOGIN babel_5890_role_vu_prepare_r1;
+GO
+
+DROP LOGIN babel_5890_role_vu_prepare_r2;
+GO
+
+DROP DATABASE babel_5890_db
+GO

--- a/test/JDBC/expected/BABEL-USER-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-USER-vu-prepare.out
@@ -39,3 +39,40 @@ GO
 
 CREATE SCHEMA babel_user_vu_prepare_sch
 GO
+
+CREATE DATABASE babel_5890_db
+GO
+
+USE babel_5890_db
+GO
+
+-- Create login and verify login is mapped to guest role, create user and verify login mapping is changed from guest role to user role
+CREATE LOGIN babel_5890_role_vu_prepare_r1 WITH PASSWORD = '1234';
+CREATE USER babel_5890_role_vu_prepare_r1 FOR LOGIN babel_5890_role_vu_prepare_r1;
+DROP USER babel_5890_role_vu_prepare_r1;
+GO
+
+-- Alter user login and verify login mapping is changed from guest role to user role
+CREATE USER babel_5890_role_vu_prepare_r2 FOR LOGIN babel_5890_role_vu_prepare_r1;
+CREATE LOGIN babel_5890_role_vu_prepare_r2 WITH PASSWORD = '1234';
+GO
+
+CREATE PROC babel_role_vu_prepare_role_mapping AS
+BEGIN
+	SELECT
+		r.rolname AS role_name,
+		m.rolname AS member_name,
+		CASE
+			WHEN (g.rolname IN ('bbf_role_admin')) then true else false
+		END AS grantor,
+		am.admin_option, 
+		am.inherit_option, 
+		am.set_option
+	FROM pg_auth_members am
+	JOIN pg_roles r ON am.roleid = r.oid
+	JOIN pg_roles m ON am.member = m.oid
+	JOIN pg_roles g ON am.grantor = g.oid
+	WHERE r.rolname IN ('babel_5890_db_guest', 'babel_5890_db_babel_5890_role_vu_prepare_r1', 'babel_5890_db_babel_5890_role_vu_prepare_r2') AND m.rolname IN ('babel_5890_role_vu_prepare_r1', 'babel_5890_role_vu_prepare_r2')
+	ORDER BY r.rolname;
+END
+GO

--- a/test/JDBC/expected/BABEL-USER-vu-verify.out
+++ b/test/JDBC/expected/BABEL-USER-vu-verify.out
@@ -382,3 +382,18 @@ GO
 varchar#!#varchar
 ~~END~~
 
+
+USE babel_5890_db
+GO
+
+ALTER USER babel_5890_role_vu_prepare_r2 WITH LOGIN = babel_5890_role_vu_prepare_r2;
+GO
+
+EXEC babel_role_vu_prepare_role_mapping
+GO
+~~START~~
+varchar#!#varchar#!#bit#!#bit#!#bit#!#bit
+babel_5890_db_babel_5890_role_vu_prepare_r2#!#babel_5890_role_vu_prepare_r2#!#1#!#0#!#1#!#1
+babel_5890_db_guest#!#babel_5890_role_vu_prepare_r1#!#1#!#0#!#1#!#1
+~~END~~
+

--- a/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-cleanup.sql
@@ -27,3 +27,24 @@ GO
 
 DROP LOGIN babel_user_vu_prepare_long_login_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 GO
+
+USE babel_5890_db
+GO
+
+DROP PROC babel_role_vu_prepare_role_mapping
+GO
+
+DROP USER babel_5890_role_vu_prepare_r2;
+GO
+
+USE master
+GO
+
+DROP LOGIN babel_5890_role_vu_prepare_r1;
+GO
+
+DROP LOGIN babel_5890_role_vu_prepare_r2;
+GO
+
+DROP DATABASE babel_5890_db
+GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-prepare.sql
@@ -39,3 +39,40 @@ GO
 
 CREATE SCHEMA babel_user_vu_prepare_sch
 GO
+
+CREATE DATABASE babel_5890_db
+GO
+
+USE babel_5890_db
+GO
+
+-- Create login and verify login is mapped to guest role, create user and verify login mapping is changed from guest role to user role
+CREATE LOGIN babel_5890_role_vu_prepare_r1 WITH PASSWORD = '1234';
+CREATE USER babel_5890_role_vu_prepare_r1 FOR LOGIN babel_5890_role_vu_prepare_r1;
+DROP USER babel_5890_role_vu_prepare_r1;
+GO
+
+-- Alter user login and verify login mapping is changed from guest role to user role
+CREATE USER babel_5890_role_vu_prepare_r2 FOR LOGIN babel_5890_role_vu_prepare_r1;
+CREATE LOGIN babel_5890_role_vu_prepare_r2 WITH PASSWORD = '1234';
+GO
+
+CREATE PROC babel_role_vu_prepare_role_mapping AS
+BEGIN
+	SELECT
+		r.rolname AS role_name,
+		m.rolname AS member_name,
+		CASE
+			WHEN (g.rolname IN ('bbf_role_admin')) then true else false
+		END AS grantor,
+		am.admin_option, 
+		am.inherit_option, 
+		am.set_option
+	FROM pg_auth_members am
+	JOIN pg_roles r ON am.roleid = r.oid
+	JOIN pg_roles m ON am.member = m.oid
+	JOIN pg_roles g ON am.grantor = g.oid
+	WHERE r.rolname IN ('babel_5890_db_guest', 'babel_5890_db_babel_5890_role_vu_prepare_r1', 'babel_5890_db_babel_5890_role_vu_prepare_r2') AND m.rolname IN ('babel_5890_role_vu_prepare_r1', 'babel_5890_role_vu_prepare_r2')
+	ORDER BY r.rolname;
+END
+GO

--- a/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-USER-vu-verify.mix
@@ -177,3 +177,12 @@ GO
 
 EXEC babel_user_vu_prepare_db_principal_proc
 GO
+
+USE babel_5890_db
+GO
+
+ALTER USER babel_5890_role_vu_prepare_r2 WITH LOGIN = babel_5890_role_vu_prepare_r2;
+GO
+
+EXEC babel_role_vu_prepare_role_mapping
+GO


### PR DESCRIPTION
In Babelfish we explictly specify bbf_role_admin as grantor while mapping login to guest user. This causes duplicate mapping when the bootstrap superuser is not bbf_role_admin.

This commit fixes the grantor to bootstrap superuser while granting guest user to login.

Task: BABEL-5890


(cherry picked from commit 3e3015465c1c12d34443d11e723ea8febecbe67f)

### Issues Resolved

BABEL-5743

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
Yes

* **Major version upgrade tests -**
Yes

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).