### PR TITLE
Get rid of different statement length handling for guest and others (…

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -611,7 +611,6 @@ create_bbf_db_internal(ParseState *pstate, const char *dbname, List *options, co
 	char        *dbo_role;
 	NameData    default_collation;
 	NameData    owner_namedata;
-	int         stmt_number = 0;
 	int         save_sec_context;
 	bool        is_set_userid = false;
 	Oid         save_userid;
@@ -752,11 +751,7 @@ create_bbf_db_internal(ParseState *pstate, const char *dbname, List *options, co
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			stmt_number++;
-			if (list_length(parsetree_list) - 1 == stmt_number)
-				wrapper->stmt_len = 19;
-			else
-				wrapper->stmt_len = 18;
+			wrapper->stmt_len = 26;
 
 			/* do this step */
 			ProcessUtility(wrapper,

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4120,10 +4120,15 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					if (strcmp(queryString, CREATE_LOGICAL_DATABASE) == 0
 						&& context == PROCESS_UTILITY_SUBCOMMAND)
 					{
-						if (pstmt->stmt_len == 19)
+						char	*dbname = get_cur_db_name();
+						char	*guest_schema = get_guest_schema_name(dbname);
+						/* Check if the schema is 'guest'. */
+						if (strcmp(guest_schema, create_schema->schemaname) == 0)
 							orig_schema = "guest";
 						else
 							orig_schema = "dbo";
+						pfree(guest_schema);
+						pfree(dbname);
 					}
 					else if (strcmp(queryString, CREATE_GUEST_SCHEMAS_DURING_UPGRADE) == 0)
 					{


### PR DESCRIPTION
### Description

Get rid of different statement length handling for guest and others. `orig_name` in CREATE SCHEMA should not rely on statement length.

### Issues Resolved

Task:  BABEL-5951
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).