### PR TITLE
Added ORDER BY for sp_helplogins procedure

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3854,6 +3854,7 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
+        ORDER BY LoginName, DBName, UserName
     END
     ELSE
     BEGIN
@@ -3906,6 +3907,7 @@ BEGIN
         WHERE 
             has_dbaccess(UExt2.database_name) = 1 AND
             LExt.orig_loginname = @input_loginname
+        ORDER BY LoginName, DBName, UserName
     END;
 
     RETURN 0;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -411,6 +411,7 @@ BEGIN
                     AND UExt4.login_name = @current_username
                 )
             )
+        ORDER BY LoginName, DBName, UserName
     END
     ELSE
     BEGIN
@@ -463,6 +464,7 @@ BEGIN
         WHERE 
             has_dbaccess(UExt2.database_name) = 1 AND
             LExt.orig_loginname = @input_loginname
+        ORDER BY LoginName, DBName, UserName
     END;
 
     RETURN 0;


### PR DESCRIPTION
Added the ORDER BY clause to sp_helplogins since this is a system proc
ordered result set is necessary.

Original PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3944
Cherry-pick - 71fe5a6c8004dc9f16b74ec804571144d1372b2b

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).