### PR TITLE
[OSS-ONLY] Version based connection reset using queries 4X Cherry Pick

### DIFF
--- a/.github/composite-actions/minor-version-upgrade-util/action.yml
+++ b/.github/composite-actions/minor-version-upgrade-util/action.yml
@@ -90,7 +90,6 @@ runs:
         tar_dir: ${{ matrix.upgrade-path.last_version }}
       run: |
         cd test/JDBC/
-        export isUpgradeTestMode=true
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           export serverCollationName=${{ inputs.server_collation_name }}
         fi

--- a/.github/composite-actions/run-verify-tests/action.yml
+++ b/.github/composite-actions/run-verify-tests/action.yml
@@ -42,7 +42,6 @@ runs:
         echo "all" > dummy_schedule
         export scheduleFile=dummy_schedule
         export physicalDatabaseName=babelfish_db
-        export isUpgradeTestMode=false
         if [[ ${{ inputs.server_collation_name }} != "default" ]]; then
           export serverCollationName=${{ inputs.server_collation_name }}
         fi

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -192,7 +192,6 @@ runs:
           export serverCollationName=${{ inputs.server_collation_name }}
         fi
         if [[ "$migr_mode" == "multi-db" ]];then
-          export isUpgradeTestMode=true
           base_dir=${{ matrix.upgrade-path.path[0] }}
           if [[ "$base_dir" == *"latest"* || ${{ inputs.dump_restore }} == 'true' ]]; then
             base_dir="latest"
@@ -216,7 +215,6 @@ runs:
             exit 1
           fi
         done
-        export isUpgradeTestMode=true
         export inputFilesPath=input
         for filename in $(grep -v "^ignore.*\|^#.*\|^cmd.*\|^all.*\|^$" upgrade/$base_dir/schedule); do
           sed -i "s/\b$filename[ ]*\b$/$filename-vu-prepare/g" upgrade/$base_dir/schedule

--- a/test/JDBC/expected/BABEL-3291.out
+++ b/test/JDBC/expected/BABEL-3291.out
@@ -68,5 +68,13 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3291_t1
 go

--- a/test/JDBC/expected/BABEL-3292.out
+++ b/test/JDBC/expected/BABEL-3292.out
@@ -1137,6 +1137,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3292_schema.t1 
 go
 

--- a/test/JDBC/expected/BABEL-3293.out
+++ b/test/JDBC/expected/BABEL-3293.out
@@ -1228,6 +1228,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3293_schema.t1 
 go
 

--- a/test/JDBC/expected/BABEL-3294.out
+++ b/test/JDBC/expected/BABEL-3294.out
@@ -188,5 +188,13 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3294_t1
 go

--- a/test/JDBC/expected/BABEL-3295.out
+++ b/test/JDBC/expected/BABEL-3295.out
@@ -185,6 +185,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3295_t1
 go
 

--- a/test/JDBC/expected/BABEL-3512.out
+++ b/test/JDBC/expected/BABEL-3512.out
@@ -899,6 +899,20 @@ Babelfish T-SQL Batch Parsing Time: 0.084 ms
 
 
 -- clean up 
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+Query Text: select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false)
+Result
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.117 ms
+~~END~~
+
+
 SET babelfish_showplan_all OFF
 GO
 

--- a/test/JDBC/expected/BABEL-3513-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3513-vu-prepare.out
@@ -101,3 +101,9 @@ go
 
 exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
 go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off'
+go

--- a/test/JDBC/expected/BABEL-3513_before_15_8_or_16_4-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-3513_before_15_8_or_16_4-vu-prepare.out
@@ -86,3 +86,9 @@ go
 
 exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
 go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off'
+go

--- a/test/JDBC/expected/BABEL-3592.out
+++ b/test/JDBC/expected/BABEL-3592.out
@@ -445,6 +445,20 @@ Babelfish T-SQL Batch Parsing Time: 0.080 ms
 
 
 -- clean up
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+Query Text: select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false)
+Result
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.121 ms
+~~END~~
+
+
 set babelfish_showplan_all off
 go
 

--- a/test/JDBC/expected/parallel_query/BABEL-3291.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3291.out
@@ -73,5 +73,13 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3291_t1
 go

--- a/test/JDBC/expected/parallel_query/BABEL-3292.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3292.out
@@ -1260,6 +1260,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3292_schema.t1 
 go
 

--- a/test/JDBC/expected/parallel_query/BABEL-3293.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3293.out
@@ -1335,6 +1335,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3293_schema.t1 
 go
 

--- a/test/JDBC/expected/parallel_query/BABEL-3294.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3294.out
@@ -188,5 +188,13 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3294_t1
 go

--- a/test/JDBC/expected/parallel_query/BABEL-3295.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3295.out
@@ -205,6 +205,14 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+off
+~~END~~
+
+
 drop table babel_3295_t1
 go
 

--- a/test/JDBC/expected/parallel_query/BABEL-3512.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3512.out
@@ -990,6 +990,20 @@ Babelfish T-SQL Batch Parsing Time: 0.071 ms
 
 
 -- clean up 
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+Query Text: select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false)
+Result
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.193 ms
+~~END~~
+
+
 SET babelfish_showplan_all OFF
 GO
 

--- a/test/JDBC/expected/parallel_query/BABEL-3513-vu-prepare.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3513-vu-prepare.out
@@ -110,3 +110,9 @@ go
 
 exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
 go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off'
+go

--- a/test/JDBC/expected/parallel_query/BABEL-3592.out
+++ b/test/JDBC/expected/parallel_query/BABEL-3592.out
@@ -452,6 +452,20 @@ Babelfish T-SQL Batch Parsing Time: 0.078 ms
 
 
 -- clean up
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+~~START~~
+text
+Query Text: select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false)
+Result
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.193 ms
+~~END~~
+
+
 set babelfish_showplan_all off
 go
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-3291.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3291.mix
@@ -35,5 +35,8 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 drop table babel_3291_t1
 go

--- a/test/JDBC/input/pg_hint_plan/BABEL-3292.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3292.mix
@@ -276,6 +276,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 drop table babel_3292_schema.t1 
 go
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-3293.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3293.mix
@@ -251,6 +251,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 drop table babel_3293_schema.t1 
 go
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-3294.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3294.mix
@@ -66,5 +66,8 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 drop table babel_3294_t1
 go

--- a/test/JDBC/input/pg_hint_plan/BABEL-3295.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3295.mix
@@ -66,6 +66,9 @@ set babelfish_showplan_all off
 go
 
 -- cleanup
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 drop table babel_3295_t1
 go
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-3512.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3512.mix
@@ -361,6 +361,9 @@ EXEC babel_3512_comment_test_2
 GO
 
 -- clean up 
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 SET babelfish_showplan_all OFF
 GO
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-3513-vu-prepare.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3513-vu-prepare.mix
@@ -49,3 +49,9 @@ go
 
 exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
 go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off'
+go

--- a/test/JDBC/input/pg_hint_plan/BABEL-3513_before_15_8_or_16_4-vu-prepare.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3513_before_15_8_or_16_4-vu-prepare.mix
@@ -49,3 +49,9 @@ go
 
 exec sp_babelfish_configure 'enable_pg_hint', 'on', 'server'
 go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off', 'server'
+go
+
+exec sp_babelfish_configure 'enable_pg_hint', 'off'
+go

--- a/test/JDBC/input/pg_hint_plan/BABEL-3592.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-3592.mix
@@ -182,6 +182,9 @@ EXEC babel_3592_proc_mixed_statements
 GO
 
 -- clean up
+select set_config('babelfishpg_tsql.enable_pg_hint', 'off', false);
+go
+
 set babelfish_showplan_all off
 go
 

--- a/test/JDBC/src/main/java/com/sqlsamples/Config.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/Config.java
@@ -32,11 +32,14 @@ public class Config {
     static boolean checkParallelQueryExpected = false;
     static boolean checkSingleDbModeExpected = false;
     static String testFileRoot = properties.getProperty("testFileRoot");
-    static boolean isUpgradeTestMode =  Boolean.parseBoolean(properties.getProperty("isUpgradeTestMode"));
     static long defaultSLA = Long.parseLong(properties.getProperty("defaultSLA"));
+    static boolean allowConnectionReset = Boolean.parseBoolean(properties.getProperty("allowConnectionReset"));
     static boolean isdbCollationMode = Boolean.parseBoolean(properties.getProperty("isdbCollationMode"));
     static String dbCollationIgnoreFileName = "./db_collation_jdbc_schedule";
     static String singleDBIgnoreFileName = "./singledb_jdbc_schedule";
+
+    static int majorVersion = 13;
+    static int minorVersion = 6;
 
     static String connectionString = constructConnectionString();
 

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCCrossDialect.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCCrossDialect.java
@@ -162,13 +162,12 @@ public class JDBCCrossDialect {
     }
 
     void closeConnectionsUtil (HashMap<String, Connection> connectionMap, BufferedWriter bw, Logger logger) {
-        boolean needSkipFirst = isUpgradeTestMode ? false : true;
+        boolean needSkipFirst = (majorVersion > 16) || (majorVersion == 16 && minorVersion >= 6) ? true : false;
         Iterator<Map.Entry<String, Connection>> iterator = connectionMap.entrySet().iterator();
 
         while (iterator.hasNext()) {
             Map.Entry<String, Connection> entry = iterator.next();
             Connection connection = entry.getValue();
-
             if (!needSkipFirst) {
                 try {
                     connection.close();
@@ -176,8 +175,9 @@ public class JDBCCrossDialect {
                     handleSQLExceptionWithFile(e, bw, logger);
                 }
             }
-            else
+            else {
                 needSkipFirst = false;
+            }
         }
     }
 
@@ -206,7 +206,6 @@ public class JDBCCrossDialect {
             resetConnectionAttributes();
         }
     }
-
 
     void terminatePsqlConnection (String strLine, BufferedWriter bw, Logger logger) {
         getConnectionAttributes(strLine);

--- a/test/JDBC/src/main/resources/config.txt
+++ b/test/JDBC/src/main/resources/config.txt
@@ -51,8 +51,8 @@ isdbCollationMode = false
 # Where to find the input, output, expected, etc.
 testFileRoot = ./
 
-# WHETHER TEST RUN MODE IS UPGRADE TEST RUN
-isUpgradeTestMode = false
-
 # Default SLA in milliseconds
 defaultSLA = 40000
+
+# WHETHER THE CONNECTION SHOULD BE ALLOWED TO RESET AFTER EACH TEST OR CLOSED AFTER EACH TEST
+allowConnectionReset = true

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -10,6 +10,7 @@ import java.io.*;
 import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.regex.*;
 import java.util.Date;
 import java.util.stream.Stream;
 
@@ -261,25 +262,93 @@ public class TestQueryFile {
 
         String logFile = testRunDir + timestamp;
         configureLogger(logFile, logger);
+
+        String URL = properties.getProperty("URL");
+        String tsql_port = properties.getProperty("tsql_port");
+        String databaseName = properties.getProperty("databaseName");
+        String user = properties.getProperty("user");
+        String password = properties.getProperty("password");
+
+        Connection getVersionCon = null;
+        Statement stmt = null;
+        ResultSet rs = null;
         
+        // Query against database to find test version
+        try {
+            getVersionCon = DriverManager.getConnection(createSQLServerConnectionString(URL, tsql_port, databaseName, user, password));
+            rs = getVersionCon.createStatement().executeQuery("SELECT @@VERSION;");
+
+            int columnCount = rs.getMetaData().getColumnCount();
+            StringBuilder queryOutputBuilder = new StringBuilder();
+
+            while (rs.next()) {
+                for (int i = 1; i <= columnCount; i++) {
+                    queryOutputBuilder.append(rs.getString(i) + " ");
+                }
+            }
+
+            String queryOutput = queryOutputBuilder.toString();
+            Pattern pattern = Pattern.compile("PostgreSQL (\\d+\\.\\d+)");
+            Matcher matcher = pattern.matcher(queryOutput);
+
+            if (matcher.find()) {
+                String versionString = matcher.group(1);
+                majorVersion = Integer.parseInt(versionString.split("\\.")[0]);
+                minorVersion = Integer.parseInt(versionString.split("\\.")[1]);
+            }
+            else {
+                majorVersion = 0;
+                minorVersion = 0;
+            }
+
+            try {
+                if (getVersionCon != null) {
+                    getVersionCon.close();
+                }
+                getVersionCon = null;
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+            return;
+        } 
+        catch (SQLException e) {
+            majorVersion = 0;
+            minorVersion = 0;
+            System.out.println("Error executing query: " + e.getMessage());
+        }
+
         summaryLogger.info("Started test suite. Now running tests...");
     }
     
     // close connections that are not null after every test
     @AfterEach
     public void closeConnections() throws SQLException, ClassNotFoundException, Throwable {
-        if (isUpgradeTestMode) {
-            if (connection_bbl != null) connection_bbl.close();
-            connection_bbl = null;
-            return;
+        if ((majorVersion > 16 || (majorVersion == 16 && minorVersion >= 6)) && allowConnectionReset) {
+            if (connection_bbl == null) {
+                return;
+            }
+            else {
+                try {
+                    connection_bbl.createStatement().execute("EXEC sys.sp_reset_connection");
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return;
+            }
         }
-        if (connection_bbl == null)
+        else {
+            try {
+                if (connection_bbl != null) {
+                    connection_bbl.close();
+                }
+                connection_bbl = null;
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
             return;
-        try{
-            connection_bbl.createStatement().execute("EXEC sys.sp_reset_connection");
-        }
-        catch (Exception e) {
-            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Description

Cherry pick from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3423

Resetting connection after each test instead of closing for versions > 16.6. Also disabling pg_hint for tests that left it open, as the enabled pg_hint setting leaks into other tests when resetting connections.

We can expect 5-6 mins of improvements for version upgrade tests with base > 16.6 and dump-restore tests. For other version upgrade tests these improvements are around 2-3 mins.

Key changes:

- Implemented connection reset for SQL servers (versions > 16.6) post-test.
- Replaced redundant 'isUpgradeTestMode' config variable with 'allowConnectionReset'.
- Eliminated dependency on GitHub Actions workflows to ensure consistent test behavior across environments.
- Optimized test execution to reduce overall completion time.

Task: [BABEL-5630](https://jira.rds.a2z.com/browse/BABEL-5630)
Signed-off-by: Siddharth Sengar [sensid@amazon.com](sensid@amazon.com)

Check List
 
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request,
I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).