### PR TITLE
Fixing flakiness of the test for Sparsevec and Vector Datatypes

### DIFF
--- a/test/JDBC/expected/TestSparsevecDatatype.out
+++ b/test/JDBC/expected/TestSparsevecDatatype.out
@@ -1429,7 +1429,7 @@ go
 
 create table t(a sparsevec(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar

--- a/test/JDBC/expected/TestVectorDatatype.out
+++ b/test/JDBC/expected/TestVectorDatatype.out
@@ -1448,7 +1448,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
@@ -3020,7 +3020,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestSparsevecDatatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestSparsevecDatatype.out
@@ -1429,7 +1429,7 @@ go
 
 create table t(a sparsevec(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestVectorDatatype.out
@@ -1448,7 +1448,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
@@ -3020,7 +3020,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar

--- a/test/JDBC/expected/parallel_query/TestSparsevecDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestSparsevecDatatype.out
@@ -1457,7 +1457,7 @@ go
 
 create table t(a sparsevec(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar

--- a/test/JDBC/expected/parallel_query/TestVectorDatatype.out
+++ b/test/JDBC/expected/parallel_query/TestVectorDatatype.out
@@ -1523,7 +1523,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
@@ -3170,7 +3170,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 ~~START~~
 nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#int#!#nvarchar#!#varchar#!#nvarchar#!#int#!#int#!#tinyint#!#smallint#!#int#!#smallint#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar

--- a/test/JDBC/input/datatypes/TestSparsevecDatatype.mix
+++ b/test/JDBC/input/datatypes/TestSparsevecDatatype.mix
@@ -566,7 +566,7 @@ go
 
 create table t(a sparsevec(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 select count(*) from sys.columns where object_id = sys.object_id('t')
 go

--- a/test/JDBC/input/datatypes/TestVectorDatatype.mix
+++ b/test/JDBC/input/datatypes/TestVectorDatatype.mix
@@ -540,7 +540,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 select count(*) from sys.columns where object_id = sys.object_id('t')
 go
@@ -1125,7 +1125,7 @@ go
 
 create table t(a vector(3), b varchar(max))
 go
-select * from information_schema.columns where table_name = 't'
+select * from information_schema.columns where table_name = 't' ORDER BY COLUMN_NAME
 go
 select count(*) from sys.columns where object_id = sys.object_id('t')
 go


### PR DESCRIPTION
### Description

Test file TestSparsevecDatatype and TestVectorDatatype seems to be failing intermittently in parallel query mode. This commit aims to fix that issue by adding order by clause to stabilize the queries.

Cherry-pick: [#3843](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3843)
Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)


### Issues Resolved


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).