### PR TITLE
Use ucol_clone instead of ucol_safeClone for ICU version >= 71

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1589,7 +1589,11 @@ icu_compare_utf8_coll(UCollator  *coll, UChar *uchar1, int32_t ulen1,
 
 	if (is_cs_ai_range_cmp)
 	{
+#if U_ICU_VERSION_MAJOR_NUM < 71
 		collator = ucol_safeClone(coll, NULL, NULL, &status);
+#else
+		collator = ucol_clone(coll, &status);
+#endif
 
 		if (U_FAILURE(status))
 			ereport(ERROR,


### PR DESCRIPTION
### Description

Cherry picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3951

ICU has deprecated `ucol_safeClone` so use its replacement for ICU >= 71

### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/3809
[BABEL-5918]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).