### PR TITLE
Support Alter Function operation when dependent loose schemabinding view exists

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3204,7 +3204,7 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 			obj.objectSubId = subId;
 
 			/* Call view dependency handling function */
-			handle_bbf_view_binding_on_object_drop(&obj, NULL, NULL);
+			handle_bbf_view_binding_on_object_drop(&obj, false);
 		}
 	}
 	if (access == OAT_DROP && classId == ProcedureRelationId)
@@ -3222,7 +3222,7 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 			obj.objectSubId = 0;
 			
 			/* Call view dependency handling for functions */
-			handle_bbf_view_binding_on_object_drop(&obj, NULL, NULL);
+			handle_bbf_view_binding_on_object_drop(&obj, false);
 		}
 	}
 	if (sql_dialect != SQL_DIALECT_TSQL)
@@ -7470,21 +7470,18 @@ create_dummy_view_query_for_broken_view(Oid viewOid)
  */
 
 bool
-handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relation depRel, ViewStmt *stmt)
+handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, bool is_alter_view)
 {
 	ScanKeyData 	key[3];
 	SysScanDesc 	scan;
 	HeapTuple 		tup;
+	Relation 		depRel;
 	List 			*processed_views = NIL;
 	Oid 			viewOid = InvalidOid;
-	bool 			is_alter_view = false;
 	bool 			is_weak_view = false;
 	bool 			processed = true;
 	bool 			updated;
-	int             nkeys = 2;
-
-	/* Check if this is an ALTER VIEW operation */
-	is_alter_view = (stmt != NULL && stmt->createOrAlter);
+	int				nkeys = 2;
 	
 	if (sql_dialect != SQL_DIALECT_TSQL || !IS_TDS_CONN())
 		return false;

--- a/contrib/babelfishpg_tsql/src/hooks.h
+++ b/contrib/babelfishpg_tsql/src/hooks.h
@@ -39,7 +39,7 @@ extern char** fetch_func_input_arg_names(HeapTuple func_tuple);
 
 extern char *update_delete_target_alias;
 extern bool sp_describe_first_result_set_inprogress;
-extern bool handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, Relation depRel, ViewStmt *viewstmt);
+extern bool handle_bbf_view_binding_on_object_drop(const ObjectAddress *droppedObject, bool is_alter_view);
 extern bool check_view_binding_dependencies(Query *viewParse);
 #endif
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -2944,6 +2944,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 						if(!cfs->is_procedure)
 						{
+							if (!(handle_bbf_view_binding_on_object_drop(&originalFunc, false)))
+							{
+								ereport(ERROR,
+										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+											errmsg("Cannot alter function %s because it is bound to a view.", NameListToString(cfs->funcname))));
+							}
 							/*
 							 * Postgres does not allow us to create functions with different return types
 							 * so we need to delete and recreate them 
@@ -2954,6 +2960,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						}
 						else if (!isSameProc) /* i.e. different signature */
 						{
+							if (!(handle_bbf_view_binding_on_object_drop(&originalFunc, false)))
+							{
+								ereport(ERROR,
+										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+											errmsg("Cannot alter function %s because it is bound to a view.", NameListToString(cfs->funcname))));
+							}
 							performDeletion(&originalFunc, DROP_RESTRICT, 0);
 							CommandCounterIncrement();
 						}
@@ -3151,7 +3163,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 							originalView.classId = RelationRelationId;
 							originalView.objectSubId = 0;
 
-							if (!(handle_bbf_view_binding_on_object_drop(&originalView, NULL, stmt)))
+							if (!(handle_bbf_view_binding_on_object_drop(&originalView, true)))
 							/* Strong view dependency found, abort the drop */
 								ereport(ERROR,
 										(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),

--- a/test/JDBC/expected/alter-function-with-weak-view-vu-cleanup.out
+++ b/test/JDBC/expected/alter-function-with-weak-view-vu-cleanup.out
@@ -1,0 +1,40 @@
+DROP VIEW IF EXISTS dbo.order_summary
+GO
+DROP VIEW IF EXISTS dbo.order_discount_summary
+GO
+DROP VIEW IF EXISTS dbo.order_final_price
+GO
+DROP VIEW IF EXISTS dbo.order_pricing_details
+GO
+DROP VIEW IF EXISTS dbo.order_regional_summary
+GO
+DROP VIEW IF EXISTS dbo.category_analytics
+GO
+DROP VIEW IF EXISTS dbo.order_details_extended
+GO
+DROP VIEW IF EXISTS dbo.high_value_orders
+GO
+DROP VIEW IF EXISTS dbo.category_summaries
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_tax
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_discount
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_base_price
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_final_price
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_regional_tax
+GO
+DROP FUNCTION IF EXISTS dbo.get_category_average
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_safe_discount
+GO
+DROP FUNCTION IF EXISTS dbo.generate_order_code
+GO
+DROP FUNCTION IF EXISTS dbo.get_orders_by_amount
+GO
+DROP FUNCTION IF EXISTS dbo.get_order_summary
+GO
+DROP TABLE IF EXISTS orders
+GO

--- a/test/JDBC/expected/alter-function-with-weak-view-vu-prepare.out
+++ b/test/JDBC/expected/alter-function-with-weak-view-vu-prepare.out
@@ -1,0 +1,197 @@
+CREATE TABLE orders (
+    order_id INT PRIMARY KEY,
+    total_amount DECIMAL(18,2)
+)
+GO
+
+INSERT INTO orders (order_id, total_amount) VALUES 
+(1, 100.00),
+(2, 200.00),
+(3, 500.00),
+(4, 1000.00)
+GO
+~~ROW COUNT: 4~~
+
+
+CREATE FUNCTION dbo.calculate_tax(@amount DECIMAL(18,2))
+    RETURNS DECIMAL(18,2)
+    AS
+    BEGIN
+        RETURN @amount * 0.1;
+    END
+GO
+
+CREATE VIEW dbo.order_summary AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_tax(total_amount) AS tax_amount,
+    total_amount + dbo.calculate_tax(total_amount) AS total_with_tax
+FROM 
+    orders
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- Multiple Views Depending on Same Function
+CREATE FUNCTION dbo.calculate_discount(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.05;
+END
+GO
+
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+CREATE FUNCTION dbo.calculate_base_price(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 1.2;
+END
+GO
+
+CREATE FUNCTION dbo.calculate_final_price(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN dbo.calculate_base_price(@amount) + dbo.calculate_tax(@amount);
+END
+GO
+
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+CREATE FUNCTION dbo.calculate_regional_tax(
+    @amount DECIMAL(18,2),
+    @region_code VARCHAR(2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN CASE 
+        WHEN @region_code = 'NY' THEN @amount * 0.08
+        WHEN @region_code = 'CA' THEN @amount * 0.09
+        ELSE @amount * 0.05
+    END
+END
+GO
+
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+ALTER TABLE orders ADD transaction_date DATE
+GO
+ALTER TABLE orders ADD customer_type VARCHAR(10)
+GO
+ALTER TABLE orders ADD category VARCHAR(20)
+GO
+
+UPDATE orders SET 
+    transaction_date = DATEADD(day, order_id, '2024-01-01'),
+    customer_type = CASE WHEN order_id % 2 = 0 THEN 'Premium' ELSE 'Regular' END,
+    category = CASE 
+        WHEN order_id = 1 THEN 'Electronics'
+        WHEN order_id = 2 THEN 'Books'
+        WHEN order_id = 3 THEN 'Electronics'
+        ELSE 'Furniture'
+    END
+GO
+~~ROW COUNT: 4~~
+
+
+-- Function using aggregates
+CREATE FUNCTION dbo.get_category_average(@category VARCHAR(20))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    DECLARE @avg_amount DECIMAL(18,2)
+    SELECT @avg_amount = AVG(total_amount)
+    FROM orders
+    WHERE category = @category
+    RETURN ISNULL(@avg_amount, 0)
+END
+GO
+
+-- Function with error handling
+CREATE FUNCTION dbo.calculate_safe_discount(
+    @amount DECIMAL(18,2),
+    @discount_percent DECIMAL(5,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    BEGIN TRY
+        IF @discount_percent > 50
+            THROW 50000, 'Discount cannot exceed 50%', 1
+        RETURN @amount * (@discount_percent / 100)
+    END TRY
+    BEGIN CATCH
+        RETURN 0
+    END CATCH
+END
+GO
+
+-- Function with string manipulations
+CREATE FUNCTION dbo.generate_order_code(
+    @order_id INT,
+    @category VARCHAR(20)
+)
+RETURNS VARCHAR(50)
+AS
+BEGIN
+    RETURN UPPER(LEFT(@category, 3)) + '-' + 
+           RIGHT('0000' + CAST(@order_id AS VARCHAR(4)), 4)
+END
+GO
+
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- Inline Table-Valued Function
+CREATE FUNCTION dbo.get_orders_by_amount(@min_amount DECIMAL(18,2))
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT 
+        order_id,
+        total_amount,
+        customer_type,
+        category
+    FROM 
+        orders
+    WHERE 
+        total_amount >= @min_amount
+)
+GO
+
+
+-- Multi-Statement Table-Valued Function
+CREATE FUNCTION dbo.get_order_summary(@category VARCHAR(20))
+RETURNS @result TABLE 
+(
+    category VARCHAR(20),
+    total_orders INT,
+    total_amount DECIMAL(18,2),
+    avg_amount DECIMAL(18,2)
+)
+AS
+BEGIN
+    INSERT INTO @result
+    SELECT 
+        category,
+        COUNT(*) as total_orders,
+        SUM(total_amount) as total_amount,
+        AVG(total_amount) as avg_amount
+    FROM 
+        orders
+    WHERE 
+        category = @category
+    GROUP BY 
+        category
+    RETURN
+END
+GO

--- a/test/JDBC/expected/alter-function-with-weak-view-vu-verify.out
+++ b/test/JDBC/expected/alter-function-with-weak-view-vu-verify.out
@@ -1,0 +1,509 @@
+SELECT * FROM dbo.order_summary
+GO
+~~START~~
+int#!#numeric#!#numeric#!#numeric
+1#!#100.00#!#10.00#!#110.00
+2#!#200.00#!#20.00#!#220.00
+3#!#500.00#!#50.00#!#550.00
+4#!#1000.00#!#100.00#!#1100.00
+~~END~~
+
+
+--preparing dependent weak views
+EXEC sp_babelfish_configure 'babelfishpg_tsql.weak_view_binding', 'on';
+GO
+
+CREATE VIEW dbo.order_discount_summary AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_discount(total_amount) AS discount_amount
+FROM 
+    orders
+GO
+
+CREATE VIEW dbo.order_final_price AS
+SELECT 
+    order_id,
+    total_amount,
+    total_amount - dbo.calculate_discount(total_amount) AS final_price
+FROM 
+    orders
+GO
+
+CREATE VIEW dbo.order_pricing_details AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_base_price(total_amount) AS base_price,
+    dbo.calculate_tax(total_amount) AS tax_amount,
+    dbo.calculate_final_price(total_amount) AS final_price
+FROM 
+    orders
+GO
+
+CREATE VIEW dbo.order_regional_summary AS
+SELECT 
+    o.order_id,
+    o.total_amount,
+    'NY' as region_code,
+    dbo.calculate_regional_tax(o.total_amount, 'NY') AS tax_amount
+FROM 
+    orders o
+GO
+
+CREATE VIEW dbo.category_analytics AS
+SELECT 
+    category,
+    COUNT(*) as order_count,
+    SUM(total_amount) as total_sales,
+    dbo.get_category_average(category) as category_average
+FROM 
+    orders
+GROUP BY 
+    category
+ORDER BY 
+    category
+GO
+
+CREATE VIEW dbo.order_details_extended AS
+SELECT 
+    order_id,
+    dbo.generate_order_code(order_id, category) as order_code,
+    total_amount,
+    customer_type,
+    CASE customer_type 
+        WHEN 'Premium' THEN 45  -- exceed 40% after change
+        ELSE 10 
+    END as discount_percent,
+    dbo.calculate_safe_discount(
+        total_amount, 
+        CASE customer_type 
+            WHEN 'Premium' THEN 45  -- exceed 40% after change
+            ELSE 10 
+        END
+    ) as safe_discount
+FROM 
+    orders
+GO
+
+-- Create views using TVFs
+CREATE VIEW dbo.high_value_orders AS
+SELECT * FROM dbo.get_orders_by_amount(500)
+GO
+
+CREATE VIEW dbo.category_summaries AS
+SELECT * FROM dbo.get_order_summary('Electronics')
+UNION ALL
+SELECT * FROM dbo.get_order_summary('Books')
+UNION ALL
+SELECT * FROM dbo.get_order_summary('Furniture')
+GO
+
+-- Alter the function to change body [ERROR: dependent strong view exists]
+ALTER FUNCTION dbo.calculate_tax
+(
+    @amount DECIMAL(18,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.15;
+END;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot alter function master_dbo.calculate_tax because it is bound to a view.)~~
+
+
+-- Alter view to weak binding
+ALTER VIEW dbo.order_summary AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_tax(total_amount) AS tax_amount,
+    total_amount + dbo.calculate_tax(total_amount) AS total_with_tax
+FROM 
+    orders;
+GO
+
+SELECT * FROM dbo.order_summary;
+GO
+~~START~~
+int#!#numeric#!#numeric#!#numeric
+1#!#100.00#!#10.00#!#110.00
+2#!#200.00#!#20.00#!#220.00
+3#!#500.00#!#50.00#!#550.00
+4#!#1000.00#!#100.00#!#1100.00
+~~END~~
+
+
+-- Now the function can be altered successfully
+ALTER FUNCTION dbo.calculate_tax
+(
+    @amount DECIMAL(18,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.15;
+END;
+GO
+
+SELECT * FROM dbo.order_summary;
+GO
+~~START~~
+int#!#numeric#!#numeric#!#numeric
+1#!#100.00#!#15.00#!#115.00
+2#!#200.00#!#30.00#!#230.00
+3#!#500.00#!#75.00#!#575.00
+4#!#1000.00#!#150.00#!#1150.00
+~~END~~
+
+
+
+------------------------------------------------------------------------------
+-- Multiple Views Depending on Same Function
+------------------------------------------------------------------------------
+SELECT * FROM dbo.order_discount_summary
+GO
+~~START~~
+int#!#numeric#!#numeric
+1#!#100.00#!#5.00
+2#!#200.00#!#10.00
+3#!#500.00#!#25.00
+4#!#1000.00#!#50.00
+~~END~~
+
+SELECT * FROM dbo.order_final_price
+GO
+~~START~~
+int#!#numeric#!#numeric
+1#!#100.00#!#95.00
+2#!#200.00#!#190.00
+3#!#500.00#!#475.00
+4#!#1000.00#!#950.00
+~~END~~
+
+
+-- Alter function to change body
+ALTER FUNCTION dbo.calculate_discount(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.10;
+END
+GO
+
+SELECT * FROM dbo.order_discount_summary 
+GO
+~~START~~
+int#!#numeric#!#numeric
+1#!#100.00#!#10.00
+2#!#200.00#!#20.00
+3#!#500.00#!#50.00
+4#!#1000.00#!#100.00
+~~END~~
+
+SELECT * FROM dbo.order_final_price      
+GO
+~~START~~
+int#!#numeric#!#numeric
+1#!#100.00#!#90.00
+2#!#200.00#!#180.00
+3#!#500.00#!#450.00
+4#!#1000.00#!#900.00
+~~END~~
+
+
+
+------------------------------------------------------------------------------
+-- Nested Function calls in 'order_pricing_details' view
+------------------------------------------------------------------------------
+SELECT * FROM dbo.order_pricing_details
+GO
+~~START~~
+int#!#numeric#!#numeric#!#numeric#!#numeric
+1#!#100.00#!#120.00#!#15.00#!#135.00
+2#!#200.00#!#240.00#!#30.00#!#270.00
+3#!#500.00#!#600.00#!#75.00#!#675.00
+4#!#1000.00#!#1200.00#!#150.00#!#1350.00
+~~END~~
+
+
+-- Alter base function
+ALTER FUNCTION dbo.calculate_base_price(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 1.3;
+END
+GO
+
+SELECT * FROM dbo.order_pricing_details
+GO
+~~START~~
+int#!#numeric#!#numeric#!#numeric#!#numeric
+1#!#100.00#!#130.00#!#15.00#!#145.00
+2#!#200.00#!#260.00#!#30.00#!#290.00
+3#!#500.00#!#650.00#!#75.00#!#725.00
+4#!#1000.00#!#1300.00#!#150.00#!#1450.00
+~~END~~
+
+
+
+------------------------------------------------------------------------------
+-- Function with Multiple Parameters
+------------------------------------------------------------------------------
+SELECT * FROM dbo.order_regional_summary
+GO
+~~START~~
+int#!#numeric#!#varchar#!#numeric
+1#!#100.00#!#NY#!#8.00
+2#!#200.00#!#NY#!#16.00
+3#!#500.00#!#NY#!#40.00
+4#!#1000.00#!#NY#!#80.00
+~~END~~
+
+
+ALTER FUNCTION dbo.calculate_regional_tax(
+    @amount DECIMAL(18,2),
+    @region_code VARCHAR(2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN CASE 
+        WHEN @region_code = 'NY' THEN @amount * 0.085
+        WHEN @region_code = 'CA' THEN @amount * 0.095
+        ELSE @amount * 0.06
+    END
+END
+GO
+
+SELECT * FROM dbo.order_regional_summary 
+GO
+~~START~~
+int#!#numeric#!#varchar#!#numeric
+1#!#100.00#!#NY#!#8.50
+2#!#200.00#!#NY#!#17.00
+3#!#500.00#!#NY#!#42.50
+4#!#1000.00#!#NY#!#85.00
+~~END~~
+
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- Test category analytics
+SELECT * FROM dbo.category_analytics ORDER BY category
+GO
+~~START~~
+varchar#!#int#!#numeric#!#numeric
+Books#!#1#!#200.00#!#200.00
+Electronics#!#2#!#600.00#!#300.00
+Furniture#!#1#!#1000.00#!#1000.00
+~~END~~
+
+
+-- Alter aggregate function
+ALTER FUNCTION dbo.get_category_average(@category VARCHAR(20))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    DECLARE @avg_amount DECIMAL(18,2)
+    SELECT @avg_amount = AVG(total_amount * 1.1) -- Add 10% to average
+    FROM orders
+    WHERE category = @category
+    RETURN ISNULL(@avg_amount, 0)
+END
+GO
+
+SELECT * FROM dbo.category_analytics ORDER BY category -- Should show higher averages
+GO
+~~START~~
+varchar#!#int#!#numeric#!#numeric
+Books#!#1#!#200.00#!#220.00
+Electronics#!#2#!#600.00#!#330.00
+Furniture#!#1#!#1000.00#!#1100.00
+~~END~~
+
+
+-- Test order details with safe discount
+SELECT * FROM dbo.order_details_extended
+GO
+~~START~~
+int#!#varchar#!#numeric#!#varchar#!#int#!#numeric
+1#!#ELE-0001#!#100.00#!#Regular#!#10#!#10.00
+2#!#BOO-0002#!#200.00#!#Premium#!#45#!#90.00
+3#!#ELE-0003#!#500.00#!#Regular#!#10#!#50.00
+4#!#FUR-0004#!#1000.00#!#Premium#!#45#!#450.00
+~~END~~
+
+
+-- Alter safe discount function
+ALTER FUNCTION dbo.calculate_safe_discount(
+    @amount DECIMAL(18,2),
+    @discount_percent DECIMAL(5,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    BEGIN TRY
+        IF @discount_percent > 40  -- Changed from 50 to 40
+            THROW 50000, 'Discount cannot exceed 40%', 1
+        RETURN @amount * (@discount_percent / 100)
+    END TRY
+    BEGIN CATCH
+        RETURN @amount * 0.05  -- Changed from 0 to 5% default discount
+    END CATCH
+END
+GO
+
+SELECT * FROM dbo.order_details_extended -- Should show different discount calculations
+GO
+~~START~~
+int#!#varchar#!#numeric#!#varchar#!#int#!#numeric
+1#!#ELE-0001#!#100.00#!#Regular#!#10#!#10.00
+2#!#BOO-0002#!#200.00#!#Premium#!#45#!#10.00
+3#!#ELE-0003#!#500.00#!#Regular#!#10#!#50.00
+4#!#FUR-0004#!#1000.00#!#Premium#!#45#!#50.00
+~~END~~
+
+
+-- Test string manipulation function
+ALTER FUNCTION dbo.generate_order_code(
+    @order_id INT,
+    @category VARCHAR(20)
+)
+RETURNS VARCHAR(50)
+AS
+BEGIN
+    RETURN UPPER(LEFT(@category, 3)) + '-' + 
+           FORMAT(@order_id, 'D5') + '-' +  -- Changed format
+           FORMAT(GETDATE(), 'yy')
+END
+GO
+
+SELECT * FROM dbo.order_details_extended -- Should show new order code format
+GO
+~~START~~
+int#!#varchar#!#numeric#!#varchar#!#int#!#numeric
+1#!#ELE-00001-25#!#100.00#!#Regular#!#10#!#10.00
+2#!#BOO-00002-25#!#200.00#!#Premium#!#45#!#10.00
+3#!#ELE-00003-25#!#500.00#!#Regular#!#10#!#50.00
+4#!#FUR-00004-25#!#1000.00#!#Premium#!#45#!#50.00
+~~END~~
+
+
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- Test Inline TVF
+SELECT * FROM dbo.high_value_orders
+GO
+~~START~~
+int#!#numeric#!#varchar#!#varchar
+3#!#500.00000000#!#Regular#!#Electronics
+4#!#1000.00000000#!#Premium#!#Furniture
+~~END~~
+
+
+-- Alter Inline TVF
+ALTER FUNCTION dbo.get_orders_by_amount(@min_amount DECIMAL(18,2))
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT 
+        order_id,
+        total_amount,
+        customer_type,
+        category,
+        CASE 
+            WHEN total_amount >= 1000 THEN 'Very High'
+            WHEN total_amount >= 500 THEN 'High'
+            ELSE 'Medium'
+        END as value_category -- Added new column
+    FROM 
+        orders
+    WHERE 
+        total_amount >= @min_amount
+)
+GO
+
+SELECT * FROM dbo.high_value_orders
+GO
+~~START~~
+int#!#numeric#!#varchar#!#varchar
+3#!#500.00000000#!#Regular#!#Electronics
+4#!#1000.00000000#!#Premium#!#Furniture
+~~END~~
+
+SELECT * FROM dbo.high_value_orders -- Should now include value_category
+GO
+~~START~~
+int#!#numeric#!#varchar#!#varchar#!#varchar
+3#!#500.00000000#!#Regular#!#Electronics#!#High
+4#!#1000.00000000#!#Premium#!#Furniture#!#Very High
+~~END~~
+
+
+-- Test Multi-Statement TVF
+SELECT * FROM dbo.category_summaries
+GO
+~~START~~
+varchar#!#int#!#numeric#!#numeric
+Electronics#!#2#!#600.00#!#300.00
+Books#!#1#!#200.00#!#200.00
+Furniture#!#1#!#1000.00#!#1000.00
+~~END~~
+
+
+
+-- Alter Multi-Statement TVF
+ALTER FUNCTION dbo.get_order_summary(@category VARCHAR(20))
+RETURNS @result TABLE 
+(
+    category VARCHAR(20),
+    total_orders INT,
+    total_amount DECIMAL(18,2),
+    avg_amount DECIMAL(18,2),
+    max_amount DECIMAL(18,2) -- Added new column
+)
+AS
+BEGIN
+    INSERT INTO @result
+    SELECT 
+        category,
+        COUNT(*) as total_orders,
+        SUM(total_amount) as total_amount,
+        AVG(total_amount) as avg_amount,
+        MAX(total_amount) as max_amount -- Added new column
+    FROM 
+        orders
+    WHERE 
+        category = @category
+    GROUP BY 
+        category
+    RETURN
+END
+GO
+
+SELECT * FROM dbo.category_summaries
+GO
+~~START~~
+varchar#!#int#!#numeric#!#numeric
+Electronics#!#2#!#600.00#!#300.00
+Books#!#1#!#200.00#!#200.00
+Furniture#!#1#!#1000.00#!#1000.00
+~~END~~
+
+SELECT * FROM dbo.category_summaries -- Should now include max_amount
+GO
+~~START~~
+varchar#!#int#!#numeric#!#numeric#!#numeric
+Electronics#!#2#!#600.00#!#300.00#!#500.00
+Books#!#1#!#200.00#!#200.00#!#200.00
+Furniture#!#1#!#1000.00#!#1000.00#!#1000.00
+~~END~~
+

--- a/test/JDBC/input/alter/alter-function-with-weak-view-vu-cleanup.sql
+++ b/test/JDBC/input/alter/alter-function-with-weak-view-vu-cleanup.sql
@@ -1,0 +1,40 @@
+DROP VIEW IF EXISTS dbo.order_summary
+GO
+DROP VIEW IF EXISTS dbo.order_discount_summary
+GO
+DROP VIEW IF EXISTS dbo.order_final_price
+GO
+DROP VIEW IF EXISTS dbo.order_pricing_details
+GO
+DROP VIEW IF EXISTS dbo.order_regional_summary
+GO
+DROP VIEW IF EXISTS dbo.category_analytics
+GO
+DROP VIEW IF EXISTS dbo.order_details_extended
+GO
+DROP VIEW IF EXISTS dbo.high_value_orders
+GO
+DROP VIEW IF EXISTS dbo.category_summaries
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_tax
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_discount
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_base_price
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_final_price
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_regional_tax
+GO
+DROP FUNCTION IF EXISTS dbo.get_category_average
+GO
+DROP FUNCTION IF EXISTS dbo.calculate_safe_discount
+GO
+DROP FUNCTION IF EXISTS dbo.generate_order_code
+GO
+DROP FUNCTION IF EXISTS dbo.get_orders_by_amount
+GO
+DROP FUNCTION IF EXISTS dbo.get_order_summary
+GO
+DROP TABLE IF EXISTS orders
+GO

--- a/test/JDBC/input/alter/alter-function-with-weak-view-vu-prepare.sql
+++ b/test/JDBC/input/alter/alter-function-with-weak-view-vu-prepare.sql
@@ -1,0 +1,193 @@
+CREATE TABLE orders (
+    order_id INT PRIMARY KEY,
+    total_amount DECIMAL(18,2)
+)
+GO
+
+INSERT INTO orders (order_id, total_amount) VALUES 
+(1, 100.00),
+(2, 200.00),
+(3, 500.00),
+(4, 1000.00)
+GO
+
+CREATE FUNCTION dbo.calculate_tax(@amount DECIMAL(18,2))
+    RETURNS DECIMAL(18,2)
+    AS
+    BEGIN
+        RETURN @amount * 0.1;
+    END
+GO
+
+CREATE VIEW dbo.order_summary AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_tax(total_amount) AS tax_amount,
+    total_amount + dbo.calculate_tax(total_amount) AS total_with_tax
+FROM 
+    orders
+GO
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+
+-- Multiple Views Depending on Same Function
+CREATE FUNCTION dbo.calculate_discount(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.05;
+END
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+
+CREATE FUNCTION dbo.calculate_base_price(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 1.2;
+END
+GO
+
+CREATE FUNCTION dbo.calculate_final_price(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN dbo.calculate_base_price(@amount) + dbo.calculate_tax(@amount);
+END
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+
+CREATE FUNCTION dbo.calculate_regional_tax(
+    @amount DECIMAL(18,2),
+    @region_code VARCHAR(2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN CASE 
+        WHEN @region_code = 'NY' THEN @amount * 0.08
+        WHEN @region_code = 'CA' THEN @amount * 0.09
+        ELSE @amount * 0.05
+    END
+END
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+
+ALTER TABLE orders ADD transaction_date DATE
+GO
+ALTER TABLE orders ADD customer_type VARCHAR(10)
+GO
+ALTER TABLE orders ADD category VARCHAR(20)
+GO
+
+UPDATE orders SET 
+    transaction_date = DATEADD(day, order_id, '2024-01-01'),
+    customer_type = CASE WHEN order_id % 2 = 0 THEN 'Premium' ELSE 'Regular' END,
+    category = CASE 
+        WHEN order_id = 1 THEN 'Electronics'
+        WHEN order_id = 2 THEN 'Books'
+        WHEN order_id = 3 THEN 'Electronics'
+        ELSE 'Furniture'
+    END
+GO
+
+-- Function using aggregates
+CREATE FUNCTION dbo.get_category_average(@category VARCHAR(20))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    DECLARE @avg_amount DECIMAL(18,2)
+    SELECT @avg_amount = AVG(total_amount)
+    FROM orders
+    WHERE category = @category
+    RETURN ISNULL(@avg_amount, 0)
+END
+GO
+
+-- Function with error handling
+CREATE FUNCTION dbo.calculate_safe_discount(
+    @amount DECIMAL(18,2),
+    @discount_percent DECIMAL(5,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    BEGIN TRY
+        IF @discount_percent > 50
+            THROW 50000, 'Discount cannot exceed 50%', 1
+        RETURN @amount * (@discount_percent / 100)
+    END TRY
+    BEGIN CATCH
+        RETURN 0
+    END CATCH
+END
+GO
+
+-- Function with string manipulations
+CREATE FUNCTION dbo.generate_order_code(
+    @order_id INT,
+    @category VARCHAR(20)
+)
+RETURNS VARCHAR(50)
+AS
+BEGIN
+    RETURN UPPER(LEFT(@category, 3)) + '-' + 
+           RIGHT('0000' + CAST(@order_id AS VARCHAR(4)), 4)
+END
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+
+-- Inline Table-Valued Function
+CREATE FUNCTION dbo.get_orders_by_amount(@min_amount DECIMAL(18,2))
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT 
+        order_id,
+        total_amount,
+        customer_type,
+        category
+    FROM 
+        orders
+    WHERE 
+        total_amount >= @min_amount
+)
+GO
+
+-- Multi-Statement Table-Valued Function
+CREATE FUNCTION dbo.get_order_summary(@category VARCHAR(20))
+RETURNS @result TABLE 
+(
+    category VARCHAR(20),
+    total_orders INT,
+    total_amount DECIMAL(18,2),
+    avg_amount DECIMAL(18,2)
+)
+AS
+BEGIN
+    INSERT INTO @result
+    SELECT 
+        category,
+        COUNT(*) as total_orders,
+        SUM(total_amount) as total_amount,
+        AVG(total_amount) as avg_amount
+    FROM 
+        orders
+    WHERE 
+        category = @category
+    GROUP BY 
+        category
+
+    RETURN
+END
+GO

--- a/test/JDBC/input/alter/alter-function-with-weak-view-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-function-with-weak-view-vu-verify.sql
@@ -1,0 +1,340 @@
+SELECT * FROM dbo.order_summary
+GO
+
+--preparing dependent weak views
+EXEC sp_babelfish_configure 'babelfishpg_tsql.weak_view_binding', 'on';
+GO
+
+CREATE VIEW dbo.order_discount_summary AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_discount(total_amount) AS discount_amount
+FROM 
+    orders
+GO
+
+CREATE VIEW dbo.order_final_price AS
+SELECT 
+    order_id,
+    total_amount,
+    total_amount - dbo.calculate_discount(total_amount) AS final_price
+FROM 
+    orders
+GO
+
+CREATE VIEW dbo.order_pricing_details AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_base_price(total_amount) AS base_price,
+    dbo.calculate_tax(total_amount) AS tax_amount,
+    dbo.calculate_final_price(total_amount) AS final_price
+FROM 
+    orders
+GO
+
+CREATE VIEW dbo.order_regional_summary AS
+SELECT 
+    o.order_id,
+    o.total_amount,
+    'NY' as region_code,
+    dbo.calculate_regional_tax(o.total_amount, 'NY') AS tax_amount
+FROM 
+    orders o
+GO
+
+CREATE VIEW dbo.category_analytics AS
+SELECT 
+    category,
+    COUNT(*) as order_count,
+    SUM(total_amount) as total_sales,
+    dbo.get_category_average(category) as category_average
+FROM 
+    orders
+GROUP BY 
+    category
+ORDER BY 
+    category
+GO
+
+CREATE VIEW dbo.order_details_extended AS
+SELECT 
+    order_id,
+    dbo.generate_order_code(order_id, category) as order_code,
+    total_amount,
+    customer_type,
+    CASE customer_type 
+        WHEN 'Premium' THEN 45  -- exceed 40% after change
+        ELSE 10 
+    END as discount_percent,
+    dbo.calculate_safe_discount(
+        total_amount, 
+        CASE customer_type 
+            WHEN 'Premium' THEN 45  -- exceed 40% after change
+            ELSE 10 
+        END
+    ) as safe_discount
+FROM 
+    orders
+GO
+
+-- Create views using TVFs
+CREATE VIEW dbo.high_value_orders AS
+SELECT * FROM dbo.get_orders_by_amount(500)
+GO
+
+CREATE VIEW dbo.category_summaries AS
+SELECT * FROM dbo.get_order_summary('Electronics')
+UNION ALL
+SELECT * FROM dbo.get_order_summary('Books')
+UNION ALL
+SELECT * FROM dbo.get_order_summary('Furniture')
+GO
+
+-- Alter the function to change body [ERROR: dependent strong view exists]
+ALTER FUNCTION dbo.calculate_tax
+(
+    @amount DECIMAL(18,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.15;
+END;
+GO
+
+-- Alter view to weak binding
+ALTER VIEW dbo.order_summary AS
+SELECT 
+    order_id,
+    total_amount,
+    dbo.calculate_tax(total_amount) AS tax_amount,
+    total_amount + dbo.calculate_tax(total_amount) AS total_with_tax
+FROM 
+    orders;
+GO
+
+SELECT * FROM dbo.order_summary;
+GO
+
+-- Now the function can be altered successfully
+ALTER FUNCTION dbo.calculate_tax
+(
+    @amount DECIMAL(18,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.15;
+END;
+GO
+
+SELECT * FROM dbo.order_summary;
+GO
+
+------------------------------------------------------------------------------
+-- Multiple Views Depending on Same Function
+------------------------------------------------------------------------------
+
+SELECT * FROM dbo.order_discount_summary
+GO
+SELECT * FROM dbo.order_final_price
+GO
+
+-- Alter function to change body
+ALTER FUNCTION dbo.calculate_discount(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 0.10;
+END
+GO
+
+SELECT * FROM dbo.order_discount_summary 
+GO
+SELECT * FROM dbo.order_final_price      
+GO
+
+------------------------------------------------------------------------------
+-- Nested Function calls in 'order_pricing_details' view
+------------------------------------------------------------------------------
+
+SELECT * FROM dbo.order_pricing_details
+GO
+
+-- Alter base function
+ALTER FUNCTION dbo.calculate_base_price(@amount DECIMAL(18,2))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN @amount * 1.3;
+END
+GO
+
+SELECT * FROM dbo.order_pricing_details
+GO
+
+------------------------------------------------------------------------------
+-- Function with Multiple Parameters
+------------------------------------------------------------------------------
+
+SELECT * FROM dbo.order_regional_summary
+GO
+
+ALTER FUNCTION dbo.calculate_regional_tax(
+    @amount DECIMAL(18,2),
+    @region_code VARCHAR(2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    RETURN CASE 
+        WHEN @region_code = 'NY' THEN @amount * 0.085
+        WHEN @region_code = 'CA' THEN @amount * 0.095
+        ELSE @amount * 0.06
+    END
+END
+GO
+
+SELECT * FROM dbo.order_regional_summary 
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+-- Test category analytics
+SELECT * FROM dbo.category_analytics ORDER BY category
+GO
+
+-- Alter aggregate function
+ALTER FUNCTION dbo.get_category_average(@category VARCHAR(20))
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    DECLARE @avg_amount DECIMAL(18,2)
+    SELECT @avg_amount = AVG(total_amount * 1.1) -- Add 10% to average
+    FROM orders
+    WHERE category = @category
+    RETURN ISNULL(@avg_amount, 0)
+END
+GO
+
+SELECT * FROM dbo.category_analytics ORDER BY category -- Should show higher averages
+GO
+
+-- Test order details with safe discount
+SELECT * FROM dbo.order_details_extended
+GO
+
+-- Alter safe discount function
+ALTER FUNCTION dbo.calculate_safe_discount(
+    @amount DECIMAL(18,2),
+    @discount_percent DECIMAL(5,2)
+)
+RETURNS DECIMAL(18,2)
+AS
+BEGIN
+    BEGIN TRY
+        IF @discount_percent > 40  -- Changed from 50 to 40
+            THROW 50000, 'Discount cannot exceed 40%', 1
+        RETURN @amount * (@discount_percent / 100)
+    END TRY
+    BEGIN CATCH
+        RETURN @amount * 0.05  -- Changed from 0 to 5% default discount
+    END CATCH
+END
+GO
+
+SELECT * FROM dbo.order_details_extended -- Should show different discount calculations
+GO
+
+-- Test string manipulation function
+ALTER FUNCTION dbo.generate_order_code(
+    @order_id INT,
+    @category VARCHAR(20)
+)
+RETURNS VARCHAR(50)
+AS
+BEGIN
+    RETURN UPPER(LEFT(@category, 3)) + '-' + 
+           FORMAT(@order_id, 'D5') + '-' +  -- Changed format
+           FORMAT(GETDATE(), 'yy')
+END
+GO
+
+SELECT * FROM dbo.order_details_extended -- Should show new order code format
+GO
+
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+
+-- Test Inline TVF
+SELECT * FROM dbo.high_value_orders
+GO
+
+-- Alter Inline TVF
+ALTER FUNCTION dbo.get_orders_by_amount(@min_amount DECIMAL(18,2))
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT 
+        order_id,
+        total_amount,
+        customer_type,
+        category,
+        CASE 
+            WHEN total_amount >= 1000 THEN 'Very High'
+            WHEN total_amount >= 500 THEN 'High'
+            ELSE 'Medium'
+        END as value_category -- Added new column
+    FROM 
+        orders
+    WHERE 
+        total_amount >= @min_amount
+)
+GO
+
+SELECT * FROM dbo.high_value_orders
+GO
+SELECT * FROM dbo.high_value_orders -- Should now include value_category
+GO
+
+-- Test Multi-Statement TVF
+SELECT * FROM dbo.category_summaries
+GO
+
+-- Alter Multi-Statement TVF
+ALTER FUNCTION dbo.get_order_summary(@category VARCHAR(20))
+RETURNS @result TABLE 
+(
+    category VARCHAR(20),
+    total_orders INT,
+    total_amount DECIMAL(18,2),
+    avg_amount DECIMAL(18,2),
+    max_amount DECIMAL(18,2) -- Added new column
+)
+AS
+BEGIN
+    INSERT INTO @result
+    SELECT 
+        category,
+        COUNT(*) as total_orders,
+        SUM(total_amount) as total_amount,
+        AVG(total_amount) as avg_amount,
+        MAX(total_amount) as max_amount -- Added new column
+    FROM 
+        orders
+    WHERE 
+        category = @category
+    GROUP BY 
+        category
+
+    RETURN
+END
+GO
+
+SELECT * FROM dbo.category_summaries
+GO
+SELECT * FROM dbo.category_summaries -- Should now include max_amount
+GO

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -463,3 +463,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -585,3 +585,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -583,3 +583,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -589,3 +589,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -590,3 +590,4 @@ babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 datetime_roundoff-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_15/schedule
+++ b/test/JDBC/upgrade/15_15/schedule
@@ -588,3 +588,4 @@ babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 datetime_roundoff-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -499,3 +499,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -519,3 +519,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -532,3 +532,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -568,3 +568,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -583,3 +583,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -592,3 +592,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -584,3 +584,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -576,3 +576,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -627,3 +627,4 @@ babel_numeric_money_oper
 babel_numeric_smallmoney_oper
 datetime_roundoff
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -625,3 +625,4 @@ babel_numeric_money_oper
 babel_numeric_smallmoney_oper
 datetime_roundoff
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -592,3 +592,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -598,3 +598,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -613,3 +613,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -619,3 +619,4 @@ babel_numeric_fixeddecimal_oper
 babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -624,3 +624,4 @@ babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 datetime_roundoff-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -628,3 +628,4 @@ babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 datetime_roundoff-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -621,3 +621,4 @@ babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 datetime_roundoff-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -635,3 +635,4 @@ babel_numeric_money_oper-before-16_10-or-17_6
 babel_numeric_smallmoney_oper-before-16_10-or-17_6
 datetime_roundoff-before-16_10-or-17_6
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/17_6/schedule
+++ b/test/JDBC/upgrade/17_6/schedule
@@ -643,3 +643,4 @@ babel_numeric_money_oper
 babel_numeric_smallmoney_oper
 datetime_roundoff
 babel_assign_nchar
+alter-function-with-weak-view

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -645,3 +645,4 @@ babel_numeric_money_oper
 babel_numeric_smallmoney_oper
 datetime_roundoff
 babel_assign_nchar
+alter-function-with-weak-view


### PR DESCRIPTION
### Description

This PR adds support for altering functions that have dependent weak schemabinding views. Previously, any attempt to alter a function that was referenced by a view would fail with a dependency error, regardless of the view schemabinding status.

### Issues Resolved

BABEL - 5943

Signed off: Rahul Parande rparande@amazon.com
### Test Scenarios Covered ###
* **Use case based -**
```
CREATE TABLE orders ( order_id INT PRIMARY KEY, total_amount DECIMAL(18,2) ) 
GO

CREATE FUNCTION dbo.calculate_tax(@amount DECIMAL(18,2)) RETURNS DECIMAL(18,2) AS BEGIN RETURN @amount * 0.1; END
GO

EXEC sp_babelfish_configure 'babelfishpg_tsql.weak_view_binding', 'on';
GO

-- Creating weak schemabinding view
CREATE VIEW dbo.order_summary AS
SELECT 
    order_id,
    total_amount,
    dbo.calculate_tax(total_amount) AS tax_amount,
    total_amount + dbo.calculate_tax(total_amount) AS total_with_tax
FROM 
    orders
GO

-- Alter Function
ALTER FUNCTION dbo.calculate_tax ( @amount DECIMAL(18,2) ) RETURNS DECIMAL(18,2) AS BEGIN RETURN @amount * 0.15; END; 
GO
```

* **Boundary conditions -**
```
CREATE FUNCTION dbo.calculate_tax(@amount DECIMAL(18,2)) RETURNS DECIMAL(18,2) AS BEGIN RETURN @amount * 0.1; END
GO

EXEC sp_babelfish_configure 'babelfishpg_tsql.weak_view_binding', 'on';
GO

-- Creating Strong schemabinding view
CREATE VIEW dbo.order_summary AS
SELECT 
    order_id,
    total_amount,
    dbo.calculate_tax(total_amount) AS tax_amount,
    total_amount + dbo.calculate_tax(total_amount) AS total_with_tax
FROM 
    orders
GO

-- Alter Function
ALTER FUNCTION dbo.calculate_tax ( @amount DECIMAL(18,2) ) RETURNS DECIMAL(18,2) AS BEGIN RETURN @amount * 0.15; END; 
GO
~~ERROR (Code: 33557097)~~

~~ERROR (Message: Cannot alter function master_dbo.calculate_tax because it is bound to a view.)~~
```

* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).