### PR TITLE
Fix Invalid read during datetimeoffset hashing

### DIFF
--- a/contrib/babelfishpg_common/src/datetimeoffset.c
+++ b/contrib/babelfishpg_common/src/datetimeoffset.c
@@ -526,8 +526,15 @@ Datum
 datetimeoffset_hash(PG_FUNCTION_ARGS)
 {
 	tsql_datetimeoffset *df = PG_GETARG_DATETIMEOFFSET(0);
+	tsql_datetimeoffset *df_copy = (tsql_datetimeoffset *) palloc0(DATETIMEOFFSET_LEN);
+	Datum result;
 
-	return hash_any((unsigned char *) df, DATETIMEOFFSET_LEN);
+	df_copy->tsql_ts = df->tsql_ts;
+	df_copy->tsql_tz = df->tsql_tz;
+
+	result = hash_any((unsigned char *) df_copy, DATETIMEOFFSET_LEN);
+	pfree(df_copy);
+	return result;
 }
 
 /* smalldatetime_datetimeoffset()


### PR DESCRIPTION
### Description
This commit fixes invalid read during Datetimeoffset hashing by creating a zero-initialized copy of the structure with only the meaningful fields.


### Issues Resolved
Task: BABEL-5940
cherry-picked: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3877

Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).