### PR TITLE
Add NULL safety check in get_current_db_search_path() for TDS connections

### DIFF
--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -76,7 +76,8 @@ get_current_pltsql_db_name(void)
 const char *
 get_current_db_search_path(void)
 {
-	Assert(IS_TDS_CONN() && current_db_search_path != NULL);
+	if (unlikely(IS_TDS_CONN() && current_db_search_path == NULL))
+		ereport(FATAL, errmsg("current database search path not set for tds session"));
 	return current_db_search_path;
 }
 


### PR DESCRIPTION
### Description

`current_db_search_path` holds the current search path for value correspoinding
to current active logical database for TDS connections. Ideally this value
should never be NULL for TDS connections. This commit adds a NULL check in
get_current_db_search_path() before trying to access it.

### Issues Resolved

[BABEL-5948]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).