### PR TITLE
Fix insert execute output parameters and nested levels issues

### DIFF
--- a/.github/scripts/scan-warnings.sh
+++ b/.github/scripts/scan-warnings.sh
@@ -49,8 +49,8 @@ if [[ "$SNAPSHOT_ACTIVE_COUNT" -ne 44 ]]; then
     ERROR_FOUND=true
 fi
 
-if [[ "$LEAK_COUNT" -ne 350 ]]; then
-    echo "Error: Expected 324 leak warnings, but found $LEAK_COUNT"
+if [[ "$LEAK_COUNT" -ne 368 ]]; then
+    echo "Error: Expected 368 leak warnings, but found $LEAK_COUNT"
     ERROR_FOUND=true
 fi
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -737,19 +737,46 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 				MemoryContextSwitchTo(oldcxt);
 			}
 
+			/* Handle the scalar value case for insert exec as well */
 			if (estate.insert_exec)
 			{
-				/* Verify if the check for estate.rettype is required here */
-				get_typlenbyval(estate.rettype, &typLen, &typByVal);
-
 				oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
 
-				/* Pass-by-reference, need to copy the data */
-				execute_call_insert_exec_retval = datumCopy(estate.retval,
-															typByVal,
-															typLen);
-
+				if (OidIsValid(estate.rettype))
+				{
+					get_typlenbyval(estate.rettype, &typLen, &typByVal);
+					
+					if (typByVal)
+					{
+						execute_call_insert_exec_retval = estate.retval;
+					}
+					else
+					{
+						/* Pass-by-reference, need to copy the data */
+						execute_call_insert_exec_retval = datumCopy(estate.retval,
+																	typByVal,
+																	typLen);
+					}
+				}
+				else
+				{
+					/* For cases where rettype is not properly set, handle gracefully */
+					typLen = -1;    /* Variable length */
+					typByVal = false; /* Pass by reference */
+					
+					/* Only proceed if we have a valid return value */
+					if (estate.retval != (Datum) 0)
+					{
+						execute_call_insert_exec_retval = estate.retval;
+					}
+					else
+					{
+						/* Skip the exec_move_row_from_datum call entirely */
+						execute_call_insert_exec_retval = (Datum) 0;
+					}
+				}
 				MemoryContextSwitchTo(oldcontext);
+
 			}
 
 			estate.retval = (Datum) 0;
@@ -5049,7 +5076,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		}
 
 		/* Update the output parameter */
-		if (stmt->insert_exec && stmt->target)
+		if (stmt->insert_exec && stmt->target && execute_call_insert_exec_retval != (Datum) 0)
 		{
 			exec_move_row_from_datum(estate, stmt->target, execute_call_insert_exec_retval);
 		}

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -737,16 +737,20 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 				MemoryContextSwitchTo(oldcxt);
 			}
 
-			get_typlenbyval(estate.rettype, &typLen, &typByVal);
+			if (estate.insert_exec)
+			{
+				/* Verify if the check for estate.rettype is required here */
+				get_typlenbyval(estate.rettype, &typLen, &typByVal);
 
-			oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
+				oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
 
-			/* Pass-by-reference, need to copy the data */
-			execute_call_insert_exec_retval = datumCopy(estate.retval,
-														typByVal,
-														typLen);
+				/* Pass-by-reference, need to copy the data */
+				execute_call_insert_exec_retval = datumCopy(estate.retval,
+															typByVal,
+															typLen);
 
-			MemoryContextSwitchTo(oldcontext);
+				MemoryContextSwitchTo(oldcontext);
+			}
 
 			estate.retval = (Datum) 0;
 			fcinfo->isnull = true;

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4416,6 +4416,25 @@ pltsql_estate_setup(PLtsql_execstate *estate,
 			((*pltsql_plugin_ptr)->func_setup) (estate, func);
 	}
 
+	/* Check for nested INSERT EXECUTE before adding to call stack */
+	if (estate->insert_exec)
+	{
+		/* Walk existing stack for any parent insert exec */
+		PLExecStateCallStack *cur = exec_state_call_stack;
+		while (cur != NULL)
+		{
+			/* Found parent insert exec */
+			if (cur->estate->insert_exec)
+			{
+				ereport(ERROR,
+					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+					errmsg("nested INSERT ... EXECUTE statements are not allowed")));
+			}
+			/* Proceed with no parent insert exec found */
+			cur = cur->next;
+		}
+	}
+
 	es_cs_entry = palloc(sizeof(PLExecStateCallStack));
 	es_cs_entry->estate = estate;
 	pltsql_init_exec_error_data(&(es_cs_entry->error_data));

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -737,15 +737,17 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 				MemoryContextSwitchTo(oldcxt);
 			}
 
-			/* Handle the scalar value case for insert exec as well */
+			/* Obtain output parameters for Insert Execute */
 			if (estate.insert_exec)
 			{
+				/* Switch to function's memory context */
 				oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
 
 				if (OidIsValid(estate.rettype))
 				{
+					/* Get return type properties */
 					get_typlenbyval(estate.rettype, &typLen, &typByVal);
-					
+
 					if (typByVal)
 					{
 						execute_call_insert_exec_retval = estate.retval;
@@ -4649,9 +4651,9 @@ is_impl_txn_required_for_execsql(PLtsql_stmt_execsql *stmt)
 
 /*
  * setup_procedure_output_target_for_insert_exec - Create output target for INSERT EXECUTE
- * 
- * Constructs a PLtsql_row to capture output parameters from a procedure call
- * within an INSERT EXECUTE context.
+ *
+ * This is a helper to adapt logic from exec_stmt_call. It constructs a PLtsql_row to capture
+ * output parameters from a procedure call within an INSERT EXECUTE context.
  */
 static void
 setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt)
@@ -4670,13 +4672,17 @@ setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_s
     int i;
     ListCell *lc;
 
+	/* Early NULL checks */
+	if (!stmt || !stmt->sqlstmt || !stmt->sqlstmt->plan || !stmt->sqlstmt->plan->plancache_list)
+		return; /* Not a procedure call */
+
     /* Extract the CallStmt from the cached plan */
     cachedPlanSource = (CachedPlanSource *) linitial(stmt->sqlstmt->plan->plancache_list);
     node = linitial_node(Query, cachedPlanSource->query_list)->utilityStmt;
-    
+
     if (node == NULL || !IsA(node, CallStmt))
         return; /* Not a procedure call */
-        
+
     funcexpr = ((CallStmt *) node)->funcexpr;
 
     /* Look up the procedure in pg_proc */
@@ -4872,6 +4878,24 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		 * Set up ParamListInfo to pass to executor
 		 */
 		paramLI = setup_param_list(estate, expr);
+
+		/* Check for nested INSERT EXECUTE statements */
+		if (stmt->insert_exec)
+		{
+			/* Walk existing stack for any parent insert exec */
+			PLExecStateCallStack *cur = exec_state_call_stack;
+			while (cur != NULL)
+			{
+				/* Found parent insert exec - this is a nested INSERT EXECUTE */
+				if (cur->estate->insert_exec)
+				{
+					ereport(ERROR,
+						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+						errmsg("nested INSERT ... EXECUTE statements are not allowed")));
+				}
+				cur = cur->next;
+			}
+		}
 
 		/* Setup output target for procedure parameters */
 		if (stmt->insert_exec && stmt->target == NULL)

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -71,6 +71,9 @@ static char *original_query_string = NULL;
 int			fetch_status_var = 0;
 int			saved_expr_kind = -1;
 
+/* Global variable to record the retval for insert exec */
+Datum execute_call_insert_exec_retval = (Datum) 0;
+
 typedef struct
 {
 	int			nargs;			/* number of arguments */
@@ -490,6 +493,10 @@ extern int
 static void
 pltsql_exec_function_cleanup(PLtsql_execstate *estate, PLtsql_function *func, ErrorContextCallback *plerrcontext);
 
+/* Function to set up row Datum */
+static void
+setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
+
 static bool	called_for_tsql_itvf_function = false;
 bool  		called_for_tsql_itvf_func(void);
 
@@ -706,6 +713,9 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 
 		if (estate.retisset || estate.insert_exec)
 		{
+			int16 typLen;
+			bool typByVal;
+			MemoryContext oldcontext;
 			ReturnSetInfo *rsi = estate.rsi;
 
 			/* Check caller can handle a set result */
@@ -726,6 +736,18 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 				rsi->setDesc = CreateTupleDescCopy(estate.tuple_store_desc);
 				MemoryContextSwitchTo(oldcxt);
 			}
+
+			get_typlenbyval(estate.rettype, &typLen, &typByVal);
+
+			oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
+
+			/* Pass-by-reference, need to copy the data */
+			execute_call_insert_exec_retval = datumCopy(estate.retval,
+														typByVal,
+														typLen);
+
+			MemoryContextSwitchTo(oldcontext);
+
 			estate.retval = (Datum) 0;
 			fcinfo->isnull = true;
 		}
@@ -4594,6 +4616,140 @@ is_impl_txn_required_for_execsql(PLtsql_stmt_execsql *stmt)
 	return true;
 }
 
+/*
+ * setup_procedure_output_target_for_insert_exec - Create output target for INSERT EXECUTE
+ * 
+ * Constructs a PLtsql_row to capture output parameters from a procedure call
+ * within an INSERT EXECUTE context.
+ */
+static void
+setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt)
+{
+    CachedPlanSource *cachedPlanSource;
+    Node *node;
+    FuncExpr *funcexpr;
+    HeapTuple func_tuple;
+    List *funcargs;
+    Oid *argtypes;
+    char **argnames;
+    char *argmodes;
+    MemoryContext oldcontext;
+    PLtsql_row *row;
+    int nfields;
+    int i;
+    ListCell *lc;
+
+    /* Extract the CallStmt from the cached plan */
+    cachedPlanSource = (CachedPlanSource *) linitial(stmt->sqlstmt->plan->plancache_list);
+    node = linitial_node(Query, cachedPlanSource->query_list)->utilityStmt;
+    
+    if (node == NULL || !IsA(node, CallStmt))
+        return; /* Not a procedure call */
+        
+    funcexpr = ((CallStmt *) node)->funcexpr;
+
+    /* Look up the procedure in pg_proc */
+    func_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcexpr->funcid));
+    if (!HeapTupleIsValid(func_tuple))
+        elog(ERROR, "cache lookup failed for function %u", funcexpr->funcid);
+
+    /* Extract function arguments, expanding any named-arg notation */
+    funcargs = expand_function_arguments(funcexpr->args,
+                                       false,
+                                       funcexpr->funcresulttype,
+                                       func_tuple);
+
+    /* Get the argument names and modes */
+    get_func_arg_info(func_tuple, &argtypes, &argnames, &argmodes);
+
+    ReleaseSysCache(func_tuple);
+
+    /*
+     * Begin constructing row Datum
+     */
+    oldcontext = MemoryContextSwitchTo(estate->func->fn_cxt);
+
+    row = (PLtsql_row *) palloc0(sizeof(PLtsql_row));
+    row->dtype = PLTSQL_DTYPE_ROW;
+    row->refname = "(unnamed row)";
+    row->lineno = -1;
+    row->varnos = (int *) palloc(sizeof(int) * list_length(funcargs));
+
+    MemoryContextSwitchTo(oldcontext);
+
+    /*
+     * Examine procedure's argument list. Each output arg position
+     * should be an unadorned pltsql variable (Datum), which we can
+     * insert into the row Datum.
+     */
+    nfields = 0;
+    i = 0;
+    foreach(lc, funcargs)
+    {
+        Node *n = lfirst(lc);
+
+        if (argmodes &&
+            (argmodes[i] == PROARGMODE_INOUT ||
+             argmodes[i] == PROARGMODE_OUT))
+        {
+            if (IsA(n, Param))
+            {
+                Param *param = (Param *) n;
+
+                /* paramid is offset by 1 (see make_datum_param()) */
+                row->varnos[nfields++] = param->paramid - 1;
+            }
+            else if (get_underlying_node_from_implicit_casting(n, T_Param) != NULL)
+            {
+                /*
+                 * T-SQL allows implicit casting in INOUT and OUT params.
+                 * Strip the casting and get the underlying Param.
+                 */
+                Param *param = (Param *) get_underlying_node_from_implicit_casting(n, T_Param);
+
+                /* paramid is offset by 1 (see make_datum_param()) */
+                row->varnos[nfields++] = param->paramid - 1;
+            }
+            else if (argmodes[i] == PROARGMODE_INOUT && IsA(n, Const))
+            {
+                /*
+                 * T-SQL allows to pass constant value as an output parameter.
+                 * Put -1 to param id. We can skip assigning actual value.
+                 */
+                row->varnos[nfields++] = -1;
+            }
+            else if (argmodes[i] == PROARGMODE_INOUT && get_underlying_node_from_implicit_casting(n, T_Const) != NULL)
+            {
+                /*
+                 * Mixture case of implicit casting + CONST. We can
+                 * skip assigning actual value.
+                 */
+                row->varnos[nfields++] = -1;
+            }
+            else
+            {
+                /* report error using parameter name, if available */
+                if (argnames && argnames[i] && argnames[i][0])
+                    ereport(ERROR,
+                            (errcode(ERRCODE_SYNTAX_ERROR),
+                             errmsg("procedure parameter \"%s\" is an output parameter but corresponding argument is not writable",
+                                    argnames[i])));
+                else
+                    ereport(ERROR,
+                            (errcode(ERRCODE_SYNTAX_ERROR),
+                             errmsg("procedure parameter %d is an output parameter but corresponding argument is not writable",
+                                    i + 1)));
+            }
+        }
+        i++;
+    }
+
+    row->nfields = nfields;
+
+    stmt->target = (PLtsql_variable *) row;
+}
+
+
 /* ----------
  * exec_stmt_execsql			Execute an SQL statement (possibly with INTO).
  *
@@ -4686,6 +4842,11 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		 */
 		paramLI = setup_param_list(estate, expr);
 
+		/* Setup output target for procedure parameters */
+		if (stmt->insert_exec && stmt->target == NULL)
+		{
+			setup_procedure_output_target_for_insert_exec(estate, stmt);
+		}
 
 		/*
 		 * Check whether the statement is an INSERT/DELETE with RETURNING
@@ -4881,6 +5042,12 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 				elog(ERROR, "SPI_execute_plan_with_paramlist failed executing query \"%s\": %s",
 					 expr->query, SPI_result_code_string(rc));
 				break;
+		}
+
+		/* Update the output parameter */
+		if (stmt->insert_exec && stmt->target)
+		{
+			exec_move_row_from_datum(estate, stmt->target, execute_call_insert_exec_retval);
 		}
 
 		if (enable_txn_in_triggers)

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4416,25 +4416,6 @@ pltsql_estate_setup(PLtsql_execstate *estate,
 			((*pltsql_plugin_ptr)->func_setup) (estate, func);
 	}
 
-	/* Check for nested INSERT EXECUTE before adding to call stack */
-	if (estate->insert_exec)
-	{
-		/* Walk existing stack for any parent insert exec */
-		PLExecStateCallStack *cur = exec_state_call_stack;
-		while (cur != NULL)
-		{
-			/* Found parent insert exec */
-			if (cur->estate->insert_exec)
-			{
-				ereport(ERROR,
-					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-					errmsg("nested INSERT ... EXECUTE statements are not allowed")));
-			}
-			/* Proceed with no parent insert exec found */
-			cur = cur->next;
-		}
-	}
-
 	es_cs_entry = palloc(sizeof(PLExecStateCallStack));
 	es_cs_entry->estate = estate;
 	pltsql_init_exec_error_data(&(es_cs_entry->error_data));

--- a/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
@@ -781,3 +781,127 @@ drop type user_defined_sch.test_tbl_type
 go
 drop schema user_defined_sch
 go
+
+
+-- Create table
+CREATE TABLE t8164 (id int)
+GO
+
+-- Create first stored procedure
+CREATE PROCEDURE p8164 AS
+BEGIN
+    DECLARE @test table (id int)
+    INSERT INTO @test VALUES (1)
+    SELECT * FROM @test
+END
+GO
+
+
+-- Create second stored procedure
+CREATE PROCEDURE p8164a AS
+BEGIN
+    INSERT INTO t8164
+    EXEC p8164
+    DECLARE @test table (id int)
+    INSERT INTO @test VALUES (2)
+    SELECT * FROM @test
+END
+GO
+
+-- Execute the nested insert
+INSERT INTO t8164
+EXEC p8164a
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Clean up objects after execution
+DROP PROCEDURE p8164a
+GO
+DROP PROCEDURE p8164
+GO
+DROP TABLE t8164
+GO
+
+-- Test output parameter for insert execute
+CREATE TABLE t (id int)
+GO
+
+CREATE PROCEDURE p (@output INT OUTPUT) AS
+    SET @output = 17
+    SELECT 18
+GO
+
+DECLARE @i INT
+INSERT INTO t EXEC p @output = @i OUTPUT
+SELECT @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+17
+~~END~~
+
+
+SELECT * FROM t
+GO
+~~START~~
+int
+18
+~~END~~
+
+
+DECLARE @i INT
+INSERT INTO t EXEC p @output = @i OUTPUT
+SELECT @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+17
+~~END~~
+
+
+SELECT * FROM t
+GO
+~~START~~
+int
+18
+18
+~~END~~
+
+
+ALTER PROCEDURE p (@output INT OUTPUT) AS
+    SET @output = 100
+    SELECT 200
+GO
+
+DECLARE @i INT
+INSERT INTO t EXEC p @output = @i OUTPUT
+SELECT @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+SELECT * FROM t
+GO
+~~START~~
+int
+18
+18
+200
+~~END~~
+
+
+DROP PROCEDURE p
+DROP TABLE t
+GO

--- a/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
@@ -783,48 +783,6 @@ drop schema user_defined_sch
 go
 
 
--- Create table
-CREATE TABLE t8164 (id int)
-GO
-
--- Create first stored procedure
-CREATE PROCEDURE p8164 AS
-BEGIN
-    DECLARE @test table (id int)
-    INSERT INTO @test VALUES (1)
-    SELECT * FROM @test
-END
-GO
-
-
--- Create second stored procedure
-CREATE PROCEDURE p8164a AS
-BEGIN
-    INSERT INTO t8164
-    EXEC p8164
-    DECLARE @test table (id int)
-    INSERT INTO @test VALUES (2)
-    SELECT * FROM @test
-END
-GO
-
--- Execute the nested insert
-INSERT INTO t8164
-EXEC p8164a
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
-
-
--- Clean up objects after execution
-DROP PROCEDURE p8164a
-GO
-DROP PROCEDURE p8164
-GO
-DROP TABLE t8164
-GO
-
 -- Test output parameter for insert execute
 CREATE TABLE t (id int)
 GO

--- a/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
@@ -863,3 +863,363 @@ int
 DROP PROCEDURE p
 DROP TABLE t
 GO
+
+-- Test multiple output parameters
+CREATE TABLE test_multi (val1 int, val2 int)
+GO
+
+CREATE PROCEDURE sp_multi_out (@out1 INT OUTPUT, @out2 INT OUTPUT) AS
+    SET @out1 = 10
+    SET @out2 = 20
+    SELECT 5, 15
+GO
+
+DECLARE @a INT, @b INT
+INSERT INTO test_multi EXEC sp_multi_out @out1 = @a OUTPUT, @out2 = @b OUTPUT
+SELECT @a, @b
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+
+SELECT * FROM test_multi
+GO
+~~START~~
+int#!#int
+5#!#15
+~~END~~
+
+
+-- Test varchar output parameter
+CREATE TABLE test_varchar (msg varchar(20))
+GO
+
+CREATE PROCEDURE sp_varchar_out (@msg VARCHAR(20) OUTPUT) AS
+    SET @msg = 'Hello'
+    SELECT 'World'
+GO
+
+DECLARE @s VARCHAR(20)
+INSERT INTO test_varchar EXEC sp_varchar_out @msg = @s OUTPUT
+SELECT @s
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Hello
+~~END~~
+
+
+SELECT * FROM test_varchar
+GO
+~~START~~
+varchar
+World
+~~END~~
+
+
+-- Test uninitialized output parameter (should be NULL)
+CREATE TABLE test_uninit (id int)
+GO
+
+CREATE PROCEDURE sp_uninit_out (@out INT OUTPUT) AS
+    SELECT 42
+GO
+
+DECLARE @u INT
+INSERT INTO test_uninit EXEC sp_uninit_out @out = @u OUTPUT
+SELECT @u
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+SELECT * FROM test_uninit
+GO
+~~START~~
+int
+42
+~~END~~
+
+
+-- Test input and output parameters together
+CREATE TABLE test_in_out (result int)
+GO
+
+CREATE PROCEDURE sp_in_out (@input INT, @output INT OUTPUT) AS
+    SET @output = @input * 2
+    SELECT @input + 10
+GO
+
+DECLARE @out_val INT
+INSERT INTO test_in_out EXEC sp_in_out 5, @output = @out_val OUTPUT
+SELECT @out_val
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+10
+~~END~~
+
+
+SELECT * FROM test_in_out
+GO
+~~START~~
+int
+15
+~~END~~
+
+
+-- Test conditional setting of output parameter
+CREATE TABLE test_conditional (flag int)
+GO
+
+CREATE PROCEDURE sp_conditional_out (@flag INT, @result INT OUTPUT) AS
+    IF @flag = 1
+        SET @result = 100
+    ELSE
+        SET @result = 200
+    SELECT @flag
+GO
+
+DECLARE @cond_result INT
+INSERT INTO test_conditional EXEC sp_conditional_out 1, @result = @cond_result OUTPUT
+SELECT @cond_result
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+DECLARE @cond_result2 INT
+INSERT INTO test_conditional EXEC sp_conditional_out 0, @result = @cond_result2 OUTPUT
+SELECT @cond_result2
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+200
+~~END~~
+
+
+SELECT * FROM test_conditional
+GO
+~~START~~
+int
+1
+0
+~~END~~
+
+
+-- Cleanup additional test objects
+DROP PROCEDURE sp_multi_out
+DROP TABLE test_multi
+GO
+
+DROP PROCEDURE sp_varchar_out
+DROP TABLE test_varchar
+GO
+
+DROP PROCEDURE sp_uninit_out
+DROP TABLE test_uninit
+GO
+
+DROP PROCEDURE sp_in_out
+DROP TABLE test_in_out
+GO
+
+DROP PROCEDURE sp_conditional_out
+DROP TABLE test_conditional
+GO
+
+
+-- Test case for nested INSERT ... EXECUTE statements
+CREATE TABLE t8164(id int);
+GO
+
+CREATE PROC p8164 AS 
+    DECLARE @test table(id int) 
+    INSERT INTO @test values (1) 
+    SELECT * FROM @test;
+GO
+
+CREATE PROC p8164a AS 
+    INSERT INTO t8164 EXEC p8164 
+    DECLARE @test table(id int) 
+    INSERT INTO @test values (2) 
+    SELECT * FROM @test;
+GO
+
+-- Should fail with nested INSERT ... EXECUTE error
+INSERT INTO t8164 EXEC p8164a;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Cleanup
+DROP PROCEDURE p8164a;
+GO
+DROP PROCEDURE p8164;
+GO
+DROP TABLE t8164;
+GO
+
+
+-- Test Case 1: Simple 2-level nesting (basic scenario)
+CREATE TABLE t_nest1(id int);
+CREATE TABLE t_nest2(id int);
+GO
+
+CREATE PROC p_inner AS 
+    SELECT 1 as id;
+GO
+
+CREATE PROC p_outer AS 
+    INSERT INTO t_nest1 EXEC p_inner; -- Nested INSERT EXEC
+    SELECT 2 as id;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_nest2 EXEC p_outer;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Cleanup
+DROP PROCEDURE p_outer;
+DROP PROCEDURE p_inner;
+DROP TABLE t_nest2;
+DROP TABLE t_nest1;
+GO
+
+-- Test Case 2: Table variable nesting
+CREATE TABLE t_var_nest(val int);
+GO
+
+CREATE PROC p_var_inner AS 
+    SELECT 100 as val;
+GO
+
+CREATE PROC p_var_outer AS 
+    DECLARE @temp table(val int);
+    INSERT INTO @temp EXEC p_var_inner; -- Nested with table variable
+    SELECT * FROM @temp;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_var_nest EXEC p_var_outer;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Cleanup
+DROP PROCEDURE p_var_outer;
+DROP PROCEDURE p_var_inner;
+DROP TABLE t_var_nest;
+GO
+
+-- Test Case 3: Transaction with nesting
+CREATE TABLE t_tran_nest(data int);
+GO
+
+CREATE PROC p_tran_inner AS 
+    SELECT 50 as data;
+GO
+
+CREATE PROC p_tran_outer AS 
+    BEGIN TRAN;
+    DECLARE @temp table(data int);
+    INSERT INTO @temp EXEC p_tran_inner; -- Nested in transaction
+    COMMIT;
+    SELECT * FROM @temp;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_tran_nest EXEC p_tran_outer;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Cleanup
+DROP PROCEDURE p_tran_outer;
+DROP PROCEDURE p_tran_inner;
+DROP TABLE t_tran_nest;
+GO
+
+-- Test Case 4: Parameter passing in nested calls
+CREATE TABLE t_param_nest(result int);
+GO
+
+CREATE PROC p_param_inner(@input int) AS 
+    SELECT @input * 2 as result;
+GO
+
+CREATE PROC p_param_outer(@value int) AS 
+    DECLARE @temp table(result int);
+    INSERT INTO @temp EXEC p_param_inner @value; -- Nested with parameters
+    SELECT * FROM @temp;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_param_nest EXEC p_param_outer 10;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Cleanup
+DROP PROCEDURE p_param_outer;
+DROP PROCEDURE p_param_inner;
+DROP TABLE t_param_nest;
+GO
+
+-- Test Case 5: Error propagation in nested calls
+CREATE TABLE t_err_nest(num int NOT NULL);
+GO
+
+CREATE PROC p_err_inner AS 
+    SELECT NULL as num; -- Will cause constraint violation
+GO
+
+CREATE PROC p_err_outer AS 
+    INSERT INTO t_err_nest EXEC p_err_inner; -- Should fail here
+    SELECT 1 as num;
+GO
+
+-- Should fail with both constraint violation and nested INSERT EXECUTE error
+DECLARE @err_temp table(num int);
+INSERT INTO @err_temp EXEC p_err_outer;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+-- Cleanup
+DROP PROCEDURE p_err_outer;
+DROP PROCEDURE p_err_inner;
+DROP TABLE t_err_nest;
+GO

--- a/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
@@ -307,44 +307,6 @@ drop schema user_defined_sch
 go
 
 
--- Create table
-CREATE TABLE t8164 (id int)
-GO
-
--- Create first stored procedure
-CREATE PROCEDURE p8164 AS
-BEGIN
-    DECLARE @test table (id int)
-    INSERT INTO @test VALUES (1)
-    SELECT * FROM @test
-END
-GO
-
--- Create second stored procedure
-CREATE PROCEDURE p8164a AS
-BEGIN
-    INSERT INTO t8164
-    EXEC p8164
-
-    DECLARE @test table (id int)
-    INSERT INTO @test VALUES (2)
-    SELECT * FROM @test
-END
-GO
-
--- Execute the nested insert
-INSERT INTO t8164
-EXEC p8164a
-GO
-
--- Clean up objects after execution
-DROP PROCEDURE p8164a
-GO
-DROP PROCEDURE p8164
-GO
-DROP TABLE t8164
-GO
-
 -- Test output parameter for insert execute
 CREATE TABLE t (id int)
 GO

--- a/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
@@ -305,3 +305,84 @@ drop type user_defined_sch.test_tbl_type
 go
 drop schema user_defined_sch
 go
+
+
+-- Create table
+CREATE TABLE t8164 (id int)
+GO
+
+-- Create first stored procedure
+CREATE PROCEDURE p8164 AS
+BEGIN
+    DECLARE @test table (id int)
+    INSERT INTO @test VALUES (1)
+    SELECT * FROM @test
+END
+GO
+
+-- Create second stored procedure
+CREATE PROCEDURE p8164a AS
+BEGIN
+    INSERT INTO t8164
+    EXEC p8164
+
+    DECLARE @test table (id int)
+    INSERT INTO @test VALUES (2)
+    SELECT * FROM @test
+END
+GO
+
+-- Execute the nested insert
+INSERT INTO t8164
+EXEC p8164a
+GO
+
+-- Clean up objects after execution
+DROP PROCEDURE p8164a
+GO
+DROP PROCEDURE p8164
+GO
+DROP TABLE t8164
+GO
+
+-- Test output parameter for insert execute
+CREATE TABLE t (id int)
+GO
+
+CREATE PROCEDURE p (@output INT OUTPUT) AS
+    SET @output = 17
+    SELECT 18
+GO
+
+DECLARE @i INT
+INSERT INTO t EXEC p @output = @i OUTPUT
+SELECT @i
+GO
+
+SELECT * FROM t
+GO
+
+DECLARE @i INT
+INSERT INTO t EXEC p @output = @i OUTPUT
+SELECT @i
+GO
+
+SELECT * FROM t
+GO
+
+ALTER PROCEDURE p (@output INT OUTPUT) AS
+    SET @output = 100
+    SELECT 200
+GO
+
+DECLARE @i INT
+INSERT INTO t EXEC p @output = @i OUTPUT
+SELECT @i
+GO
+
+SELECT * FROM t
+GO
+
+DROP PROCEDURE p
+DROP TABLE t
+GO

--- a/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXECUTE.sql
@@ -348,3 +348,271 @@ GO
 DROP PROCEDURE p
 DROP TABLE t
 GO
+
+-- Test multiple output parameters
+CREATE TABLE test_multi (val1 int, val2 int)
+GO
+
+CREATE PROCEDURE sp_multi_out (@out1 INT OUTPUT, @out2 INT OUTPUT) AS
+    SET @out1 = 10
+    SET @out2 = 20
+    SELECT 5, 15
+GO
+
+DECLARE @a INT, @b INT
+INSERT INTO test_multi EXEC sp_multi_out @out1 = @a OUTPUT, @out2 = @b OUTPUT
+SELECT @a, @b
+GO
+
+SELECT * FROM test_multi
+GO
+
+-- Test varchar output parameter
+CREATE TABLE test_varchar (msg varchar(20))
+GO
+
+CREATE PROCEDURE sp_varchar_out (@msg VARCHAR(20) OUTPUT) AS
+    SET @msg = 'Hello'
+    SELECT 'World'
+GO
+
+DECLARE @s VARCHAR(20)
+INSERT INTO test_varchar EXEC sp_varchar_out @msg = @s OUTPUT
+SELECT @s
+GO
+
+SELECT * FROM test_varchar
+GO
+
+-- Test uninitialized output parameter (should be NULL)
+CREATE TABLE test_uninit (id int)
+GO
+
+CREATE PROCEDURE sp_uninit_out (@out INT OUTPUT) AS
+    SELECT 42
+GO
+
+DECLARE @u INT
+INSERT INTO test_uninit EXEC sp_uninit_out @out = @u OUTPUT
+SELECT @u
+GO
+
+SELECT * FROM test_uninit
+GO
+
+-- Test input and output parameters together
+CREATE TABLE test_in_out (result int)
+GO
+
+CREATE PROCEDURE sp_in_out (@input INT, @output INT OUTPUT) AS
+    SET @output = @input * 2
+    SELECT @input + 10
+GO
+
+DECLARE @out_val INT
+INSERT INTO test_in_out EXEC sp_in_out 5, @output = @out_val OUTPUT
+SELECT @out_val
+GO
+
+SELECT * FROM test_in_out
+GO
+
+-- Test conditional setting of output parameter
+CREATE TABLE test_conditional (flag int)
+GO
+
+CREATE PROCEDURE sp_conditional_out (@flag INT, @result INT OUTPUT) AS
+    IF @flag = 1
+        SET @result = 100
+    ELSE
+        SET @result = 200
+    SELECT @flag
+GO
+
+DECLARE @cond_result INT
+INSERT INTO test_conditional EXEC sp_conditional_out 1, @result = @cond_result OUTPUT
+SELECT @cond_result
+GO
+
+DECLARE @cond_result2 INT
+INSERT INTO test_conditional EXEC sp_conditional_out 0, @result = @cond_result2 OUTPUT
+SELECT @cond_result2
+GO
+
+SELECT * FROM test_conditional
+GO
+
+-- Cleanup additional test objects
+DROP PROCEDURE sp_multi_out
+DROP TABLE test_multi
+GO
+
+DROP PROCEDURE sp_varchar_out
+DROP TABLE test_varchar
+GO
+
+DROP PROCEDURE sp_uninit_out
+DROP TABLE test_uninit
+GO
+
+DROP PROCEDURE sp_in_out
+DROP TABLE test_in_out
+GO
+
+DROP PROCEDURE sp_conditional_out
+DROP TABLE test_conditional
+GO
+
+
+-- Test case for nested INSERT ... EXECUTE statements
+CREATE TABLE t8164(id int);
+GO
+
+CREATE PROC p8164 AS 
+    DECLARE @test table(id int) 
+    INSERT INTO @test values (1) 
+    SELECT * FROM @test;
+GO
+
+CREATE PROC p8164a AS 
+    INSERT INTO t8164 EXEC p8164 
+    DECLARE @test table(id int) 
+    INSERT INTO @test values (2) 
+    SELECT * FROM @test;
+GO
+
+-- Should fail with nested INSERT ... EXECUTE error
+INSERT INTO t8164 EXEC p8164a;
+GO
+
+-- Cleanup
+DROP PROCEDURE p8164a;
+GO
+DROP PROCEDURE p8164;
+GO
+DROP TABLE t8164;
+GO
+
+
+-- Test Case 1: Simple 2-level nesting (basic scenario)
+CREATE TABLE t_nest1(id int);
+CREATE TABLE t_nest2(id int);
+GO
+
+CREATE PROC p_inner AS 
+    SELECT 1 as id;
+GO
+
+CREATE PROC p_outer AS 
+    INSERT INTO t_nest1 EXEC p_inner; -- Nested INSERT EXEC
+    SELECT 2 as id;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_nest2 EXEC p_outer;
+GO
+
+-- Cleanup
+DROP PROCEDURE p_outer;
+DROP PROCEDURE p_inner;
+DROP TABLE t_nest2;
+DROP TABLE t_nest1;
+GO
+
+-- Test Case 2: Table variable nesting
+CREATE TABLE t_var_nest(val int);
+GO
+
+CREATE PROC p_var_inner AS 
+    SELECT 100 as val;
+GO
+
+CREATE PROC p_var_outer AS 
+    DECLARE @temp table(val int);
+    INSERT INTO @temp EXEC p_var_inner; -- Nested with table variable
+    SELECT * FROM @temp;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_var_nest EXEC p_var_outer;
+GO
+
+-- Cleanup
+DROP PROCEDURE p_var_outer;
+DROP PROCEDURE p_var_inner;
+DROP TABLE t_var_nest;
+GO
+
+-- Test Case 3: Transaction with nesting
+CREATE TABLE t_tran_nest(data int);
+GO
+
+CREATE PROC p_tran_inner AS 
+    SELECT 50 as data;
+GO
+
+CREATE PROC p_tran_outer AS 
+    BEGIN TRAN;
+    DECLARE @temp table(data int);
+    INSERT INTO @temp EXEC p_tran_inner; -- Nested in transaction
+    COMMIT;
+    SELECT * FROM @temp;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_tran_nest EXEC p_tran_outer;
+GO
+
+-- Cleanup
+DROP PROCEDURE p_tran_outer;
+DROP PROCEDURE p_tran_inner;
+DROP TABLE t_tran_nest;
+GO
+
+-- Test Case 4: Parameter passing in nested calls
+CREATE TABLE t_param_nest(result int);
+GO
+
+CREATE PROC p_param_inner(@input int) AS 
+    SELECT @input * 2 as result;
+GO
+
+CREATE PROC p_param_outer(@value int) AS 
+    DECLARE @temp table(result int);
+    INSERT INTO @temp EXEC p_param_inner @value; -- Nested with parameters
+    SELECT * FROM @temp;
+GO
+
+-- Should fail with nested INSERT EXECUTE error
+INSERT INTO t_param_nest EXEC p_param_outer 10;
+GO
+
+-- Cleanup
+DROP PROCEDURE p_param_outer;
+DROP PROCEDURE p_param_inner;
+DROP TABLE t_param_nest;
+GO
+
+-- Test Case 5: Error propagation in nested calls
+CREATE TABLE t_err_nest(num int NOT NULL);
+GO
+
+CREATE PROC p_err_inner AS 
+    SELECT NULL as num; -- Will cause constraint violation
+GO
+
+CREATE PROC p_err_outer AS 
+    INSERT INTO t_err_nest EXEC p_err_inner; -- Should fail here
+    SELECT 1 as num;
+GO
+
+-- Should fail with both constraint violation and nested INSERT EXECUTE error
+DECLARE @err_temp table(num int);
+INSERT INTO @err_temp EXEC p_err_outer;
+GO
+
+-- Cleanup
+DROP PROCEDURE p_err_outer;
+DROP PROCEDURE p_err_inner;
+DROP TABLE t_err_nest;
+GO


### PR DESCRIPTION
### Description

This commit addresses issues with INSERT ... EXECUTE statements in stored procedures, specifically fixing output parameter handling and preventing unsupported nested execution scenarios.

### Issues
1. **Output Parameter Handling**: INSERT ... EXECUTE statements with output parameters were not properly capturing and assigning return values from executed stored procedures
2. **Nested INSERT ... EXECUTE statements**: Need to block nested INSERT ... EXECUTE statements


### Changes
1. Added a new function setup_procedure_output_target_for_insert_exec() to prepares output parameter targets for INSERT ... EXECUTE statements by analyzing the called procedure's signature and setting up appropriate data structures
2. Maintained a global variable execute_call_insert_exec_retval to pass return values between execution contexts when procedures are called via INSERT ... EXECUTE
3. Added stack traversal logic to detect nested INSERT ... EXECUTE calls and provide error message


### Test Scenarios Covered ###
The output parameters has been properly updated
```
1> CREATE TABLE t (id int);
2> go
1> CREATE PROCEDURE p (@output INT OUTPUT) AS SET @output = 17; select 18;
2> go
1> DECLARE @i INT; INSERT INTO t EXEC p @output = @i OUTPUT; SELECT @i;
2> go

(1 rows affected)
@i
-----------
         17

(1 rows affected)
1> select * from t;
         18

(1 rows affected)
1> DECLARE @i INT; INSERT INTO t EXEC p @output = @i OUTPUT; SELECT @i;
2> go

(1 rows affected)
@i
-----------
         17

(1 rows affected)
1> select * from t;
2> go
id
-----------
         18
         18

(2 rows affected)
1> alter PROCEDURE p (@output INT OUTPUT) AS SET @output = 100; select 200;
2> go
1>
2> DECLARE @i INT; INSERT INTO t EXEC p @output = @i OUTPUT; SELECT @i;
3> go

(1 rows affected)
@i
-----------
        100

(1 rows affected)
1> select * from t;
2> go
id
-----------
         18
         18
        200

(3 rows affected)
```

nested INSERT ... EXECUTE scenarios are blocked
```
1> CREATE TABLE t8164(id int)
2> go
1> CREATE PROC p8164 AS DECLARE @test table(id int) insert into @test values (1) SELECT * FROM @test
2> go
1> CREATE PROC p8164a AS insert into t8164 exec p8164 DECLARE @test table(id int) insert into @test values (2) SELECT * FROM @test
2>
3> go
1>
2>
3> INSERT INTO t8164 EXEC p8164a
4> go
Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
nested INSERT ... EXECUTE statements are not allowed
```