### PR TITLE
Fix issues with TVP NULL in TDS RPC packets (#3799)

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsrpc.c
@@ -289,7 +289,8 @@ DeclareVariables(TDSRequestSP req, FunctionCallInfo *fcinfo, unsigned long optio
 		tempFuncInfo = TdsLookupTypeFunctionsByTdsId(token->type, token->maxLen);
 		isNull = token->isNull;
 
-		if (!isNull && fcinfo)
+		/* For NULL TVP we will create empty table. */
+		if ((!isNull || token->type == TDS_TYPE_TABLE) && fcinfo)
 			pval = tempFuncInfo->recvFuncPtr(req->messageData, token);
 		else
 			pval = (Datum) 0;
@@ -299,7 +300,7 @@ DeclareVariables(TDSRequestSP req, FunctionCallInfo *fcinfo, unsigned long optio
 																   token->paramMeta.pgTypeOid,	/* oid */
 																   GetTypModForToken(token),	/* typmod */
 																   paramName,	/* name */
-																   (token->flags == 0) ?
+																   (token->flags == 0 || token->type == TDS_TYPE_TABLE) ? /* TVP being READONLY */
 																   PROARGMODE_IN : PROARGMODE_INOUT,	/* mode */
 																   pval,	/* datum */
 																   isNull,	/* null */
@@ -374,7 +375,8 @@ SetVariables(TDSRequestSP req, FunctionCallInfo *fcinfo)
 			tempFuncInfo = TdsLookupTypeFunctionsByTdsId(token->type, token->maxLen);
 			isNull = token->isNull;
 
-			if (!isNull)
+			/* For NULL TVP we will create empty table. */
+			if (!isNull || token->type == TDS_TYPE_TABLE)
 				pval = tempFuncInfo->recvFuncPtr(req->messageData, token);
 			else
 				pval = (Datum) 0;
@@ -382,7 +384,7 @@ SetVariables(TDSRequestSP req, FunctionCallInfo *fcinfo)
 			pltsql_plugin_handler_ptr->pltsql_declare_var_callback(token->paramMeta.pgTypeOid,	/* oid */
 																   GetTypModForToken(token),	/* typmod */
 																   NULL,	/* name */
-																   (token->flags == 0) ?
+																   (token->flags == 0 || token->type == TDS_TYPE_TABLE) ?  /* TVP being READONLY */
 																   PROARGMODE_IN : PROARGMODE_INOUT,	/* mode */
 																   pval,	/* datum */
 																   isNull,	/* null */
@@ -977,7 +979,8 @@ DeclareSPVariables(TDSRequestSP req, FunctionCallInfo *fcinfo)
 		tempFuncInfo = TdsLookupTypeFunctionsByTdsId(token->type, token->maxLen);
 		isNull = token->isNull;
 
-		if (!isNull)
+		/* For NULL TVP we will create empty table. */
+		if (!isNull || token->type == TDS_TYPE_TABLE)
 			pval = tempFuncInfo->recvFuncPtr(req->messageData, token);
 		else
 			pval = (Datum) 0;
@@ -986,7 +989,7 @@ DeclareSPVariables(TDSRequestSP req, FunctionCallInfo *fcinfo)
 															   token->paramMeta.pgTypeOid,	/* oid */
 															   GetTypModForToken(token),	/* typmod */
 															   paramName,	/* name */
-															   (token->flags == 0) ?
+															   (token->flags == 0 || token->type == TDS_TYPE_TABLE) ?  /* TVP being READONLY */
 															   PROARGMODE_IN : PROARGMODE_INOUT,	/* mode */
 															   pval,	/* datum */
 															   isNull,	/* null */

--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2667,7 +2667,8 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		token->tvpInfo->rowData = token->tvpInfo->rowData->nextRow;
 		pfree(tempRow);
 	}
-	pfree(token->tvpInfo->colMetaData);
+	if (token->tvpInfo->colMetaData)
+		pfree(token->tvpInfo->colMetaData);
 
 	item = (TvpLookupItem *) palloc(sizeof(TvpLookupItem));
 	item->name = downcase_truncate_identifier(token->paramMeta.colName.data,

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -708,21 +708,18 @@ SetColMetadataForTvp(ParameterToken temp, const StringInfo message, uint64_t *of
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("Column ordering token for TVP is not currently supported in Babelfish")));
-
-		if (messageData[*offset] != TVP_END_TOKEN)
-			ereport(ERROR,
-					(errcode(ERRCODE_PROTOCOL_VIOLATION),
-					 errmsg("The incoming tabular data stream (TDS) remote procedure call (RPC) protocol stream is incorrect. "
-							"Table-valued parameter %d (\"%s\"), row %d, column %d: Data type 0x%02X (user-defined table type) "
-							"unexpected token encountered processing a table-valued parameter.",
-							temp->paramOrdinal + 1, temp->paramMeta.colName.data, 1, i + 1, colmetadata[i].columnTdsType)));
-		(*offset)++;
 	}
 	else
 	{
 		temp->isNull = true;	/* If TVP is NULL. */
 		(*offset) += 2;
 	}
+	if (messageData[*offset] != TVP_END_TOKEN)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROTOCOL_VIOLATION),
+					errmsg("The incoming tabular data stream (TDS) remote procedure call (RPC) protocol stream is incorrect. "
+						"Table-valued parameter encountered unexpected end token.")));
+	(*offset)++;
 	SetTvpRowData(temp, message, offset);
 }
 

--- a/test/dotnet/ExpectedOutput/TestTvp.out
+++ b/test/dotnet/ExpectedOutput/TestTvp.out
@@ -2,22 +2,26 @@
 #Q#Select * from @a 
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
 1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#Select * from @a 
 #Q#drop type tableType
 #Q#create schema testtvp
 #Q#create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @a 
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
 1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#Select * from @a 
 #Q#drop type testtvp.tableType
 #Q#drop schema testtvp
 #Q#create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
 1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#Create table tvp_table(a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 #Q#create procedure tvp_proc @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong READONLY AS BEGIN insert into tvp_table select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+#Q#tvp_proc
 #Q#tvp_proc
 #Q#Select * from tvp_table
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
@@ -30,38 +34,48 @@
 #Q#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 #D#int#!#smallint#!#bigint#!#tinyint#!#bit#!#char#!#nchar#!#varchar#!#nvarchar#!#varbinary#!#binary#!#date#!#datetime#!#money#!#uniqueidentifier#!#float#!#real#!#decimal#!#decimal#!#time#!#datetime2
 1#!#1#!#1#!#1#!#True#!#hi        #!#hi        #!#hi#!#hi#!#4949#!#494900000000#!#10/10/2022 00:00:00#!#10/10/2022 10:10:10#!#143.5000#!#ce8af10a-2709-43b0-9e4e-a02753929d17#!#12.11#!#13.11#!#1.330#!#45.122#!#10:10:10#!#10/10/2022 10:10:10
+#Q#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#drop type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#drop schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#create table t(a int)
 #Q#create type t1 as table (a int)
 #Q#create procedure proc1 @t2 as t1 readonly as begin set nocount on; insert into t (a) select a from @t2 end
 #Q#proc1
+#Q#proc1
 #Q#Select * from t
 #D#int
+5
 5
 #Q#create table tab1(a int)
 #Q#create schema test_tvp1
 #Q#create type test_tvp1.t1 as table (a int)
 #Q#create procedure proc2 @t2 as test_tvp1.t1 readonly as begin set nocount on; insert into tab1 (a) select a from @t2 end
 #Q#proc2
+#Q#proc2
 #Q#Select * from tab1
 #D#int
+5
 5
 #Q#create table t2(a int)
 #Q#create procedure test_tvp1.proc1 @t2 test_tvp1.t1 readonly as begin set nocount on; insert into t2 (a) select a from @t2 end
 #Q#test_tvp1.proc1
+#Q#test_tvp1.proc1
 #Q#Select * from t2
 #D#int
+5
 5
 #Q#create table t3(a int)
 #Q#create schema test_tvp2
 #Q#create procedure test_tvp2.proc2 @t2 as test_tvp1.t1 readonly as begin set nocount on; insert into t3 (a) select a from @t2 end
 #Q#test_tvp2.proc2
+#Q#test_tvp2.proc2
 #Q#Select * from t3
 #D#int
 5
+5
 #Q#create table t4(a int)
 #Q#create procedure test_tvp2.proc3 @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as t1 READONLY AS BEGIN insert into t4 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+#Q#test_tvp2.proc3
 #Q#test_tvp2.proc3
 #Q#Select * from t4
 #D#int
@@ -69,6 +83,7 @@
 #Q#create table t5(a int)
 #Q#create type test_tvp2.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 as table (a int)
 #Q#create procedure test_tvp2.proc4 @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as test_tvp2.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t5 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+#Q#test_tvp2.proc4
 #Q#test_tvp2.proc4
 #Q#Select * from t5
 #D#int
@@ -78,11 +93,13 @@
 #Q#create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 as table (a int)
 #Q#create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.proc5 @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t6 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 #Q#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.proc5
+#Q#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.proc5
 #Q#Select * from t6
 #D#int
 5
 #Q#create table t7(a int)
 #Q#create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t7 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+#Q#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#Select * from t7
 #D#int
@@ -90,6 +107,7 @@
 #Q#create table t10(a int)
 #Q#create type tvp_type as table (a int)
 #Q#create procedure proc7 @random int, @t2 tvp_type READONLY AS BEGIN insert into t10 select * from @t2 END
+#Q#proc7
 #Q#proc7
 #Q#Select * from t10
 #D#int
@@ -127,11 +145,13 @@
 #Q#create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 as table (a int)
 #Q#create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t8 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 #Q#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
+#Q#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
 #Q#Select * from t8
 #D#int
 5
 #Q#create table t9(a int)
 #Q#create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong_new @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t9 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
+#Q#db1.this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong_new
 #Q#db1.this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong_new
 #Q#Select * from t9
 #D#int

--- a/test/dotnet/input/Datatypes/TestTvp.txt
+++ b/test/dotnet/input/Datatypes/TestTvp.txt
@@ -1,18 +1,21 @@
 #test tvp without schema
 create type tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 prepst#!#Select * from @a #!#tvp|-|a|-|tableType|-|../../../utils/tvp-dotnet.csv
+prepst#!#Select * from @a #!#tvp|-|a|-|tableType|-|<null>
 drop type tableType
 
 #test tvp with schema
 create schema testtvp
 create type testtvp.tableType as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 prepst#!#Select * from @a #!#tvp|-|a|-|testtvp.tableType|-|../../../utils/tvp-dotnet.csv
+prepst#!#Select * from @a #!#tvp|-|a|-|testtvp.tableType|-|<null>
 drop type testtvp.tableType
 drop schema testtvp
 
 #test tvp with huge type name and parameter name
 create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 prepst#!#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|../../../utils/tvp-dotnet.csv
+prepst#!#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|<null>
 drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 
 #test tvp with huge type name and parameter name but this time executing a stored proc using SP CUSTOMTYPE
@@ -20,6 +23,7 @@ Create table tvp_table(a int, b smallint, c bigint, d tinyint, e bit, f char(10)
 create type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 create procedure tvp_proc @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong READONLY AS BEGIN insert into tvp_table select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#tvp_proc#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|../../../utils/tvp-dotnet.csv
+storedproc#!#prep#!#tvp_proc#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|<null>
 
 Select * from tvp_table
 drop procedure tvp_proc
@@ -30,6 +34,7 @@ drop type this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooo
 create schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
 create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as table (a int, b smallint, c bigint, d tinyint, e bit, f char(10), g nchar(10), h varchar(10), i nvarchar(10), l varbinary(10), m binary(10), n date, o datetime, p money, q uniqueidentifier,r float, s real, t numeric(4,3), u decimal(5,3), v time(5), w datetime2(5))
 prepst#!#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|../../../utils/tvp-dotnet.csv
+prepst#!#Select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-|<null>
 drop type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong
 drop schema this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong
 
@@ -38,6 +43,7 @@ create table t(a int)
 create type t1 as table (a int)
 create procedure proc1 @t2 as t1 readonly as begin set nocount on; insert into t (a) select a from @t2 end
 storedproc#!#prep#!#proc1#!#tvp|-|t2|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#proc1#!#tvp|-|t2|-| |-|<null>
 Select * from t
 
 # test with schema for type and without passing tvpTypeName
@@ -46,12 +52,14 @@ create schema test_tvp1
 create type test_tvp1.t1 as table (a int)
 create procedure proc2 @t2 as test_tvp1.t1 readonly as begin set nocount on; insert into tab1 (a) select a from @t2 end
 storedproc#!#prep#!#proc2#!#tvp|-|t2|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#proc2#!#tvp|-|t2|-| |-|<null>
 Select * from tab1
 
 # test with schema for proc and type in same schema and without passing tvpTypeName
 create table t2(a int)
 create procedure test_tvp1.proc1 @t2 test_tvp1.t1 readonly as begin set nocount on; insert into t2 (a) select a from @t2 end
 storedproc#!#prep#!#test_tvp1.proc1#!#tvp|-|t2|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#test_tvp1.proc1#!#tvp|-|t2|-| |-|<null>
 Select * from t2
 
 # test with schema for proc and type in different schema and without passing tvpTypeName
@@ -59,12 +67,14 @@ create table t3(a int)
 create schema test_tvp2
 create procedure test_tvp2.proc2 @t2 as test_tvp1.t1 readonly as begin set nocount on; insert into t3 (a) select a from @t2 end
 storedproc#!#prep#!#test_tvp2.proc2#!#tvp|-|t2|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#test_tvp2.proc2#!#tvp|-|t2|-| |-|<null>
 Select * from t3
 
 # executing stored proc without passing tvp value for huge parameter name and without passing tvpTypeName
 create table t4(a int)
 create procedure test_tvp2.proc3 @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as t1 READONLY AS BEGIN insert into t4 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#test_tvp2.proc3#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#test_tvp2.proc3#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|<null>
 Select * from t4
 
 # when parameter and type both are very long, and both are part of schema other than dbo and without passing tvpTypeName
@@ -72,6 +82,7 @@ create table t5(a int)
 create type test_tvp2.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 as table (a int)
 create procedure test_tvp2.proc4 @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as test_tvp2.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t5 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#test_tvp2.proc4#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#test_tvp2.proc4#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|<null>
 Select * from t5
 
 # when parameter and type both are very long, and both are part of a very long schema other than dbo and without passing tvpTypeName
@@ -80,12 +91,14 @@ create schema this_schema_name_is_also_very_looooooooooooooooooooooooooooooooooo
 create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 as table (a int)
 create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.proc5 @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t6 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.proc5#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.proc5#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|<null>
 Select * from t6
 
 # when parameter, type, schema and procedure name are very long and without passing tvpTypeName
 create table t7(a int)
 create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t7 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|<null>
 Select * from t7
 
 # procedure having multiple args, without passing tvp tvpTypeName
@@ -93,6 +106,7 @@ create table t10(a int)
 create type tvp_type as table (a int)
 create procedure proc7 @random int, @t2 tvp_type READONLY AS BEGIN insert into t10 select * from @t2 END
 storedproc#!#prep#!#proc7#!#int|-|random|-|20|-|input#!#tvp|-|t2|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#proc7#!#int|-|random|-|20|-|input#!#tvp|-|t2|-| |-|<null>
 Select * from t10
 
 drop procedure proc1
@@ -130,12 +144,14 @@ create schema this_schema_name_is_also_very_looooooooooooooooooooooooooooooooooo
 create type this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 as table (a int)
 create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t8 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|<null>
 Select * from t8
 
 # creating a db and creating objects in it and executing the proc with db specification
 create table t9(a int)
 create procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong_new @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong as this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_tvp_type_name_is_very_loooooooooooooooooooooooooooooooooooooooooong5 READONLY AS BEGIN insert into t9 select * from @this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong END
 storedproc#!#prep#!#db1.this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong_new#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|../../../utils/tvp-test-dotnet.csv
+storedproc#!#prep#!#db1.this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong_new#!#tvp|-|this_tvp_parameter_name_is_very_loooooooooooooooooooooooooooooooooooooooooong|-| |-|<null>
 Select * from t9
 
 drop procedure this_schema_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong.this_proc_name_is_also_very_loooooooooooooooooooooooooooooooooooooooooong

--- a/test/dotnet/src/PrepareExecBinding.cs
+++ b/test/dotnet/src/PrepareExecBinding.cs
@@ -112,8 +112,13 @@ namespace BabelfishDotnetFramework
 									break;	
 								}
 								((SqlParameter) sqlCmd.Parameters[param[1].Trim()]).TypeName = param[2].Trim();
-								var temp = testUtils.FetchTvpValueUsingSqlDataRecord(param[3].Trim());
-								((SqlParameter) sqlCmd.Parameters[param[1].Trim()]).SqlValue = temp;
+								if (param[3].ToLowerInvariant() == "<null>")
+									((SqlParameter) sqlCmd.Parameters[param[1].Trim()]).SqlValue = null;
+								else
+								{
+									var temp = testUtils.FetchTvpValueUsingSqlDataRecord(param[3].Trim());
+									((SqlParameter) sqlCmd.Parameters[param[1].Trim()]).SqlValue = temp;
+								}
 								sqlCmd.Parameters[param[1].Trim()].Size = 1000;
 							}
 								break;
@@ -288,8 +293,13 @@ namespace BabelfishDotnetFramework
 									break;	
 								}
 								((SqlParameter) parameter).TypeName = param[2].Trim();
-								var temp = testUtils.FetchTvpValueUsingSqlDataRecord(param[3].Trim());
-								((SqlParameter) parameter).SqlValue = temp;
+								if (param[3].ToLowerInvariant() == "<null>")
+									((SqlParameter) parameter).SqlValue = null;
+								else
+								{
+									var temp = testUtils.FetchTvpValueUsingSqlDataRecord(param[3].Trim());
+									((SqlParameter) parameter).SqlValue = temp;
+								}
 								parameter.Size = 1000;
 							}
 								break;


### PR DESCRIPTION
With this commit we make the optional TVP_END token for column metadata non-optional. This is required since TVP_NULL always has a TVP_END token for for column metadata which precedes the TVP_END token for row data. We also fix creating empty table for TVP instead of sending isNull true which is the default TSQL behaviour and while doing so we make sure to send it as IN parameters and not INOUT/OUT since they are READONLY parameters.

Issues Resolved
BABEL-5907

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).