### PR TITLE
Get rid of different statement length handling for guest and others (…

### DIFF
--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -474,7 +474,6 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 	NameData    default_collation;
 	NameData    owner_namedata;
 	const char *prev_current_user;
-	int			stmt_number = 0;
 	int 			save_sec_context;
 	bool 			is_set_userid = false;
 	Oid 			save_userid;

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -582,11 +582,7 @@ create_bbf_db_internal(const char *dbname, List *options, const char *owner, int
 			wrapper->canSetTag = false;
 			wrapper->utilityStmt = stmt;
 			wrapper->stmt_location = 0;
-			stmt_number++;
-			if (list_length(parsetree_list) == stmt_number)
-				wrapper->stmt_len = 19;
-			else
-				wrapper->stmt_len = 18;
+			wrapper->stmt_len = 26;
 
 			/* do this step */
 			ProcessUtility(wrapper,

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3575,10 +3575,15 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					if (strcmp(queryString, "(CREATE LOGICAL DATABASE )") == 0
 						&& context == PROCESS_UTILITY_SUBCOMMAND)
 					{
-						if (pstmt->stmt_len == 19)
+						char	*dbname = get_cur_db_name();
+						char	*guest_schema = get_guest_schema_name(dbname);
+						/* Check if the schema is 'guest'. */
+						if (strcmp(guest_schema, create_schema->schemaname) == 0)
 							orig_schema = "guest";
 						else
 							orig_schema = "dbo";
+						pfree(guest_schema);
+						pfree(dbname);
 					}
 
 					if (prev_ProcessUtility)


### PR DESCRIPTION
### Description

Get rid of different statement length handling for guest and others. `orig_name` in CREATE SCHEMA should not rely on statement length.

### Issues Resolved

Task:  BABEL-5951
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).