### PR TITLE
[TEST-ONLY] Fix flakiness in restricted_objects-vu-cleanup

### DIFF
--- a/test/JDBC/expected/restricted_objects-vu-cleanup.out
+++ b/test/JDBC/expected/restricted_objects-vu-cleanup.out
@@ -78,26 +78,6 @@ GO
 DROP LOGIN babel_5146_case_l;
 GO
 
--- psql
--- Need to terminate active session before cleaning up the login
-SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
-WHERE sys.suser_name(usesysid) = 'babel_5146_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
-GO
-~~START~~
-bool
-t
-~~END~~
-
-
--- Wait to sync with another session
-SELECT pg_sleep(1);
-GO
-~~START~~
-void
-
-~~END~~
-
-
 -- tsql
 USE msdb;
 GO

--- a/test/JDBC/expected/restricted_objects-vu-verify.out
+++ b/test/JDBC/expected/restricted_objects-vu-verify.out
@@ -42,6 +42,7 @@ GO
 
 ~~ERROR (Message: must be owner of view syspolicy_system_health_state)~~
 
+-- terminate-tsql-conn user=babel_5146_user_l1 password=abc
 
 -- psql user=babel_5146_user_l1 password=abc
 -- should throw error
@@ -69,7 +70,7 @@ GO
     Server SQLState: 42501)~~
 
 
--- terminate-tsql-conn user=babel_5146_user_l1 password=abc
+-- terminate-psql-conn user=babel_5146_user_l1 password=abc
 
 -- tsql user=babel_5146_owner_l password=abc
 -- should throw error

--- a/test/JDBC/input/restricted_objects-vu-cleanup.mix
+++ b/test/JDBC/input/restricted_objects-vu-cleanup.mix
@@ -78,16 +78,6 @@ GO
 DROP LOGIN babel_5146_case_l;
 GO
 
--- psql
--- Need to terminate active session before cleaning up the login
-SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
-WHERE sys.suser_name(usesysid) = 'babel_5146_user_l1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
-GO
-
--- Wait to sync with another session
-SELECT pg_sleep(1);
-GO
-
 -- tsql
 USE msdb;
 GO

--- a/test/JDBC/input/restricted_objects-vu-verify.mix
+++ b/test/JDBC/input/restricted_objects-vu-verify.mix
@@ -30,6 +30,7 @@ GO
 
 EXEC dbo.babel_5146_prepare_p3;
 GO
+-- terminate-tsql-conn user=babel_5146_user_l1 password=abc
 
 -- psql user=babel_5146_user_l1 password=abc
 -- should throw error
@@ -42,7 +43,7 @@ GO
 DROP VIEW msdb_dbo.syspolicy_configuration;
 GO
 
--- terminate-tsql-conn user=babel_5146_user_l1 password=abc
+-- terminate-psql-conn user=babel_5146_user_l1 password=abc
 
 -- tsql user=babel_5146_owner_l password=abc
 -- should throw error


### PR DESCRIPTION
### Description

Fix flakiness in restricted_objects-vu-cleanup

### Issues Resolved

[BABEL-5729]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).