### PR TITLE
Include members of session user in permission check of sys.server_permissions (#3942)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -3324,8 +3324,8 @@ FROM pg_catalog.pg_roles AS Base
 INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname 
 WHERE(pg_has_role(sys.suser_id(), 'sysadmin'::TEXT, 'MEMBER')
   OR pg_has_role(sys.suser_id(), 'securityadmin'::TEXT, 'MEMBER')
-  OR Base.rolname = sys.suser_name() COLLATE sys.database_default 
-  OR Base.rolname = (SELECT pg_get_userbyid(super_user) FROM super_user))
+  OR pg_has_role(sys.suser_id(), Ext.rolname, 'MEMBER')
+  OR Base.rolname = (SELECT pg_get_userbyid(super_user) FROM super_user) COLLATE sys.database_default)
   AND Ext.type IN ('S', 'U') 
 UNION ALL 
 SELECT 

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -108,8 +108,8 @@ FROM pg_catalog.pg_roles AS Base
 INNER JOIN sys.babelfish_authid_login_ext AS Ext ON Base.rolname = Ext.rolname 
 WHERE(pg_has_role(sys.suser_id(), 'sysadmin'::TEXT, 'MEMBER')
   OR pg_has_role(sys.suser_id(), 'securityadmin'::TEXT, 'MEMBER')
-  OR Base.rolname = sys.suser_name() COLLATE sys.database_default 
-  OR Base.rolname = (SELECT pg_get_userbyid(super_user) FROM super_user))
+  OR pg_has_role(sys.suser_id(), Ext.rolname, 'MEMBER')
+  OR Base.rolname = (SELECT pg_get_userbyid(super_user) FROM super_user) COLLATE sys.database_default)
   AND Ext.type IN ('S', 'U') 
 UNION ALL 
 SELECT 


### PR DESCRIPTION
Include members of session user in permission check of sys.server_permissions

Issues Resolved
BABEL-5961

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).