### PR TITLE
[OSS-ONLY] Fix crash during tuple update for broken view by registering an active transaction snapshot

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -7044,6 +7044,7 @@ repair_broken_view_recursive(Oid viewOid, List *visitedViews)
 	Query 			*query = NULL;
 	Query 			*currentQuery = NULL;
 	bool 			repaired = false;
+	bool 			snapshot_registered = false;
 	char 			*schema_name = NULL; 
 	char 			*viewdef = NULL;
 	char 			*orig_db_name;
@@ -7065,6 +7066,11 @@ repair_broken_view_recursive(Oid viewOid, List *visitedViews)
 	/* Check if the view is a dummy view and do repair */
 	if (is_dummy_view(viewOid) && bbf_view_is_broken(viewOid))
 	{	
+		if (!ActiveSnapshotSet())
+		{
+			PushActiveSnapshot(GetTransactionSnapshot());
+			snapshot_registered = true;
+		}
 		viewdef = bbf_view_get_definition(viewOid);
 		
 		/* This should never happen */
@@ -7159,6 +7165,8 @@ repair_broken_view_recursive(Oid viewOid, List *visitedViews)
 		else
 			repaired = false; 
 		pfree(viewdef);
+		if (snapshot_registered)
+			PopActiveSnapshot();
 	}
 	viewRel = relation_open(viewOid, AccessShareLock);
 


### PR DESCRIPTION
This code is open source only as we have similar commit in gitfarm 5_X_DEV which will be cherry picked to 5_3_Stable so no need to cherry pick from here
Cherry-picked from : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3963
### Description

Added transaction snapshot management to prevent crashes during tuple updates of broken views. The code now checks if an active snapshot exists, registers one if needed, and properly cleans it up after view repair operations are complete. This fix ensures data consistency and prevents crashes during view updates.
### Issues Resolved

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).