### PR TITLE
Fix crash when running RESET ALL in babelfish_db

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4599,6 +4599,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 			{
 				VariableSetStmt *variable_set = (VariableSetStmt *) parsetree;
 
+				if (!variable_set->name)
+					break;
+
 				if(strcmp(variable_set->name, "SESSION CHARACTERISTICS") == 0)
 				{
 					ListCell   		*head;

--- a/test/JDBC/expected/TestBasicInterop.out
+++ b/test/JDBC/expected/TestBasicInterop.out
@@ -214,3 +214,8 @@ int
 
 DROP TABLE babel_5446
 GO
+
+-- psql
+-- BABEL-5805
+RESET ALL;
+GO

--- a/test/JDBC/input/interoperability/TestBasicInterop.mix
+++ b/test/JDBC/input/interoperability/TestBasicInterop.mix
@@ -141,3 +141,8 @@ SELECT @@trancount
 GO
 DROP TABLE babel_5446
 GO
+
+-- psql
+-- BABEL-5805
+RESET ALL;
+GO


### PR DESCRIPTION
### Description

Add null check for VariableSetStmt->name field before accessing it
to avoid crashing during RESET ALL from postgres endpoint.

### Issues Resolved

[BABEL-5805]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).