### PR TITLE
Support for weak binding views to allow dropping of underlying objects 5_3_STABLE

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -4481,8 +4481,14 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 		 */
 		if (pg_strcasecmp(property, "isschemabound") == 0)
 		{
+			bool is_weak_view = false;
+			bool is_view = (type == OBJECT_TYPE_VIEW);
+
+			if (is_view)
+				check_is_tsql_view(object_id, &is_weak_view);
+
 			pfree(property);
-			PG_RETURN_INT32(0);
+			PG_RETURN_INT32(is_view ? ((int) !is_weak_view) : 0);
 		}
 		/*
 		 * For ExecIsQuotedIdentOn and ExecIsAnsiNullsOn, we hardcoded it to 1

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -1199,17 +1199,40 @@ get_bbf_view_def_idx_oid()
 }
 
 HeapTuple
-search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid, const char *logical_schema_name, const char *view_name)
+search_bbf_view_def(Relation bbf_view_def_rel, Oid viewOid)
 {
 
 	ScanKeyData scanKey[3];
 	SysScanDesc scan;
 	HeapTuple	scantup,
 				oldtup;
+	Oid 		schema_id;
+	char 		*schema_name = NULL;
+	char		*view_name = NULL;
+	const char  *logical_schema_name = NULL;
+	int16 		dbid = InvalidDbid;
 
-	if (!DbidIsValid(dbid) || logical_schema_name == NULL || view_name == NULL)
+	if (!OidIsValid(viewOid))
 		return NULL;
 
+	schema_id = get_rel_namespace(viewOid);
+	schema_name = get_namespace_name(schema_id);
+	view_name = get_rel_name(viewOid);
+	
+	if (!schema_name)
+		return NULL;
+	
+	logical_schema_name = get_logical_schema_name(schema_name, true);
+	dbid = get_dbid_from_physical_schema_name(schema_name, true);
+
+	if (!DbidIsValid(dbid) || logical_schema_name == NULL || view_name == NULL)
+	{
+		pfree(view_name);
+		pfree(schema_name);
+		if (logical_schema_name)
+			pfree((char *) logical_schema_name);
+		return NULL;
+	}
 
 	/* Search and drop the definition */
 	ScanKeyInit(&scanKey[0],
@@ -1239,7 +1262,7 @@ search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid, const char *logical_s
 
 /* Checks if it is view created during v2.2.0 or after that */
 bool
-check_is_tsql_view(Oid relid)
+check_is_tsql_view(Oid relid, bool *is_weak_view)
 {
 	Oid			schema_oid;
 	Relation	bbf_view_def_rel;
@@ -1249,10 +1272,17 @@ check_is_tsql_view(Oid relid)
 	int16		logical_dbid;
 	const char *logical_schema_name;
 	bool		is_tsql_view = false;
+	bool 		bisnull;
+	Datum 		flag_values_datum;
+	uint64 		flag_values;
 
 	view_name = get_rel_name(relid);
 	schema_oid = get_rel_namespace(relid);
 	schema_name = get_namespace_name(schema_oid);
+
+	if (is_weak_view != NULL)
+		*is_weak_view = false;
+
 	if (view_name == NULL || schema_name == NULL || is_shared_schema(schema_name))
 	{
 		if (view_name)
@@ -1273,12 +1303,27 @@ check_is_tsql_view(Oid relid)
 	}
 	/* Fetch the relation */
 	bbf_view_def_rel = table_open(get_bbf_view_def_oid(), AccessShareLock);
-
-	scantup = search_bbf_view_def(bbf_view_def_rel, logical_dbid, logical_schema_name, view_name);
+	scantup = search_bbf_view_def(bbf_view_def_rel, relid);
 
 	if (HeapTupleIsValid(scantup))
 	{
 		is_tsql_view = true;
+
+		/* Check if the view is a weak bound view */
+		if (is_weak_view != NULL)
+		{
+			flag_values_datum = heap_getattr(scantup, 
+								Anum_bbf_view_def_flag_values,
+								RelationGetDescr(bbf_view_def_rel), 
+								&bisnull);
+			
+			if (!bisnull)
+			{
+				flag_values = DatumGetUInt64(flag_values_datum);
+				*is_weak_view = (flag_values & BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW) != 0;
+			}
+		}
+
 		heap_freetuple(scantup);
 	}
 	table_close(bbf_view_def_rel, AccessShareLock);

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -202,18 +202,22 @@ typedef FormData_authid_user_ext *Form_authid_user_ext;
 #define Anum_bbf_view_def_schema_name 2
 #define Anum_bbf_view_def_object_name 3
 #define Anum_bbf_view_def_definition 4
+#define Anum_bbf_view_def_flag_validity 5
+#define Anum_bbf_view_def_flag_values 6
 #define BBF_VIEW_DEF_NUM_COLS 8
 #define BBF_VIEW_DEF_FLAG_IS_ANSI_NULLS_ON (1<<0)
 #define BBF_VIEW_DEF_FLAG_USES_QUOTED_IDENTIFIER (1<<1)
 #define BBF_VIEW_DEF_FLAG_CREATED_IN_OR_AFTER_2_4 (0<<2)
+#define BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW (1<<3)
+#define BBF_VIEW_DEF_FLAG_IS_BROKEN (1<<4)
+
 extern Oid	bbf_view_def_oid;
 extern Oid	bbf_view_def_idx_oid;
 
 extern Oid	get_bbf_view_def_oid(void);
 extern Oid	get_bbf_view_def_idx_oid(void);
-extern HeapTuple search_bbf_view_def(Relation bbf_view_def_rel, int16 dbid,
-									 const char *logical_schema_name, const char *view_name);
-extern bool check_is_tsql_view(Oid relid);
+extern HeapTuple search_bbf_view_def(Relation bbf_view_def_rel, Oid viewOid);
+extern bool check_is_tsql_view(Oid relid, bool *is_weak_view);
 extern void clean_up_bbf_view_def(int16 dbid);
 extern void drop_bbf_schema_permission_entries(int16 dbid);
 

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -18,6 +18,7 @@
 #define PLTSQL_DEFAULT_LANGUAGE "us_english"
 
 static int	migration_mode = SINGLE_DB;
+bool		pltsql_weak_view_binding = false;
 bool		enable_ownership_structure = false;
 
 bool		enable_metadata_inconsistency_check = true;
@@ -630,6 +631,16 @@ define_custom_variables(void)
 							 GUC_NO_RESET_ALL,
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("babelfishpg_tsql.weak_view_binding",
+							 gettext_noop("Sets the default binding mode for views."),
+							 gettext_noop("When set to false (default), views will bind to the schema of its underlying tables or other objects" 
+										  "When set to true, views created will have weak binding and are no longer bound to schema of its underlying" 
+										  "objects unless explicitly declared in create/alter DDL"),
+							 &pltsql_weak_view_binding,
+							 false,  /* Default is strong binding (false) */
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
 
 	/* ANTLR parser */
 	DefineCustomBoolVariable("babelfishpg_tsql.dump_antlr_query_graph",

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -20,6 +20,7 @@ extern bool pltsql_enable_create_alter_view_from_pg;
 extern bool pltsql_enable_linked_servers;
 extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;
+extern bool pltsql_weak_view_binding;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -18,14 +18,17 @@
 #include "catalog/pg_attrdef_d.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_db_role_setting.h"
+#include "catalog/pg_depend.h"	/* Required in handle_bbf_view_binding_on_object_drop to access pg_rewrite dependencies */
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_trigger_d.h"
 #include "catalog/pg_type.h"
+#include "catalog/pg_rewrite.h"
 #include "catalog/pg_operator.h"
 #include "catalog/pg_tablespace.h"
 #include "commands/copy.h"
+#include "commands/comment.h"
 #include "commands/dbcommands.h"
 #include "commands/explain.h"
 #include "commands/extension.h"
@@ -61,11 +64,13 @@
 #include "parser/scansup.h"
 #include "replication/logical.h"
 #include "rewrite/rewriteHandler.h"
+#include "rewrite/rewriteSupport.h"
 #include "storage/lock.h"
 #include "storage/sinvaladt.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
@@ -169,6 +174,8 @@ static void transform_pivot_clause(ParseState *pstate, SelectStmt *stmt);
 static void transform_unpivot_clause(ParseState *pstate, SelectStmt *stmt);
 static bool transform_unpivot_clause_recursive(Node **node, List **measure_cols, List **unpivot_src_cols);
 static List* filter_star_targetlist_for_unpivot(ParseState *pstate, SelectStmt *stmt, List **source_cols);
+static bool repair_broken_views(Query *parsetree);
+
 /*****************************************
  * 			Commands Hooks
  *****************************************/
@@ -267,6 +274,19 @@ static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
 static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
 static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
 
+/*********************************************************
+ * 			Weak Binding Views Related Declarations
+ *********************************************************/
+static bool bbf_view_is_broken(Oid viewOid);
+static char *bbf_view_get_definition(Oid viewOid);
+static bool bbf_view_set_broken(Oid viewOid, bool mark_broken);
+static void find_all_view_references(Node *node, List **view_oids);
+static Query *create_dummy_view_query_for_broken_view(Oid viewOid);
+static bool repair_broken_view_recursive(Oid viewOid, List *visitedViews);
+static bool is_dummy_view(Oid viewOid);
+static bool update_bbf_view_flags(Oid viewOid, uint64 flags_to_set, uint64 flags_to_clear, bool update_validity);
+static Oid get_view_oid_from_rule(Oid ruleOid);
+
 /* Save hook values in case of unload */
 static core_yylex_hook_type prev_core_yylex_hook = NULL;
 static pre_transform_returning_hook_type prev_pre_transform_returning_hook = NULL;
@@ -335,6 +355,7 @@ static ExecFuncProc_AclCheck_hook_type prev_ExecFuncProc_AclCheck_hook = NULL;
 static bbf_execute_grantstmt_as_dbsecadmin_hook_type prev_bbf_execute_grantstmt_as_dbsecadmin_hook = NULL;
 static bbf_check_member_has_direct_priv_to_grant_role_hook_type prev_bbf_check_member_has_direct_priv_to_grant_role_hook = NULL;
 static validateCachedPlanSearchPath_hook_type prev_validateCachedPlanSearchPath_hook = NULL;
+static pre_QueryRewrite_hook_type prev_pre_QueryRewrite_hook = NULL;
 ExecInitParallelPlan_hook_type prev_ExecInitParallelPlan_hook = NULL;
 ParallelQueryMain_hook_type prev_ParallelQueryMain_hook = NULL;
 
@@ -589,6 +610,10 @@ InstallExtendedHooks(void)
 	ExecCheckOneRelPerms_hook = bbf_ExecCheckOneRelPerms;
 
 	get_domain_typmodin_hook = get_domain_typmodin;
+
+	prev_pre_QueryRewrite_hook = pre_QueryRewrite_hook;
+	pre_QueryRewrite_hook = repair_broken_views;
+
 }
 
 void
@@ -664,6 +689,7 @@ UninstallExtendedHooks(void)
 	bbf_execute_grantstmt_as_dbsecadmin_hook = prev_bbf_execute_grantstmt_as_dbsecadmin_hook;
 	bbf_check_member_has_direct_priv_to_grant_role_hook = prev_bbf_check_member_has_direct_priv_to_grant_role_hook;
 	validateCachedPlanSearchPath_hook = prev_validateCachedPlanSearchPath_hook;
+	pre_QueryRewrite_hook = prev_pre_QueryRewrite_hook;
 
 	bbf_InitializeParallelDSM_hook = NULL;
 	bbf_ParallelWorkerMain_hook = NULL;
@@ -3132,11 +3158,44 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 		(*prev_object_access_hook) (access, classId, objectId, subId, arg);
 
 	if (access == OAT_DROP && classId == RelationRelationId)
+	{	
+		char relkind;
+		relkind = get_rel_relkind(objectId);
+
 		pltsql_drop_view_definition(objectId);
+		
+		/* Handle view dependencies for tables and views */
+		if (sql_dialect == SQL_DIALECT_TSQL && IS_TDS_CONN() &&
+			(relkind == RELKIND_RELATION || relkind == RELKIND_VIEW))
+		{
+			ObjectAddress obj;
 
+			obj.classId = RelationRelationId;
+			obj.objectId = objectId;
+			obj.objectSubId = subId;
+
+			/* Call view dependency handling function */
+			handle_bbf_view_binding_on_object_drop(&obj, NULL, NULL);
+		}
+	}
 	if (access == OAT_DROP && classId == ProcedureRelationId)
-		pltsql_drop_func_default_positions(objectId);
+	{
+		if(subId != -1)
+			pltsql_drop_func_default_positions(objectId);
 
+		/* Handle view dependencies for functions */
+		if (sql_dialect == SQL_DIALECT_TSQL && IS_TDS_CONN() && subId == -1)
+		{
+			ObjectAddress obj;
+			
+			obj.classId = ProcedureRelationId;
+			obj.objectId = objectId;
+			obj.objectSubId = 0;
+			
+			/* Call view dependency handling for functions */
+			handle_bbf_view_binding_on_object_drop(&obj, NULL, NULL);
+		}
+	}
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
 
@@ -3421,6 +3480,13 @@ pltsql_store_view_definition(const char *queryString, ObjectAddress address)
 	char	   *physical_schemaname;
 	const char *logical_schemaname;
 	char	   *original_query = get_original_query_string();
+	bool        is_strong_view;
+
+	is_strong_view = false;
+	if (pltsql_weak_view_binding)
+		is_strong_view = get_is_schemabinding_view();
+	else
+		is_strong_view = true;
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
@@ -3490,6 +3556,13 @@ pltsql_store_view_definition(const char *queryString, ObjectAddress address)
 	flag_validity |= BBF_VIEW_DEF_FLAG_CREATED_IN_OR_AFTER_2_4;
 	flag_values |= BBF_VIEW_DEF_FLAG_CREATED_IN_OR_AFTER_2_4;
 
+	/* Set the strong/weak view flag */
+	if (!is_strong_view)
+	{
+		flag_validity |= BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW;
+		flag_values |= BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW;
+	}
+	
 	new_record[0] = Int16GetDatum(dbid);
 	new_record[1] = CStringGetTextDatum(logical_schemaname);
 	new_record[2] = CStringGetTextDatum(NameStr(form_reltup->relname));
@@ -3566,8 +3639,7 @@ pltsql_drop_view_definition(Oid objectId)
 
 	/* Fetch the relation */
 	bbf_view_def_rel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
-
-	scantup = search_bbf_view_def(bbf_view_def_rel, dbid, logical_schemaname, objectname);
+	scantup = search_bbf_view_def(bbf_view_def_rel, objectId);
 
 	if (HeapTupleIsValid(scantup))
 	{
@@ -6617,4 +6689,857 @@ get_domain_typmodin(Type typ)
 		ReleaseSysCache(tup);
 	}
 	return typmodin;
+}
+
+/*
+ * Get the OID of a view from its rule
+ *
+ * This function looks up a rule in pg_rewrite and returns the OID of the
+ * view that the rule belongs to (from the ev_class field).
+ *
+ * Parameters:
+ * - ruleOid: OID of the rule
+ * - pg_rewrite_rel: Open relation handle for pg_rewrite
+ *
+ * Returns:
+ * - The OID of the view if found
+ * - InvalidOid if the rule wasn't found or doesn't belong to a view
+ */
+static Oid
+get_view_oid_from_rule(Oid ruleOid)
+{
+	ScanKeyData 	key[1];
+	SysScanDesc 	scan;
+	HeapTuple 		tuple;
+	Relation 		pg_rewrite_rel;
+	Form_pg_rewrite rule_form;
+	Oid 			viewOid = InvalidOid;
+
+	pg_rewrite_rel = table_open(RewriteRelationId, AccessShareLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_rewrite_oid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(ruleOid));
+				
+	scan = systable_beginscan(pg_rewrite_rel, RewriteOidIndexId, true,
+							NULL, 1, key);
+							
+	tuple = systable_getnext(scan);
+	
+	if (!HeapTupleIsValid(tuple))
+	{
+		elog(ERROR, "cache lookup failed for rule with OID %u", ruleOid);
+	}
+	rule_form = (Form_pg_rewrite) GETSTRUCT(tuple);
+	viewOid = rule_form->ev_class;
+	
+	systable_endscan(scan);
+	table_close(pg_rewrite_rel, AccessShareLock);
+	return viewOid;
+}
+
+/*
+ * Update a view's flags in its babelfish_view_def tuple
+ *
+ * Parameters:
+ * - tuple: The view definition tuple
+ * - rel: The relation descriptor for babelfish_view_def
+ * - flags_to_set: Flags to set (OR with existing flags)
+ * - flags_to_clear: Flags to clear (AND NOT with existing flags)
+ * - update_validity: If true, update flag_validity as well
+ *
+ * Returns:
+ * - The updated tuple (caller must free)
+ * - NULL if the update failed
+ */
+static bool
+update_bbf_view_flags(Oid viewOid, uint64 flags_to_set, uint64 flags_to_clear, bool update_validity)
+{
+	HeapTuple 	tuple, newtup;
+	Relation 	brel;
+	Datum 		values_datum, 
+				validity_datum;
+	uint64 		flag_values, 
+				flag_validity;
+	bool 		isnull;
+	bool 		updated = false;
+
+	Datum 		values[BBF_VIEW_DEF_NUM_COLS];
+	bool 		nulls[BBF_VIEW_DEF_NUM_COLS];
+	bool 		replaces[BBF_VIEW_DEF_NUM_COLS];
+	
+	brel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
+	tuple = search_bbf_view_def(brel, viewOid);
+	
+	if (!HeapTupleIsValid(tuple))
+	{
+		table_close(brel, RowExclusiveLock);
+		return false;
+	}
+		
+	values_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_values,
+							RelationGetDescr(brel), &isnull);
+	if (isnull)
+	{
+		heap_freetuple(tuple);
+		table_close(brel, RowExclusiveLock);
+		return false;
+	}
+		
+	flag_values = DatumGetUInt64(values_datum);
+	flag_values = (flag_values | flags_to_set) & ~flags_to_clear;
+	
+	validity_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_validity,
+							RelationGetDescr(brel), &isnull);
+	flag_validity = DatumGetUInt64(validity_datum);
+
+	if (update_validity)
+		flag_validity = (flag_validity | flags_to_set) & ~flags_to_clear;
+	
+	memset(values, 0, sizeof(values));
+	memset(nulls, false, sizeof(nulls));
+	memset(replaces, false, sizeof(replaces));
+	
+	replaces[Anum_bbf_view_def_flag_values - 1] = true;
+	values[Anum_bbf_view_def_flag_values - 1] = UInt64GetDatum(flag_values);
+	
+	if (update_validity)
+	{
+		replaces[Anum_bbf_view_def_flag_validity - 1] = true;
+		values[Anum_bbf_view_def_flag_validity - 1] = UInt64GetDatum(flag_validity);
+	}
+	
+	newtup = heap_modify_tuple(tuple, RelationGetDescr(brel),
+							values, nulls, replaces);
+							
+	if (newtup)
+	{
+		CatalogTupleUpdate(brel, &tuple->t_self, newtup);
+		heap_freetuple(newtup);
+		updated = true;
+	}
+	
+	heap_freetuple(tuple);
+	table_close(brel, RowExclusiveLock);
+	Assert(newtup);
+	
+	return updated;
+}
+
+/*
+ * Check if a view is marked as broken in babelfish_view_def
+ */
+static bool
+bbf_view_is_broken(Oid viewOid)
+{
+	HeapTuple 	tuple;
+	Relation 	brel;
+	bool 		is_broken = false;
+
+	brel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
+	tuple = search_bbf_view_def(brel, viewOid);
+
+	if (HeapTupleIsValid(tuple))
+	{
+		bool 	isnull;
+		Datum 	values_datum, 
+				validity_datum;
+		
+		values_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_values,
+								RelationGetDescr(brel), &isnull);
+		validity_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_validity,
+								RelationGetDescr(brel), &isnull);
+								
+		if (!isnull)
+		{
+			uint64 flag_values = DatumGetUInt64(values_datum);
+			uint64 flag_validity = DatumGetUInt64(validity_datum);
+			
+			is_broken = ((flag_values & BBF_VIEW_DEF_FLAG_IS_BROKEN) != 0) &&
+					((flag_validity & BBF_VIEW_DEF_FLAG_IS_BROKEN) != 0);
+		}
+		
+		heap_freetuple(tuple);
+	}
+	table_close(brel, AccessShareLock);
+	return is_broken;
+}
+
+/*
+ * Get the definition text of a view from babelfish_view_def
+ */
+static char *
+bbf_view_get_definition(Oid viewOid)
+{
+	HeapTuple 	tuple;
+	Relation 	brel;
+	char 		*definition = NULL;
+
+	brel = table_open(get_bbf_view_def_oid(), AccessShareLock);	
+	tuple = search_bbf_view_def(brel, viewOid);
+
+	if (HeapTupleIsValid(tuple))
+	{
+		bool 	isnull;
+		Datum 	def_datum;
+		
+		def_datum = heap_getattr(tuple, Anum_bbf_view_def_definition,
+							RelationGetDescr(brel), &isnull);
+							
+		if (!isnull)
+			definition = TextDatumGetCString(def_datum);
+		
+		heap_freetuple(tuple);
+	}
+	table_close(brel, AccessShareLock);
+	return definition;
+}
+
+/*
+ * Mark a view as broken or not broken in babelfish_view_def
+ */
+static bool
+bbf_view_set_broken(Oid viewOid, bool mark_broken)
+{
+	Relation 	brel;
+	HeapTuple 	tuple;
+	Datum 		values_datum, 
+				validity_datum;
+	uint64 		flag_values, 
+				flag_validity;
+	bool 		isnull;
+	bool 		is_weak_view;
+	bool 		is_broken;
+	bool 		updated = false;
+	
+	brel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
+	tuple = search_bbf_view_def(brel, viewOid);
+	
+	if (!HeapTupleIsValid(tuple))
+	{
+		table_close(brel, RowExclusiveLock);
+		return false;
+	}
+	values_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_values,
+							RelationGetDescr(brel), &isnull);
+	if (isnull)
+	{
+		heap_freetuple(tuple);
+		table_close(brel, RowExclusiveLock);
+		return false;
+	}
+	
+	validity_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_validity,
+							RelationGetDescr(brel), &isnull);
+	
+	flag_values = DatumGetUInt64(values_datum);
+	flag_validity = DatumGetUInt64(validity_datum);
+	
+	/* Check if view is weak-bound */
+	is_weak_view = (flag_values & BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW) != 0 &&
+				(flag_validity & BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW) != 0;
+	
+	/* Cannot mark a strong-bound view as broken */
+	if (mark_broken && !is_weak_view)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+				errmsg("cannot mark schema-bound view as broken"),
+				errdetail("View %s uses strong binding", get_rel_name(viewOid))));
+	}
+	
+	/* Check if current broken status already matches requested status */
+	is_broken = (flag_values & BBF_VIEW_DEF_FLAG_IS_BROKEN) != 0 &&
+					(flag_validity & BBF_VIEW_DEF_FLAG_IS_BROKEN) != 0;
+					
+	if (is_broken == mark_broken)
+	{
+		heap_freetuple(tuple);
+		table_close(brel, RowExclusiveLock);
+		return false;
+	}
+	
+	/* Update the flags */
+	if (mark_broken)
+		updated = update_bbf_view_flags(viewOid, BBF_VIEW_DEF_FLAG_IS_BROKEN, 0, true);
+	else
+		updated = update_bbf_view_flags(viewOid, 0, BBF_VIEW_DEF_FLAG_IS_BROKEN, true);
+	
+	heap_freetuple(tuple);
+	table_close(brel, RowExclusiveLock);
+	return updated;
+}
+
+/*
+ * Checks if a view is a dummy view created during object drop processing
+ *
+ * A dummy view has a specific structure:
+ * - SELECT command type
+ * - Empty FROM clause (no tables referenced)
+ * - No WHERE clause
+ * - Target list contains only constants
+ *
+ * Parameters:
+ * - viewOid: OID of the view to check
+ *
+ * Returns:
+ * - true if the view is a dummy view, false otherwise
+ */
+static bool
+is_dummy_view(Oid viewOid)
+{
+	Relation 	viewRel;
+	Query 		*viewQuery = NULL;
+	bool 		is_dummy = false;
+	ListCell 	*lc;
+
+	viewRel = relation_open(viewOid, AccessShareLock);
+	viewQuery = get_view_query(viewRel);
+
+	if (viewQuery->commandType == CMD_SELECT &&
+			viewQuery->jointree &&
+			list_length(viewQuery->jointree->fromlist) == 0 &&
+			viewQuery->jointree->quals == NULL)
+	{
+		is_dummy = true;	
+		foreach(lc, viewQuery->targetList)
+		{
+			TargetEntry *te = (TargetEntry *) lfirst(lc);
+			if (te->resjunk || !IsA(te->expr, Const) || !((Const *) (te->expr))->constisnull)
+			{
+				is_dummy = false;
+				break;
+			}
+		}
+	}
+	relation_close(viewRel, AccessShareLock);
+	return is_dummy;
+}
+
+/*
+ * Repair a broken view and all views it depend on
+ *
+ * This function repairs a view that has become broken due to underlying objects
+ * being dropped and recreated. It works by:
+ * 1. Retrieving the original view definition from babelfish_view_def
+ * 2. Parsing and analyzing this definition to create a new query tree
+ * 3. Recursively repairing any views that this view depends on
+ * 4. Updating the view's rule in pg_rewrite with the new query tree
+ *
+ * Parameters:
+ * - viewOid: OID of the view to repair
+ * - visitedViews: List of view OIDs already visited (to prevent infinite recursion)
+ *
+ * Returns:
+ * - true if the view was successfully repaired, false otherwise
+ */
+static bool
+repair_broken_view_recursive(Oid viewOid, List *visitedViews)
+{
+	int16 			logical_dbid;
+	List 			*parsetree_list;
+	RawStmt 		*rawstmt;
+	ViewStmt 		*viewStmt;
+	Query 			*query = NULL;
+	Query 			*currentQuery = NULL;
+	bool 			repaired = false;
+	char 			*schema_name = NULL; 
+	char 			*viewdef = NULL;
+	char 			*orig_db_name;
+	List 			*referenced_views = NIL;
+	ListCell 		*lc, 
+					*lc1;
+	RangeVar 		*rangevar;
+	ObjectAddress 	address;
+	Relation 		viewRel;
+	ANTLR_result 	result;
+	PLtsql_stmt_execsql *stmt_sql = NULL;
+
+	/* Check if we've already visited this view to avoid infinite recursion */
+	if (list_member_oid(visitedViews, viewOid))
+		return true;
+
+	visitedViews = lappend_oid(visitedViews, viewOid);
+    
+	/* Check if the view is a dummy view and do repair */
+	if (is_dummy_view(viewOid) && bbf_view_is_broken(viewOid))
+	{	
+		viewdef = bbf_view_get_definition(viewOid);
+		
+		/* This should never happen */
+		if (viewdef == NULL)
+		{
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+					errmsg("view with OID %u does not have a definition in babelfish_view_def", viewOid)));
+		}
+
+		/* We require view definition to be parsed by antlr parser first because it
+		 * may happen that this definition may contain "WITH SCHEMABINDING" clause which is not 
+		 * supported in bison parser. The antlr parser processes this clause correctly (by ignoring it), 
+		 * allowing us to avoid syntax errors when parsing T-SQL view definitions 
+		 */
+		result = antlr_parser_cpp(viewdef);
+
+		if(!(result.success && pltsql_parse_result && pltsql_parse_result->body))
+		{
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+					errmsg("could not parse view definition for view OID %u", viewOid)));
+		}
+
+		/* Extract the SQL statement from the ANTLR parser result */
+		foreach(lc1, pltsql_parse_result->body)
+		{
+			PLtsql_stmt *s = (PLtsql_stmt *) lfirst(lc1);
+			if (s->cmd_type == PLTSQL_STMT_EXECSQL)
+			{
+				stmt_sql = (PLtsql_stmt_execsql *) s;
+				break;
+			}
+		}
+		if (stmt_sql && stmt_sql->sqlstmt)
+		{
+			/* Use the rewritten SQL statement from ANTLR to parse */
+			parsetree_list = raw_parser(stmt_sql->sqlstmt->query, RAW_PARSE_DEFAULT);
+		}
+		else
+		{
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+					errmsg("could not find SQL statement in view definition for view OID %u", viewOid)));
+		}
+
+		rawstmt = (RawStmt *) linitial(parsetree_list);
+		viewStmt = (ViewStmt *) rawstmt->stmt;
+		if (viewStmt->query == NULL)
+		{
+			ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+					errmsg("view definition for view OID %u does not contain a select query", viewOid)));
+		}
+
+		orig_db_name = get_cur_db_name();
+		PG_TRY();
+		{
+			Oid 	schema_id;
+			schema_id = get_rel_namespace(viewOid);
+			schema_name = get_namespace_name(schema_id);
+			logical_dbid = get_dbid_from_physical_schema_name(schema_name, true);
+			set_cur_user_db_and_path(get_db_name(logical_dbid), true);
+			
+			/* Transform the query into a Query structure */
+			rawstmt = makeNode(RawStmt);
+			rawstmt->stmt = viewStmt->query;
+			rawstmt->stmt_location = -1;
+			rawstmt->stmt_len = 0;
+			
+			query = parse_analyze_fixedparams(rawstmt, viewdef, NULL, 0, NULL);
+		}
+		PG_FINALLY();
+		{
+			set_cur_user_db_and_path(orig_db_name, true);
+			pfree(orig_db_name);
+		}
+		PG_END_TRY();
+		
+		if (query!= NULL && query->commandType == CMD_SELECT)
+		{
+			rangevar = copyObject(viewStmt->view);
+			rangevar->schemaname = schema_name;
+			address = bbf_define_virtual_relation(rangevar, query->targetList, true, viewStmt->options, query);
+
+			if (OidIsValid(address.objectId))
+			{
+				/* Unset broken flag as the view is now repaired in babelfish_view_def */
+				repaired = bbf_view_set_broken(viewOid, false);
+			}	
+		}
+		else
+			repaired = false; 
+		pfree(viewdef);
+	}
+	viewRel = relation_open(viewOid, AccessShareLock);
+
+	currentQuery = get_view_query(viewRel);
+	if (currentQuery)
+	{
+		find_all_view_references((Node *) currentQuery, &referenced_views);
+
+		foreach(lc, referenced_views)
+		{
+			Oid referenced_view_oid = lfirst_oid(lc);
+			/* This will detect circular dependencies and repair broken views */
+			if (repair_broken_view_recursive(referenced_view_oid, visitedViews))
+				repaired = true;
+		}
+	}
+	relation_close(viewRel, AccessShareLock);
+
+	if (repaired)
+		CommandCounterIncrement();
+	return repaired;
+}
+
+/*
+ * View repair hook implementation
+ *
+ * This function is called during query rewrite when a view is accessed.
+ * It checks if any views in the query needs repair (have dummy query trees) and repairs them
+ * using the original definition stored in babelfish_view_def.
+ *
+ * The hook works by:
+ * 1. Finding all views referenced in the query, including those in subqueries and sublinks
+ * 2. Attempting to repair each view by calling repair_broken_view_recursive
+ * 3. Returning true if any views were repaired, false otherwise
+ *
+ * Parameters:
+ * - parsetree: The query tree being processed
+ *
+ * Returns:
+ * - true if any views were repaired, false otherwise
+ */
+static bool
+repair_broken_views(Query *parsetree)
+{
+	ListCell 	*lc;
+	List 		*visitedViews = NIL;
+	List 		*view_oids = NIL;
+	bool 		repaired = false;
+	
+	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
+		return false;
+
+	/* Find all views referenced in the query, including those in subqueries and sublinks */
+	find_all_view_references((Node *)parsetree, &view_oids);
+
+	foreach(lc, view_oids)
+	{
+		if (repair_broken_view_recursive(lfirst_oid(lc), visitedViews))
+			repaired = true;
+	}
+	return repaired;
+}
+
+/*
+ * create_dummy_view_query
+ *
+ * Create a dummy Query node that returns NULL values for all columns
+ * in the specified relation. This is used to create placeholder views
+ * when an underlying table, view or function is dropped.
+ *
+ * Parameters:
+ *   viewOid - OID of the view for which to create a dummy query
+ *
+ * Returns:
+ *   A Query node with NULL constants for each column of the original view
+ */
+static Query *
+create_dummy_view_query_for_broken_view(Oid viewOid)
+{
+	Relation 	viewRel;
+	TupleDesc 	tupdesc;
+	Query 		*dummyQuery;
+	List 		*targetList = NIL;
+	int 		i;
+	
+	viewRel = relation_open(viewOid, AccessShareLock);
+	tupdesc = RelationGetDescr(viewRel);
+
+	/* Create a dummy Query node that returns NULL values for all columns */
+	dummyQuery = makeNode(Query);
+	dummyQuery->commandType = CMD_SELECT;
+	dummyQuery->querySource = QSRC_ORIGINAL;
+	dummyQuery->canSetTag = true;
+	/* empty jointree */
+	dummyQuery->jointree = makeNode(FromExpr);
+	
+	/* Build target list with NULL constants for each column */
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(tupdesc, i);
+		TargetEntry *te;
+		Const *nullconst;
+
+		/* Create a NULL constant of the appropriate type */
+		nullconst = makeNullConst(
+			att->atttypid,
+			att->atttypmod,
+			att->attcollation);
+
+		/* Create a target entry with the original column name */
+		te = makeTargetEntry((Expr *) nullconst,
+							i + 1,
+							pstrdup(NameStr(att->attname)),
+							false);
+							
+		targetList = lappend(targetList, te);
+	}
+	dummyQuery->targetList = targetList;
+	relation_close(viewRel, AccessShareLock);
+	
+	return dummyQuery;
+}
+
+/*
+ * Handle view dependencies during object drop or alter operations.
+ * This function manages the behavior of dependent views when their referenced objects
+ * (tables, views, functions) are being dropped or altered.
+ *
+ * The function implements different behaviors based on the operation type:
+ *
+ * For DROP operations:
+ * - Identifies all views that directly depend on the dropped object
+ * - For weak views: marks them as broken and creates dummy view definitions
+ * - For strong views: the drop will be prevented through postgresql
+ *
+ * For ALTER VIEW operations (DROP + CREATE):
+ * - converts all dependent views to weak binding and marks them broken when 
+ * babelfishpg_tsql.weak_view_binding is enabled
+ *
+ * View Binding Modes:
+ * - Strong binding (WITH SCHEMABINDING): Views have strict dependencies, prevent drops
+ * - Weak binding: Views can become "broken" when references are dropped, allowing
+ *   the operation to proceed while maintaining view metadata for potential repair
+ *
+ * Broken Views:
+ * When a view is marked as broken, a dummy query is created that returns NULL values
+ * for all columns, maintaining the view's structure while indicating the dependency
+ * failure. These views can potentially be repaired later if the dependencies are restored.
+ *
+ * Parameters:
+ * - droppedObject: ObjectAddress of the object being dropped/altered
+ * - depRel: Open relation handle for pg_depend
+ * - stmt: ViewStmt for ALTER VIEW operations, NULL for DROP operations
+ *
+ * Returns:
+ * - true: Operation can proceed (dependencies handled appropriately)
+ * - false: Should not occur with current logic (kept for compatibility)
+ *
+ * Note: This function only operates in T-SQL dialect with TDS connections.
+ * For other dialects, it returns false immediately without processing.
+ */
+
+bool
+handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relation depRel, ViewStmt *stmt)
+{
+	ScanKeyData 	key[3];
+	SysScanDesc 	scan;
+	HeapTuple 		tup;
+	List 			*processed_views = NIL;
+	Oid 			viewOid = InvalidOid;
+	bool 			is_alter_view = false;
+	bool 			is_weak_view = false;
+	bool 			processed = true;
+	bool 			updated;
+	int             nkeys = 2;
+
+	/* Check if this is an ALTER VIEW operation */
+	is_alter_view = (stmt != NULL && stmt->createOrAlter);
+	
+	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
+		return false;
+	
+	depRel = table_open(DependRelationId, AccessShareLock);
+	
+	ScanKeyInit(&key[0],
+				Anum_pg_depend_refclassid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(droppedObject->classId));
+	ScanKeyInit(&key[1],
+				Anum_pg_depend_refobjid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(droppedObject->objectId));
+	if (droppedObject->objectSubId)
+	{
+		ScanKeyInit(&key[2],
+					Anum_pg_depend_refobjsubid,
+					BTEqualStrategyNumber, F_INT4EQ,
+					Int32GetDatum(droppedObject->objectSubId));
+		nkeys = 3;
+	}
+	scan = systable_beginscan(depRel, DependReferenceIndexId, true,
+								NULL, nkeys, key);
+	
+	/* Loop over all the direct dependents */
+	while ((tup = systable_getnext(scan)) != NULL)
+	{
+		Form_pg_depend depform = (Form_pg_depend) GETSTRUCT(tup);
+		
+		/* Only handle entries for pg_rewrite rules with NORMAL dependency */
+		if (depform->classid != RewriteRelationId || depform->deptype != DEPENDENCY_NORMAL)
+			continue;
+		
+		viewOid = get_view_oid_from_rule(depform->objid);
+		
+		if (OidIsValid(viewOid) && !list_member_oid(processed_views, viewOid))
+		{
+			processed_views = lappend_oid(processed_views, viewOid);
+			
+			/* DROP operation: if dependent is weak view, mark broken */
+			is_weak_view = false;
+			if (check_is_tsql_view(viewOid, &is_weak_view) && is_weak_view)
+			{
+				/* Mark view as broken */
+				updated = bbf_view_set_broken(viewOid, true);
+				
+				/* If the view was successfully marked as broken, create a dummy query */
+				if (updated)
+				{
+					Query *dummyQuery = create_dummy_view_query_for_broken_view(viewOid);
+					StoreViewQuery(viewOid, dummyQuery, true);
+				}
+				CommandCounterIncrement();
+			}
+			else if (is_alter_view && pltsql_weak_view_binding)
+			{
+				/* ALTER operation: mark weak & broken */
+				update_bbf_view_flags(viewOid, BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW, 0, true);
+				CommandCounterIncrement();
+				
+				updated = bbf_view_set_broken(viewOid, true);
+				
+				/* If the view was successfully marked as broken, create a dummy query */
+				if (updated)
+				{
+					Query *dummyQuery = create_dummy_view_query_for_broken_view(viewOid);
+					StoreViewQuery(viewOid, dummyQuery, true);
+				}
+			}
+			else
+			{
+				processed = false;
+				break;
+			}
+		}
+	}
+	systable_endscan(scan);
+	table_close(depRel, AccessShareLock);
+	list_free(processed_views);
+	CommandCounterIncrement();	
+	return processed;
+}
+
+/*
+ * Check if a schema-bound view references any non-schema-bound views
+ *
+ * This function is called during view creation to enforce the SQL Server rule
+ * that schema-bound views cannot reference non-schema-bound views. It finds
+ * all views referenced in the query (including those in subqueries and sublinks)
+ * and checks if any of them are weak (non-schema-bound) views.
+ *
+ * The function works by:
+ * 1. Finding all views referenced in the query
+ * 2. Checking each view to see if it's a weak view
+ * 3. Throwing an error if any weak views are found
+ *
+ * Parameters:
+ * - viewParse: The query tree for the view being created
+ *
+ * Returns:
+ * - true if no weak view dependencies are found
+ * - false if weak view dependencies are found (after throwing an error)
+ */
+bool
+check_view_binding_dependencies(Query *viewParse)
+{
+	List 		*referenced_views = NIL;
+	ListCell 	*lc;
+	bool	 	is_strong_view = get_is_schemabinding_view();
+
+	if(sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
+		return true;
+
+	if (pltsql_weak_view_binding && !is_strong_view)
+		return true;
+
+	/* Find all view referenced in the query, including those in subqueries*/
+	find_all_view_references((Node *) viewParse, &referenced_views);
+	
+	foreach(lc, referenced_views)
+	{
+		Oid 	viewOid = lfirst_oid(lc);
+		bool 	is_weak_view = false;
+		
+		/* check if view is weakly schema bound */
+		if (check_is_tsql_view(viewOid, &is_weak_view) && is_weak_view)
+		{
+			/* Found a weak view dependency - this is not allowed for schema-bound views */				
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("cannot create schema-bound view that references a non-schema-bound view"),
+					errdetail("Schema-bound views cannot reference non-schema-bound views.")));
+			return false;
+		}
+	}
+	list_free(referenced_views);
+	return true;
+}
+
+/*
+ * Find all view references in a query, including those in subqueries and sublinks
+ */
+typedef struct
+{
+	List	**view_oids;
+} find_view_dependencies_context;
+
+static bool
+find_view_references_walker(Node *node, find_view_dependencies_context *context)
+{
+	if (node == NULL)
+		return false;
+	
+	if (IsA(node, RangeTblEntry))
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) node;
+		
+		/* Check for views in regular relations */
+		if (rte->rtekind == RTE_RELATION && get_rel_relkind(rte->relid) == RELKIND_VIEW)
+		{
+			if (!list_member_oid(*(context->view_oids), rte->relid))
+				*(context->view_oids) = lappend_oid(*(context->view_oids), rte->relid);
+		}
+
+		if (rte->rtekind == RTE_SUBQUERY && rte->subquery)
+		{
+			if (find_view_references_walker((Node *)rte->subquery, context))
+				return true;
+		}
+		/* We've handled the RangeTblEntry, so don't pass it to expression_tree_walker */
+		return false;
+	}
+	
+	if (IsA(node, Query))
+	{
+		return query_tree_walker((Query *) node, 
+								find_view_references_walker,
+								(void *) context,
+								QTW_EXAMINE_RTES_BEFORE);
+	}
+	return expression_tree_walker(node, find_view_references_walker,
+								  (void *) context);
+}
+
+/*
+ * Find all view references in a query tree
+ *
+ * This function identifies all views that are referenced in the given query,
+ * including those in subqueries and sublinks (like EXISTS clauses).
+ *
+ * Parameters:
+ * - node: The query tree or expression to search for view references
+ * - view_oids: Pointer to a list where view OIDs will be collected
+ */
+void
+find_all_view_references(Node *node, List **view_oids)
+{
+	find_view_dependencies_context context;
+	context.view_oids = view_oids;
+
+	query_or_expression_tree_walker(node,
+									find_view_references_walker,
+									(void *) &context,
+									QTW_EXAMINE_RTES_BEFORE);
 }

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -39,5 +39,7 @@ extern char** fetch_func_input_arg_names(HeapTuple func_tuple);
 
 extern char *update_delete_target_alias;
 extern bool sp_describe_first_result_set_inprogress;
+extern bool handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relation depRel, ViewStmt *viewstmt);
+extern bool check_view_binding_dependencies(Query *viewParse);
 #endif
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -67,6 +67,7 @@
 uint64		rowcount_var = 0;
 List	   *columns_updated_list = NIL;
 static char *original_query_string = NULL;
+static bool is_schemabinding_view = true;
 
 int			fetch_status_var = 0;
 int			saved_expr_kind = -1;
@@ -4824,6 +4825,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 						  (strcmp(estate->func->fn_signature, "inline_code_block") != 0);
 
 	original_query_string = stmt->original_query ? stmt->original_query : NULL;
+	is_schemabinding_view = stmt->is_schemabinding;
 
 	if (is_cross_db)
 	{
@@ -5272,6 +5274,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	PG_FINALLY();
 	{
 		original_query_string = NULL;
+		is_schemabinding_view = true;
 
 		if (is_cross_db)
 		{
@@ -10476,6 +10479,15 @@ char *
 get_original_query_string(void)
 {
 	return original_query_string;
+}
+
+/*
+ * Get the is_schemabinding flag for the view definition.
+ */
+bool
+get_is_schemabinding_view(void)
+{
+	return is_schemabinding_view;
 }
 
 Datum pltsql_exec_tsql_cast_value(Datum value, bool *isnull,

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -25,6 +25,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_depend.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
@@ -262,6 +263,7 @@ static guc_push_old_value_hook_type prev_guc_push_old_value_hook = NULL;
 static validate_set_config_function_hook_type prev_validate_set_config_function_hook = NULL;
 static void pltsql_guc_push_old_value(struct config_generic *gconf, GucAction action);
 bool		current_query_is_create_tbl_check_constraint = false;
+static bool pltsql_current_query_is_view_definition = false;
 
 /* Configurations */
 bool		pltsql_trace_tree = false;
@@ -1127,6 +1129,17 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 				if (!get_rel_name(tsql_identity_insert.rel_oid))
 					tsql_identity_insert.valid = false;
 			}
+		}
+	}
+	else if (query->commandType == CMD_SELECT)
+	{
+		if (pltsql_current_query_is_view_definition)
+		{
+			/* This is a SELECT query, which is part of a view definition.
+			 * Check if CREATE VIEW is allowed as per binding rules.
+			 * This check will happen when calling parse_analyze_fixed_params() present in DefineView()
+			 */
+			check_view_binding_dependencies(query);
 		}
 	}
 	else if (query->commandType == CMD_UTILITY)
@@ -2461,7 +2474,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					ViewStmt   *vstmt = (ViewStmt *) parsetree;
 					Oid			relid = RangeVarGetRelid(vstmt->view, NoLock, true);
 
-					if (vstmt->replace && check_is_tsql_view(relid))
+					if (vstmt->replace && check_is_tsql_view(relid, NULL))
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_INTERNAL_ERROR),
@@ -2477,7 +2490,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					{
 						Oid			relid = RangeVarGetRelid(atstmt->relation, NoLock, true);
 
-						if (check_is_tsql_view(relid))
+						if (check_is_tsql_view(relid, NULL))
 						{
 							ereport(ERROR,
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2496,7 +2509,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					{
 						Oid			relid = RangeVarGetRelid(rnstmt->relation, NoLock, true);
 
-						if (check_is_tsql_view(relid))
+						if (check_is_tsql_view(relid, NULL))
 						{
 							ereport(ERROR,
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2513,7 +2526,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					{
 						Oid			relid = RangeVarGetRelid(altschstmt->relation, NoLock, true);
 
-						if (check_is_tsql_view(relid))
+						if (check_is_tsql_view(relid, NULL))
 						{
 							ereport(ERROR,
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -2818,6 +2831,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					PG_TRY();
 					{
 						StartTransactionCommand();
+						pltsql_current_query_is_view_definition = true;
 						
 						/* Without this, DDL event triggers won't fire for ALTER VIEW operations
 						 * Currently T-SQL DDL triggers are not supported, but this code block is required for PostgreSQL DDL event triggers. 
@@ -2859,6 +2873,14 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							originalView.objectId = oldViewOid;
 							originalView.classId = RelationRelationId;
 							originalView.objectSubId = 0;
+
+							if (!(handle_bbf_view_binding_on_object_drop(&originalView, NULL, stmt)))
+							/* Strong view dependency found, abort the drop */
+								ereport(ERROR,
+										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+											errmsg("cannot alter view because other objects depend on it"),
+											errdetail("Object cannot be altered because it is referenced by a schema-bound view.")));
+
 							performDeletion(&originalView, DROP_RESTRICT, 0);
 							CommandCounterIncrement();
 			
@@ -2891,14 +2913,28 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					}
 					PG_FINALLY();
 					{
+						pltsql_current_query_is_view_definition = false;
 						if (needCleanup)
 							EventTriggerEndCompleteQuery();
 					}
 					PG_END_TRY();
 					return; 
 				}
-				/* check that no T-SQL ALTER VIEW operations reach this point because they should have been handled earlier in the code.*/
-				Assert(!(sql_dialect == SQL_DIALECT_TSQL && stmt->createOrAlter));
+				else if(sql_dialect == SQL_DIALECT_TSQL)
+				{
+					PG_TRY();
+					{
+						pltsql_current_query_is_view_definition = true;
+						call_prev_ProcessUtility(pstmt, queryString, readOnlyTree, 
+												context, params, queryEnv, dest, qc);
+					}
+					PG_FINALLY();
+					{
+						pltsql_current_query_is_view_definition = false;
+					}
+					PG_END_TRY();
+					return;
+				}
 				break;
 			}
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1178,6 +1178,7 @@ typedef struct PLtsql_stmt_execsql
 	bool		is_create_view; /* CREATE VIEW? */
 	bool		is_set_tran_isolation; /* SET TRANSACTION ISOLATION? */
 	char	   *original_query; /* Only for batch level statement. */
+	bool        is_schemabinding; /* Is schema binding? */
 } PLtsql_stmt_execsql;
 
 /*
@@ -2107,6 +2108,7 @@ extern void pltsql_exec_get_datum_type_info(PLtsql_execstate *estate,
 extern int	get_insert_bulk_rows_per_batch(void);
 extern int	get_insert_bulk_kilobytes_per_batch(void);
 extern char *get_original_query_string(void);
+extern bool get_is_schemabinding_view(void);
 extern AclMode string_to_privilege(const char *privname);
 extern const char *privilege_to_string(AclMode privilege);
 extern Oid get_owner_of_schema(const char *schema);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -4452,6 +4452,19 @@ handleBatchLevelStatement(TSqlParser::Batch_level_statementContext *ctx, tsqlSel
 	if (ctx->create_or_alter_view())
 	{
 		execsql->is_create_view = true;
+		// Check if the view has SCHEMABINDING
+		if (ctx->create_or_alter_view()->WITH().size() > 0)
+		{
+			auto options = ctx->create_or_alter_view()->view_attribute();
+			for (auto option : options)
+			{
+				if (option->SCHEMABINDING())
+				{
+					execsql->is_schemabinding = true;
+					break;
+				}
+			}
+		}
 		if (ctx->create_or_alter_view()->simple_name() && ctx->create_or_alter_view()->simple_name()->schema)
 		{
 			std::string schema_name = stripQuoteFromId(ctx->create_or_alter_view()->simple_name()->schema);

--- a/test/JDBC/expected/alter-view-vu-verify.out
+++ b/test/JDBC/expected/alter-view-vu-verify.out
@@ -399,7 +399,7 @@ ALTER VIEW alter_v24 AS SELECT a,b FROM alter_t;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: cannot drop view alter_v24 because other objects depend on it)~~
+~~ERROR (Message: cannot alter view because other objects depend on it)~~
 
 
 SELECT * FROM alter_v24;

--- a/test/JDBC/expected/weak-binding-vu-cleanup.out
+++ b/test/JDBC/expected/weak-binding-vu-cleanup.out
@@ -1,0 +1,240 @@
+USE master;
+GO
+
+-- Drop views in view_test schema
+DROP VIEW IF EXISTS view_test.strong_view2;
+GO
+
+DROP VIEW IF EXISTS view_test.strong_view1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view2;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view3;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_complex1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_complex2;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_function;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_function1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_type_view;
+GO
+
+DROP TRIGGER IF EXISTS view_test.trg_view_insert;
+GO
+
+DROP VIEW IF EXISTS view_test.trigger_view;
+GO
+
+DROP TABLE IF EXISTS view_test.trigger_base_table;
+GO
+
+DROP TABLE IF EXISTS view_test.trigger_audit_table;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_binary_view;
+GO
+
+DROP VIEW IF EXISTS view_test.computed_view;
+GO
+
+DROP TABLE IF EXISTS view_test.computed_table;
+GO
+
+DROP VIEW IF EXISTS view_test.datetime_view1;
+GO
+
+DROP VIEW IF EXISTS view_test.datetime_view;
+GO
+
+DROP VIEW IF EXISTS view_test.numeric_view;
+GO
+
+DROP VIEW IF EXISTS view_test.doc_view;
+GO
+
+DROP VIEW IF EXISTS view_test.string_view;
+GO
+
+DROP VIEW IF EXISTS view_test.complex_view;
+GO
+
+DROP VIEW IF EXISTS view_test.compute_view;
+GO
+
+DROP TABLE IF EXISTS view_test.datetime_test;
+GO
+
+DROP TABLE IF EXISTS view_test.numeric_test;
+GO
+
+DROP TABLE IF EXISTS view_test.doc_test;
+GO
+
+DROP TABLE IF EXISTS view_test.string_test;
+GO
+
+DROP TABLE IF EXISTS view_test.complex_test;
+GO
+
+DROP TABLE IF EXISTS view_test.compute_test;
+GO
+
+-- Drop views in master database
+DROP VIEW IF EXISTS test_view;
+GO
+
+DROP VIEW IF EXISTS test_view2;
+GO
+
+DROP VIEW IF EXISTS master_v1;
+GO
+
+DROP VIEW IF EXISTS master_v2;
+GO
+
+DROP VIEW IF EXISTS master_v3;
+GO
+
+DROP VIEW IF EXISTS master_v4;
+GO
+
+DROP VIEW IF EXISTS v2_strong;
+GO
+
+DROP VIEW IF EXISTS v1_strong;
+GO
+
+
+-- USE test_db;
+-- GO
+DROP VIEW IF EXISTS test_db_v3;
+GO
+
+DROP VIEW IF EXISTS test_db_v2;
+GO
+
+DROP VIEW IF EXISTS test_db_v1;
+GO
+
+DROP VIEW IF EXISTS test_db_v4;
+GO
+
+DROP VIEW IF EXISTS self_ref_v2;
+GO
+
+DROP VIEW IF EXISTS self_ref_v1;
+GO
+
+DROP VIEW IF EXISTS dependent_view;
+GO
+
+DROP VIEW IF EXISTS test_view;
+GO
+
+DROP VIEW IF EXISTS vw_fnc_check;
+GO
+
+DROP VIEW IF EXISTS dml_test_view;
+GO
+
+DROP VIEW IF EXISTS multi_table_complex_view;
+GO
+
+DROP VIEW IF EXISTS avg_d_per_c;
+GO
+
+DROP VIEW IF EXISTS above_avg_d;
+GO
+
+DROP VIEW IF EXISTS complex_nested_view;
+GO
+
+DROP VIEW IF EXISTS no_top_level;
+GO
+
+USE master;
+GO
+
+-- Drop tables in view_test schema
+DROP TABLE IF EXISTS view_test.base_table1;
+GO
+
+DROP TABLE IF EXISTS view_test.base_table2;
+GO
+
+DROP TABLE IF EXISTS view_test.base_table3;
+GO
+
+DROP TABLE IF EXISTS view_test.type_test_table;
+GO
+
+DROP TABLE IF EXISTS test_table_for_strong_view;
+GO
+
+DROP TABLE IF EXISTS view_test.binary_test_table
+GO
+
+DROP TABLE IF EXISTS self_ref_t1;
+GO
+
+DROP TABLE IF EXISTS test_ord;
+GO
+
+DROP TABLE IF EXISTS customer;
+GO
+
+DROP TABLE IF EXISTS test_table;
+GO
+
+DROP TABLE IF EXISTS t;
+GO
+
+DROP TABLE IF EXISTS dml_test_table;
+GO
+
+DROP TABLE IF EXISTS cmp_t;
+GO
+
+DROP TABLE IF EXISTS cmp_t2;
+GO
+
+DROP TABLE IF EXISTS cmp_t3;
+GO
+
+-- Drop functions
+DROP FUNCTION IF EXISTS view_test.sample_function;
+GO
+
+DROP FUNCTION IF EXISTS view_test.sample_function1;
+GO
+
+DROP FUNCTION IF EXISTS fnc_dependancy_check;
+GO
+
+DROP SCHEMA IF EXISTS view_test;
+GO
+
+DROP DATABASE IF EXISTS test_db;
+GO
+
+-- Reset the GUC setting to default
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'false', false);
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/expected/weak-binding-vu-prepare.out
+++ b/test/JDBC/expected/weak-binding-vu-prepare.out
@@ -1,0 +1,125 @@
+-- Create test schemas and tables
+CREATE SCHEMA view_test;
+GO
+
+CREATE TABLE view_test.base_table1 (
+    id INT,
+    name VARCHAR(50)
+);
+GO
+
+CREATE TABLE view_test.base_table2 (
+    id INT,
+    name VARCHAR(50)
+);
+GO
+
+CREATE TABLE view_test.base_table3 (
+    id INT PRIMARY KEY,
+    category VARCHAR(50)
+);
+GO
+
+INSERT INTO view_test.base_table1 VALUES 
+    (1, 'Test1'),
+    (2, 'Test2'),
+    (3, 'Test3');
+GO
+~~ROW COUNT: 3~~
+
+
+INSERT INTO view_test.base_table2 VALUES 
+    (1, 'Test1'),
+    (2, 'Test2'),
+    (3, 'Test3');
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE VIEW view_test.strong_view1 AS 
+    SELECT id, name FROM view_test.base_table1;
+GO
+
+CREATE VIEW view_test.strong_view2 AS 
+    SELECT id, name FROM view_test.strong_view1;
+GO
+
+CREATE VIEW view_test.weak_view1 AS 
+    SELECT * FROM view_test.base_table2;
+GO
+
+CREATE VIEW view_test.weak_view2 AS 
+    SELECT * FROM view_test.weak_view1;
+GO
+
+CREATE FUNCTION view_test.sample_function1()
+RETURNS TABLE AS
+RETURN (
+    SELECT id, name FROM view_test.base_table2
+);
+GO
+
+CREATE VIEW view_test.weak_view_function1 AS
+SELECT * FROM view_test.sample_function1();
+GO
+
+CREATE TABLE test_table_for_strong_view (
+    id INT,
+    name VARCHAR(50)
+);
+GO
+
+
+/* Script from customer */
+CREATE TABLE customer (
+    customer_id INT IDENTITY(1,1) PRIMARY KEY,
+    customer_name TEXT NOT NULL
+);
+GO
+
+CREATE FUNCTION fnc_dependancy_check (@param1 NVARCHAR(100),
+                                        @param2 NVARCHAR(100),
+                                        @param3 NVARCHAR(100))
+    RETURNS NVARCHAR(300)
+    AS
+        BEGIN
+            RETURN @param1 + ' - ' + @param2 + ' - ' + @param3;
+    END;
+GO
+
+CREATE VIEW vw_fnc_check AS
+SELECT customer_id,
+       fnc_dependancy_check(customer_name, 'Code', 'Desc') AS code_desc
+FROM customer;
+GO
+
+DROP FUNCTION fnc_dependancy_check;
+GO
+~~ERROR (Code: 3729)~~
+
+~~ERROR (Message: cannot drop function fnc_dependancy_check(nvarchar,nvarchar,nvarchar) because other objects depend on it)~~
+
+
+CREATE TABLE test_ord (
+    order_id INT PRIMARY KEY,
+    customer_id INT REFERENCES customer(customer_id),
+    order_date DATE NOT NULL
+);
+GO
+
+CREATE VIEW test_view AS
+SELECT c.customer_id, c.customer_name, o.order_id, o.order_date
+FROM customer c
+JOIN test_ord o ON c.customer_id = o.customer_id
+GO
+
+CREATE VIEW dependent_view AS
+SELECT customer_id, customer_name FROM test_view;
+GO
+
+DROP VIEW test_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot drop view test_view because other objects depend on it)~~
+

--- a/test/JDBC/expected/weak-binding-vu-verify.out
+++ b/test/JDBC/expected/weak-binding-vu-verify.out
@@ -1,0 +1,1917 @@
+------------------------------------------------------------
+-- Test to DROP the objects that has dependent views
+------------------------------------------------------------
+USE master
+GO
+
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+-- [view_test.strong_view1] has dependent view [view_test.strong_view2] [ERROR] 
+DROP VIEW view_test.strong_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot drop view master_view_test.strong_view1 because other objects depend on it)~~
+
+
+-- [view_test.base_table1] has dependent views [view_test.strong_view1] and [view_test.strong_view2] [ERROR]
+DROP TABLE view_test.base_table1;
+GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop table master_view_test.base_table1 because other objects depend on it)~~
+
+
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+ALTER VIEW view_test.strong_view1 AS 
+    SELECT * FROM view_test.base_table1;
+GO
+
+DROP TABLE view_test.base_table1;
+GO
+
+SELECT * FROM view_test.strong_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table1" does not exist)~~
+
+
+SELECT * FROM view_test.strong_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table1" does not exist)~~
+
+
+
+-- Recreate the base table
+CREATE TABLE view_test.base_table1 (
+    id INT,
+    name VARCHAR(50)
+);
+SELECT * FROM view_test.strong_view2;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+SELECT * FROM view_test.strong_view1;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+------------------------------------------------------------
+-- Dropping a view having dependent weak view
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+ALTER VIEW view_test.weak_view1 AS 
+    SELECT * FROM view_test.base_table2;
+GO
+
+-- [view_test.weak_view1] has dependent weak view [view_test.weak_view2]
+DROP VIEW view_test.weak_view1;
+GO
+
+-- Verify result for dependent view [Should give ERROR]
+SELECT * FROM view_test.weak_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.weak_view1" does not exist)~~
+
+
+-- Recreate the dropped view back
+-- Set the GUC to true to allow weak binding views
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW view_test.weak_view1 AS 
+    SELECT * FROM view_test.base_table2;
+GO
+
+SELECT * FROM view_test.weak_view1;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+3#!#Test3
+~~END~~
+
+
+SELECT * FROM view_test.weak_view2;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+3#!#Test3
+~~END~~
+
+
+------------------------------------------------------------
+-- Test to check the behavior of weak binding views 
+-- when the base table is dropped
+------------------------------------------------------------
+DROP TABLE view_test.base_table2;
+GO
+
+-- Verify result for dependent view [Should give ERROR]
+SELECT * FROM view_test.weak_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table2" does not exist)~~
+
+
+-- [Should give ERROR]
+SELECT * FROM view_test.weak_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table2" does not exist)~~
+
+
+-- Recreate the base table
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view2;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+SELECT * FROM view_test.weak_view1;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+
+------------------------------------------------------------
+-- SET GUC to false and test the drop behavior on objects
+-- with dependent weak views
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+DROP TABLE view_test.base_table2;
+GO
+
+-- Recreate the base table with different structure (more columns)
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    description VARCHAR(100)  -- New column added
+);
+GO
+
+-- Verify result for dependent view 
+SELECT * FROM view_test.weak_view2;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- Verify result for dependent view 
+SELECT * FROM view_test.weak_view1;
+GO
+~~START~~
+int#!#varchar#!#varchar
+~~END~~
+
+
+DROP TABLE view_test.base_table2;
+GO
+
+-- Recreate the base table with less columns
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot drop columns from view)~~
+
+
+SELECT * FROM view_test.weak_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot drop columns from view)~~
+
+
+
+------------------------------------------------------------
+-- Test with multiple base tables
+------------------------------------------------------------
+-- Create view with join
+CREATE VIEW view_test.weak_view3 AS
+SELECT a.id, a.name, b.category 
+FROM view_test.base_table2 a
+JOIN view_test.base_table3 b ON a.id = b.id;
+GO
+
+-- Drop one of the base tables [ERROR]
+DROP TABLE view_test.base_table3;
+GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop table master_view_test.base_table3 because other objects depend on it)~~
+
+
+-- Set GUC to true 
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+ALTER VIEW view_test.weak_view3 AS
+SELECT a.id, a.name, b.category 
+FROM view_test.base_table2 a
+JOIN view_test.base_table3 b ON a.id = b.id;
+GO
+
+DROP TABLE view_test.base_table3;
+GO
+
+-- Verify view behavior [ERROR]
+SELECT * FROM view_test.weak_view3;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table3" does not exist)~~
+
+
+-- Recreate the base table
+CREATE TABLE view_test.base_table3 (
+    id INT PRIMARY KEY,
+    category VARCHAR(50)
+);
+GO
+
+-- Verify view behavior
+SELECT * FROM view_test.weak_view3;
+GO
+~~START~~
+int#!#varchar#!#varchar
+~~END~~
+
+
+
+------------------------------------------------------------
+-- Test with creating strong view referencing weak view
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'false', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+-- [ERROR]
+CREATE VIEW view_test.strong_view3 AS
+SELECT * FROM view_test.weak_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot create schema-bound view that references a non-schema-bound view)~~
+
+
+------------------------------------------------------------
+-- Test with complex queries in views
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- Create view with aggregations
+CREATE VIEW view_test.weak_view_complex1 AS
+SELECT name, COUNT(*) as count, SUM(id) as sum_id
+FROM view_test.base_table2
+GROUP BY name;
+GO
+
+-- Create view with subquery
+CREATE VIEW view_test.weak_view_complex2 AS
+SELECT * FROM view_test.base_table2 a
+WHERE EXISTS (SELECT 1 FROM view_test.weak_view1 b WHERE a.id = b.id);
+GO
+
+-- Drop and recreate base table
+DROP TABLE view_test.base_table2;
+GO
+
+SELECT * FROM view_test.weak_view_complex1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table2" does not exist)~~
+
+
+SELECT * FROM view_test.weak_view_complex2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.base_table2" does not exist)~~
+
+
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+SELECT * FROM view_test.weak_view_complex1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change name of view column "name" to "est")~~
+
+
+SELECT * FROM view_test.weak_view_complex2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot drop columns from view)~~
+
+
+
+------------------------------------------------------------
+-- Test to drop functions that has dependent views
+------------------------------------------------------------
+-- Create a function that is used in a view
+CREATE FUNCTION view_test.sample_function()
+RETURNS TABLE AS
+RETURN (
+    SELECT id, name FROM view_test.base_table2
+);
+GO
+
+-- Create a view that uses the function
+CREATE VIEW view_test.weak_view_function AS
+SELECT * FROM view_test.sample_function();
+GO
+
+-- Drop the function
+DROP FUNCTION view_test.sample_function();
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view_function;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function view_test.sample_function() does not exist)~~
+
+
+-- Recreate the function
+CREATE FUNCTION view_test.sample_function()
+RETURNS TABLE AS
+RETURN (
+    SELECT id, name FROM view_test.base_table2
+);
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view_function;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- Drop the view
+DROP VIEW view_test.weak_view_function;
+GO
+
+DROP FUNCTION view_test.sample_function1();
+GO
+~~ERROR (Code: 3729)~~
+
+~~ERROR (Message: cannot drop function master_view_test.sample_function1() because other objects depend on it)~~
+
+
+-- Change view to weak binding
+ALTER VIEW view_test.weak_view_function1 AS
+SELECT * FROM view_test.sample_function1();
+GO
+
+DROP FUNCTION view_test.sample_function1();
+GO
+
+SELECT * FROM view_test.weak_view_function1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: function view_test.sample_function1() does not exist)~~
+
+
+
+----------------------------------------------------------------
+-- Test with metadata queries after dropping underlying objects
+----------------------------------------------------------------
+USE master;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY,b VARCHAR(50),c VARCHAR(50), d INT);
+GO
+
+CREATE VIEW master_v1 AS
+    SELECT a, b FROM t WHERE d = 1;
+GO
+
+DROP TABLE t;
+GO
+
+SELECT OBJECT_DEFINITION (OBJECT_ID(N'master_v1'))
+GO
+~~START~~
+nvarchar
+CREATE VIEW master_v1 AS<newline>    SELECT a, b FROM t WHERE d = 1;<newline>
+~~END~~
+
+
+------------------------------------------------------------
+-- Test with data type changes in base tables
+------------------------------------------------------------
+USE master;
+GO
+
+-- Create a new base table for testing
+CREATE TABLE view_test.type_test_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+-- Create a weak binding view
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW view_test.weak_type_view AS
+SELECT id, value FROM view_test.type_test_table;
+GO
+
+SELECT * FROM view_test.weak_type_view;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- Drop and recreate with different data type
+DROP TABLE view_test.type_test_table;
+GO
+
+CREATE TABLE view_test.type_test_table (
+    id INT PRIMARY KEY,
+    value INT  -- Changed from VARCHAR to INT
+);
+GO
+
+-- Verify view behavior with type mismatch
+SELECT * FROM view_test.weak_type_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "value" from "varchar"(50) to integer)~~
+
+
+-- Insert data and test again
+INSERT INTO view_test.type_test_table VALUES (1, 100), (2, 200);
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM view_test.weak_type_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "value" from "varchar"(50) to integer)~~
+
+
+USE master;
+GO
+
+-- Create a new base table for testing with binary data
+CREATE TABLE view_test.binary_test_table (
+    id INT PRIMARY KEY,
+    binary_data VARBINARY(50)
+);
+GO
+
+-- Create a weak binding view
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW view_test.weak_binary_view AS
+SELECT id, binary_data FROM view_test.binary_test_table;
+GO
+
+-- Insert some binary data
+INSERT INTO view_test.binary_test_table 
+VALUES (1, 0x48656C6C6F), (2, 0x576F726C64);
+GO
+~~ROW COUNT: 2~~
+
+
+-- View the initial data
+SELECT * FROM view_test.weak_binary_view;
+GO
+~~START~~
+int#!#varbinary
+1#!#48656C6C6F
+2#!#576F726C64
+~~END~~
+
+
+DROP TABLE view_test.binary_test_table;
+GO
+
+-- Recreate the table with a different data type
+CREATE TABLE view_test.binary_test_table (
+    id INT PRIMARY KEY,
+    binary_data VARCHAR(50)  -- Changed from VARBINARY to VARCHAR
+);
+GO
+
+-- Insert hexadecimal strings
+INSERT INTO view_test.binary_test_table 
+VALUES (1, '0x48656C6C6F'), (2, '0x576F726C64');
+GO
+~~ROW COUNT: 2~~
+
+
+-- View the data after type change
+SELECT * FROM view_test.weak_binary_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "binary_data" from varbinary(50) to "varchar"(50))~~
+
+
+-- Try to convert the hexadecimal strings back to binary
+SELECT id, CAST(binary_data AS VARBINARY(50)) AS converted_binary
+FROM view_test.weak_binary_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "binary_data" from varbinary(50) to "varchar"(50))~~
+
+
+USE master;
+GO
+
+-- 1. Test Case: Date/Time Conversions
+------------------------------------
+CREATE TABLE view_test.datetime_test (
+    id INT PRIMARY KEY,
+    date_col DATETIME
+);
+GO
+
+CREATE VIEW view_test.datetime_view AS
+SELECT id, date_col FROM view_test.datetime_test;
+GO
+
+CREATE VIEW view_test.datetime_view1 AS
+SELECT id, date_col FROM view_test.datetime_view;
+GO
+
+-- Insert valid datetime
+INSERT INTO view_test.datetime_test VALUES (1, '2024-01-01 12:00:00');
+GO
+~~ROW COUNT: 1~~
+
+
+-- View initial data
+SELECT * FROM view_test.datetime_view;
+GO
+~~START~~
+int#!#datetime
+1#!#2024-01-01 12:00:00.0
+~~END~~
+
+
+SELECT * FROM view_test.datetime_view1;
+GO
+~~START~~
+int#!#datetime
+1#!#2024-01-01 12:00:00.0
+~~END~~
+
+
+-- Change to VARCHAR
+DROP TABLE view_test.datetime_test;
+GO
+
+CREATE TABLE view_test.datetime_test (
+    id INT PRIMARY KEY,
+    date_col VARCHAR(50)
+);
+GO
+
+-- This should work (valid date string)
+INSERT INTO view_test.datetime_test VALUES (1, '2024-01-01 12:00:00');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO view_test.datetime_test VALUES (2, 'not a date');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * from view_test.datetime_view
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "date_col" from datetime to "varchar"(50))~~
+
+
+SELECT * FROM view_test.datetime_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "date_col" from datetime to "varchar"(50))~~
+
+
+-- 2. Test Case: Numeric Precision Changes
+----------------------------------------
+CREATE TABLE view_test.numeric_test (
+    id INT PRIMARY KEY,
+    num_col DECIMAL(10,2)
+);
+GO
+
+CREATE VIEW view_test.numeric_view AS
+SELECT id, num_col FROM view_test.numeric_test;
+GO
+
+INSERT INTO view_test.numeric_test VALUES (1, 123.45);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.numeric_view
+GO
+~~START~~
+int#!#numeric
+1#!#123.45
+~~END~~
+
+
+-- Change precision
+DROP TABLE view_test.numeric_test;
+GO
+
+CREATE TABLE view_test.numeric_test (
+    id INT PRIMARY KEY,
+    num_col DECIMAL(5,1)  -- Smaller precision
+);
+GO
+
+-- This should work
+INSERT INTO view_test.numeric_test VALUES (1, 123.4);
+GO
+~~ROW COUNT: 1~~
+
+
+-- This should fail (overflow)
+INSERT INTO view_test.numeric_test VALUES (2, 12345.67);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT * FROM view_test.numeric_view
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "num_col" from "decimal"(10,2) to "decimal"(5,1))~~
+
+
+-- 3. Test Case: XML/JSON Conversions
+-----------------------------------
+CREATE TABLE view_test.doc_test (
+    id INT PRIMARY KEY,
+    doc_col XML
+);
+GO
+
+CREATE VIEW view_test.doc_view AS
+SELECT id, doc_col FROM view_test.doc_test;
+GO
+
+-- Insert valid XML
+INSERT INTO view_test.doc_test VALUES (1, '<root><item>Test</item></root>');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.doc_view
+GO
+~~START~~
+int#!#xml
+1#!#<root><item>Test</item></root>
+~~END~~
+
+
+-- Change to VARCHAR
+DROP TABLE view_test.doc_test;
+GO
+
+CREATE TABLE view_test.doc_test (
+    id INT PRIMARY KEY,
+    doc_col VARCHAR(MAX)
+);
+GO
+
+-- Valid XML as string
+INSERT INTO view_test.doc_test VALUES (1, '<root><item>Test</item></root>');
+-- Invalid XML structure
+INSERT INTO view_test.doc_test VALUES (2, '<root><item>Test</root>');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.doc_view
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "doc_col" from xml to "varchar")~~
+
+
+-- 4. Test Case: Unicode to Non-Unicode
+-------------------------------------
+CREATE TABLE view_test.string_test (
+    id INT PRIMARY KEY,
+    str_col NVARCHAR(100)
+);
+GO
+
+CREATE VIEW view_test.string_view AS
+SELECT id, str_col FROM view_test.string_test;
+GO
+
+-- Insert Unicode data
+INSERT INTO view_test.string_test VALUES (1, N'Hello 世界');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.string_view
+GO
+~~START~~
+int#!#nvarchar
+1#!#Hello 世界
+~~END~~
+
+
+-- Change to non-Unicode
+DROP TABLE view_test.string_test;
+GO
+
+CREATE TABLE view_test.string_test (
+    id INT PRIMARY KEY,
+    str_col VARCHAR(100)
+);
+GO
+
+-- This might cause data loss for non-ASCII characters
+INSERT INTO view_test.string_test VALUES (1, 'Hello 世界');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.string_view
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "str_col" from nvarchar(100) to "varchar"(100))~~
+
+
+-- 5. Test Case: Multiple Column Type Changes
+------------------------------------------
+CREATE TABLE view_test.complex_test (
+    id INT PRIMARY KEY,
+    col1 INT,
+    col2 VARCHAR(50),
+    col3 DATETIME
+);
+GO
+
+CREATE VIEW view_test.complex_view AS
+SELECT id, col1, col2, col3 FROM view_test.complex_test;
+GO
+
+INSERT INTO view_test.complex_test VALUES (1, 100, 'Test', '2024-01-01');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.complex_view
+GO
+~~START~~
+int#!#int#!#varchar#!#datetime
+1#!#100#!#Test#!#2024-01-01 00:00:00.0
+~~END~~
+
+
+-- Change multiple column types
+DROP TABLE view_test.complex_test;
+GO
+
+CREATE TABLE view_test.complex_test (
+    id INT PRIMARY KEY,
+    col1 DECIMAL(10,2),  -- INT to DECIMAL
+    col2 NVARCHAR(50),   -- VARCHAR to NVARCHAR
+    col3 DATE           -- DATETIME to DATE
+);
+GO
+
+-- Test different scenarios
+INSERT INTO view_test.complex_test VALUES 
+    (1, 100.50, N'Test', '2024-01-01'),
+    (2, 999999.99, N'Test2', '2024-01-01');
+GO
+~~ROW COUNT: 2~~
+
+
+-- Should fail due to decimal overflow
+INSERT INTO view_test.complex_test VALUES 
+    (3, 99999999.99, N'Test3', '2024-01-01');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.complex_view
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot change data type of view column "col1" from integer to "decimal"(10,2))~~
+
+
+-- 6. Test Case: Computed Columns
+-------------------------------
+CREATE TABLE view_test.compute_test (
+    id INT PRIMARY KEY,
+    val1 INT,
+    val2 INT,
+    computed_col AS (val1 + val2)
+);
+GO
+
+CREATE VIEW view_test.compute_view AS
+SELECT id, val1, val2, computed_col FROM view_test.compute_test;
+GO
+
+INSERT INTO view_test.compute_test VALUES (1, 10, 20);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.compute_view
+GO
+~~START~~
+int#!#int#!#int#!#int
+1#!#10#!#20#!#30
+~~END~~
+
+
+-- Change computation logic
+DROP TABLE view_test.compute_test;
+GO
+
+CREATE TABLE view_test.compute_test (
+    id INT PRIMARY KEY,
+    val1 INT,
+    val2 INT,
+    computed_col AS (val1 * val2)  -- Changed from addition to multiplication
+);
+GO
+
+INSERT INTO view_test.compute_test VALUES (1, 10, 20);
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.compute_view
+GO
+~~START~~
+int#!#int#!#int#!#int
+1#!#10#!#20#!#200
+~~END~~
+
+
+------------------------------------------------------------
+-- Test with triggers on views
+------------------------------------------------------------
+USE master;
+GO
+
+CREATE TABLE view_test.trigger_base_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+CREATE TABLE view_test.trigger_audit_table (
+    id INT,
+    action VARCHAR(10)
+);
+GO
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW view_test.trigger_view AS
+SELECT * FROM view_test.trigger_base_table;
+GO
+
+CREATE TRIGGER trg_view_insert ON view_test.trigger_view
+INSTEAD OF INSERT
+AS
+BEGIN
+    INSERT INTO view_test.trigger_base_table
+    SELECT id, value FROM inserted;
+    
+    INSERT INTO view_test.trigger_audit_table
+    SELECT id, 'INSERT' FROM inserted;
+END;
+GO
+
+-- Test trigger
+INSERT INTO view_test.trigger_view VALUES (1, 'test');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM view_test.trigger_audit_table;
+GO
+~~START~~
+int#!#varchar
+1#!#INSERT
+~~END~~
+
+
+-- Drop base table and recreate [We can drop table even if it has child view that has dependent trigger Table1 --> View1 --> trigger]
+-- We can also drop view if it has dependent trigger (trigger will also get dropped along with view)
+DROP TABLE view_test.trigger_base_table;
+GO
+
+CREATE TABLE view_test.trigger_base_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+DROP VIEW view_test.trigger_view;
+GO
+
+-- Test trigger after table recreation
+INSERT INTO view_test.trigger_view VALUES (2, 'test2');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.trigger_view" does not exist)~~
+
+
+SELECT * FROM view_test.trigger_audit_table;
+GO
+~~START~~
+int#!#varchar
+1#!#INSERT
+~~END~~
+
+
+------------------------------------------------------------
+-- Test with temporary tables
+------------------------------------------------------------
+USE master;
+GO
+
+-- Create temporary table
+CREATE TABLE #temp_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+INSERT INTO #temp_table VALUES (1, 'temp1'), (2, 'temp2');
+GO
+~~ROW COUNT: 2~~
+
+
+-- Create weak binding view on temp table
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW view_test.temp_view AS
+SELECT * FROM #temp_table;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Views or functions are not allowed on temporary tables. Table names that begin with '#' denote temporary tables.)~~
+
+
+-- Test view
+SELECT * FROM view_test.temp_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "view_test.temp_view" does not exist)~~
+
+
+DROP TABLE #temp_table;
+GO
+
+------------------------------------------------------------
+-- Test with computed columns
+------------------------------------------------------------
+USE master;
+GO
+
+-- Create table with computed column
+CREATE TABLE view_test.computed_table (
+    id INT PRIMARY KEY,
+    value INT,
+    computed_value AS (value * 2)
+);
+GO
+
+INSERT INTO view_test.computed_table (id, value) VALUES (1, 10), (2, 20);
+GO
+~~ROW COUNT: 2~~
+
+
+-- Create weak binding view
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW view_test.computed_view AS
+SELECT id, value, computed_value FROM view_test.computed_table;
+GO
+
+-- Test view
+SELECT * FROM view_test.computed_view;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#20
+2#!#20#!#40
+~~END~~
+
+
+-- Drop and recreate with different computation
+DROP TABLE view_test.computed_table;
+GO
+
+CREATE TABLE view_test.computed_table (
+    id INT PRIMARY KEY,
+    value INT,
+    computed_value AS (value * 3)  -- Changed from *2 to *3
+);
+GO
+
+INSERT INTO view_test.computed_table (id, value) VALUES (1, 10), (2, 20);
+GO
+~~ROW COUNT: 2~~
+
+
+-- Test view after computation change
+SELECT * FROM view_test.computed_view;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#30
+2#!#20#!#60
+~~END~~
+
+
+
+------------------------------------------------------------
+-- Set of user operations performed to change strong view 
+-- to weak view
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW v1_strong WITH SCHEMABINDING AS SELECT * FROM test_table_for_strong_view;
+GO
+
+CREATE VIEW v2_strong WITH SCHEMABINDING AS SELECT * FROM v1_strong;
+GO
+
+DROP TABLE IF EXISTS test_table_for_strong_view;
+GO
+~~ERROR (Code: 3726)~~
+
+~~ERROR (Message: cannot drop table test_table_for_strong_view because other objects depend on it)~~
+
+
+DROP VIEW v1_strong;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: cannot drop view v1_strong because other objects depend on it)~~
+
+
+ALTER VIEW v1_strong AS SELECT * FROM test_table_for_strong_view;
+GO
+
+DROP TABLE test_table_for_strong_view;
+GO
+
+SELECT * FROM v1_strong;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "test_table_for_strong_view" does not exist)~~
+
+
+SELECT * FROM v2_strong;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "test_table_for_strong_view" does not exist)~~
+
+
+CREATE TABLE test_table_for_strong_view (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+SELECT * FROM v1_strong;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+SELECT * FROM v2_strong;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+
+
+---------------------------------------------------------------
+-- Test to check INSERT/UPDATE/DELETE operations on broken view
+-- during view repair
+---------------------------------------------------------------
+-- INSERT
+CREATE TABLE t (a INT PRIMARY KEY,b VARCHAR(50),c VARCHAR(50), d INT);
+GO
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW insert_v1 AS
+    SELECT a, b FROM t;
+GO
+
+CREATE VIEW insert_v2 AS
+    SELECT * FROM insert_v1;
+GO
+
+DROP TABLE t;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY,b VARCHAR(50),c VARCHAR(50));
+GO
+
+INSERT INTO insert_v1 VALUES (1,'b')
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM insert_v2;
+GO
+~~START~~
+int#!#varchar
+1#!#b
+~~END~~
+
+
+SELECT * FROM insert_v1;
+GO
+~~START~~
+int#!#varchar
+1#!#b
+~~END~~
+
+
+DROP VIEW insert_v2;
+GO
+
+DROP VIEW insert_v1;
+GO
+
+DROP TABLE t;
+GO
+
+
+-- UPDATE
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+CREATE VIEW update_v1 AS
+    SELECT a, b, d FROM t;
+GO
+
+CREATE VIEW update_v2 AS
+    SELECT * FROM update_v1;
+GO
+
+DROP TABLE t;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+UPDATE update_v1 SET b = 'updated_b';
+GO
+
+SELECT * FROM update_v2;
+GO
+~~START~~
+int#!#varchar#!#int
+~~END~~
+
+
+SELECT * FROM update_v1;
+GO
+~~START~~
+int#!#varchar#!#int
+~~END~~
+
+
+DROP VIEW update_v2;
+GO
+
+DROP VIEW update_v1;
+GO
+
+DROP TABLE t;
+GO
+
+
+
+---------------------------------------------------------------
+-- Test to check DELETE operations on broken view
+-- during view repair
+---------------------------------------------------------------
+-- DELETE
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+CREATE VIEW delete_v1 AS
+    SELECT a, b, d FROM t;
+GO
+
+CREATE VIEW delete_v2 AS
+    SELECT * FROM delete_v1;
+GO
+
+DROP TABLE t;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+DELETE FROM delete_v1 WHERE a = 2;
+GO
+
+SELECT * FROM delete_v2;
+GO
+~~START~~
+int#!#varchar#!#int
+~~END~~
+
+
+SELECT * FROM delete_v1;
+GO
+~~START~~
+int#!#varchar#!#int
+~~END~~
+
+
+DROP VIEW delete_v2;
+GO
+
+DROP VIEW delete_v1;
+GO
+
+---------------------------------------------------------------
+-- Test to check self referencing views during ALTER
+---------------------------------------------------------------
+CREATE TABLE self_ref_t1 (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE VIEW self_ref_v1 AS
+    SELECT a, b FROM self_ref_t1;
+GO
+
+CREATE VIEW self_ref_v2 AS
+    SELECT * FROM self_ref_v1;
+GO
+
+-- Create a self-referencing view [ERROR]
+ALTER VIEW self_ref_v1 AS
+    SELECT a FROM self_ref_v1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "self_ref_v1" does not exist)~~
+
+
+-- Attempt to alter view that creates circular reference [ERROR]
+ALTER VIEW self_ref_v1 AS
+    SELECT a FROM self_ref_v1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "self_ref_v1" does not exist)~~
+
+
+ALTER VIEW vw_fnc_check AS
+    SELECT customer_id,
+        fnc_dependancy_check(customer_name, 'Code', 'Desc') AS code_desc
+    FROM customer;
+GO
+
+DROP FUNCTION fnc_dependancy_check;
+GO
+
+ALTER VIEW test_view AS
+SELECT c.customer_id, c.customer_name, o.order_id, o.order_date
+FROM customer c
+JOIN test_ord o ON c.customer_id = o.customer_id;
+GO
+
+DROP VIEW test_view;
+GO
+
+SELECT * FROM dependent_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "test_view" does not exist)~~
+
+
+CREATE VIEW test_view AS
+SELECT c.customer_id, c.customer_name, o.order_id, o.order_date
+FROM customer c
+JOIN test_ord o ON c.customer_id = o.customer_id;
+GO
+
+SELECT * FROM dependent_view;
+GO
+~~START~~
+int#!#text
+~~END~~
+
+
+
+---------------------------------------------------------------
+-- DMLs on views with weak binding
+---------------------------------------------------------------
+CREATE TABLE dml_test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+CREATE VIEW dml_test_view AS
+    SELECT id, name FROM dml_test_table;
+GO
+
+INSERT INTO dml_test_view (id, name) VALUES (1, 'Test1'), (2, 'Test2');
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM dml_test_view;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+~~END~~
+
+
+UPDATE dml_test_view SET name = 'UpdatedTest1' WHERE id = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dml_test_view;
+GO
+~~START~~
+int#!#varchar
+2#!#Test2
+1#!#UpdatedTest1
+~~END~~
+
+
+DELETE FROM dml_test_view WHERE id = 2;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM dml_test_view;
+GO
+~~START~~
+int#!#varchar
+1#!#UpdatedTest1
+~~END~~
+
+
+-- View with top-level query having an empty rtable
+CREATE VIEW no_top_level AS
+    SELECT 
+        (SELECT MAX(id) FROM dml_test_view) AS max_id,
+        (SELECT MIN(id) FROM dml_test_view) AS min_id;
+GO
+
+
+---------------------------------------------------------------
+-- Broken Views referenced inside CTE statements
+---------------------------------------------------------------
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte;
+GO
+~~START~~
+int#!#varchar
+1#!#UpdatedTest1
+~~END~~
+
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte WHERE id = 1;
+GO
+~~START~~
+int#!#varchar
+1#!#UpdatedTest1
+~~END~~
+
+
+DROP TABLE dml_test_table;
+GO
+
+CREATE TABLE dml_test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    description VARCHAR(100)
+);
+GO
+
+INSERT INTO dml_test_view (id, name) VALUES (1, 'Test1'), (2, 'Test2');
+GO
+~~ROW COUNT: 2~~
+
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+~~END~~
+
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte WHERE id = 1;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+~~END~~
+
+
+-- View with top-level query having an empty rtable and broken view
+SELECT * FROM no_top_level;
+GO
+~~START~~
+int#!#int
+2#!#1
+~~END~~
+
+
+
+---------------------------------------------------------------
+-- Broken Views referenced inside subqueries
+---------------------------------------------------------------
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+~~END~~
+
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery WHERE id = 1;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+~~END~~
+
+
+DROP TABLE dml_test_table;
+GO
+
+CREATE TABLE dml_test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    description VARCHAR(100)
+);
+GO
+
+INSERT INTO dml_test_view (id, name) VALUES (1, 'Test1'), (2, 'Test2');
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+~~END~~
+
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery WHERE id = 1;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+~~END~~
+
+
+
+---------------------------------------------------------------
+-- Broken Views in subqueries inside where clause
+---------------------------------------------------------------
+SELECT * FROM dml_test_view
+WHERE id IN (
+    SELECT id FROM dml_test_view WHERE name LIKE 'Test%'
+);
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+~~END~~
+
+
+SELECT * FROM dml_test_view
+WHERE id IN (
+    SELECT id FROM dml_test_view WHERE id = 2
+);
+GO
+~~START~~
+int#!#varchar
+2#!#Test2
+~~END~~
+
+
+
+---------------------------------------------------------------
+-- Views as derived tables
+---------------------------------------------------------------
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+2#!#Test2
+~~END~~
+
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table WHERE id = 1;
+GO
+~~START~~
+int#!#varchar
+1#!#Test1
+~~END~~
+
+
+
+-- Multiple derived tables in a single query
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table1,
+(
+    SELECT * FROM dml_test_view
+) AS derived_table2
+WHERE derived_table1.id = derived_table2.id;
+GO
+~~START~~
+int#!#varchar#!#int#!#varchar
+1#!#Test1#!#1#!#Test1
+2#!#Test2#!#2#!#Test2
+~~END~~
+
+
+
+-- Combining multiple approaches
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table1
+JOIN (
+    SELECT * FROM dml_test_view
+) AS derived_table2 ON derived_table1.id = derived_table2.id
+WHERE derived_table1.name LIKE 'Test%';
+GO
+~~START~~
+int#!#varchar#!#int#!#varchar
+1#!#Test1#!#1#!#Test1
+2#!#Test2#!#2#!#Test2
+~~END~~
+
+
+------------------------------------------------------------
+-- Test with complex view definition
+------------------------------------------------------------
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE TABLE cmp_t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+CREATE TABLE cmp_t2 ( id INT PRIMARY KEY, a INT, e VARCHAR(50));
+GO
+
+CREATE TABLE cmp_t3 ( id INT PRIMARY KEY, a INT, f DATE );
+GO
+
+CREATE VIEW multi_table_complex_view AS
+SELECT 
+    cmp_t.a,
+    cmp_t.b,
+    cmp_t.c,
+    subq.e,
+    subq.f
+FROM cmp_t
+JOIN (
+    -- Subquery with multiple table references
+    SELECT 
+        cmp_t2.a,
+        cmp_t2.e,
+        cmp_t3.f
+    FROM cmp_t2
+    JOIN cmp_t3 ON cmp_t2.a = cmp_t3.a
+    WHERE cmp_t2.id IN (
+        SELECT a
+        FROM cmp_t 
+        WHERE d > (SELECT AVG(d) FROM cmp_t)
+    )
+) AS subq ON cmp_t.a = subq.a
+UNION ALL
+SELECT 
+    cmp_t.a,
+    cmp_t.b,
+    cmp_t.c,
+    subq2.e,
+    subq2.f
+FROM cmp_t
+LEFT JOIN (
+    -- Another subquery with multiple table references
+    SELECT 
+        cmp_t2.a,
+        cmp_t2.e,
+        cmp_t3.f
+    FROM cmp_t2
+    FULL OUTER JOIN cmp_t3 ON cmp_t2.a = cmp_t3.a
+    WHERE EXISTS (
+        SELECT 1 
+        FROM cmp_t 
+        WHERE cmp_t.a = cmp_t2.a OR cmp_t.a = cmp_t3.a
+    )
+) AS subq2 ON cmp_t.a = subq2.a
+WHERE cmp_t.d < (SELECT MAX(d) FROM cmp_t);
+GO
+
+DROP TABLE cmp_t;
+GO
+
+SELECT * FROM multi_table_complex_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "cmp_t" does not exist)~~
+
+
+-- Recreate the base table
+CREATE TABLE cmp_t (
+    a INT PRIMARY KEY,
+    b VARCHAR(50),
+    c VARCHAR(50),
+    d INT
+);
+GO
+
+SELECT * FROM multi_table_complex_view;
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar#!#date
+~~END~~
+
+
+CREATE VIEW avg_d_per_c AS
+SELECT c, AVG(d) AS avg_d
+FROM t
+GROUP BY c;
+GO
+
+CREATE VIEW above_avg_d AS
+SELECT t.a, t.b, t.c, t.d
+FROM t
+JOIN avg_d_per_c ON t.c = avg_d_per_c.c
+WHERE t.d > avg_d_per_c.avg_d;
+GO
+
+CREATE VIEW complex_nested_view AS
+SELECT 
+    t.a,
+    t.b,
+    t.c,
+    t.d,
+    (SELECT AVG(avg_d) FROM avg_d_per_c) AS overall_avg_d
+FROM t
+WHERE t.a IN (
+    SELECT a
+    FROM above_avg_d
+    WHERE above_avg_d.d > (
+        SELECT AVG(d)
+        FROM t AS t2
+        WHERE t2.c IN (
+            SELECT c
+            FROM avg_d_per_c
+            WHERE avg_d > (SELECT AVG(avg_d) FROM avg_d_per_c)
+        )
+    )
+);
+GO
+
+DROP VIEW avg_d_per_c;
+GO
+
+SELECT * FROM complex_nested_view;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "avg_d_per_c" does not exist)~~
+
+
+-- Recreate the base table
+CREATE VIEW avg_d_per_c AS
+SELECT c, AVG(d) AS avg_d
+FROM t
+GROUP BY c;
+GO
+
+SELECT * FROM complex_nested_view;
+GO
+~~START~~
+int#!#varchar#!#varchar#!#int#!#int
+~~END~~
+

--- a/test/JDBC/input/views/weak-binding-vu-cleanup.sql
+++ b/test/JDBC/input/views/weak-binding-vu-cleanup.sql
@@ -1,0 +1,235 @@
+USE master;
+GO
+
+-- Drop views in view_test schema
+DROP VIEW IF EXISTS view_test.strong_view2;
+GO
+
+DROP VIEW IF EXISTS view_test.strong_view1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view2;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view3;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_complex1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_complex2;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_function;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_view_function1;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_type_view;
+GO
+
+DROP TRIGGER IF EXISTS view_test.trg_view_insert;
+GO
+
+DROP VIEW IF EXISTS view_test.trigger_view;
+GO
+
+DROP TABLE IF EXISTS view_test.trigger_base_table;
+GO
+
+DROP TABLE IF EXISTS view_test.trigger_audit_table;
+GO
+
+DROP VIEW IF EXISTS view_test.weak_binary_view;
+GO
+
+DROP VIEW IF EXISTS view_test.computed_view;
+GO
+
+DROP TABLE IF EXISTS view_test.computed_table;
+GO
+
+DROP VIEW IF EXISTS view_test.datetime_view1;
+GO
+
+DROP VIEW IF EXISTS view_test.datetime_view;
+GO
+
+DROP VIEW IF EXISTS view_test.numeric_view;
+GO
+
+DROP VIEW IF EXISTS view_test.doc_view;
+GO
+
+DROP VIEW IF EXISTS view_test.string_view;
+GO
+
+DROP VIEW IF EXISTS view_test.complex_view;
+GO
+
+DROP VIEW IF EXISTS view_test.compute_view;
+GO
+
+DROP TABLE IF EXISTS view_test.datetime_test;
+GO
+
+DROP TABLE IF EXISTS view_test.numeric_test;
+GO
+
+DROP TABLE IF EXISTS view_test.doc_test;
+GO
+
+DROP TABLE IF EXISTS view_test.string_test;
+GO
+
+DROP TABLE IF EXISTS view_test.complex_test;
+GO
+
+DROP TABLE IF EXISTS view_test.compute_test;
+GO
+
+-- Drop views in master database
+DROP VIEW IF EXISTS test_view;
+GO
+
+DROP VIEW IF EXISTS test_view2;
+GO
+
+DROP VIEW IF EXISTS master_v1;
+GO
+
+DROP VIEW IF EXISTS master_v2;
+GO
+
+DROP VIEW IF EXISTS master_v3;
+GO
+
+DROP VIEW IF EXISTS master_v4;
+GO
+
+DROP VIEW IF EXISTS v2_strong;
+GO
+
+DROP VIEW IF EXISTS v1_strong;
+GO
+
+-- USE test_db;
+-- GO
+
+DROP VIEW IF EXISTS test_db_v3;
+GO
+
+DROP VIEW IF EXISTS test_db_v2;
+GO
+
+DROP VIEW IF EXISTS test_db_v1;
+GO
+
+DROP VIEW IF EXISTS test_db_v4;
+GO
+
+DROP VIEW IF EXISTS self_ref_v2;
+GO
+
+DROP VIEW IF EXISTS self_ref_v1;
+GO
+
+DROP VIEW IF EXISTS dependent_view;
+GO
+
+DROP VIEW IF EXISTS test_view;
+GO
+
+DROP VIEW IF EXISTS vw_fnc_check;
+GO
+
+DROP VIEW IF EXISTS dml_test_view;
+GO
+
+DROP VIEW IF EXISTS multi_table_complex_view;
+GO
+
+DROP VIEW IF EXISTS avg_d_per_c;
+GO
+
+DROP VIEW IF EXISTS above_avg_d;
+GO
+
+DROP VIEW IF EXISTS complex_nested_view;
+GO
+
+DROP VIEW IF EXISTS no_top_level;
+GO
+
+USE master;
+GO
+
+-- Drop tables in view_test schema
+DROP TABLE IF EXISTS view_test.base_table1;
+GO
+
+DROP TABLE IF EXISTS view_test.base_table2;
+GO
+
+DROP TABLE IF EXISTS view_test.base_table3;
+GO
+
+DROP TABLE IF EXISTS view_test.type_test_table;
+GO
+
+DROP TABLE IF EXISTS test_table_for_strong_view;
+GO
+
+DROP TABLE IF EXISTS view_test.binary_test_table
+GO
+
+DROP TABLE IF EXISTS self_ref_t1;
+GO
+
+DROP TABLE IF EXISTS test_ord;
+GO
+
+DROP TABLE IF EXISTS customer;
+GO
+
+DROP TABLE IF EXISTS test_table;
+GO
+
+DROP TABLE IF EXISTS t;
+GO
+
+DROP TABLE IF EXISTS dml_test_table;
+GO
+
+DROP TABLE IF EXISTS cmp_t;
+GO
+
+DROP TABLE IF EXISTS cmp_t2;
+GO
+
+DROP TABLE IF EXISTS cmp_t3;
+GO
+
+-- Drop functions
+DROP FUNCTION IF EXISTS view_test.sample_function;
+GO
+
+DROP FUNCTION IF EXISTS view_test.sample_function1;
+GO
+
+DROP FUNCTION IF EXISTS fnc_dependancy_check;
+GO
+
+DROP SCHEMA IF EXISTS view_test;
+GO
+
+DROP DATABASE IF EXISTS test_db;
+GO
+
+-- Reset the GUC setting to default
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'false', false);
+GO

--- a/test/JDBC/input/views/weak-binding-vu-prepare.sql
+++ b/test/JDBC/input/views/weak-binding-vu-prepare.sql
@@ -1,0 +1,113 @@
+-- Create test schemas and tables
+CREATE SCHEMA view_test;
+GO
+
+CREATE TABLE view_test.base_table1 (
+    id INT,
+    name VARCHAR(50)
+);
+GO
+
+CREATE TABLE view_test.base_table2 (
+    id INT,
+    name VARCHAR(50)
+);
+GO
+
+CREATE TABLE view_test.base_table3 (
+    id INT PRIMARY KEY,
+    category VARCHAR(50)
+);
+GO
+
+INSERT INTO view_test.base_table1 VALUES 
+    (1, 'Test1'),
+    (2, 'Test2'),
+    (3, 'Test3');
+GO
+
+INSERT INTO view_test.base_table2 VALUES 
+    (1, 'Test1'),
+    (2, 'Test2'),
+    (3, 'Test3');
+GO
+
+CREATE VIEW view_test.strong_view1 AS 
+    SELECT id, name FROM view_test.base_table1;
+GO
+
+CREATE VIEW view_test.strong_view2 AS 
+    SELECT id, name FROM view_test.strong_view1;
+GO
+
+CREATE VIEW view_test.weak_view1 AS 
+    SELECT * FROM view_test.base_table2;
+GO
+
+CREATE VIEW view_test.weak_view2 AS 
+    SELECT * FROM view_test.weak_view1;
+GO
+
+CREATE FUNCTION view_test.sample_function1()
+RETURNS TABLE AS
+RETURN (
+    SELECT id, name FROM view_test.base_table2
+);
+GO
+
+CREATE VIEW view_test.weak_view_function1 AS
+SELECT * FROM view_test.sample_function1();
+GO
+
+CREATE TABLE test_table_for_strong_view (
+    id INT,
+    name VARCHAR(50)
+);
+GO
+
+/* Script from customer */
+
+CREATE TABLE customer (
+    customer_id INT IDENTITY(1,1) PRIMARY KEY,
+    customer_name TEXT NOT NULL
+);
+GO
+
+CREATE FUNCTION fnc_dependancy_check (@param1 NVARCHAR(100),
+                                        @param2 NVARCHAR(100),
+                                        @param3 NVARCHAR(100))
+    RETURNS NVARCHAR(300)
+    AS
+        BEGIN
+            RETURN @param1 + ' - ' + @param2 + ' - ' + @param3;
+    END;
+GO
+
+CREATE VIEW vw_fnc_check AS
+SELECT customer_id,
+       fnc_dependancy_check(customer_name, 'Code', 'Desc') AS code_desc
+FROM customer;
+GO
+
+DROP FUNCTION fnc_dependancy_check;
+GO
+
+CREATE TABLE test_ord (
+    order_id INT PRIMARY KEY,
+    customer_id INT REFERENCES customer(customer_id),
+    order_date DATE NOT NULL
+);
+GO
+
+CREATE VIEW test_view AS
+SELECT c.customer_id, c.customer_name, o.order_id, o.order_date
+FROM customer c
+JOIN test_ord o ON c.customer_id = o.customer_id
+GO
+
+CREATE VIEW dependent_view AS
+SELECT customer_id, customer_name FROM test_view;
+GO
+
+DROP VIEW test_view;
+GO

--- a/test/JDBC/input/views/weak-binding-vu-verify.sql
+++ b/test/JDBC/input/views/weak-binding-vu-verify.sql
@@ -1,0 +1,1336 @@
+------------------------------------------------------------
+-- Test to DROP the objects that has dependent views
+------------------------------------------------------------
+USE master
+GO
+
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'false', false)
+GO
+-- [view_test.strong_view1] has dependent view [view_test.strong_view2] [ERROR] 
+DROP VIEW view_test.strong_view1;
+GO
+
+-- [view_test.base_table1] has dependent views [view_test.strong_view1] and [view_test.strong_view2] [ERROR]
+DROP TABLE view_test.base_table1;
+GO
+
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+ALTER VIEW view_test.strong_view1 AS 
+    SELECT * FROM view_test.base_table1;
+GO
+
+DROP TABLE view_test.base_table1;
+GO
+
+SELECT * FROM view_test.strong_view1;
+GO
+
+SELECT * FROM view_test.strong_view2;
+GO
+
+-- Recreate the base table
+CREATE TABLE view_test.base_table1 (
+    id INT,
+    name VARCHAR(50)
+);
+
+SELECT * FROM view_test.strong_view2;
+GO
+
+SELECT * FROM view_test.strong_view1;
+GO
+
+------------------------------------------------------------
+-- Dropping a view having dependent weak view
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+ALTER VIEW view_test.weak_view1 AS 
+    SELECT * FROM view_test.base_table2;
+GO
+
+-- [view_test.weak_view1] has dependent weak view [view_test.weak_view2]
+DROP VIEW view_test.weak_view1;
+GO
+
+-- Verify result for dependent view [Should give ERROR]
+SELECT * FROM view_test.weak_view2;
+GO
+
+-- Recreate the dropped view back
+-- Set the GUC to true to allow weak binding views
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW view_test.weak_view1 AS 
+    SELECT * FROM view_test.base_table2;
+GO
+
+SELECT * FROM view_test.weak_view1;
+GO
+
+SELECT * FROM view_test.weak_view2;
+GO
+
+------------------------------------------------------------
+-- Test to check the behavior of weak binding views 
+-- when the base table is dropped
+------------------------------------------------------------
+DROP TABLE view_test.base_table2;
+GO
+
+-- Verify result for dependent view [Should give ERROR]
+SELECT * FROM view_test.weak_view2;
+GO
+
+-- [Should give ERROR]
+SELECT * FROM view_test.weak_view1;
+GO
+
+-- Recreate the base table
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view2;
+GO
+
+SELECT * FROM view_test.weak_view1;
+GO
+
+------------------------------------------------------------
+-- SET GUC to false and test the drop behavior on objects
+-- with dependent weak views
+------------------------------------------------------------
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'false', false)
+GO
+
+DROP TABLE view_test.base_table2;
+GO
+
+-- Recreate the base table with different structure (more columns)
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    description VARCHAR(100)  -- New column added
+);
+GO
+
+-- Verify result for dependent view 
+SELECT * FROM view_test.weak_view2;
+GO
+
+-- Verify result for dependent view 
+SELECT * FROM view_test.weak_view1;
+GO
+
+DROP TABLE view_test.base_table2;
+GO
+
+-- Recreate the base table with less columns
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view2;
+GO
+
+SELECT * FROM view_test.weak_view1;
+GO
+
+------------------------------------------------------------
+-- Test with multiple base tables
+------------------------------------------------------------
+
+-- Create view with join
+CREATE VIEW view_test.weak_view3 AS
+SELECT a.id, a.name, b.category 
+FROM view_test.base_table2 a
+JOIN view_test.base_table3 b ON a.id = b.id;
+GO
+
+-- Drop one of the base tables [ERROR]
+DROP TABLE view_test.base_table3;
+GO
+
+-- Set GUC to true 
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+ALTER VIEW view_test.weak_view3 AS
+SELECT a.id, a.name, b.category 
+FROM view_test.base_table2 a
+JOIN view_test.base_table3 b ON a.id = b.id;
+GO
+
+DROP TABLE view_test.base_table3;
+GO
+
+-- Verify view behavior [ERROR]
+SELECT * FROM view_test.weak_view3;
+GO
+
+-- Recreate the base table
+CREATE TABLE view_test.base_table3 (
+    id INT PRIMARY KEY,
+    category VARCHAR(50)
+);
+GO
+
+-- Verify view behavior
+SELECT * FROM view_test.weak_view3;
+GO
+
+------------------------------------------------------------
+-- Test with creating strong view referencing weak view
+------------------------------------------------------------
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'false', false)
+GO
+
+-- [ERROR]
+CREATE VIEW view_test.strong_view3 AS
+SELECT * FROM view_test.weak_view1;
+GO
+
+------------------------------------------------------------
+-- Test with complex queries in views
+------------------------------------------------------------
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+-- Create view with aggregations
+CREATE VIEW view_test.weak_view_complex1 AS
+SELECT name, COUNT(*) as count, SUM(id) as sum_id
+FROM view_test.base_table2
+GROUP BY name;
+GO
+
+-- Create view with subquery
+CREATE VIEW view_test.weak_view_complex2 AS
+SELECT * FROM view_test.base_table2 a
+WHERE EXISTS (SELECT 1 FROM view_test.weak_view1 b WHERE a.id = b.id);
+GO
+
+-- Drop and recreate base table
+DROP TABLE view_test.base_table2;
+GO
+
+SELECT * FROM view_test.weak_view_complex1;
+GO
+
+SELECT * FROM view_test.weak_view_complex2;
+GO
+
+CREATE TABLE view_test.base_table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+SELECT * FROM view_test.weak_view_complex1;
+GO
+
+SELECT * FROM view_test.weak_view_complex2;
+GO
+
+------------------------------------------------------------
+-- Test to drop functions that has dependent views
+------------------------------------------------------------
+
+-- Create a function that is used in a view
+CREATE FUNCTION view_test.sample_function()
+RETURNS TABLE AS
+RETURN (
+    SELECT id, name FROM view_test.base_table2
+);
+GO
+
+-- Create a view that uses the function
+CREATE VIEW view_test.weak_view_function AS
+SELECT * FROM view_test.sample_function();
+GO
+
+-- Drop the function
+DROP FUNCTION view_test.sample_function();
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view_function;
+GO
+
+-- Recreate the function
+CREATE FUNCTION view_test.sample_function()
+RETURNS TABLE AS
+RETURN (
+    SELECT id, name FROM view_test.base_table2
+);
+GO
+
+-- Verify result for dependent view
+SELECT * FROM view_test.weak_view_function;
+GO
+
+-- Drop the view
+DROP VIEW view_test.weak_view_function;
+GO
+
+DROP FUNCTION view_test.sample_function1();
+GO
+
+-- Change view to weak binding
+ALTER VIEW view_test.weak_view_function1 AS
+SELECT * FROM view_test.sample_function1();
+GO
+
+DROP FUNCTION view_test.sample_function1();
+GO
+
+SELECT * FROM view_test.weak_view_function1;
+GO
+
+----------------------------------------------------------------
+-- Test with metadata queries after dropping underlying objects
+----------------------------------------------------------------
+
+USE master;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY,b VARCHAR(50),c VARCHAR(50), d INT);
+GO
+
+CREATE VIEW master_v1 AS
+    SELECT a, b FROM t WHERE d = 1;
+GO
+
+DROP TABLE t;
+GO
+
+SELECT OBJECT_DEFINITION (OBJECT_ID(N'master_v1'))
+GO
+
+------------------------------------------------------------
+-- Test with data type changes in base tables
+------------------------------------------------------------
+USE master;
+GO
+
+-- Create a new base table for testing
+CREATE TABLE view_test.type_test_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+-- Create a weak binding view
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW view_test.weak_type_view AS
+SELECT id, value FROM view_test.type_test_table;
+GO
+
+SELECT * FROM view_test.weak_type_view;
+GO
+
+-- Drop and recreate with different data type
+DROP TABLE view_test.type_test_table;
+GO
+
+CREATE TABLE view_test.type_test_table (
+    id INT PRIMARY KEY,
+    value INT  -- Changed from VARCHAR to INT
+);
+GO
+
+-- Verify view behavior with type mismatch
+SELECT * FROM view_test.weak_type_view;
+GO
+
+-- Insert data and test again
+INSERT INTO view_test.type_test_table VALUES (1, 100), (2, 200);
+GO
+
+SELECT * FROM view_test.weak_type_view;
+GO
+
+USE master;
+GO
+
+-- Create a new base table for testing with binary data
+CREATE TABLE view_test.binary_test_table (
+    id INT PRIMARY KEY,
+    binary_data VARBINARY(50)
+);
+GO
+
+-- Create a weak binding view
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false);
+GO
+
+CREATE VIEW view_test.weak_binary_view AS
+SELECT id, binary_data FROM view_test.binary_test_table;
+GO
+
+-- Insert some binary data
+INSERT INTO view_test.binary_test_table 
+VALUES (1, 0x48656C6C6F), (2, 0x576F726C64);
+GO
+
+-- View the initial data
+SELECT * FROM view_test.weak_binary_view;
+GO
+
+DROP TABLE view_test.binary_test_table;
+GO
+
+-- Recreate the table with a different data type
+CREATE TABLE view_test.binary_test_table (
+    id INT PRIMARY KEY,
+    binary_data VARCHAR(50)  -- Changed from VARBINARY to VARCHAR
+);
+GO
+
+-- Insert hexadecimal strings
+INSERT INTO view_test.binary_test_table 
+VALUES (1, '0x48656C6C6F'), (2, '0x576F726C64');
+GO
+
+-- View the data after type change
+SELECT * FROM view_test.weak_binary_view;
+GO
+
+-- Try to convert the hexadecimal strings back to binary
+SELECT id, CAST(binary_data AS VARBINARY(50)) AS converted_binary
+FROM view_test.weak_binary_view;
+GO
+
+USE master;
+GO
+
+-- 1. Test Case: Date/Time Conversions
+------------------------------------
+CREATE TABLE view_test.datetime_test (
+    id INT PRIMARY KEY,
+    date_col DATETIME
+);
+GO
+
+CREATE VIEW view_test.datetime_view AS
+SELECT id, date_col FROM view_test.datetime_test;
+GO
+
+CREATE VIEW view_test.datetime_view1 AS
+SELECT id, date_col FROM view_test.datetime_view;
+GO
+
+-- Insert valid datetime
+INSERT INTO view_test.datetime_test VALUES (1, '2024-01-01 12:00:00');
+GO
+
+-- View initial data
+SELECT * FROM view_test.datetime_view;
+GO
+
+SELECT * FROM view_test.datetime_view1;
+GO
+
+-- Change to VARCHAR
+DROP TABLE view_test.datetime_test;
+GO
+
+CREATE TABLE view_test.datetime_test (
+    id INT PRIMARY KEY,
+    date_col VARCHAR(50)
+);
+GO
+
+-- This should work (valid date string)
+INSERT INTO view_test.datetime_test VALUES (1, '2024-01-01 12:00:00');
+GO
+
+INSERT INTO view_test.datetime_test VALUES (2, 'not a date');
+GO
+
+SELECT * from view_test.datetime_view
+GO
+
+SELECT * FROM view_test.datetime_view1;
+GO
+
+-- 2. Test Case: Numeric Precision Changes
+----------------------------------------
+CREATE TABLE view_test.numeric_test (
+    id INT PRIMARY KEY,
+    num_col DECIMAL(10,2)
+);
+GO
+
+CREATE VIEW view_test.numeric_view AS
+SELECT id, num_col FROM view_test.numeric_test;
+GO
+
+INSERT INTO view_test.numeric_test VALUES (1, 123.45);
+GO
+
+SELECT * FROM view_test.numeric_view
+GO
+
+-- Change precision
+DROP TABLE view_test.numeric_test;
+GO
+
+CREATE TABLE view_test.numeric_test (
+    id INT PRIMARY KEY,
+    num_col DECIMAL(5,1)  -- Smaller precision
+);
+GO
+
+-- This should work
+INSERT INTO view_test.numeric_test VALUES (1, 123.4);
+GO
+
+-- This should fail (overflow)
+INSERT INTO view_test.numeric_test VALUES (2, 12345.67);
+GO
+
+SELECT * FROM view_test.numeric_view
+GO
+
+-- 3. Test Case: XML/JSON Conversions
+-----------------------------------
+CREATE TABLE view_test.doc_test (
+    id INT PRIMARY KEY,
+    doc_col XML
+);
+GO
+
+CREATE VIEW view_test.doc_view AS
+SELECT id, doc_col FROM view_test.doc_test;
+GO
+
+-- Insert valid XML
+INSERT INTO view_test.doc_test VALUES (1, '<root><item>Test</item></root>');
+GO
+
+SELECT * FROM view_test.doc_view
+GO
+
+-- Change to VARCHAR
+DROP TABLE view_test.doc_test;
+GO
+
+CREATE TABLE view_test.doc_test (
+    id INT PRIMARY KEY,
+    doc_col VARCHAR(MAX)
+);
+GO
+
+-- Valid XML as string
+INSERT INTO view_test.doc_test VALUES (1, '<root><item>Test</item></root>');
+-- Invalid XML structure
+INSERT INTO view_test.doc_test VALUES (2, '<root><item>Test</root>');
+GO
+
+SELECT * FROM view_test.doc_view
+GO
+
+-- 4. Test Case: Unicode to Non-Unicode
+-------------------------------------
+CREATE TABLE view_test.string_test (
+    id INT PRIMARY KEY,
+    str_col NVARCHAR(100)
+);
+GO
+
+CREATE VIEW view_test.string_view AS
+SELECT id, str_col FROM view_test.string_test;
+GO
+
+-- Insert Unicode data
+INSERT INTO view_test.string_test VALUES (1, N'Hello 世界');
+GO
+
+SELECT * FROM view_test.string_view
+GO
+
+-- Change to non-Unicode
+DROP TABLE view_test.string_test;
+GO
+
+CREATE TABLE view_test.string_test (
+    id INT PRIMARY KEY,
+    str_col VARCHAR(100)
+);
+GO
+
+-- This might cause data loss for non-ASCII characters
+INSERT INTO view_test.string_test VALUES (1, 'Hello 世界');
+GO
+
+SELECT * FROM view_test.string_view
+GO
+
+-- 5. Test Case: Multiple Column Type Changes
+------------------------------------------
+CREATE TABLE view_test.complex_test (
+    id INT PRIMARY KEY,
+    col1 INT,
+    col2 VARCHAR(50),
+    col3 DATETIME
+);
+GO
+
+CREATE VIEW view_test.complex_view AS
+SELECT id, col1, col2, col3 FROM view_test.complex_test;
+GO
+
+INSERT INTO view_test.complex_test VALUES (1, 100, 'Test', '2024-01-01');
+GO
+
+SELECT * FROM view_test.complex_view
+GO
+
+-- Change multiple column types
+DROP TABLE view_test.complex_test;
+GO
+
+CREATE TABLE view_test.complex_test (
+    id INT PRIMARY KEY,
+    col1 DECIMAL(10,2),  -- INT to DECIMAL
+    col2 NVARCHAR(50),   -- VARCHAR to NVARCHAR
+    col3 DATE           -- DATETIME to DATE
+);
+GO
+
+-- Test different scenarios
+INSERT INTO view_test.complex_test VALUES 
+    (1, 100.50, N'Test', '2024-01-01'),
+    (2, 999999.99, N'Test2', '2024-01-01');
+GO
+
+-- Should fail due to decimal overflow
+INSERT INTO view_test.complex_test VALUES 
+    (3, 99999999.99, N'Test3', '2024-01-01');
+GO
+
+SELECT * FROM view_test.complex_view
+GO
+
+-- 6. Test Case: Computed Columns
+-------------------------------
+CREATE TABLE view_test.compute_test (
+    id INT PRIMARY KEY,
+    val1 INT,
+    val2 INT,
+    computed_col AS (val1 + val2)
+);
+GO
+
+CREATE VIEW view_test.compute_view AS
+SELECT id, val1, val2, computed_col FROM view_test.compute_test;
+GO
+
+INSERT INTO view_test.compute_test VALUES (1, 10, 20);
+GO
+
+SELECT * FROM view_test.compute_view
+GO
+
+-- Change computation logic
+DROP TABLE view_test.compute_test;
+GO
+
+CREATE TABLE view_test.compute_test (
+    id INT PRIMARY KEY,
+    val1 INT,
+    val2 INT,
+    computed_col AS (val1 * val2)  -- Changed from addition to multiplication
+);
+GO
+
+INSERT INTO view_test.compute_test VALUES (1, 10, 20);
+GO
+
+SELECT * FROM view_test.compute_view
+GO
+
+------------------------------------------------------------
+-- Test with triggers on views
+------------------------------------------------------------
+USE master;
+GO
+
+CREATE TABLE view_test.trigger_base_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+CREATE TABLE view_test.trigger_audit_table (
+    id INT,
+    action VARCHAR(10)
+);
+GO
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW view_test.trigger_view AS
+SELECT * FROM view_test.trigger_base_table;
+GO
+
+CREATE TRIGGER trg_view_insert ON view_test.trigger_view
+INSTEAD OF INSERT
+AS
+BEGIN
+    INSERT INTO view_test.trigger_base_table
+    SELECT id, value FROM inserted;
+    
+    INSERT INTO view_test.trigger_audit_table
+    SELECT id, 'INSERT' FROM inserted;
+END;
+GO
+
+-- Test trigger
+INSERT INTO view_test.trigger_view VALUES (1, 'test');
+GO
+
+SELECT * FROM view_test.trigger_audit_table;
+GO
+
+-- Drop base table and recreate [We can drop table even if it has child view that has dependent trigger Table1 --> View1 --> trigger]
+-- We can also drop view if it has dependent trigger (trigger will also get dropped along with view)
+DROP TABLE view_test.trigger_base_table;
+GO
+
+CREATE TABLE view_test.trigger_base_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+DROP VIEW view_test.trigger_view;
+GO
+
+-- Test trigger after table recreation
+INSERT INTO view_test.trigger_view VALUES (2, 'test2');
+GO
+
+SELECT * FROM view_test.trigger_audit_table;
+GO
+
+------------------------------------------------------------
+-- Test with temporary tables
+------------------------------------------------------------
+USE master;
+GO
+
+-- Create temporary table
+CREATE TABLE #temp_table (
+    id INT PRIMARY KEY,
+    value VARCHAR(50)
+);
+GO
+
+INSERT INTO #temp_table VALUES (1, 'temp1'), (2, 'temp2');
+GO
+
+-- Create weak binding view on temp table
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW view_test.temp_view AS
+SELECT * FROM #temp_table;
+GO
+
+-- Test view
+SELECT * FROM view_test.temp_view;
+GO
+
+DROP TABLE #temp_table;
+GO
+
+------------------------------------------------------------
+-- Test with computed columns
+------------------------------------------------------------
+USE master;
+GO
+
+-- Create table with computed column
+CREATE TABLE view_test.computed_table (
+    id INT PRIMARY KEY,
+    value INT,
+    computed_value AS (value * 2)
+);
+GO
+
+INSERT INTO view_test.computed_table (id, value) VALUES (1, 10), (2, 20);
+GO
+
+-- Create weak binding view
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW view_test.computed_view AS
+SELECT id, value, computed_value FROM view_test.computed_table;
+GO
+
+-- Test view
+SELECT * FROM view_test.computed_view;
+GO
+
+-- Drop and recreate with different computation
+DROP TABLE view_test.computed_table;
+GO
+
+CREATE TABLE view_test.computed_table (
+    id INT PRIMARY KEY,
+    value INT,
+    computed_value AS (value * 3)  -- Changed from *2 to *3
+);
+GO
+
+INSERT INTO view_test.computed_table (id, value) VALUES (1, 10), (2, 20);
+GO
+
+-- Test view after computation change
+SELECT * FROM view_test.computed_view;
+GO
+
+------------------------------------------------------------
+-- Set of user operations performed to change strong view 
+-- to weak view
+------------------------------------------------------------
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW v1_strong WITH SCHEMABINDING AS SELECT * FROM test_table_for_strong_view;
+GO
+
+CREATE VIEW v2_strong WITH SCHEMABINDING AS SELECT * FROM v1_strong;
+GO
+
+DROP TABLE IF EXISTS test_table_for_strong_view;
+GO
+
+DROP VIEW v1_strong;
+GO
+
+ALTER VIEW v1_strong AS SELECT * FROM test_table_for_strong_view;
+GO
+
+DROP TABLE test_table_for_strong_view;
+GO
+
+SELECT * FROM v1_strong;
+GO
+
+SELECT * FROM v2_strong;
+GO
+
+CREATE TABLE test_table_for_strong_view (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+SELECT * FROM v1_strong;
+GO
+
+SELECT * FROM v2_strong;
+GO
+
+---------------------------------------------------------------
+-- Test to check INSERT/UPDATE/DELETE operations on broken view
+-- during view repair
+---------------------------------------------------------------
+
+-- INSERT
+
+CREATE TABLE t (a INT PRIMARY KEY,b VARCHAR(50),c VARCHAR(50), d INT);
+GO
+
+select set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW insert_v1 AS
+    SELECT a, b FROM t;
+GO
+
+CREATE VIEW insert_v2 AS
+    SELECT * FROM insert_v1;
+GO
+
+DROP TABLE t;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY,b VARCHAR(50),c VARCHAR(50));
+GO
+
+INSERT INTO insert_v1 VALUES (1,'b')
+GO
+
+SELECT * FROM insert_v2;
+GO
+
+SELECT * FROM insert_v1;
+GO
+
+DROP VIEW insert_v2;
+GO
+
+DROP VIEW insert_v1;
+GO
+
+DROP TABLE t;
+GO
+
+-- UPDATE
+
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+CREATE VIEW update_v1 AS
+    SELECT a, b, d FROM t;
+GO
+
+CREATE VIEW update_v2 AS
+    SELECT * FROM update_v1;
+GO
+
+DROP TABLE t;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+UPDATE update_v1 SET b = 'updated_b';
+GO
+
+SELECT * FROM update_v2;
+GO
+
+SELECT * FROM update_v1;
+GO
+
+DROP VIEW update_v2;
+GO
+
+DROP VIEW update_v1;
+GO
+
+DROP TABLE t;
+GO
+
+---------------------------------------------------------------
+-- Test to check DELETE operations on broken view
+-- during view repair
+---------------------------------------------------------------
+
+-- DELETE
+
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+CREATE VIEW delete_v1 AS
+    SELECT a, b, d FROM t;
+GO
+
+CREATE VIEW delete_v2 AS
+    SELECT * FROM delete_v1;
+GO
+
+DROP TABLE t;
+GO
+
+CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+DELETE FROM delete_v1 WHERE a = 2;
+GO
+
+SELECT * FROM delete_v2;
+GO
+
+SELECT * FROM delete_v1;
+GO
+
+DROP VIEW delete_v2;
+GO
+
+DROP VIEW delete_v1;
+GO
+
+---------------------------------------------------------------
+-- Test to check self referencing views during ALTER
+---------------------------------------------------------------
+CREATE TABLE self_ref_t1 (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE VIEW self_ref_v1 AS
+    SELECT a, b FROM self_ref_t1;
+GO
+
+CREATE VIEW self_ref_v2 AS
+    SELECT * FROM self_ref_v1;
+GO
+
+-- Create a self-referencing view [ERROR]
+ALTER VIEW self_ref_v1 AS
+    SELECT a FROM self_ref_v1;
+GO
+
+-- Attempt to alter view that creates circular reference [ERROR]
+ALTER VIEW self_ref_v1 AS
+    SELECT a FROM self_ref_v1;
+GO
+
+ALTER VIEW vw_fnc_check AS
+    SELECT customer_id,
+        fnc_dependancy_check(customer_name, 'Code', 'Desc') AS code_desc
+    FROM customer;
+GO
+
+DROP FUNCTION fnc_dependancy_check;
+GO
+
+ALTER VIEW test_view AS
+SELECT c.customer_id, c.customer_name, o.order_id, o.order_date
+FROM customer c
+JOIN test_ord o ON c.customer_id = o.customer_id;
+GO
+
+DROP VIEW test_view;
+GO
+
+SELECT * FROM dependent_view;
+GO
+
+CREATE VIEW test_view AS
+SELECT c.customer_id, c.customer_name, o.order_id, o.order_date
+FROM customer c
+JOIN test_ord o ON c.customer_id = o.customer_id;
+GO
+
+SELECT * FROM dependent_view;
+GO
+
+---------------------------------------------------------------
+-- DMLs on views with weak binding
+---------------------------------------------------------------
+
+CREATE TABLE dml_test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+);
+GO
+
+CREATE VIEW dml_test_view AS
+    SELECT id, name FROM dml_test_table;
+GO
+
+INSERT INTO dml_test_view (id, name) VALUES (1, 'Test1'), (2, 'Test2');
+GO
+
+SELECT * FROM dml_test_view;
+GO
+
+UPDATE dml_test_view SET name = 'UpdatedTest1' WHERE id = 1;
+GO
+
+SELECT * FROM dml_test_view;
+GO
+
+DELETE FROM dml_test_view WHERE id = 2;
+GO
+
+SELECT * FROM dml_test_view;
+GO
+
+-- View with top-level query having an empty rtable
+CREATE VIEW no_top_level AS
+    SELECT 
+        (SELECT MAX(id) FROM dml_test_view) AS max_id,
+        (SELECT MIN(id) FROM dml_test_view) AS min_id;
+GO
+
+---------------------------------------------------------------
+-- Broken Views referenced inside CTE statements
+---------------------------------------------------------------
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte;
+GO
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte WHERE id = 1;
+GO
+
+DROP TABLE dml_test_table;
+GO
+
+CREATE TABLE dml_test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    description VARCHAR(100)
+);
+GO
+
+INSERT INTO dml_test_view (id, name) VALUES (1, 'Test1'), (2, 'Test2');
+GO
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte;
+GO
+
+WITH cte AS (
+    SELECT * FROM dml_test_view
+)
+SELECT * FROM cte WHERE id = 1;
+GO
+
+-- View with top-level query having an empty rtable and broken view
+SELECT * FROM no_top_level;
+GO
+
+---------------------------------------------------------------
+-- Broken Views referenced inside subqueries
+---------------------------------------------------------------
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery;
+GO
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery WHERE id = 1;
+GO
+
+DROP TABLE dml_test_table;
+GO
+
+CREATE TABLE dml_test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    description VARCHAR(100)
+);
+GO
+
+INSERT INTO dml_test_view (id, name) VALUES (1, 'Test1'), (2, 'Test2');
+GO
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery;
+GO
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS subquery WHERE id = 1;
+GO
+
+---------------------------------------------------------------
+-- Broken Views in subqueries inside where clause
+---------------------------------------------------------------
+
+SELECT * FROM dml_test_view
+WHERE id IN (
+    SELECT id FROM dml_test_view WHERE name LIKE 'Test%'
+);
+GO
+
+SELECT * FROM dml_test_view
+WHERE id IN (
+    SELECT id FROM dml_test_view WHERE id = 2
+);
+GO
+
+---------------------------------------------------------------
+-- Views as derived tables
+---------------------------------------------------------------
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table;
+GO
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table WHERE id = 1;
+GO
+
+-- Multiple derived tables in a single query
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table1,
+(
+    SELECT * FROM dml_test_view
+) AS derived_table2
+WHERE derived_table1.id = derived_table2.id;
+GO
+
+-- Combining multiple approaches
+
+SELECT * FROM (
+    SELECT * FROM dml_test_view
+) AS derived_table1
+JOIN (
+    SELECT * FROM dml_test_view
+) AS derived_table2 ON derived_table1.id = derived_table2.id
+WHERE derived_table1.name LIKE 'Test%';
+GO
+
+------------------------------------------------------------
+-- Test with complex view definition
+------------------------------------------------------------
+SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false)
+GO
+
+CREATE TABLE cmp_t (a INT PRIMARY KEY, b VARCHAR(50), c VARCHAR(50), d INT);
+GO
+
+CREATE TABLE cmp_t2 ( id INT PRIMARY KEY, a INT, e VARCHAR(50));
+GO
+
+CREATE TABLE cmp_t3 ( id INT PRIMARY KEY, a INT, f DATE );
+GO
+
+CREATE VIEW multi_table_complex_view AS
+SELECT 
+    cmp_t.a,
+    cmp_t.b,
+    cmp_t.c,
+    subq.e,
+    subq.f
+FROM cmp_t
+JOIN (
+    -- Subquery with multiple table references
+    SELECT 
+        cmp_t2.a,
+        cmp_t2.e,
+        cmp_t3.f
+    FROM cmp_t2
+    JOIN cmp_t3 ON cmp_t2.a = cmp_t3.a
+    WHERE cmp_t2.id IN (
+        SELECT a
+        FROM cmp_t 
+        WHERE d > (SELECT AVG(d) FROM cmp_t)
+    )
+) AS subq ON cmp_t.a = subq.a
+UNION ALL
+SELECT 
+    cmp_t.a,
+    cmp_t.b,
+    cmp_t.c,
+    subq2.e,
+    subq2.f
+FROM cmp_t
+LEFT JOIN (
+    -- Another subquery with multiple table references
+    SELECT 
+        cmp_t2.a,
+        cmp_t2.e,
+        cmp_t3.f
+    FROM cmp_t2
+    FULL OUTER JOIN cmp_t3 ON cmp_t2.a = cmp_t3.a
+    WHERE EXISTS (
+        SELECT 1 
+        FROM cmp_t 
+        WHERE cmp_t.a = cmp_t2.a OR cmp_t.a = cmp_t3.a
+    )
+) AS subq2 ON cmp_t.a = subq2.a
+WHERE cmp_t.d < (SELECT MAX(d) FROM cmp_t);
+GO
+
+DROP TABLE cmp_t;
+GO
+
+SELECT * FROM multi_table_complex_view;
+GO
+
+-- Recreate the base table
+CREATE TABLE cmp_t (
+    a INT PRIMARY KEY,
+    b VARCHAR(50),
+    c VARCHAR(50),
+    d INT
+);
+GO
+
+SELECT * FROM multi_table_complex_view;
+GO
+
+CREATE VIEW avg_d_per_c AS
+SELECT c, AVG(d) AS avg_d
+FROM t
+GROUP BY c;
+GO
+
+CREATE VIEW above_avg_d AS
+SELECT t.a, t.b, t.c, t.d
+FROM t
+JOIN avg_d_per_c ON t.c = avg_d_per_c.c
+WHERE t.d > avg_d_per_c.avg_d;
+GO
+
+CREATE VIEW complex_nested_view AS
+SELECT 
+    t.a,
+    t.b,
+    t.c,
+    t.d,
+    (SELECT AVG(avg_d) FROM avg_d_per_c) AS overall_avg_d
+FROM t
+WHERE t.a IN (
+    SELECT a
+    FROM above_avg_d
+    WHERE above_avg_d.d > (
+        SELECT AVG(d)
+        FROM t AS t2
+        WHERE t2.c IN (
+            SELECT c
+            FROM avg_d_per_c
+            WHERE avg_d > (SELECT AVG(avg_d) FROM avg_d_per_c)
+        )
+    )
+);
+GO
+
+DROP VIEW avg_d_per_c;
+GO
+
+SELECT * FROM complex_nested_view;
+GO
+
+-- Recreate the base table
+CREATE VIEW avg_d_per_c AS
+SELECT c, AVG(d) AS avg_d
+FROM t
+GROUP BY c;
+GO
+
+SELECT * FROM complex_nested_view;
+GO

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -457,3 +457,4 @@ round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
+weak-binding

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -578,3 +578,4 @@ test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -577,3 +577,4 @@ test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -582,3 +582,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -582,3 +582,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -493,3 +493,4 @@ round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
+weak-binding

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -513,3 +513,4 @@ round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
+weak-binding

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -526,3 +526,4 @@ round_return_type_test-before-16_9-or-17_5
 alter-view
 test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
+weak-binding

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -562,3 +562,4 @@ test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -577,3 +577,4 @@ test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -586,3 +586,4 @@ test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -578,3 +578,4 @@ test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -570,3 +570,4 @@ test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -619,3 +619,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj
+weak-binding

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -586,3 +586,4 @@ test_conv_int_to_varbinary_binary_before_16_6_or_15_10
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -592,3 +592,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -607,3 +607,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -612,3 +612,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -616,3 +616,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -620,3 +620,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -613,3 +613,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -627,3 +627,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+weak-binding

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -636,3 +636,4 @@ money_smallmoney
 money_smallmoney_bit_dep_obj
 user_token-dep
 len
+weak-binding


### PR DESCRIPTION
Cherry picked commit from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3806

### Description

Currently, Babelfish only supports strong binding for views, which prevents dropping or altering referenced objects when views depend on them. This behavior differs from SQL Server, which by default allows dropping underlying tables or views unless WITH SCHEMABINDING is explicitly specified.
With this change, Babelfish now supports configurable view binding modes:
1. Strong binding (default): Prevents dropping referenced objects if views depend on them
2. Weak binding: Allows dropping of referenced objects

This feature aligns Babelfish more closely with SQL Server's behavior, providing greater flexibility
Key aspects include:

- A new GUC parameter `babelfishpg_tsql.weak_view_binding` to control the default binding behavior (default is false)
- Support for explicit `WITH SCHEMABINDING` to create strongly bound views regardless of the GUC setting
- Ability to create weakly bound views by default when the GUC is enabled
- Proper handling of `ALTER VIEW` operations in both binding modes

In SQL Server, views are weakly bound by default, allowing underlying objects to be dropped or altered. With our implementation, users can now choose between SQL Server's default behavior (weak binding) or the previously enforced behavior (strong binding).

#### Important Limitation : 
This implementation currently only addresses DROP operations on tables, views, functions, procedures as well as ALTER operations on views when these objects are bound by dependent views. ALTER TABLE/ ALTER FUNCTION operations (such as dropping columns or changing data types) are still restricted when dependent views exist, regardless of binding mode. This differs from SQL Server's behavior, where weak binding also allows ALTER operations on referenced objects.
When the same underlying object is recreated, its broken child view will get repaired only if it follows postgresql restrictions for CREATE OR REPLACE VIEW. [The new query must generate the same columns that were generated by the existing view query (that is, the same column names in the same order and with the same data types), but it may add additional columns to the end of the list] 
https://www.postgresql.org/docs/current/sql-createview.html#:~:text=The%20new%20query,be%20completely%20different.

### Issues Resolved

BABEL-1660

Signed-off-by: Rahul Parande [rparande@amazon.com](mailto:rparande@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).