### PR TITLE
Remove custom 'createOrAlter' field in ViewStmt and grammar 

### DIFF
--- a/.github/workflows/manual_tags.yml
+++ b/.github/workflows/manual_tags.yml
@@ -26,15 +26,18 @@ jobs:
           fetch-depth: 0
       - name: Run create-tag script
         env:
+          TAG_ID: ${{ github.event.inputs.tagId }}
           message: ${{ github.event.inputs.message }}
         # Run when commit hash is not provided (then the tag will be created on the latest commit of the current branch)
-        if: ${{github.event.inputs.commit_hash == ''}} 
+        if: ${{ github.event.inputs.commit_hash == '' }}
         run: |
-            bash ./.github/scripts/create-tag.sh -t ${{github.event.inputs.tagId}}
+            bash ./.github/scripts/create-tag.sh -t "$TAG_ID"
       - name: Run create-tag script when commit hash is provided
         env:
+          TAG_ID: ${{ github.event.inputs.tagId }}
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
           message: ${{ github.event.inputs.message }}
         # Run when commit hash is provided, tag will be created on top of the commit hash
-        if: ${{github.event.inputs.commit_hash != ''}} 
+        if: ${{ github.event.inputs.commit_hash != '' }}
         run: |
-            bash ./.github/scripts/create-tag.sh -c ${{github.event.inputs.commit_hash}} -t ${{github.event.inputs.tagId}}
+            bash ./.github/scripts/create-tag.sh -c "$COMMIT_HASH" -t "$TAG_ID"

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -4154,9 +4154,8 @@ tsql_AlterViewStmt:
                     n->aliases = $4;
                     n->query = $7;
                     n->replace = true;
-                    n->options = $5;
+                    n->options = lappend($5, makeDefElem("tsql_alter_view_op", (Node *)makeInteger(1), -1));
                     n->withCheckOption = $8;
-                    n->createOrAlter = true;
                     $$ = (Node *) n;
                 }
             | CREATE OR TSQL_ALTER VIEW qualified_name opt_column_list opt_reloptions
@@ -4167,9 +4166,8 @@ tsql_AlterViewStmt:
                     n->aliases = $6;
                     n->query = $9;
                     n->replace = false;
-                    n->options = $7;
+                    n->options = lappend($7, makeDefElem("tsql_alter_view_op", (Node *)makeInteger(1), -1));
                     n->withCheckOption = $10;
-                    n->createOrAlter = true;
                     $$ = (Node *) n;
                 }
         ;

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -4146,31 +4146,31 @@ tsql_AlterFunctionStmt:
 		;
 
 tsql_AlterViewStmt: 
-            TSQL_ALTER VIEW qualified_name opt_column_list opt_reloptions
-                AS SelectStmt opt_check_option
-                {
-                    ViewStmt *n = makeNode(ViewStmt);
-                    n->view = $3;
-                    n->aliases = $4;
-                    n->query = $7;
-                    n->replace = true;
-                    n->options = lappend($5, makeDefElem("tsql_alter_view_op", (Node *)makeInteger(1), -1));
-                    n->withCheckOption = $8;
-                    $$ = (Node *) n;
-                }
-            | CREATE OR TSQL_ALTER VIEW qualified_name opt_column_list opt_reloptions
-                AS SelectStmt opt_check_option
-                {
-                    ViewStmt *n = makeNode(ViewStmt);
-                    n->view = $5;
-                    n->aliases = $6;
-                    n->query = $9;
-                    n->replace = false;
-                    n->options = lappend($7, makeDefElem("tsql_alter_view_op", (Node *)makeInteger(1), -1));
-                    n->withCheckOption = $10;
-                    $$ = (Node *) n;
-                }
-        ;
+			TSQL_ALTER VIEW qualified_name opt_column_list opt_reloptions
+				AS SelectStmt opt_check_option
+				{
+					ViewStmt *n = makeNode(ViewStmt);
+					n->view = $3;
+					n->aliases = $4;
+					n->query = $7;
+					n->replace = true;
+					n->options = lappend($5, makeDefElem("tsql_alter_view_op", (Node *)makeInteger(1), -1));
+					n->withCheckOption = $8;
+					$$ = (Node *) n;
+				}
+			| CREATE OR TSQL_ALTER VIEW qualified_name opt_column_list opt_reloptions
+				AS SelectStmt opt_check_option
+				{
+					ViewStmt *n = makeNode(ViewStmt);
+					n->view = $5;
+					n->aliases = $6;
+					n->query = $9;
+					n->replace = false;
+					n->options = lappend($7, makeDefElem("tsql_alter_view_op", (Node *)makeInteger(1), -1));
+					n->withCheckOption = $10;
+					$$ = (Node *) n;
+				}
+		;
 		
 /*
  * These rules define the WITH clause in a CREATE PROCEDURE

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -7481,7 +7481,7 @@ handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, bool 
 				}
 				CommandCounterIncrement();
 			}
-			else if (tsql_alter_view_op && pltsql_weak_view_binding)
+			else if (is_alter_view && pltsql_weak_view_binding)
 			{
 				/* ALTER operation: mark weak & broken */
 				update_bbf_view_flags(viewOid, BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW, 0, true);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -7421,15 +7421,27 @@ handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relat
 	HeapTuple 		tup;
 	List 			*processed_views = NIL;
 	Oid 			viewOid = InvalidOid;
-	bool 			is_alter_view = false;
 	bool 			is_weak_view = false;
 	bool 			processed = true;
 	bool 			updated;
-	int             nkeys = 2;
+	int 			nkeys = 2;
+	ListCell 		*option;
+	bool 			tsql_alter_view_op = false;
 
-	/* Check if this is an ALTER VIEW operation */
-	is_alter_view = (stmt != NULL && stmt->createOrAlter);
-	
+	if (stmt != NULL)
+	{
+		foreach(option, stmt->options)
+		{
+			DefElem *def = (DefElem *) lfirst(option);
+			
+			if (strcmp(def->defname, "tsql_alter_view_op") == 0)
+			{
+				tsql_alter_view_op = true;
+				break;
+			}
+		}
+	}
+
 	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
 		return false;
 	
@@ -7484,7 +7496,7 @@ handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relat
 				}
 				CommandCounterIncrement();
 			}
-			else if (is_alter_view && pltsql_weak_view_binding)
+			else if (tsql_alter_view_op && pltsql_weak_view_binding)
 			{
 				/* ALTER operation: mark weak & broken */
 				update_bbf_view_flags(viewOid, BBF_VIEW_DEF_FLAG_IS_WEAK_VIEW, 0, true);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3204,7 +3204,7 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 			obj.objectSubId = subId;
 
 			/* Call view dependency handling function */
-			handle_bbf_view_binding_on_object_drop(&obj, NULL, NULL);
+			handle_bbf_view_binding_on_object_drop(&obj, false);
 		}
 	}
 	if (access == OAT_DROP && classId == ProcedureRelationId)
@@ -3222,7 +3222,7 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 			obj.objectSubId = 0;
 			
 			/* Call view dependency handling for functions */
-			handle_bbf_view_binding_on_object_drop(&obj, NULL, NULL);
+			handle_bbf_view_binding_on_object_drop(&obj, false);
 		}
 	}
 	if (sql_dialect != SQL_DIALECT_TSQL)
@@ -7414,34 +7414,19 @@ create_dummy_view_query_for_broken_view(Oid viewOid)
  */
 
 bool
-handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relation depRel, ViewStmt *stmt)
+handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, bool is_alter_view)
 {
 	ScanKeyData 	key[3];
 	SysScanDesc 	scan;
 	HeapTuple 		tup;
+	Relation 		depRel;
 	List 			*processed_views = NIL;
 	Oid 			viewOid = InvalidOid;
 	bool 			is_weak_view = false;
 	bool 			processed = true;
 	bool 			updated;
-	int 			nkeys = 2;
-	ListCell 		*option;
-	bool 			tsql_alter_view_op = false;
-
-	if (stmt != NULL)
-	{
-		foreach(option, stmt->options)
-		{
-			DefElem *def = (DefElem *) lfirst(option);
-			
-			if (strcmp(def->defname, "tsql_alter_view_op") == 0)
-			{
-				tsql_alter_view_op = true;
-				break;
-			}
-		}
-	}
-
+	int             nkeys = 2;
+	
 	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
 		return false;
 	

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -39,7 +39,7 @@ extern char** fetch_func_input_arg_names(HeapTuple func_tuple);
 
 extern char *update_delete_target_alias;
 extern bool sp_describe_first_result_set_inprogress;
-extern bool handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relation depRel, ViewStmt *viewstmt);
+extern bool handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, bool is_alter_view);
 extern bool check_view_binding_dependencies(Query *viewParse);
 #endif
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2907,7 +2907,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							originalView.classId = RelationRelationId;
 							originalView.objectSubId = 0;
 
-							if (!(handle_bbf_view_binding_on_object_drop(&originalView, NULL, stmt)))
+							if (!(handle_bbf_view_binding_on_object_drop(&originalView, true)))
 							/* Strong view dependency found, abort the drop */
 								ereport(ERROR,
 										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2680,12 +2680,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 						if(!cfs->is_procedure)
 						{
-							if (!(handle_bbf_view_binding_on_object_drop(&originalFunc, NULL, NULL)))
-							{
-								ereport(ERROR,
-										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
-											errmsg("Cannot drop function %s because it is bound to a view.", NameListToString(cfs->funcname))));
-							}
 							/*
 							 * Postgres does not allow us to create functions with different return types
 							 * so we need to delete and recreate them 
@@ -2696,12 +2690,6 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 						else if (!isSameProc) /* i.e. different signature */
 						{
-							if (!(handle_bbf_view_binding_on_object_drop(&originalFunc, NULL, NULL)))
-							{
-								ereport(ERROR,
-										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
-											errmsg("Cannot drop function %s because it is bound to a view.", NameListToString(cfs->funcname))));
-							}
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
 							CommandCounterIncrement();
 						}

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2680,6 +2680,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 						if(!cfs->is_procedure)
 						{
+							if (!(handle_bbf_view_binding_on_object_drop(&originalFunc, NULL, NULL)))
+							{
+								ereport(ERROR,
+										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+											errmsg("Cannot drop function %s because it is bound to a view.", NameListToString(cfs->funcname))));
+							}
 							/*
 							 * Postgres does not allow us to create functions with different return types
 							 * so we need to delete and recreate them 
@@ -2690,6 +2696,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 						else if (!isSameProc) /* i.e. different signature */
 						{
+							if (!(handle_bbf_view_binding_on_object_drop(&originalFunc, NULL, NULL)))
+							{
+								ereport(ERROR,
+										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+											errmsg("Cannot drop function %s because it is bound to a view.", NameListToString(cfs->funcname))));
+							}
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
 							CommandCounterIncrement();
 						}
@@ -2803,18 +2815,38 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 			case T_ViewStmt:
 			{
 				ViewStmt *stmt = (ViewStmt *) parsetree;
+				bool tsql_alter_view_op = false;
 
 				/*
 				 * We are using PostgreSQL's existing ViewStmt node which is shared between PostgreSQL's
 				 * CREATE VIEW and T-SQL's ALTER VIEW/CREATE OR ALTER VIEW operations. To properly distinguish 
-				 * between these operations and not let CREATE VIEW inside this case we use createOrAlter flag
+				 * between these operations we use a special option named "tsql_view_op" in the options list, 
+				 * which is set in the grammar for T-SQL view operations (ALTER VIEW and CREATE OR ALTER VIEW).
 				 *
-				 * Since both CREATE VIEW and CREATE OR ALTER VIEW set replace = false initially,
-				 * we use the 'createOrAlter' flag to distinguish between them and implement the
-				 * correct behavior when a view already exists
+				 * For both operations, we set different values for the 'replace' flag:
+				 * - For ALTER VIEW: replace = true
+				 * - For CREATE OR ALTER VIEW: replace = false (initially)
+				 * 
+				 * This allows us to implement the correct behavior when a view already exists:
+				 * - ALTER VIEW will fail if the view doesn't exist
+				 * - CREATE OR ALTER VIEW will create the view if it doesn't exist
 				 */
 
-				if (sql_dialect == SQL_DIALECT_TSQL && (stmt->createOrAlter))    
+				if (sql_dialect == SQL_DIALECT_TSQL)
+				{
+					ListCell *option;
+					foreach(option, stmt->options)
+					{
+						DefElem *def = (DefElem *) lfirst(option);
+						
+						if (strcmp(def->defname, "tsql_alter_view_op") == 0)
+						{
+							tsql_alter_view_op = true;
+							break;
+						}
+					}
+				}
+				if (sql_dialect == SQL_DIALECT_TSQL && tsql_alter_view_op)
 				{
 					/*
 					 * 1. Retrieve the OID of the old view using `RangeVarGetRelid()`.


### PR DESCRIPTION
This PR modifies how we identify T-SQL `ALTER VIEW` and `CREATE OR ALTER VIEW` operations. Instead of using a custom field added to the PostgreSQL ViewStmt structure, we now use the standard options list mechanism instead

This PR includes following changes:

- Updated grammar rules to add a marker in the options list
- Added logic to check for this option in alter view operation handling

Engine PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/607
### Issues Resolved

BABEL-5939

Signed off by: Rahul Parande rparande@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).