### PR TITLE
[OSS-ONLY] fix ccache path in gitHub actions

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -50,7 +50,7 @@ runs:
         fi
         $GITHUB_WORKSPACE/.github/scripts/clone_engine_repo "$REPOSITORY_OWNER" "$ENGINE_BRANCH"
         cd postgresql_modified_for_babelfish
-        rm -rf ~/.ccache
+        rm -rf ~/.cache
         if [[ ${{inputs.tap_tests}} == "yes" ]]; then
           echo "CRESTORE_KEY=$(git rev-parse --short HEAD)-tapTest" >> $GITHUB_ENV
         elif [[ ${{inputs.code_coverage}} == "yes" ]]; then
@@ -67,7 +67,7 @@ runs:
       if: ${{ github.event_name == 'pull_request' }} || ${{ inputs.code_coverage == 'yes' }}
       with:
         path: 
-          ~/.ccache
+          ~/.cache
         key: 
           random-random
         restore-keys: 

--- a/.github/composite-actions/save-ccache/action.yml
+++ b/.github/composite-actions/save-ccache/action.yml
@@ -24,7 +24,7 @@ runs:
       if: env.SAVE_CACHE_HERE == 1
       with:
         path: 
-          ~/.ccache
+          ~/.cache
         key: 
           ccache-${{ env.CCACHE_KEY }}
 
@@ -32,7 +32,7 @@ runs:
       if: always()
       shell: bash
       run: |
-        rm -rf ~/.ccache
+        rm -rf ~/.cache
         echo "CCACHE_KEY=" >> $GITHUB_ENV
         echo "SAVE_CCACHE=" >> $GITHUB_ENV
         echo "SAVE_CACHE_HERE=" >> $GITHUB_ENV


### PR DESCRIPTION
### Description

Fix ccache path in gitHub actions

### Issues Resolved

[No Jira]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).