### PR TITLE
Added sp_helplogins - stored proc that provides information about logins and users associated with those logins

### DIFF
--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -104,7 +104,8 @@ runs:
 
           # Get the list of all the Babelfish logins in a file
           query="SELECT orig_loginname, default_database_name, default_language_name, type, \
-                pg_has_role(rolname, 'sysadmin', 'member') AS is_sysadmin_member \
+                pg_has_role(rolname, 'sysadmin', 'member') AS is_sysadmin_member, \
+                pg_has_role(rolname, 'securityadmin', 'member') AS is_securityadmin_member \
                 FROM sys.babelfish_authid_login_ext \
                 WHERE rolname NOT IN ('jdbc_user', 'sysadmin', 'bbf_role_admin', 'test@ABC');"
           ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/logins_file.txt
@@ -229,13 +230,14 @@ runs:
           done < <(tail -n +3 ~/upgrade/domains_file.txt | head -n -2)
 
           # Loop through the list of all the Babelfish logins and create them one by one.
-          while IFS='|' read -r name db lang type sa; do
+          while IFS='|' read -r name db lang type sa seca; do
             # Remove leading and trailing spaces
             orig_loginname="$(echo "${name}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             def_db="$(echo "${db}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             def_lang="$(echo "${lang}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             login_type="$(echo "${type}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             is_sysadmin_member="$(echo "${sa}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+            is_securityadmin_member="$(echo "${seca}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             if [[ $login_type == 'U' ]];then
               sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "CREATE LOGIN [$orig_loginname] FROM WINDOWS WITH default_database = [$def_db], default_language = [$def_lang];"
             else
@@ -243,6 +245,9 @@ runs:
             fi
             if [[ $is_sysadmin_member == 't' ]];then
               sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "ALTER ROLE sysadmin ADD MEMBER [$orig_loginname];"
+            fi
+            if [[ $is_securityadmin_member == 't' ]];then
+              sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "ALTER ROLE securityadmin ADD MEMBER [$orig_loginname];"
             fi
           done < <(tail -n +3 ~/upgrade/logins_file.txt | head -n -2)
           

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -105,7 +105,7 @@ runs:
           # Get the list of all the Babelfish logins in a file
           query="SELECT orig_loginname, default_database_name, default_language_name, type, \
                 pg_has_role(rolname, 'sysadmin', 'member') AS is_sysadmin_member, \
-                pg_has_role(rolname, 'securityadmin', 'member') AS is_securityadmin_member \
+                (case when exists (select 1 from pg_roles where rolname = 'securityadmin') then pg_has_role(rolname, 'securityadmin', 'member') else 'f' end) AS is_securityadmin_member  \
                 FROM sys.babelfish_authid_login_ext \
                 WHERE rolname NOT IN ('jdbc_user', 'sysadmin', 'bbf_role_admin', 'test@ABC');"
           ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "$query" > ~/upgrade/logins_file.txt

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ test/JDBC/target/maven-status/*
 test/JDBC/target/surefire-reports/*
 test/JDBC/target/test-classes/*
 
-contrib/babelfishpg_common/sql/babelfishpg_common--[0-9].[0-9].[0-9]--[0-9].[0-9].[0-9].sql
-contrib/babelfishpg_common/sql/babelfishpg_common--[0-9].[0-9].[0-9].sql
+contrib/babelfishpg_common/sql/babelfishpg_common--[0-9]*.[0-9]*.[0-9]*--[0-9]*.[0-9]*.[0-9]*.sql
+contrib/babelfishpg_common/sql/babelfishpg_common--[0-9]*.[0-9]*.[0-9]*.sql
 contrib/babelfishpg_common/src/geo_parser.c
 contrib/babelfishpg_common/src/geo_scan.c
 contrib/babelfishpg_money/babelfishpg_money--[0-9].[0-9].[0-9].sql

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3755,3 +3755,160 @@ BEGIN
 END;
 $$ LANGUAGE pltsql;
 GRANT EXECUTE ON PROCEDURE sys.sp_procedure_params_100_managed TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.sp_helplogins(IN "@loginname" sys.sysname DEFAULT NULL)
+LANGUAGE pltsql
+AS $$
+DECLARE @input_loginname sys.sysname;
+DECLARE @current_username sys.nvarchar(128)
+DECLARE @is_sysadmin BIT
+BEGIN
+
+    IF is_srvrolemember('securityadmin') = 0 
+    BEGIN
+        RAISERROR('User does not have permission to perform this action.', 16, 1);
+		RETURN 0;
+    END
+
+    SET @current_username = LOWER(sys.suser_name());
+    SET @is_sysadmin = is_srvrolemember('sysadmin');
+    
+    IF @loginname IS NULL
+    BEGIN    
+        SELECT DISTINCT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
+            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
+            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
+            CASE 
+                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
+                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
+                ELSE CAST('no' AS sys.char(5))
+            END AS AUser,
+            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
+        FROM pg_catalog.pg_roles AS Base 
+        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
+        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
+        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
+        WHERE LExt.type NOT IN ('R', 'Z')
+
+        -- first selector in the union is to get all the mapped users
+        -- second selector in the union is to get all the mapped database/user-defined roles
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
+            CAST('User' AS sys.char(8)) AS UserOrAlias
+        FROM sys.babelfish_authid_user_ext UExt
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
+        WHERE UExt.type != 'R' AND  
+            UExt.orig_username != 'guest' AND 
+            has_dbaccess(UExt.database_name) = 1 AND
+            (
+                @is_sysadmin = 1 OR
+                UExt.login_name = @current_username OR
+                ISNULL(UExt.login_name, '') = '' OR
+                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+                EXISTS (
+                    SELECT 1 
+                    FROM pg_catalog.pg_auth_members AS Authmbr
+                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname
+                    WHERE UExt1.orig_username IN ('db_securityadmin', 'db_accessadmin') 
+                    AND UExt2.database_name = UExt.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+                    AND UExt2.login_name = @current_username
+                )
+            )
+        UNION
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt1.orig_username AS sys.SYSNAME) AS UserName,
+            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias 
+        FROM pg_catalog.pg_auth_members AS Authmbr
+        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
+        WHERE 
+            has_dbaccess(UExt2.database_name) = 1 AND
+            (
+                @is_sysadmin = 1 OR
+                UExt2.login_name = @current_username OR
+                ISNULL(UExt2.login_name, '') = '' OR
+                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+                EXISTS (
+                    SELECT 1
+                    FROM pg_catalog.pg_auth_members AS Authmbr
+                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt3 ON PGR1.rolname = UExt3.rolname
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt4 ON PGR2.rolname = UExt4.rolname
+                    WHERE UExt3.orig_username IN ('db_securityadmin', 'db_accessadmin') 
+                    AND UExt4.database_name = UExt2.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+                    AND UExt4.login_name = @current_username
+                )
+            )
+    END
+    ELSE
+    BEGIN
+        SET @input_loginname = sys.RTRIM(@loginname);
+
+        SELECT DISTINCT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
+            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
+            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
+            CASE 
+                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
+                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
+                ELSE CAST('no' AS sys.char(5))
+            END AS AUser,
+            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
+        FROM pg_catalog.pg_roles AS Base 
+        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
+        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
+        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
+        WHERE LExt.type NOT IN ('R', 'Z') AND LExt.orig_loginname = @input_loginname
+        
+        -- first selector in the union is to get all the mapped users
+        -- second selector in the union is to get all the mapped database/user-defined roles
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
+            CAST('User' AS sys.char(8)) AS UserOrAlias 
+        FROM sys.babelfish_authid_user_ext UExt
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
+        WHERE UExt.type != 'R' AND  
+            UExt.orig_username != 'guest' AND 
+            has_dbaccess(UExt.database_name) = 1 AND
+            LExt.orig_loginname = @input_loginname
+        UNION
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt1.orig_username AS SYS.SYSNAME) AS UserName,
+            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias
+        FROM pg_catalog.pg_auth_members AS Authmbr
+        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
+        WHERE 
+            has_dbaccess(UExt2.database_name) = 1 AND
+            LExt.orig_loginname = @input_loginname
+    END;
+
+    RETURN 0;
+END;
+$$;
+GRANT EXECUTE ON PROCEDURE sys.sp_helplogins TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3822,7 +3822,6 @@ BEGIN
                     AND UExt2.login_name = @current_username
                 )
             )
-        ORDER BY LExt.orig_loginname
         UNION
         SELECT
             CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
@@ -3855,7 +3854,7 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
-        ORDER BY LExt.orig_loginname
+        ORDER BY LoginName
     END
     ELSE
     BEGIN

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3822,6 +3822,7 @@ BEGIN
                     AND UExt2.login_name = @current_username
                 )
             )
+        ORDER BY LExt.orig_loginname
         UNION
         SELECT
             CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
@@ -3854,6 +3855,7 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
+        ORDER BY LExt.orig_loginname
     END
     ELSE
     BEGIN

--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3854,7 +3854,6 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
-        ORDER BY LoginName
     END
     ELSE
     BEGIN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -170,6 +170,163 @@ WHERE(pg_has_role(sys.suser_id(), 'sysadmin'::TEXT, 'MEMBER')
   AND Ext.type = 'S';
 GRANT SELECT ON sys.sql_logins TO PUBLIC;
 
+CREATE OR REPLACE PROCEDURE sys.sp_helplogins(IN "@loginname" sys.sysname DEFAULT NULL)
+LANGUAGE pltsql
+AS $$
+DECLARE @input_loginname sys.sysname;
+DECLARE @current_username sys.nvarchar(128)
+DECLARE @is_sysadmin BIT
+BEGIN
+
+    IF is_srvrolemember('securityadmin') = 0 
+    BEGIN
+        RAISERROR('User does not have permission to perform this action.', 16, 1);
+		RETURN 0;
+    END
+
+    SET @current_username = LOWER(sys.suser_name());
+    SET @is_sysadmin = is_srvrolemember('sysadmin');
+    
+    IF @loginname IS NULL
+    BEGIN    
+        SELECT DISTINCT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
+            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
+            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
+            CASE 
+                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
+                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
+                ELSE CAST('no' AS sys.char(5))
+            END AS AUser,
+            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
+        FROM pg_catalog.pg_roles AS Base 
+        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
+        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
+        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
+        WHERE LExt.type NOT IN ('R', 'Z')
+
+        -- first selector in the union is to get all the mapped users
+        -- second selector in the union is to get all the mapped database/user-defined roles
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
+            CAST('User' AS sys.char(8)) AS UserOrAlias
+        FROM sys.babelfish_authid_user_ext UExt
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
+        WHERE UExt.type != 'R' AND  
+            UExt.orig_username != 'guest' AND 
+            has_dbaccess(UExt.database_name) = 1 AND
+            (
+                @is_sysadmin = 1 OR
+                UExt.login_name = @current_username OR
+                ISNULL(UExt.login_name, '') = '' OR
+                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+                EXISTS (
+                    SELECT 1 
+                    FROM pg_catalog.pg_auth_members AS Authmbr
+                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname
+                    WHERE UExt1.orig_username IN ('db_securityadmin', 'db_accessadmin') 
+                    AND UExt2.database_name = UExt.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+                    AND UExt2.login_name = @current_username
+                )
+            )
+        UNION
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt1.orig_username AS sys.SYSNAME) AS UserName,
+            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias 
+        FROM pg_catalog.pg_auth_members AS Authmbr
+        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
+        WHERE 
+            has_dbaccess(UExt2.database_name) = 1 AND
+            (
+                @is_sysadmin = 1 OR
+                UExt2.login_name = @current_username OR
+                ISNULL(UExt2.login_name, '') = '' OR
+                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+                EXISTS (
+                    SELECT 1
+                    FROM pg_catalog.pg_auth_members AS Authmbr
+                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt3 ON PGR1.rolname = UExt3.rolname
+                    INNER JOIN sys.babelfish_authid_user_ext AS UExt4 ON PGR2.rolname = UExt4.rolname
+                    WHERE UExt3.orig_username IN ('db_securityadmin', 'db_accessadmin') 
+                    AND UExt4.database_name = UExt2.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+                    AND UExt4.login_name = @current_username
+                )
+            )
+    END
+    ELSE
+    BEGIN
+        SET @input_loginname = sys.RTRIM(@loginname);
+
+        SELECT DISTINCT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
+            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
+            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
+            CASE 
+                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
+                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
+                ELSE CAST('no' AS sys.char(5))
+            END AS AUser,
+            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
+        FROM pg_catalog.pg_roles AS Base 
+        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
+        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
+        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
+        WHERE LExt.type NOT IN ('R', 'Z') AND LExt.orig_loginname = @input_loginname
+        
+        -- first selector in the union is to get all the mapped users
+        -- second selector in the union is to get all the mapped database/user-defined roles
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
+            CAST('User' AS sys.char(8)) AS UserOrAlias 
+        FROM sys.babelfish_authid_user_ext UExt
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
+        WHERE UExt.type != 'R' AND  
+            UExt.orig_username != 'guest' AND 
+            has_dbaccess(UExt.database_name) = 1 AND
+            LExt.orig_loginname = @input_loginname
+        UNION
+        SELECT
+            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
+            CAST(UExt1.orig_username AS SYS.SYSNAME) AS UserName,
+            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias
+        FROM pg_catalog.pg_auth_members AS Authmbr
+        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
+        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
+        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
+        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
+        WHERE 
+            has_dbaccess(UExt2.database_name) = 1 AND
+            LExt.orig_loginname = @input_loginname
+    END;
+
+    RETURN 0;
+END;
+$$;
+GRANT EXECUTE ON PROCEDURE sys.sp_helplogins TO PUBLIC;
+
 CREATE OR REPLACE FUNCTION sys.isnumeric(IN expr ANYELEMENT)
 RETURNS INTEGER AS
 'babelfishpg_tsql', 'isnumeric'

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -268,7 +268,6 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
-        ORDER BY LoginName
     END
     ELSE
     BEGIN

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -268,6 +268,7 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
+        ORDER BY LoginName
     END
     ELSE
     BEGIN

--- a/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlUnsupportedFeatureHandler.cpp
@@ -1712,7 +1712,6 @@ const char *unsupported_sp_procedures[] = {
 	"sp_generate_database_ledger_digest",
 	"sp_grantdbaccess",
 	"sp_grantlogin",
-	"sp_helplogins",
 	"sp_helpntgroup",
 	"sp_helpremotelogin",
 	"sp_helprotect",

--- a/test/JDBC/README.md
+++ b/test/JDBC/README.md
@@ -373,6 +373,30 @@ Input file type: `.mix`
 
 ---
 
+### Ignoring non-deterministic columns in the diff
+In case there are columns like identifier which are non-deterministic and change across each run, you can ignore such columns without any SQL changes. Use the `-- ignore_columns` options and pass the column numbers to be ignored.
+```sql
+-- ignore_columns <comman separated column numbers to be ignored>
+<SQL statements>
+GO -- after this delimiter, the ignore_columns will be reset and not apply hereafter, unless specified again
+``` 
+
+**Note:** If there are multiple result sets, the specified columns will be ignored from the first result only.
+
+**Example:**
+```sql
+-- tsql
+-- ignore_columns 2
+SELECT name, id FROM mytable1;
+SELECT name FROM mytable2
+GO
+```
+
+In this case, the column number 2 i.e. the id will be ignored from the first result set and the second result set outputslike normal.
+
+
+---
+
 ### **IMPORTANT**
 - If you want to execute a SQL Batch in `.txt` input files, you will need to specify the batch in a single line without the `GO` batch separator. This is needed because for `.txt` files, the test framework treates every line as a standalone statement/command that can be executed against the server.
 - You CANNOT group functionalities from a different file type. For example, you cannot execute prep-exec statements (functionality of `.txt` input file) in a `.mix` file. 

--- a/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
+++ b/test/JDBC/expected/BABEL_GRANT_CONNECT-vu-verify.out
@@ -59,6 +59,10 @@ go
 ~~ERROR (Message: User 'guest' cannot be dropped, it can only be disabled. The user is already disabled in the current database.)~~
 
 
+-- re-enabling connect on guest user
+grant connect to guest;
+go
+
 -- reset the login password
 alter login grant_connect_abc with password = 'Babel123'
 go

--- a/test/JDBC/expected/restricted_objects-vu-cleanup.out
+++ b/test/JDBC/expected/restricted_objects-vu-cleanup.out
@@ -104,3 +104,6 @@ GO
 
 DROP LOGIN babel_5146_user_l1;
 GO
+
+GRANT CONNECT TO guest;
+GO

--- a/test/JDBC/expected/z_sp_helplogins-vu-cleanup.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-cleanup.out
@@ -1,0 +1,88 @@
+-- tsql user=jdbc_user password=12345678 database=master
+drop user if exists userof_sp_helplogins_testlogin 
+GO
+
+drop login sp_helplogins_testlogin
+GO
+
+drop user if exists userof_testloginwithsecurityadmin
+GO
+
+drop user if exists userof_testloginwithsecurityadmin_indb1
+GO
+
+drop login testloginwithsecurityadmin
+GO
+
+drop login testloginwithsecurityadmin2
+GO
+
+drop user if exists u_testloginwithsecadminanddbsec
+drop login testloginwithsecadminanddbsec
+GO
+
+drop login testloginwithsysadmin
+GO
+
+drop login testloginindb1
+GO
+
+drop user if exists userof_testloginindb1
+GO
+
+drop login testloginwithoutusers
+GO
+
+drop user if exists u_testloginwithotherdefdb
+GO
+
+drop login testloginwithotherdefdb
+GO
+
+use sp_helplogins_db1
+GO
+alter role sp_helplogins_role drop member userof_testloginwithsecurityadmin2
+GO
+drop role sp_helplogins_role;
+GO
+use master
+GO
+
+drop user if exists userof_testloginwithsecurityadmin2
+GO
+
+drop user [userof@sp$chars*logins];
+drop login [sp_help@logins$with%sp*chars];
+GO
+
+-- creating login and user of longer lengths
+declare @loginname sys.sysname = cast(repeat('a', 63) as sysname);
+declare @username sys.sysname = cast(repeat('b', 63) as sysname);
+declare @droploginstmt varchar(max) = 'DROP LOGIN [' + @loginName + ']';
+declare @dropuserstmt varchar(max) = 'DROP USER [' + @username + ']'
+exec (@dropuserstmt)
+exec (@droploginstmt)
+GO
+
+drop user if exists sp_helplogins_vu_windows_user;
+drop login [helplogins\win]
+GO
+
+drop user if exists u_sp_helplogin_loginwithusermemberofdbowner
+drop login sp_helplogin_loginwithusermemberofdbowner
+GO
+
+drop login sp_helplogin_loginwithdifferentdefaultdb;
+GO
+
+drop login sp_helplogin_loginownerofdb;
+GO
+
+drop database sp_helplogins_db1;
+GO
+
+drop database sp_helplogins_db2;
+GO
+
+drop database sp_helplogins_db3;
+GO

--- a/test/JDBC/expected/z_sp_helplogins-vu-prepare.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-prepare.out
@@ -1,0 +1,71 @@
+-- create a dummy db
+create database sp_helplogins_db1
+GO
+
+create database sp_helplogins_db2
+GO
+
+create database sp_helplogins_db3
+GO
+
+-- create a login with user in master with securityadmin server role
+-- create login with user in master with db_securityadmin role
+create login sp_helplogins_testlogin with password = '12345678'
+create user userof_sp_helplogins_testlogin for login sp_helplogins_testlogin
+GO
+
+-- create a login which does not have any users
+create login testloginwithoutusers with password = '12345678'
+GO
+
+-- create a login and a user in sp_helplogins_db1
+create login testloginindb1 with password = '12345678'
+GO
+
+use sp_helplogins_db1
+GO
+
+create user userof_testloginindb1 for login testloginindb1
+GO
+
+create login testloginwithotherdefdb with password = '12345678', default_database = sp_helplogins_db1
+GO
+
+create user u_testloginwithotherdefdb for login testloginwithotherdefdb
+GO
+
+use master;
+GO
+
+-- create login and user with special chars
+create login [sp_help@logins$with%sp*chars] with password = '12345678';
+create user [userof@sp$chars*logins] for login [sp_help@logins$with%sp*chars]
+GO
+
+-- creating login and user of longer lengths
+declare @loginname sys.sysname = cast(repeat('a', 63) as sysname);
+declare @username sys.sysname = cast(repeat('b', 63) as sysname);
+declare @pass varchar(10) = '12345678';
+declare @createloginstmt varchar(max) = 'CREATE LOGIN [' + @loginName + '] WITH PASSWORD = ''' + @pass + '''';
+declare @createuserstmt varchar(max) = 'CREATE USER [' + @username + '] FOR LOGIN [' + @loginname + ']'
+exec (@createloginstmt)
+exec (@createuserstmt)
+GO
+
+-- create a windows login and user
+create login [helplogins\win] from windows;
+create user sp_helplogins_vu_windows_user for login [helplogins\win]
+GO
+
+-- creating another login which does not have a user but is a owner of a database
+create login sp_helplogin_loginownerofdb with password = '12345678';
+GO
+
+-- creating a login which does not have a user but has a different default database
+create login sp_helplogin_loginwithdifferentdefaultdb with password = '12345678', default_database = sp_helplogins_db3;
+GO
+
+-- creating a login which has a user which is a member of the db_owner db role (this is not the same as the login being owner of the db)
+create login sp_helplogin_loginwithusermemberofdbowner with password = '12345678'
+create user u_sp_helplogin_loginwithusermemberofdbowner for login sp_helplogin_loginwithusermemberofdbowner
+GO

--- a/test/JDBC/expected/z_sp_helplogins-vu-verify.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-verify.out
@@ -1,0 +1,484 @@
+-- tsql
+
+-- creating dependent logins in verify
+create login testloginwithsecurityadmin with password = '12345678'
+create user userof_testloginwithsecurityadmin for login testloginwithsecurityadmin
+GO
+
+-- creating a login with sysadmin permissions without a user
+create login testloginwithsysadmin with password = '12345678'
+alter server role sysadmin add member testloginwithsysadmin
+GO
+
+-- creating a login with securityadmin and db_securityadmin on master with a user
+create login testloginwithsecadminanddbsec with password = '12345678'
+alter server role securityadmin add member testloginwithsecadminanddbsec
+create user u_testloginwithsecadminanddbsec for login testloginwithsecadminanddbsec
+alter role db_securityadmin add member u_testloginwithsecadminanddbsec
+GO
+
+-- create another user for login testloginwithsecurityadmin in sp_helplogins_db1
+use sp_helplogins_db1
+GO
+create user userof_testloginwithsecurityadmin_indb1 for login testloginwithsecurityadmin
+GO
+use master
+GO
+
+-- create a login which is a member of securityadmin server role
+-- and has a user with db_securityadmin role in sp_helplogins_db1
+create login testloginwithsecurityadmin2 with password = '12345678'
+GO
+
+use sp_helplogins_db1
+GO
+create user userof_testloginwithsecurityadmin2 for login testloginwithsecurityadmin2
+GO
+use master
+GO
+
+-------- alter all logins password for dnr and upgrade
+alter login sp_helplogins_testlogin with password = '12345678'
+GO
+
+alter login testloginwithotherdefdb with password = '12345678'
+GO
+
+alter login testloginwithoutusers with password = '12345678'
+GO
+
+alter login [sp_help@logins$with%sp*chars] with password = '12345678'
+GO
+
+alter login testloginindb1 with password = '12345678'
+GO
+
+-------- alter roles and add users and logins 
+alter role db_securityadmin add member userof_sp_helplogins_testlogin
+GO
+
+alter server role securityadmin add member testloginwithsecurityadmin
+GO
+
+alter server role securityadmin add member testloginwithsecurityadmin2
+GO
+
+use sp_helplogins_db1
+GO
+
+alter role db_securityadmin add member userof_testloginwithsecurityadmin2
+GO
+
+-- create database role
+create role sp_helplogins_role;
+alter role sp_helplogins_role add member userof_testloginwithsecurityadmin2
+GO
+
+-- add user to a fixed db role
+alter role db_datareader add member u_testloginwithotherdefdb
+GO
+
+-- change owner of sp_helplogins_db2 to sp_help@logins$with%sp*chars
+use sp_helplogins_db2
+GO
+EXEC sp_changedbowner 'sp_help@logins$with%sp*chars'
+GO
+use master
+GO
+
+-- change owner of sp_helplogins_db3 to sp_helplogin_loginownerofdb
+use sp_helplogins_db3
+GO
+EXEC sp_changedbowner 'sp_helplogin_loginownerofdb'
+GO
+use master
+GO
+
+-- alter db_owner role add member
+alter role db_owner add member u_sp_helplogin_loginwithusermemberofdbowner
+GO
+
+-- tsql user=jdbc_user password=12345678
+-- since this is sysadmin, it has all the permissions over all the databases
+-- this login will see every login and user across all databases
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#!#User    
+helplogins\win#!#master#!#sp_helplogins_vu_windows_user#!#User    
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
+jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
+sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#db_owner#!#MemberOf
+sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#dbo#!#User    
+sp_helplogin_loginownerofdb#!#sp_helplogins_db3#!#db_owner#!#MemberOf
+sp_helplogin_loginownerofdb#!#sp_helplogins_db3#!#dbo#!#User    
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#db_owner#!#MemberOf
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#u_sp_helplogin_loginwithusermemberofdbowner#!#User    
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+testloginindb1#!#sp_helplogins_db1#!#userof_testloginindb1#!#User    
+testloginwithotherdefdb#!#sp_helplogins_db1#!#db_datareader#!#MemberOf
+testloginwithotherdefdb#!#sp_helplogins_db1#!#u_testloginwithotherdefdb#!#User    
+testloginwithsecadminanddbsec#!#master#!#db_securityadmin#!#MemberOf
+testloginwithsecadminanddbsec#!#master#!#u_testloginwithsecadminanddbsec#!#User    
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin_indb1#!#User    
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#db_securityadmin#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#sp_helplogins_role#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin2#!#User    
+~~END~~
+
+
+-- tsql user=sp_helplogins_testlogin password=12345678
+-- since this login is not a member of securityadmin, it will not be able to call the proc 
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: User does not have permission to perform this action.)~~
+
+
+-- tsql user=testloginwithsecurityadmin password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins, but only users which are either attached to it or superuser 
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
+jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin_indb1#!#User    
+~~END~~
+
+
+-- tsql user=testloginwithsecurityadmin2 password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins and since it also has db_securityadmin in sp_helplogins_db1
+-- it will also see all the users in that database
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
+jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+testloginindb1#!#sp_helplogins_db1#!#userof_testloginindb1#!#User    
+testloginwithotherdefdb#!#sp_helplogins_db1#!#db_datareader#!#MemberOf
+testloginwithotherdefdb#!#sp_helplogins_db1#!#u_testloginwithotherdefdb#!#User    
+testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin_indb1#!#User    
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#db_securityadmin#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#sp_helplogins_role#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin2#!#User    
+~~END~~
+
+
+-- tsql user=testloginwithsysadmin password=12345678
+-- since this is sysadmin, it has all the permissions over all the databases
+-- this login will see every login and user across all databases
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#!#User    
+helplogins\win#!#master#!#sp_helplogins_vu_windows_user#!#User    
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
+jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
+sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#db_owner#!#MemberOf
+sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#dbo#!#User    
+sp_helplogin_loginownerofdb#!#sp_helplogins_db3#!#db_owner#!#MemberOf
+sp_helplogin_loginownerofdb#!#sp_helplogins_db3#!#dbo#!#User    
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#db_owner#!#MemberOf
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#u_sp_helplogin_loginwithusermemberofdbowner#!#User    
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+testloginindb1#!#sp_helplogins_db1#!#userof_testloginindb1#!#User    
+testloginwithotherdefdb#!#sp_helplogins_db1#!#db_datareader#!#MemberOf
+testloginwithotherdefdb#!#sp_helplogins_db1#!#u_testloginwithotherdefdb#!#User    
+testloginwithsecadminanddbsec#!#master#!#db_securityadmin#!#MemberOf
+testloginwithsecadminanddbsec#!#master#!#u_testloginwithsecadminanddbsec#!#User    
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin_indb1#!#User    
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#db_securityadmin#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#sp_helplogins_role#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin2#!#User    
+~~END~~
+
+
+-- tsql user=testloginwithsecadminanddbsec password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins and since it also has db_securityadmin in master
+-- it will also see all the users in that database
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#!#User    
+helplogins\win#!#master#!#sp_helplogins_vu_windows_user#!#User    
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#db_owner#!#MemberOf
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#u_sp_helplogin_loginwithusermemberofdbowner#!#User    
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+testloginwithsecadminanddbsec#!#master#!#db_securityadmin#!#MemberOf
+testloginwithsecadminanddbsec#!#master#!#u_testloginwithsecadminanddbsec#!#User    
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+~~END~~
+
+
+-- tsql user=jdbc_user password=12345678
+-- ignore_columns 2
+EXEC sp_helplogins 'jdbc_user'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+jdbc_user#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
+jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin_indb1#!#User    
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin2'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#db_securityadmin#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#sp_helplogins_role#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin2#!#User    
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin2  '
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#db_securityadmin#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#sp_helplogins_role#!#MemberOf
+testloginwithsecurityadmin2#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin2#!#User    
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins ' testloginwithsecurityadmin2 '
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_help@logins$with%sp*chars'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
+sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#db_owner#!#MemberOf
+sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#dbo#!#User    
+~~END~~
+
+
+-- ignore_columns 2
+EXEC sp_helplogins ' '
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+~~END~~
+

--- a/test/JDBC/expected/z_sp_helplogins-vu-verify.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-verify.out
@@ -1,3 +1,7 @@
+-- psql
+CALL sys.analyze_babelfish_catalogs();
+GO
+
 -- tsql
 
 -- creating dependent logins in verify

--- a/test/JDBC/input/BABEL_GRANT_CONNECT-vu-verify.mix
+++ b/test/JDBC/input/BABEL_GRANT_CONNECT-vu-verify.mix
@@ -39,6 +39,10 @@ go
 drop user guest;
 go
 
+-- re-enabling connect on guest user
+grant connect to guest;
+go
+
 -- reset the login password
 alter login grant_connect_abc with password = 'Babel123'
 go

--- a/test/JDBC/input/restricted_objects-vu-cleanup.mix
+++ b/test/JDBC/input/restricted_objects-vu-cleanup.mix
@@ -94,3 +94,6 @@ GO
 
 DROP LOGIN babel_5146_user_l1;
 GO
+
+GRANT CONNECT TO guest;
+GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-cleanup.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-cleanup.mix
@@ -1,0 +1,88 @@
+-- tsql user=jdbc_user password=12345678 database=master
+drop user if exists userof_sp_helplogins_testlogin 
+GO
+
+drop login sp_helplogins_testlogin
+GO
+
+drop user if exists userof_testloginwithsecurityadmin
+GO
+
+drop user if exists userof_testloginwithsecurityadmin_indb1
+GO
+
+drop login testloginwithsecurityadmin
+GO
+
+drop login testloginwithsecurityadmin2
+GO
+
+drop user if exists u_testloginwithsecadminanddbsec
+drop login testloginwithsecadminanddbsec
+GO
+
+drop login testloginwithsysadmin
+GO
+
+drop login testloginindb1
+GO
+
+drop user if exists userof_testloginindb1
+GO
+
+drop login testloginwithoutusers
+GO
+
+drop user if exists u_testloginwithotherdefdb
+GO
+
+drop login testloginwithotherdefdb
+GO
+
+use sp_helplogins_db1
+GO
+alter role sp_helplogins_role drop member userof_testloginwithsecurityadmin2
+GO
+drop role sp_helplogins_role;
+GO
+use master
+GO
+
+drop user if exists userof_testloginwithsecurityadmin2
+GO
+
+drop user [userof@sp$chars*logins];
+drop login [sp_help@logins$with%sp*chars];
+GO
+
+-- creating login and user of longer lengths
+declare @loginname sys.sysname = cast(repeat('a', 63) as sysname);
+declare @username sys.sysname = cast(repeat('b', 63) as sysname);
+declare @droploginstmt varchar(max) = 'DROP LOGIN [' + @loginName + ']';
+declare @dropuserstmt varchar(max) = 'DROP USER [' + @username + ']'
+exec (@dropuserstmt)
+exec (@droploginstmt)
+GO
+
+drop user if exists sp_helplogins_vu_windows_user;
+drop login [helplogins\win]
+GO
+
+drop user if exists u_sp_helplogin_loginwithusermemberofdbowner
+drop login sp_helplogin_loginwithusermemberofdbowner
+GO
+
+drop login sp_helplogin_loginwithdifferentdefaultdb;
+GO
+
+drop login sp_helplogin_loginownerofdb;
+GO
+
+drop database sp_helplogins_db1;
+GO
+
+drop database sp_helplogins_db2;
+GO
+
+drop database sp_helplogins_db3;
+GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
@@ -1,0 +1,71 @@
+-- create a dummy db
+create database sp_helplogins_db1
+GO
+
+create database sp_helplogins_db2
+GO
+
+create database sp_helplogins_db3
+GO
+
+-- create a login with user in master with securityadmin server role
+-- create login with user in master with db_securityadmin role
+create login sp_helplogins_testlogin with password = '12345678'
+create user userof_sp_helplogins_testlogin for login sp_helplogins_testlogin
+GO
+
+-- create a login which does not have any users
+create login testloginwithoutusers with password = '12345678'
+GO
+
+-- create a login and a user in sp_helplogins_db1
+create login testloginindb1 with password = '12345678'
+GO
+
+use sp_helplogins_db1
+GO
+
+create user userof_testloginindb1 for login testloginindb1
+GO
+
+create login testloginwithotherdefdb with password = '12345678', default_database = sp_helplogins_db1
+GO
+
+create user u_testloginwithotherdefdb for login testloginwithotherdefdb
+GO
+
+use master;
+GO
+
+-- create login and user with special chars
+create login [sp_help@logins$with%sp*chars] with password = '12345678';
+create user [userof@sp$chars*logins] for login [sp_help@logins$with%sp*chars]
+GO
+
+-- creating login and user of longer lengths
+declare @loginname sys.sysname = cast(repeat('a', 63) as sysname);
+declare @username sys.sysname = cast(repeat('b', 63) as sysname);
+declare @pass varchar(10) = '12345678';
+declare @createloginstmt varchar(max) = 'CREATE LOGIN [' + @loginName + '] WITH PASSWORD = ''' + @pass + '''';
+declare @createuserstmt varchar(max) = 'CREATE USER [' + @username + '] FOR LOGIN [' + @loginname + ']'
+exec (@createloginstmt)
+exec (@createuserstmt)
+GO
+
+-- create a windows login and user
+create login [helplogins\win] from windows;
+create user sp_helplogins_vu_windows_user for login [helplogins\win]
+GO
+
+-- creating another login which does not have a user but is a owner of a database
+create login sp_helplogin_loginownerofdb with password = '12345678';
+GO
+
+-- creating a login which does not have a user but has a different default database
+create login sp_helplogin_loginwithdifferentdefaultdb with password = '12345678', default_database = sp_helplogins_db3;
+GO
+
+-- creating a login which has a user which is a member of the db_owner db role (this is not the same as the login being owner of the db)
+create login sp_helplogin_loginwithusermemberofdbowner with password = '12345678'
+create user u_sp_helplogin_loginwithusermemberofdbowner for login sp_helplogin_loginwithusermemberofdbowner
+GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
@@ -1,6 +1,6 @@
 -- sla 100000
 -- tsql
-select count(*) from sys.server_principals where type = 'S';
+select count(*) from sys.server_principals where type != 'R';
 GO
 
 -- create a dummy db

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
@@ -1,3 +1,8 @@
+-- sla 100000
+-- tsql
+select count(*) from sys.server_principals where type = 'S';
+GO
+
 -- create a dummy db
 create database sp_helplogins_db1
 GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
@@ -1,8 +1,4 @@
 -- sla 100000
--- tsql
-select count(*) from sys.server_principals where type != 'R';
-GO
-
 -- create a dummy db
 create database sp_helplogins_db1
 GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-verify.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-verify.mix
@@ -1,0 +1,175 @@
+-- tsql
+
+-- creating dependent logins in verify
+create login testloginwithsecurityadmin with password = '12345678'
+create user userof_testloginwithsecurityadmin for login testloginwithsecurityadmin
+GO
+
+-- creating a login with sysadmin permissions without a user
+create login testloginwithsysadmin with password = '12345678'
+alter server role sysadmin add member testloginwithsysadmin
+GO
+
+-- creating a login with securityadmin and db_securityadmin on master with a user
+create login testloginwithsecadminanddbsec with password = '12345678'
+alter server role securityadmin add member testloginwithsecadminanddbsec
+create user u_testloginwithsecadminanddbsec for login testloginwithsecadminanddbsec
+alter role db_securityadmin add member u_testloginwithsecadminanddbsec
+GO
+
+-- create another user for login testloginwithsecurityadmin in sp_helplogins_db1
+use sp_helplogins_db1
+GO
+create user userof_testloginwithsecurityadmin_indb1 for login testloginwithsecurityadmin
+GO
+use master
+GO
+
+-- create a login which is a member of securityadmin server role
+-- and has a user with db_securityadmin role in sp_helplogins_db1
+create login testloginwithsecurityadmin2 with password = '12345678'
+GO
+
+use sp_helplogins_db1
+GO
+create user userof_testloginwithsecurityadmin2 for login testloginwithsecurityadmin2
+GO
+use master
+GO
+
+-------- alter all logins password for dnr and upgrade
+alter login sp_helplogins_testlogin with password = '12345678'
+GO
+
+alter login testloginwithotherdefdb with password = '12345678'
+GO
+
+alter login testloginwithoutusers with password = '12345678'
+GO
+
+alter login [sp_help@logins$with%sp*chars] with password = '12345678'
+GO
+
+alter login testloginindb1 with password = '12345678'
+GO
+
+-------- alter roles and add users and logins 
+alter role db_securityadmin add member userof_sp_helplogins_testlogin
+GO
+
+alter server role securityadmin add member testloginwithsecurityadmin
+GO
+
+alter server role securityadmin add member testloginwithsecurityadmin2
+GO
+
+use sp_helplogins_db1
+GO
+
+alter role db_securityadmin add member userof_testloginwithsecurityadmin2
+GO
+
+-- create database role
+create role sp_helplogins_role;
+alter role sp_helplogins_role add member userof_testloginwithsecurityadmin2
+GO
+
+-- add user to a fixed db role
+alter role db_datareader add member u_testloginwithotherdefdb
+GO
+
+-- change owner of sp_helplogins_db2 to sp_help@logins$with%sp*chars
+use sp_helplogins_db2
+GO
+EXEC sp_changedbowner 'sp_help@logins$with%sp*chars'
+GO
+use master
+GO
+
+-- change owner of sp_helplogins_db3 to sp_helplogin_loginownerofdb
+use sp_helplogins_db3
+GO
+EXEC sp_changedbowner 'sp_helplogin_loginownerofdb'
+GO
+use master
+GO
+
+-- alter db_owner role add member
+alter role db_owner add member u_sp_helplogin_loginwithusermemberofdbowner
+GO
+
+-- tsql user=jdbc_user password=12345678
+-- since this is sysadmin, it has all the permissions over all the databases
+-- this login will see every login and user across all databases
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- tsql user=sp_helplogins_testlogin password=12345678
+-- since this login is not a member of securityadmin, it will not be able to call the proc 
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- tsql user=testloginwithsecurityadmin password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins, but only users which are either attached to it or superuser 
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- tsql user=testloginwithsecurityadmin2 password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins and since it also has db_securityadmin in sp_helplogins_db1
+-- it will also see all the users in that database
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- tsql user=testloginwithsysadmin password=12345678
+-- since this is sysadmin, it has all the permissions over all the databases
+-- this login will see every login and user across all databases
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- tsql user=testloginwithsecadminanddbsec password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins and since it also has db_securityadmin in master
+-- it will also see all the users in that database
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- tsql user=jdbc_user password=12345678
+-- ignore_columns 2
+EXEC sp_helplogins 'jdbc_user'
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin'
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin2'
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin2  '
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins ' testloginwithsecurityadmin2 '
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_help@logins$with%sp*chars'
+GO
+
+-- ignore_columns 2
+EXEC sp_helplogins ' '
+GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-verify.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-verify.mix
@@ -1,3 +1,7 @@
+-- psql
+CALL sys.analyze_babelfish_catalogs();
+GO
+
 -- tsql
 
 -- creating dependent logins in verify

--- a/test/JDBC/singledb_jdbc_schedule
+++ b/test/JDBC/singledb_jdbc_schedule
@@ -2,6 +2,11 @@
 # 1. Lines starting with '#' will be treated as comments
 # 2. To ignore any test file, add an entry like ignore#!#<test_file_name>
 
+# because these inherently execute with more than one db
+ignore#!#z_sp_helplogins-vu-prepare
+ignore#!#z_sp_helplogins-vu-verify
+ignore#!#z_sp_helplogins-vu-cleanup
+
 ignore#!#test_db_collation-vu-prepare
 ignore#!#test_db_collation-vu-verify
 ignore#!#test_db_collation-vu-cleanup

--- a/test/JDBC/src/main/java/com/sqlsamples/CompareResults.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/CompareResults.java
@@ -23,7 +23,7 @@ import static java.util.Objects.isNull;
 public class CompareResults {
 
     // function to write result set into a file
-    public static void writeResultSetToFile(BufferedWriter bw, ResultSet rs, Logger logger) {
+    public static void writeResultSetToFile(BufferedWriter bw, ResultSet rs, Logger logger, FilterConditions filterConditions) {
         try {
             bw.write("~~START~~");
             bw.newLine();
@@ -32,30 +32,36 @@ public class CompareResults {
             int cols = rsmd.getColumnCount();
 
             if (outputColumnName) {
-	        for (int i = 1; i <= cols; i++) {
-                    bw.write(rsmd.getColumnName(i));
-                    if (i != cols) bw.write("#!#");
+	            for (int i = 1; i <= cols; i++) {
+                    if (shouldNotIgnoreColumn(filterConditions, i)) {
+                        bw.write(rsmd.getColumnName(i));
+                        if (i != cols) bw.write("#!#");
+                    }                    
                 }
                 bw.newLine();
-	    }
+	        }
 
             for (int i = 1; i <= cols; i++) {
-                bw.write(rsmd.getColumnTypeName(i));
-                if (i != cols) bw.write("#!#");
+                if (shouldNotIgnoreColumn(filterConditions, i)) {
+                    bw.write(rsmd.getColumnTypeName(i));
+                    if (i != cols) bw.write("#!#");
+                }
             }
             bw.newLine();
 
             while (rs.next()) {
                 for (int i = 1; i <= cols; i++) {
-                    if(isNull(rs.getObject(i))){
-                        bw.write("<NULL>");
-                    } else {
-                        String str = rs.getString(i);
-                        str = str.replaceAll("[\r\n]+", "<newline>");
-                        bw.write(str);
-                    }
+                    if (shouldNotIgnoreColumn(filterConditions, i)) {
+                        if(isNull(rs.getObject(i))){
+                            bw.write("<NULL>");
+                        } else {
+                            String str = rs.getString(i);
+                            str = str.replaceAll("[\r\n]+", "<newline>");
+                            bw.write(str);
+                        }
 
-                    if (i != cols) bw.write("#!#");
+                        if (i != cols) bw.write("#!#");
+                    }
                 }
                 bw.newLine();
             }
@@ -71,6 +77,10 @@ public class CompareResults {
         } catch (IOException ioe) {
             logger.error("IO Exception: " + ioe.getMessage(), ioe);
         }
+    }
+
+    private static boolean shouldNotIgnoreColumn(FilterConditions filterConditions, int col) {
+        return isNull(filterConditions) || isNull(filterConditions.getColsToIgnore()) || !filterConditions.getColsToIgnore().contains(col);
     }
 
     // function to write the tuple, result set cursor is pointing to, into a file
@@ -135,9 +145,8 @@ public class CompareResults {
     }
 
     // processes all the results sequentially that we get from executing a JDBC Statement
-    static void processResults(Statement stmt, BufferedWriter bw, int resultsProcessed, boolean resultSetExist, boolean warningExist, Logger logger) {
+    static void processResults(Statement stmt, BufferedWriter bw, int resultsProcessed, boolean resultSetExist, boolean warningExist, Logger logger, FilterConditions filterConditions) {
         int updateCount = -9;  // initialize to impossible value
-
         while (true) {
             boolean exceptionOccurred = true;
             do {
@@ -152,7 +161,7 @@ public class CompareResults {
                 }
                 resultsProcessed++;
             } while (exceptionOccurred);
-
+            
             if ((!resultSetExist) && (updateCount == -1)) {
                 break;
             }
@@ -166,7 +175,10 @@ public class CompareResults {
             }
             if (resultSetExist) {
                 try (ResultSet rs = stmt.getResultSet()) {
-                    writeResultSetToFile(bw, rs, logger);
+                    if (resultsProcessed == 1)
+                        writeResultSetToFile(bw, rs, logger, filterConditions);
+                    else 
+                        writeResultSetToFile(bw, rs, logger, null);
                 } catch (SQLException e) {
                     handleSQLExceptionWithFile(e, bw, logger);
                 }

--- a/test/JDBC/src/main/java/com/sqlsamples/FilterConditions.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/FilterConditions.java
@@ -1,0 +1,15 @@
+package com.sqlsamples;
+import java.util.Set;
+import java.util.HashSet;
+
+public class FilterConditions {
+    public FilterConditions(final Set<Integer> colsToIgnore) {
+        this.colsToIgnore = colsToIgnore;
+    }
+
+    private Set<Integer> colsToIgnore;
+
+    public Set<Integer> getColsToIgnore() {
+        return this.colsToIgnore;
+    }
+}

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCCallableStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCCallableStatement.java
@@ -58,7 +58,7 @@ public class JDBCCallableStatement {
                 handleSQLExceptionWithFile(e, bw, logger);
                 resultsProcessed++;
             }
-            CompareResults.processResults(cstmt_bbl, bw, resultsProcessed, resultSetExist, warningExist, logger);
+            CompareResults.processResults(cstmt_bbl, bw, resultsProcessed, resultSetExist, warningExist, logger, null);
         } catch (IOException ioe) {
             logger.error("IO Exception: " + ioe.getMessage(), ioe);
         }

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCMetadata.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCMetadata.java
@@ -49,7 +49,7 @@ public class JDBCMetadata {
 
     private static void testGetCatalogs(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta) throws SQLException {
         ResultSet rs = dbmeta.getCatalogs();
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetColumnPrivileges(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -63,7 +63,7 @@ public class JDBCMetadata {
         String table = parts[2];
         String column = parts[3];
         ResultSet rs = dbmeta.getColumnPrivileges(catalog, schema, table, column);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetTables(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -80,7 +80,7 @@ public class JDBCMetadata {
             types = Arrays.copyOfRange(parts, 3, parts.length);
         }
         ResultSet rs = dbmeta.getTables(catalog, schema, table, types);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetColumns(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -97,7 +97,7 @@ public class JDBCMetadata {
             column = parts[3];
         }
         ResultSet rs = dbmeta.getColumns(catalog, schema, table, column);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetFunctions(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -113,7 +113,7 @@ public class JDBCMetadata {
             function = parts[2];
         }
         ResultSet rs = dbmeta.getFunctions(catalog, schema, function);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetFunctionColumns(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -130,7 +130,7 @@ public class JDBCMetadata {
             column = parts[3];
         }
         ResultSet rs = dbmeta.getFunctionColumns(catalog, schema, function, column);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetBestRowIdentifier(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -145,7 +145,7 @@ public class JDBCMetadata {
         int scope = Integer.parseInt(parts[3]);
         boolean nullable = Boolean.parseBoolean(parts[4]);
         ResultSet rs = dbmeta.getBestRowIdentifier(catalog, schema, table, scope, nullable);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetCrossReference(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -161,7 +161,7 @@ public class JDBCMetadata {
         String schema2 = parts[4];
         String table2 = parts[5];
         ResultSet rs = dbmeta.getCrossReference(catalog1, schema1, table1, catalog2, schema2, table2);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetExportedKeys(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -174,7 +174,7 @@ public class JDBCMetadata {
         String schema = parts[1];
         String table = parts[2];
         ResultSet rs = dbmeta.getExportedKeys(catalog, schema, table);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetImportedKeys(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -187,7 +187,7 @@ public class JDBCMetadata {
         String schema = parts[1];
         String table = parts[2];
         ResultSet rs = dbmeta.getImportedKeys(catalog, schema, table);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetIndexInfo(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -202,7 +202,7 @@ public class JDBCMetadata {
         boolean unique = Boolean.parseBoolean(parts[3]);
         boolean approximate = Boolean.parseBoolean(parts[4]);
         ResultSet rs = dbmeta.getIndexInfo(catalog, schema, table, unique, approximate);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetMaxConnections(BufferedWriter bw, DatabaseMetaData dbmeta) throws SQLException, IOException {
@@ -229,7 +229,7 @@ public class JDBCMetadata {
         String schema = parts[1];
         String table = parts[2];
         ResultSet rs = dbmeta.getPrimaryKeys(catalog, schema, table);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetProcedureColumns(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -246,7 +246,7 @@ public class JDBCMetadata {
             column = parts[3];
         }
         ResultSet rs = dbmeta.getProcedureColumns(catalog, schema, procedure, column);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetProcedures(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -262,7 +262,7 @@ public class JDBCMetadata {
             procedure = parts[2];
         }
         ResultSet rs = dbmeta.getProcedures(catalog, schema, procedure);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetSchemas(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -277,7 +277,7 @@ public class JDBCMetadata {
             schema = parts[1];
         }
         ResultSet rs = dbmeta.getSchemas(catalog, schema);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetTablePrivileges(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta, String data) throws SQLException {
@@ -290,12 +290,12 @@ public class JDBCMetadata {
         String schema = parts[1];
         String table = parts[2];
         ResultSet rs = dbmeta.getTablePrivileges(catalog, schema, table);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetTypeInfo(BufferedWriter bw, Logger logger, DatabaseMetaData dbmeta) throws SQLException {
         ResultSet rs = dbmeta.getTypeInfo();
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 
     private static void testGetUserName(BufferedWriter bw, DatabaseMetaData dbmeta) throws SQLException, IOException {
@@ -322,6 +322,6 @@ public class JDBCMetadata {
         String schema = parts[1];
         String table = parts[2];
         ResultSet rs = dbmeta.getVersionColumns(catalog, schema, table);
-        CompareResults.writeResultSetToFile(bw, rs, logger);
+        CompareResults.writeResultSetToFile(bw, rs, logger, null);
     }
 }

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCPreparedStatement.java
@@ -63,7 +63,7 @@ public class JDBCPreparedStatement {
                 handleSQLExceptionWithFile(e, bw, logger);
                 resultsProcessed++;
             }
-            CompareResults.processResults(pstmt_bbl, bw, resultsProcessed, resultSetExist, warningExist, logger);
+            CompareResults.processResults(pstmt_bbl, bw, resultsProcessed, resultSetExist, warningExist, logger, null);
         } catch (IOException ioe) {
             logger.error("IO Exception: " + ioe.getMessage(), ioe);
         }

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCStatement.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCStatement.java
@@ -32,7 +32,7 @@ public class JDBCStatement {
     }
 
     // function to write output of executed statement to a file
-    void testStatementWithFile(String SQL, BufferedWriter bw, String strLine, Logger logger){
+    void testStatementWithFile(String SQL, BufferedWriter bw, String strLine, Logger logger, FilterConditions filterConditions){
         try {
             bw.write(strLine);
             bw.newLine();
@@ -49,7 +49,7 @@ public class JDBCStatement {
                 handleSQLExceptionWithFile(e, bw, logger);
                 resultsProcessed++;
             }
-            CompareResults.processResults(stmt_bbl, bw, resultsProcessed, resultSetExist, warningExist,logger);
+            CompareResults.processResults(stmt_bbl, bw, resultsProcessed, resultSetExist, warningExist, logger, filterConditions);
         } catch (IOException ioe) {
             logger.error("IO Exception: " + ioe.getMessage(), ioe);
         }

--- a/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
@@ -4,6 +4,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.sql.*;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import static com.sqlsamples.Config.*;
 import static com.sqlsamples.Statistics.exec_times;
@@ -52,6 +55,7 @@ public class batch_run {
             DataInputStream in;
             BufferedReader br;
             boolean bashMode = false;
+            FilterConditions filterConditions = null;
 
             fstream = new FileInputStream(testFilePath);
             // get the object of DataInputStream
@@ -301,6 +305,18 @@ public class batch_run {
                         checkSingleDbModeExpected = true;
                         continue;
                     }
+
+                    if (strLine.toLowerCase().startsWith("-- ignore_columns")) {
+                        String[] parts = strLine.split("-- ignore_columns\\s+");
+                        Set<Integer> colsToIgnore = new HashSet<>();
+                        if (parts.length > 1) {
+                            String[] numbers = parts[1].split(",");
+                            for (String num : numbers) {
+                                colsToIgnore.add(Integer.parseInt(num.trim()));
+                            }
+                            filterConditions = new FilterConditions(colsToIgnore);
+                        }
+                    }
                     // execute statement as a normal SQL statement
                     if (isSQLFile) {
                         if (!strLine.equalsIgnoreCase("GO")) {
@@ -343,7 +359,11 @@ public class batch_run {
 
                     jdbcStatement.closeStatements(bw, logger);
                     jdbcStatement.createStatements(con_bbl, bw, logger);
-                    jdbcStatement.testStatementWithFile(SQL, bw, strLine, logger);
+                    jdbcStatement.testStatementWithFile(SQL, bw, strLine, logger, filterConditions);
+                }
+                // reset certain objects after first sql batch
+                if (strLine.equalsIgnoreCase("GO")) {
+                    filterConditions = null;
                 }
                 long endTime = System.nanoTime();
                 long duration = (endTime - startTime);

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -457,6 +457,7 @@ Test-sp_rename
 Test-sp_rename-dep
 Test-sp_set_session_context
 Test-sp_set_session_context-dep
+z_sp_helplogins
 Test-Role-Member
 TestSQLVariant
 TestTableType

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -71,7 +71,6 @@ Could not find tests for procedure babel_datatype_precedence_initializer
 Could not find tests for procedure initialize_babel_extras
 Could not find tests for procedure initialize_babelfish
 Could not find tests for procedure remove_babelfish
-Could not find tests for procedure sys.analyze_babelfish_catalogs
 Could not find tests for procedure sys.babel_drop_all_dbs
 Could not find tests for procedure sys.babel_drop_all_logins
 Could not find tests for procedure sys.babel_initialize_logins
@@ -181,7 +180,6 @@ Could not find upgrade tests for procedure babel_datatype_precedence_initializer
 Could not find upgrade tests for procedure initialize_babel_extras
 Could not find upgrade tests for procedure initialize_babelfish
 Could not find upgrade tests for procedure remove_babelfish
-Could not find upgrade tests for procedure sys.analyze_babelfish_catalogs
 Could not find upgrade tests for procedure sys.babel_drop_all_dbs
 Could not find upgrade tests for procedure sys.babel_drop_all_logins
 Could not find upgrade tests for procedure sys.babel_initialize_logins


### PR DESCRIPTION
### Cherry-pick - bdf91b646238bac6ec75f96616f720fdbbfd1cb6 ([PR-3733](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3733))

Added sp_helplogins which is a system stored procedure that provides information about logins (both SQL and Windows) and users associated with those logins.

sp_helplogins [ [ @LoginNamePattern = ] N'LoginNamePattern' ] [ ; ] @LoginNamePattern is sys.sysname, with a default of NULL . If specified, @loginnamepattern must exist.

It returns two result sets -
First view - information about all logins present on the server. Second view - information about each login and its mapping with a user in a database or its membership with a database-role

### Issues Resolved

Task - BABEL-5742, BABEL-5789

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).