### PR TITLE
handle_dropdb() check has been moved to upper side of superuser check…

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -703,6 +703,12 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 		return;
 	}
 
+	/* Case that deal with Drop Database */
+	if (nodeTag(parsetree) == T_DropdbStmt)
+	{
+		handle_result = handle_dropdb((DropdbStmt *) parsetree);		
+	}
+
 	/* Ignore any of this for real superusers */
 	if (superuser())
 	{
@@ -717,10 +723,6 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 			break;
 		case T_RenameStmt:
 			handle_result = handle_rename((RenameStmt *) parsetree);
-			break;
-			/* Case that deal with Drop Database */
-		case T_DropdbStmt:
-			handle_result = handle_dropdb((DropdbStmt *) parsetree);
 			break;
 		case T_AlterRoleStmt:
 			handle_result = handle_alter_role((AlterRoleStmt*)parsetree);


### PR DESCRIPTION
### Description

Previously, Babelfish-protected databases could be dropped by superusers using generic SQL clients (e.g., psql) without triggering the intended safeguards. This occurred because the logic to intercept and handle DROP DATABASE for Babelfish was placed after a superuser() check in tdsutils_ProcessUtility(). As a result, the handler handle_dropdb() was never reached for superusers.

This merge request reorders the logic so that the handle_dropdb() function is called before the superuser() check. This ensures that Babelfish databases are always validated and protected against direct deletion unless sys.remove_babelfish() has been explicitly called — even for superusers. This change enforces a consistent and safe behavior across all client types.


### Issues Resolved

[#3875] Babelfish database can be dropped via SQL clients without proper cleanup, leading to reinitialization failure

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).