### PR TITLE
Fix duplicate cast function creation for binary bytea

### DIFF
--- a/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.2.0--5.3.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/babelfish_common_helper--5.2.0--5.3.0.sql
@@ -13,8 +13,14 @@ RETURNS sys.BBF_BINARY
 AS 'babelfishpg_common', 'byteabinary'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE CAST (pg_catalog.BYTEA AS sys.BBF_BINARY)
-WITH FUNCTION sys.byteabinary(pg_catalog.BYTEA, integer, boolean) AS ASSIGNMENT;
+DO $$
+BEGIN
+    CREATE CAST (pg_catalog.BYTEA AS sys.BBF_BINARY)
+    WITH FUNCTION sys.byteabinary(pg_catalog.BYTEA, integer, boolean) AS ASSIGNMENT;
+EXCEPTION WHEN duplicate_object THEN
+    -- Silently ignore if cast already exists
+END;
+$$;
 
 -- casting from binary to bytea
 CREATE OR REPLACE FUNCTION sys.binarybytea(sys.BBF_BINARY, integer, boolean)
@@ -22,8 +28,14 @@ RETURNS pg_catalog.BYTEA
 AS 'babelfishpg_common', 'binarybytea'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE CAST (sys.BBF_BINARY AS pg_catalog.BYTEA)
-WITH FUNCTION sys.binarybytea(sys.BBF_BINARY, integer, boolean) AS ASSIGNMENT;
+DO $$
+BEGIN
+    CREATE CAST (sys.BBF_BINARY AS pg_catalog.BYTEA)
+    WITH FUNCTION sys.binarybytea(sys.BBF_BINARY, integer, boolean) AS ASSIGNMENT;
+EXCEPTION WHEN duplicate_object THEN
+    -- Silently ignore if cast already exists
+END;
+$$;
 
 -- Operator class for numeric_ops to incorporate various operator between numeric and int4 for Index scan
 DO $$


### PR DESCRIPTION
### Description

The cast functions (binary -> bytea and bytea -> binary) created in this [PR](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3767) should be encapsulated in a DO...BEGIN...END block to prevent duplicate cast function creation issues, like this:

This encapsulation ensures the cast functions are created only once and avoids any duplicate function creation errors during multiple executions.



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).