### PR TITLE
Add sanity check if new_database exists

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -4933,6 +4933,7 @@ rename_tsql_db(char *old_db_name, char *new_db_name)
 	Oid save_userid = InvalidOid;
 	int save_sec_context = 0;
 	int dbid = get_db_id(old_db_name);
+	int new_dbid = get_db_id(new_db_name);
 	int tries;
 	Oid     	prev_current_user = InvalidOid;
 
@@ -4948,6 +4949,15 @@ rename_tsql_db(char *old_db_name, char *new_db_name)
 		ereport(ERROR,
 			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("Cannot change the name of the system database %s.", old_db_name)));
+
+
+	/*
+	 * Check that the new_db_name does not exist.
+	 */
+	if (new_dbid)
+		ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				errmsg("The database %s already exists. Specify a unique database name.", new_db_name)));
 
 	/* 
 	 * Check permission on the given database.

--- a/test/JDBC/expected/Test_sp_rename_database-vu-verify.out
+++ b/test/JDBC/expected/Test_sp_rename_database-vu-verify.out
@@ -158,7 +158,7 @@ exec sp_rename_procedure @a = 'sp_rename_database1', @b = 'sp_rename_database1'
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "sp_rename_database1_dbo" already exists)~~
+~~ERROR (Message: The database sp_rename_database1 already exists. Specify a unique database name.)~~
 
 
 -- Renaming system databases is prohibited

--- a/test/JDBC/expected/Test_sp_renamedb-vu-verify.out
+++ b/test/JDBC/expected/Test_sp_renamedb-vu-verify.out
@@ -158,7 +158,7 @@ exec sp_renamedb_procedure @a = 'sp_renamedb_database1', @b = 'sp_renamedb_datab
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: schema "sp_renamedb_database1_dbo" already exists)~~
+~~ERROR (Message: The database sp_renamedb_database1 already exists. Specify a unique database name.)~~
 
 
 -- Renaming system databases is prohibited


### PR DESCRIPTION
During renaming of a database, add Sanity check if new database name already exists

Task: BABEL-5436


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).