### PR TITLE
Create active snapshot when updating various system catalogs accessing TOAST tables

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -3106,10 +3106,11 @@ add_entry_to_bbf_schema_perms(const char *schema_name,
 									new_record_bbf_schema,
 									new_record_nulls_bbf_schema);
 
-	/* Insert new record in the bbf_authid_user_ext table */
+	/* Insert new record in the babelfish_schema_permissions table */
 	CatalogTupleInsert(bbf_schema_rel, tuple_bbf_schema);
+	heap_freetuple(tuple_bbf_schema);
 
-	/* Close bbf_authid_user_ext, but keep lock till commit */
+	/* Close babelfish_schema_permissions, but keep lock till commit */
 	table_close(bbf_schema_rel, RowExclusiveLock);
 
 	/* make sure later steps can see the entry added here */

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3012,7 +3012,13 @@ exec_stmt_grantdb(PLtsql_execstate *estate, PLtsql_stmt_grantdb *stmt)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("Cannot disable access to the guest user in master or tempdb.")));
+		/*
+		 * Adding entries for user_can_connect might involve TOAST table access, so ensure we
+		 * have a valid snapshot.
+		 */
+		PushActiveSnapshot(GetTransactionSnapshot());
 		alter_user_can_connect(stmt->is_grant, grantee_name, dbname);
+		PopActiveSnapshot();
 	}
 	return PLTSQL_RC_OK;
 }
@@ -3774,6 +3780,12 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					errmsg("Cannot find the schema \"%s\", because it does not exist or you do not have permission.", stmt->schema_name)));
 
+		/*
+		 * Executing GRANT ON SCHEMA might involve TOAST table access, so ensure we
+		 * have a valid snapshot.
+		 */
+		PushActiveSnapshot(GetTransactionSnapshot());
+
 		/* Execute the GRANT SCHEMA subcommands. */
 		for (i = 0; i < NUMBER_OF_PERMISSIONS; i++)
 		{
@@ -3800,6 +3812,7 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 				update_privileges_of_object(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, stmt->privileges, rolname, OBJ_SCHEMA, false);
 			}
 		}
+		PopActiveSnapshot();
 		pfree(rolname);
 	}
 	pfree(user);
@@ -3837,8 +3850,14 @@ exec_stmt_change_dbowner(PLtsql_execstate *estate, PLtsql_stmt_change_dbowner *s
 		/* Is the current login already DB owner? */
 		if (get_role_oid(get_owner_of_db(stmt->db_name), true) == GetSessionUserId())
 		{
+			/*
+			 * Update the owner of a database might involve TOAST table access, so ensure we
+			 * have a valid snapshot.
+			 */
+			PushActiveSnapshot(GetTransactionSnapshot());
 			/* Current login is DB owner, so perform the update */
-			update_db_owner(stmt->new_owner_name, stmt->db_name);	
+			update_db_owner(stmt->new_owner_name, stmt->db_name);
+			PopActiveSnapshot();
 			return PLTSQL_RC_OK;	
 		}			
 	}		
@@ -3874,7 +3893,14 @@ exec_stmt_change_dbowner(PLtsql_execstate *estate, PLtsql_stmt_change_dbowner *s
 
 	/* Grant dbo role to the new owner */
 	grant_revoke_role_to_login(stmt->new_owner_name, get_dbo_role_name(stmt->db_name), true);
+
+	/*
+	 * Update the owner of a database might involve TOAST table access, so ensure we
+	 * have a valid snapshot.
+	 */
+	PushActiveSnapshot(GetTransactionSnapshot());
 	update_db_owner(stmt->new_owner_name, stmt->db_name);
+	PopActiveSnapshot();
 
 	return PLTSQL_RC_OK;
 }


### PR DESCRIPTION
### Description

Create active snapshot when updating various system catalogs accessing TOAST tables for the queries we are completely handling in T-SQL.


### Issues Resolved

Issue: BABEL-5917
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



