### PR TITLE
Rectified sp_helplogins stored proc for certain cases (#3918)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -3764,153 +3764,102 @@ DECLARE @current_username sys.nvarchar(128)
 DECLARE @is_sysadmin BIT
 BEGIN
 
-    IF is_srvrolemember('securityadmin') = 0 
-    BEGIN
-        RAISERROR('User does not have permission to perform this action.', 16, 1);
+	IF is_srvrolemember('securityadmin') = 0 
+	BEGIN
+		RAISERROR('User does not have permission to perform this action.', 16, 1);
 		RETURN 0;
-    END
+	END
 
-    SET @current_username = LOWER(sys.suser_name());
-    SET @is_sysadmin = is_srvrolemember('sysadmin');
+	SET @current_username = LOWER(sys.suser_name());
+	SET @is_sysadmin = is_srvrolemember('sysadmin');
+
+	SET @input_loginname = sys.RTRIM(@loginname);
+
+	SELECT DISTINCT
+		CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+		CAST(CAST(Base.oid AS INT) AS sys.varbinary(85)) AS SID,
+		CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
+		CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
+		CASE
+		    WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
+		    WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
+		    ELSE CAST('no' AS sys.char(5))
+		END AS AUser,
+		CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
+	FROM pg_catalog.pg_roles AS Base
+	INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
+	LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
+	LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
+	WHERE LExt.type NOT IN ('R', 'Z') AND
+	      (@loginname IS NULL OR LExt.orig_loginname = @input_loginname)
+
+	-- first selector in the union is to get all the mapped users
+	-- second selector in the union is to get all the mapped database/user-defined roles
+	SELECT
+		CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+		CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
+		CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
+		CAST('User' AS sys.char(8)) AS UserOrAlias
+	FROM sys.babelfish_authid_user_ext UExt
+	LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
+	LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
+	WHERE UExt.type != 'R' AND  
+		UExt.orig_username != 'guest' AND 
+		has_dbaccess(UExt.database_name) = 1 AND
+		(@loginname IS NULL OR LExt.orig_loginname = @input_loginname) AND
+		(
+			@is_sysadmin = 1 OR
+			LExt.orig_loginname = @current_username OR
+			ISNULL(UExt.login_name, '') = '' OR
+			-- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+			EXISTS (
+				SELECT 1 
+				FROM pg_catalog.pg_auth_members AS Authmbr
+				INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+				INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname
+				WHERE UExt1.orig_username IN ('db_owner', 'db_securityadmin', 'db_accessadmin') 
+				AND UExt2.database_name = UExt.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+				AND UExt2.login_name = @current_username
+			)
+		)
+	UNION
+	SELECT
+		CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+		CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
+		CAST(UExt1.orig_username AS sys.SYSNAME) AS UserName,
+		CAST('MemberOf' AS sys.char(8)) AS UserOrAlias
+	FROM pg_catalog.pg_auth_members AS Authmbr
+	INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+	INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+	INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
+	INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
+	LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
+	LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
+	WHERE 
+		has_dbaccess(UExt2.database_name) = 1 AND
+		(@loginname IS NULL OR LExt.orig_loginname = @input_loginname) AND
+		(
+			@is_sysadmin = 1 OR
+			LExt.orig_loginname = @current_username OR
+			ISNULL(UExt2.login_name, '') = '' OR
+			-- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+			EXISTS (
+				SELECT 1
+				FROM pg_catalog.pg_auth_members AS Authmbr
+				INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+				INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt3 ON PGR1.rolname = UExt3.rolname
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt4 ON PGR2.rolname = UExt4.rolname
+				WHERE UExt3.orig_username IN ('db_owner', 'db_securityadmin', 'db_accessadmin') 
+				AND UExt4.database_name = UExt2.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+				AND UExt4.login_name = @current_username
+			)
+		)
+	ORDER BY LoginName, DBName, UserName
     
-    IF @loginname IS NULL
-    BEGIN    
-        SELECT DISTINCT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
-            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
-            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
-            CASE 
-                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
-                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
-                ELSE CAST('no' AS sys.char(5))
-            END AS AUser,
-            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
-        FROM pg_catalog.pg_roles AS Base 
-        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
-        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
-        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
-        WHERE LExt.type NOT IN ('R', 'Z')
-
-        -- first selector in the union is to get all the mapped users
-        -- second selector in the union is to get all the mapped database/user-defined roles
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
-            CAST('User' AS sys.char(8)) AS UserOrAlias
-        FROM sys.babelfish_authid_user_ext UExt
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
-        WHERE UExt.type != 'R' AND  
-            UExt.orig_username != 'guest' AND 
-            has_dbaccess(UExt.database_name) = 1 AND
-            (
-                @is_sysadmin = 1 OR
-                UExt.login_name = @current_username OR
-                ISNULL(UExt.login_name, '') = '' OR
-                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
-                EXISTS (
-                    SELECT 1 
-                    FROM pg_catalog.pg_auth_members AS Authmbr
-                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname
-                    WHERE UExt1.orig_username IN ('db_securityadmin', 'db_accessadmin') 
-                    AND UExt2.database_name = UExt.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
-                    AND UExt2.login_name = @current_username
-                )
-            )
-        UNION
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt1.orig_username AS sys.SYSNAME) AS UserName,
-            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias 
-        FROM pg_catalog.pg_auth_members AS Authmbr
-        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
-        WHERE 
-            has_dbaccess(UExt2.database_name) = 1 AND
-            (
-                @is_sysadmin = 1 OR
-                UExt2.login_name = @current_username OR
-                ISNULL(UExt2.login_name, '') = '' OR
-                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
-                EXISTS (
-                    SELECT 1
-                    FROM pg_catalog.pg_auth_members AS Authmbr
-                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt3 ON PGR1.rolname = UExt3.rolname
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt4 ON PGR2.rolname = UExt4.rolname
-                    WHERE UExt3.orig_username IN ('db_securityadmin', 'db_accessadmin') 
-                    AND UExt4.database_name = UExt2.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
-                    AND UExt4.login_name = @current_username
-                )
-            )
-        ORDER BY LoginName, DBName, UserName
-    END
-    ELSE
-    BEGIN
-        SET @input_loginname = sys.RTRIM(@loginname);
-
-        SELECT DISTINCT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
-            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
-            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
-            CASE 
-                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
-                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
-                ELSE CAST('no' AS sys.char(5))
-            END AS AUser,
-            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
-        FROM pg_catalog.pg_roles AS Base 
-        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
-        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
-        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
-        WHERE LExt.type NOT IN ('R', 'Z') AND LExt.orig_loginname = @input_loginname
-        
-        -- first selector in the union is to get all the mapped users
-        -- second selector in the union is to get all the mapped database/user-defined roles
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
-            CAST('User' AS sys.char(8)) AS UserOrAlias 
-        FROM sys.babelfish_authid_user_ext UExt
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
-        WHERE UExt.type != 'R' AND  
-            UExt.orig_username != 'guest' AND 
-            has_dbaccess(UExt.database_name) = 1 AND
-            LExt.orig_loginname = @input_loginname
-        UNION
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt1.orig_username AS SYS.SYSNAME) AS UserName,
-            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias
-        FROM pg_catalog.pg_auth_members AS Authmbr
-        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
-        WHERE 
-            has_dbaccess(UExt2.database_name) = 1 AND
-            LExt.orig_loginname = @input_loginname
-        ORDER BY LoginName, DBName, UserName
-    END;
-
-    RETURN 0;
+	RETURN 0;
 END;
 $$;
 GRANT EXECUTE ON PROCEDURE sys.sp_helplogins TO PUBLIC;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.6.0--4.7.0.sql
@@ -321,153 +321,102 @@ DECLARE @current_username sys.nvarchar(128)
 DECLARE @is_sysadmin BIT
 BEGIN
 
-    IF is_srvrolemember('securityadmin') = 0 
-    BEGIN
-        RAISERROR('User does not have permission to perform this action.', 16, 1);
+	IF is_srvrolemember('securityadmin') = 0 
+	BEGIN
+		RAISERROR('User does not have permission to perform this action.', 16, 1);
 		RETURN 0;
-    END
+	END
 
-    SET @current_username = LOWER(sys.suser_name());
-    SET @is_sysadmin = is_srvrolemember('sysadmin');
+	SET @current_username = LOWER(sys.suser_name());
+	SET @is_sysadmin = is_srvrolemember('sysadmin');
+
+	SET @input_loginname = sys.RTRIM(@loginname);
+
+	SELECT DISTINCT
+		CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+		CAST(CAST(Base.oid AS INT) AS sys.varbinary(85)) AS SID,
+		CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
+		CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
+		CASE
+		    WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
+		    WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
+		    ELSE CAST('no' AS sys.char(5))
+		END AS AUser,
+		CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
+	FROM pg_catalog.pg_roles AS Base
+	INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
+	LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
+	LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
+	WHERE LExt.type NOT IN ('R', 'Z') AND
+	      (@loginname IS NULL OR LExt.orig_loginname = @input_loginname)
+
+	-- first selector in the union is to get all the mapped users
+	-- second selector in the union is to get all the mapped database/user-defined roles
+	SELECT
+		CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+		CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
+		CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
+		CAST('User' AS sys.char(8)) AS UserOrAlias
+	FROM sys.babelfish_authid_user_ext UExt
+	LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
+	LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
+	WHERE UExt.type != 'R' AND  
+		UExt.orig_username != 'guest' AND 
+		has_dbaccess(UExt.database_name) = 1 AND
+		(@loginname IS NULL OR LExt.orig_loginname = @input_loginname) AND
+		(
+			@is_sysadmin = 1 OR
+			LExt.orig_loginname = @current_username OR
+			ISNULL(UExt.login_name, '') = '' OR
+			-- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+			EXISTS (
+				SELECT 1 
+				FROM pg_catalog.pg_auth_members AS Authmbr
+				INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+				INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname
+				WHERE UExt1.orig_username IN ('db_owner', 'db_securityadmin', 'db_accessadmin') 
+				AND UExt2.database_name = UExt.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+				AND UExt2.login_name = @current_username
+			)
+		)
+	UNION
+	SELECT
+		CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
+		CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
+		CAST(UExt1.orig_username AS sys.SYSNAME) AS UserName,
+		CAST('MemberOf' AS sys.char(8)) AS UserOrAlias
+	FROM pg_catalog.pg_auth_members AS Authmbr
+	INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+	INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+	INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
+	INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
+	LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
+	LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
+	WHERE 
+		has_dbaccess(UExt2.database_name) = 1 AND
+		(@loginname IS NULL OR LExt.orig_loginname = @input_loginname) AND
+		(
+			@is_sysadmin = 1 OR
+			LExt.orig_loginname = @current_username OR
+			ISNULL(UExt2.login_name, '') = '' OR
+			-- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
+			EXISTS (
+				SELECT 1
+				FROM pg_catalog.pg_auth_members AS Authmbr
+				INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
+				INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt3 ON PGR1.rolname = UExt3.rolname
+				INNER JOIN sys.babelfish_authid_user_ext AS UExt4 ON PGR2.rolname = UExt4.rolname
+				WHERE UExt3.orig_username IN ('db_owner', 'db_securityadmin', 'db_accessadmin') 
+				AND UExt4.database_name = UExt2.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
+				AND UExt4.login_name = @current_username
+			)
+		)
+	ORDER BY LoginName, DBName, UserName
     
-    IF @loginname IS NULL
-    BEGIN    
-        SELECT DISTINCT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
-            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
-            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
-            CASE 
-                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
-                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
-                ELSE CAST('no' AS sys.char(5))
-            END AS AUser,
-            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
-        FROM pg_catalog.pg_roles AS Base 
-        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
-        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
-        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
-        WHERE LExt.type NOT IN ('R', 'Z')
-
-        -- first selector in the union is to get all the mapped users
-        -- second selector in the union is to get all the mapped database/user-defined roles
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
-            CAST('User' AS sys.char(8)) AS UserOrAlias
-        FROM sys.babelfish_authid_user_ext UExt
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
-        WHERE UExt.type != 'R' AND  
-            UExt.orig_username != 'guest' AND 
-            has_dbaccess(UExt.database_name) = 1 AND
-            (
-                @is_sysadmin = 1 OR
-                UExt.login_name = @current_username OR
-                ISNULL(UExt.login_name, '') = '' OR
-                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
-                EXISTS (
-                    SELECT 1 
-                    FROM pg_catalog.pg_auth_members AS Authmbr
-                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname
-                    WHERE UExt1.orig_username IN ('db_securityadmin', 'db_accessadmin') 
-                    AND UExt2.database_name = UExt.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
-                    AND UExt2.login_name = @current_username
-                )
-            )
-        UNION
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt1.orig_username AS sys.SYSNAME) AS UserName,
-            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias 
-        FROM pg_catalog.pg_auth_members AS Authmbr
-        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
-        WHERE 
-            has_dbaccess(UExt2.database_name) = 1 AND
-            (
-                @is_sysadmin = 1 OR
-                UExt2.login_name = @current_username OR
-                ISNULL(UExt2.login_name, '') = '' OR
-                -- a co-related query to find out if the current_user is a member of db_securityadmin or db_accessadmin role in database - UExt.database_name 
-                EXISTS (
-                    SELECT 1
-                    FROM pg_catalog.pg_auth_members AS Authmbr
-                    INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-                    INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt3 ON PGR1.rolname = UExt3.rolname
-                    INNER JOIN sys.babelfish_authid_user_ext AS UExt4 ON PGR2.rolname = UExt4.rolname
-                    WHERE UExt3.orig_username IN ('db_securityadmin', 'db_accessadmin') 
-                    AND UExt4.database_name = UExt2.database_name -- filter to check if the processing db is equal to the outer query db, since we want to find if the user is a member of the roles in the outer db
-                    AND UExt4.login_name = @current_username
-                )
-            )
-        ORDER BY LoginName, DBName, UserName
-    END
-    ELSE
-    BEGIN
-        SET @input_loginname = sys.RTRIM(@loginname);
-
-        SELECT DISTINCT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(CAST(Base.oid AS BIGINT) AS sys.varbinary(85)) AS SID,
-            CAST(LExt.default_database_name AS SYS.SYSNAME) AS DefDBName,
-            CAST(LExt.default_language_name AS SYS.SYSNAME) AS DefLangName,
-            CASE 
-                WHEN Ext.login_name IS NOT NULL AND Ext.login_name = LExt.rolname COLLATE database_default THEN CAST('yes' AS sys.char(5)) -- if there exists a mapping between user and logins, then we can say that there are users attached to this login
-                WHEN Db.owner COLLATE database_default = LExt.orig_loginname THEN CAST('yes' AS sys.char(5)) -- this is the case for superuser
-                ELSE CAST('no' AS sys.char(5))
-            END AS AUser,
-            CAST('no' AS sys.char(7)) AS ARemote -- Currently we do not support linking local logins to remote logins
-        FROM pg_catalog.pg_roles AS Base 
-        INNER JOIN sys.babelfish_authid_login_ext AS LExt ON Base.rolname = LExt.rolname
-        LEFT JOIN sys.babelfish_authid_user_ext AS Ext ON Ext.login_name = Base.rolname AND Ext.type != 'R'
-        LEFT JOIN sys.babelfish_sysdatabases AS Db ON Db.owner COLLATE database_default = LExt.orig_loginname
-        WHERE LExt.type NOT IN ('R', 'Z') AND LExt.orig_loginname = @input_loginname
-        
-        -- first selector in the union is to get all the mapped users
-        -- second selector in the union is to get all the mapped database/user-defined roles
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt.orig_username AS SYS.SYSNAME) AS UserName,
-            CAST('User' AS sys.char(8)) AS UserOrAlias 
-        FROM sys.babelfish_authid_user_ext UExt
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt.login_name, ''), Db.owner)
-        WHERE UExt.type != 'R' AND  
-            UExt.orig_username != 'guest' AND 
-            has_dbaccess(UExt.database_name) = 1 AND
-            LExt.orig_loginname = @input_loginname
-        UNION
-        SELECT
-            CAST(LExt.orig_loginname AS sys.SYSNAME) AS LoginName,
-            CAST(UExt2.database_name AS sys.SYSNAME) AS DBName,
-            CAST(UExt1.orig_username AS SYS.SYSNAME) AS UserName,
-            CAST('MemberOf' AS sys.char(8)) AS UserOrAlias
-        FROM pg_catalog.pg_auth_members AS Authmbr
-        INNER JOIN pg_catalog.pg_roles AS PGR1 ON PGR1.oid = Authmbr.roleid
-        INNER JOIN pg_catalog.pg_roles AS PGR2 ON PGR2.oid = Authmbr.member
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt1 ON PGR1.rolname = UExt1.rolname AND UExt1.type = 'R'
-        INNER JOIN sys.babelfish_authid_user_ext AS UExt2 ON PGR2.rolname = UExt2.rolname AND UExt2.orig_username != 'db_owner'
-        LEFT JOIN sys.babelfish_sysdatabases Db ON Db.name COLLATE database_default = UExt1.database_name
-        LEFT JOIN sys.babelfish_authid_login_ext LExt ON LExt.rolname COLLATE database_default = COALESCE(NULLIF(UExt2.login_name, ''), Db.owner)
-        WHERE 
-            has_dbaccess(UExt2.database_name) = 1 AND
-            LExt.orig_loginname = @input_loginname
-        ORDER BY LoginName, DBName, UserName
-    END;
-
-    RETURN 0;
+	RETURN 0;
 END;
 $$;
 GRANT EXECUTE ON PROCEDURE sys.sp_helplogins TO PUBLIC;

--- a/test/JDBC/expected/Test-sp_helpsrvrolemember-vu-verify.out
+++ b/test/JDBC/expected/Test-sp_helpsrvrolemember-vu-verify.out
@@ -1,9 +1,13 @@
+SET NOCOUNT ON
+GO
+
 INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
+-- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+-- justanotherloginwithsecad created within z_sp_helplogins
+WHERE MemberName NOT IN ('justanotherloginwithsecad')
 GO
 ~~START~~
 varchar#!#varchar#!#int
@@ -19,8 +23,6 @@ GO
 
 INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'sysadmin'
 GO
-~~ROW COUNT: 2~~
-
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
 GO
@@ -39,8 +41,6 @@ GO
 
 INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'sysadmin'
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
 GO
@@ -67,8 +67,6 @@ GO
 
 INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'sysadmin    '
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
 GO
@@ -122,6 +120,9 @@ INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EX
 GO
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
+-- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+-- justanotherloginwithsecad created within z_sp_helplogins
+WHERE MemberName NOT IN ('justanotherloginwithsecad')
 GO
 ~~START~~
 varchar#!#varchar#!#int

--- a/test/JDBC/expected/securityadmin_role-vu-verify.out
+++ b/test/JDBC/expected/securityadmin_role-vu-verify.out
@@ -33,6 +33,8 @@ TRUNCATE TABLE sadm_sp_helpsrvrolemember_tbl
 GO
 
 -- sp_helpsrvrolemember
+SET NOCOUNT ON
+GO
 INSERT INTO sadm_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'securityadmin'
 GO
 
@@ -615,10 +617,10 @@ TRUNCATE TABLE sadm_sp_helpsrvrolemember_tbl
 GO
 
 -- sp_helpsrvrolemember
+SET NOCOUNT ON
+GO
 INSERT INTO sadm_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'securityadmin'
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM sadm_sp_helpsrvrolemember_tbl where MemberName like '%securityadmin%'
 GO

--- a/test/JDBC/expected/sys_server_role_members-vu-prepare.out
+++ b/test/JDBC/expected/sys_server_role_members-vu-prepare.out
@@ -25,7 +25,11 @@ FROM sys.server_role_members AS server_role_members
 INNER JOIN sys.server_principals AS roles
     ON server_role_members.role_principal_id = roles.principal_id
 INNER JOIN sys.server_principals AS members 
-    ON server_role_members.member_principal_id = members.principal_id order by MemberPrincipalName;
+    ON server_role_members.member_principal_id = members.principal_id
+-- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+-- (justanotherloginwithsecad) created within z_sp_helplogins
+WHERE members.name NOT IN ('justanotherloginwithsecad')
+ORDER BY MemberPrincipalName;
 GO
 
 CREATE FUNCTION sys_server_role_members_vu_prepare_func ()
@@ -39,7 +43,11 @@ RETURN (
         INNER JOIN sys.server_principals AS roles
             ON server_role_members.role_principal_id = roles.principal_id
         INNER JOIN sys.server_principals AS members
-            ON server_role_members.member_principal_id = members.principal_id order by MemberPrincipalName
+            ON server_role_members.member_principal_id = members.principal_id
+        -- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+        -- (justanotherloginwithsecad) created within z_sp_helplogins
+        WHERE members.name NOT IN ('justanotherloginwithsecad')
+		order by MemberPrincipalName
     );
 GO
 
@@ -53,6 +61,10 @@ BEGIN
     INNER JOIN sys.server_principals AS roles
         ON server_role_members.role_principal_id = roles.principal_id
     INNER JOIN sys.server_principals AS members
-        ON server_role_members.member_principal_id = members.principal_id order by MemberPrincipalName;
+        ON server_role_members.member_principal_id = members.principal_id
+    -- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+    -- (justanotherloginwithsecad) created within z_sp_helplogins
+    WHERE members.name NOT IN ('justanotherloginwithsecad')
+	order by MemberPrincipalName
 END;
 GO

--- a/test/JDBC/expected/z_sp_helplogins-vu-cleanup.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-cleanup.out
@@ -72,6 +72,10 @@ drop user if exists u_sp_helplogin_loginwithusermemberofdbowner
 drop login sp_helplogin_loginwithusermemberofdbowner
 GO
 
+drop user if exists u_justanotherloginwithsecad
+drop login justanotherloginwithsecad
+GO
+
 drop login sp_helplogin_loginwithdifferentdefaultdb;
 GO
 

--- a/test/JDBC/expected/z_sp_helplogins-vu-prepare.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-prepare.out
@@ -69,3 +69,10 @@ GO
 create login sp_helplogin_loginwithusermemberofdbowner with password = '12345678'
 create user u_sp_helplogin_loginwithusermemberofdbowner for login sp_helplogin_loginwithusermemberofdbowner
 GO
+
+-- creating a user which is a member of securityadmin and db_accessadmin
+create login justanotherloginwithsecad with password = '12345678';
+alter server role securityadmin add member justanotherloginwithsecad;
+create user u_justanotherloginwithsecad for login justanotherloginwithsecad;
+alter role db_accessadmin add member u_justanotherloginwithsecad;
+GO

--- a/test/JDBC/expected/z_sp_helplogins-vu-verify.out
+++ b/test/JDBC/expected/z_sp_helplogins-vu-verify.out
@@ -57,6 +57,12 @@ GO
 alter login testloginindb1 with password = '12345678'
 GO
 
+alter login sp_helplogin_loginwithusermemberofdbowner with password = '12345678'
+GO
+
+alter login justanotherloginwithsecad with password = '12345678'
+GO
+
 -------- alter roles and add users and logins 
 alter role db_securityadmin add member userof_sp_helplogins_testlogin
 GO
@@ -65,6 +71,9 @@ alter server role securityadmin add member testloginwithsecurityadmin
 GO
 
 alter server role securityadmin add member testloginwithsecurityadmin2
+GO
+
+alter server role securityadmin add member sp_helplogin_loginwithusermemberofdbowner
 GO
 
 use sp_helplogins_db1
@@ -113,6 +122,7 @@ varchar#!#varchar#!#varchar#!#char#!#char
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
 helplogins\win#!#master#!#English#!#yes  #!#no     
 jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
 sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
@@ -139,6 +149,8 @@ jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
 jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
 jdbc_user#!#tempdb#!#db_owner#!#MemberOf
 jdbc_user#!#tempdb#!#dbo#!#User    
+justanotherloginwithsecad#!#master#!#db_accessadmin#!#MemberOf
+justanotherloginwithsecad#!#master#!#u_justanotherloginwithsecad#!#User    
 sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
 sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#db_owner#!#MemberOf
 sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#dbo#!#User    
@@ -182,6 +194,7 @@ varchar#!#varchar#!#varchar#!#char#!#char
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
 helplogins\win#!#master#!#English#!#yes  #!#no     
 jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
 sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
@@ -211,6 +224,62 @@ testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadm
 ~~END~~
 
 
+-- we can query for the login which is currently connected 
+-- to the session and we WILL BE able to see the user for 
+-- that login
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+testloginwithsecurityadmin#!#sp_helplogins_db1#!#userof_testloginwithsecurityadmin_indb1#!#User    
+~~END~~
+
+
+-- HOWEVER if we explicitly query for other logins with users, 
+-- the corresponding users should not be visible
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+~~END~~
+
+
+-- but if we query for superuser the logins and its users should be visible
+-- but only from the databases that this user has access to
+-- ignore_columns 2
+EXEC sp_helplogins 'jdbc_user'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+jdbc_user#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
+jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+~~END~~
+
+
 -- tsql user=testloginwithsecurityadmin2 password=12345678
 -- since this login is a member of securityadmin, it will be able to call the proc
 -- it will see all logins and since it also has db_securityadmin in sp_helplogins_db1
@@ -223,6 +292,7 @@ varchar#!#varchar#!#varchar#!#char#!#char
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
 helplogins\win#!#master#!#English#!#yes  #!#no     
 jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
 sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
@@ -268,6 +338,7 @@ varchar#!#varchar#!#varchar#!#char#!#char
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
 helplogins\win#!#master#!#English#!#yes  #!#no     
 jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
 sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
@@ -294,6 +365,8 @@ jdbc_user#!#sp_helplogins_db1#!#db_owner#!#MemberOf
 jdbc_user#!#sp_helplogins_db1#!#dbo#!#User    
 jdbc_user#!#tempdb#!#db_owner#!#MemberOf
 jdbc_user#!#tempdb#!#dbo#!#User    
+justanotherloginwithsecad#!#master#!#db_accessadmin#!#MemberOf
+justanotherloginwithsecad#!#master#!#u_justanotherloginwithsecad#!#User    
 sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
 sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#db_owner#!#MemberOf
 sp_help@logins$with%sp*chars#!#sp_helplogins_db2#!#dbo#!#User    
@@ -328,6 +401,7 @@ varchar#!#varchar#!#varchar#!#char#!#char
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
 helplogins\win#!#master#!#English#!#yes  #!#no     
 jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
 sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
 sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
@@ -352,6 +426,8 @@ jdbc_user#!#msdb#!#db_owner#!#MemberOf
 jdbc_user#!#msdb#!#dbo#!#User    
 jdbc_user#!#tempdb#!#db_owner#!#MemberOf
 jdbc_user#!#tempdb#!#dbo#!#User    
+justanotherloginwithsecad#!#master#!#db_accessadmin#!#MemberOf
+justanotherloginwithsecad#!#master#!#u_justanotherloginwithsecad#!#User    
 sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
 sp_helplogin_loginwithusermemberofdbowner#!#master#!#db_owner#!#MemberOf
 sp_helplogin_loginwithusermemberofdbowner#!#master#!#u_sp_helplogin_loginwithusermemberofdbowner#!#User    
@@ -484,5 +560,154 @@ varchar#!#varchar#!#varchar#!#char#!#char
 
 ~~START~~
 varchar#!#varchar#!#varchar#!#char
+~~END~~
+
+
+-- tsql user=sp_helplogin_loginwithusermemberofdbowner password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins and since it also has db_owner in master
+-- it will also see all the users in that database
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#!#User    
+helplogins\win#!#master#!#sp_helplogins_vu_windows_user#!#User    
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+justanotherloginwithsecad#!#master#!#db_accessadmin#!#MemberOf
+justanotherloginwithsecad#!#master#!#u_justanotherloginwithsecad#!#User    
+sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#db_owner#!#MemberOf
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#u_sp_helplogin_loginwithusermemberofdbowner#!#User    
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+testloginwithsecadminanddbsec#!#master#!#db_securityadmin#!#MemberOf
+testloginwithsecadminanddbsec#!#master#!#u_testloginwithsecadminanddbsec#!#User    
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+~~END~~
+
+
+-- and also it will be able to see users for which it calls
+-- the proc explicitly
+-- ignore_columns 2
+EXEC sp_helplogins 'jdbc_user'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+jdbc_user#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+~~END~~
+
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+~~END~~
+
+
+-- tsql user=justanotherloginwithsecad password=12345678
+-- since it is a member of securityadmin, it will be able to call the proc
+-- and since it is also member of db_accessadmin in master db,
+-- it can view the users in master db
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#English#!#yes  #!#no     
+helplogins\win#!#master#!#English#!#yes  #!#no     
+jdbc_user#!#master#!#English#!#yes  #!#no     
+justanotherloginwithsecad#!#master#!#English#!#yes  #!#no     
+sp_help@logins$with%sp*chars#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginownerofdb#!#master#!#English#!#yes  #!#no     
+sp_helplogin_loginwithdifferentdefaultdb#!#sp_helplogins_db3#!#English#!#no   #!#no     
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#English#!#yes  #!#no     
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+testloginindb1#!#master#!#English#!#yes  #!#no     
+testloginwithotherdefdb#!#sp_helplogins_db1#!#English#!#yes  #!#no     
+testloginwithoutusers#!#master#!#English#!#no   #!#no     
+testloginwithsecadminanddbsec#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin#!#master#!#English#!#yes  #!#no     
+testloginwithsecurityadmin2#!#master#!#English#!#yes  #!#no     
+testloginwithsysadmin#!#master#!#English#!#no   #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#!#master#!#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#!#User    
+helplogins\win#!#master#!#sp_helplogins_vu_windows_user#!#User    
+jdbc_user#!#master#!#db_owner#!#MemberOf
+jdbc_user#!#master#!#dbo#!#User    
+jdbc_user#!#msdb#!#db_owner#!#MemberOf
+jdbc_user#!#msdb#!#dbo#!#User    
+jdbc_user#!#tempdb#!#db_owner#!#MemberOf
+jdbc_user#!#tempdb#!#dbo#!#User    
+justanotherloginwithsecad#!#master#!#db_accessadmin#!#MemberOf
+justanotherloginwithsecad#!#master#!#u_justanotherloginwithsecad#!#User    
+sp_help@logins$with%sp*chars#!#master#!#userof@sp$chars*logins#!#User    
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#db_owner#!#MemberOf
+sp_helplogin_loginwithusermemberofdbowner#!#master#!#u_sp_helplogin_loginwithusermemberofdbowner#!#User    
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
+testloginwithsecadminanddbsec#!#master#!#db_securityadmin#!#MemberOf
+testloginwithsecadminanddbsec#!#master#!#u_testloginwithsecadminanddbsec#!#User    
+testloginwithsecurityadmin#!#master#!#userof_testloginwithsecurityadmin#!#User    
+~~END~~
+
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#char#!#char
+sp_helplogins_testlogin#!#master#!#English#!#yes  #!#no     
+~~END~~
+
+~~START~~
+varchar#!#varchar#!#varchar#!#char
+sp_helplogins_testlogin#!#master#!#db_securityadmin#!#MemberOf
+sp_helplogins_testlogin#!#master#!#userof_sp_helplogins_testlogin#!#User    
 ~~END~~
 

--- a/test/JDBC/input/ownership/sys_server_role_members-vu-prepare.mix
+++ b/test/JDBC/input/ownership/sys_server_role_members-vu-prepare.mix
@@ -25,7 +25,11 @@ FROM sys.server_role_members AS server_role_members
 INNER JOIN sys.server_principals AS roles
     ON server_role_members.role_principal_id = roles.principal_id
 INNER JOIN sys.server_principals AS members 
-    ON server_role_members.member_principal_id = members.principal_id order by MemberPrincipalName;
+    ON server_role_members.member_principal_id = members.principal_id
+-- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+-- (justanotherloginwithsecad) created within z_sp_helplogins
+WHERE members.name NOT IN ('justanotherloginwithsecad')
+ORDER BY MemberPrincipalName;
 GO
 
 CREATE FUNCTION sys_server_role_members_vu_prepare_func ()
@@ -39,7 +43,11 @@ RETURN (
         INNER JOIN sys.server_principals AS roles
             ON server_role_members.role_principal_id = roles.principal_id
         INNER JOIN sys.server_principals AS members
-            ON server_role_members.member_principal_id = members.principal_id order by MemberPrincipalName
+            ON server_role_members.member_principal_id = members.principal_id
+        -- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+        -- (justanotherloginwithsecad) created within z_sp_helplogins
+        WHERE members.name NOT IN ('justanotherloginwithsecad')
+		order by MemberPrincipalName
     );
 GO
 
@@ -53,6 +61,10 @@ BEGIN
     INNER JOIN sys.server_principals AS roles
         ON server_role_members.role_principal_id = roles.principal_id
     INNER JOIN sys.server_principals AS members
-        ON server_role_members.member_principal_id = members.principal_id order by MemberPrincipalName;
+        ON server_role_members.member_principal_id = members.principal_id
+    -- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+    -- (justanotherloginwithsecad) created within z_sp_helplogins
+    WHERE members.name NOT IN ('justanotherloginwithsecad')
+	order by MemberPrincipalName
 END;
 GO

--- a/test/JDBC/input/securityadmin_role-vu-verify.mix
+++ b/test/JDBC/input/securityadmin_role-vu-verify.mix
@@ -18,6 +18,8 @@ TRUNCATE TABLE sadm_sp_helpsrvrolemember_tbl
 GO
 
 -- sp_helpsrvrolemember
+SET NOCOUNT ON
+GO
 INSERT INTO sadm_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'securityadmin'
 GO
 
@@ -407,6 +409,8 @@ TRUNCATE TABLE sadm_sp_helpsrvrolemember_tbl
 GO
 
 -- sp_helpsrvrolemember
+SET NOCOUNT ON
+GO
 INSERT INTO sadm_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember 'securityadmin'
 GO
 

--- a/test/JDBC/input/storedProcedures/Test-sp_helpsrvrolemember-vu-verify.sql
+++ b/test/JDBC/input/storedProcedures/Test-sp_helpsrvrolemember-vu-verify.sql
@@ -1,7 +1,13 @@
+SET NOCOUNT ON
+GO
+
 INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EXEC sp_helpsrvrolemember
 GO
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
+-- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+-- justanotherloginwithsecad created within z_sp_helplogins
+WHERE MemberName NOT IN ('justanotherloginwithsecad')
 GO
 
 TRUNCATE TABLE test_sp_helpsrvrolemember_tbl
@@ -73,6 +79,9 @@ INSERT INTO test_sp_helpsrvrolemember_tbl (ServerRole, MemberName, MemberSID) EX
 GO
 
 SELECT ServerRole, MemberName, (CASE WHEN MemberSID IS NULL THEN 0 ELSE 1 END) FROM test_sp_helpsrvrolemember_tbl
+-- a where clause which applies the NOT IN operator to remove all members added outside of this testcase
+-- justanotherloginwithsecad created within z_sp_helplogins
+WHERE MemberName NOT IN ('justanotherloginwithsecad')
 GO
 
 EXEC sp_helpsrvrolemember 'error'

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-cleanup.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-cleanup.mix
@@ -72,6 +72,10 @@ drop user if exists u_sp_helplogin_loginwithusermemberofdbowner
 drop login sp_helplogin_loginwithusermemberofdbowner
 GO
 
+drop user if exists u_justanotherloginwithsecad
+drop login justanotherloginwithsecad
+GO
+
 drop login sp_helplogin_loginwithdifferentdefaultdb;
 GO
 

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-prepare.mix
@@ -1,4 +1,4 @@
--- sla 120000
+-- sla 150000
 -- create a dummy db
 create database sp_helplogins_db1
 GO
@@ -69,4 +69,11 @@ GO
 -- creating a login which has a user which is a member of the db_owner db role (this is not the same as the login being owner of the db)
 create login sp_helplogin_loginwithusermemberofdbowner with password = '12345678'
 create user u_sp_helplogin_loginwithusermemberofdbowner for login sp_helplogin_loginwithusermemberofdbowner
+GO
+
+-- creating a user which is a member of securityadmin and db_accessadmin
+create login justanotherloginwithsecad with password = '12345678';
+alter server role securityadmin add member justanotherloginwithsecad;
+create user u_justanotherloginwithsecad for login justanotherloginwithsecad;
+alter role db_accessadmin add member u_justanotherloginwithsecad;
 GO

--- a/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-verify.mix
+++ b/test/JDBC/input/storedProcedures/z_sp_helplogins-vu-verify.mix
@@ -57,6 +57,12 @@ GO
 alter login testloginindb1 with password = '12345678'
 GO
 
+alter login sp_helplogin_loginwithusermemberofdbowner with password = '12345678'
+GO
+
+alter login justanotherloginwithsecad with password = '12345678'
+GO
+
 -------- alter roles and add users and logins 
 alter role db_securityadmin add member userof_sp_helplogins_testlogin
 GO
@@ -65,6 +71,9 @@ alter server role securityadmin add member testloginwithsecurityadmin
 GO
 
 alter server role securityadmin add member testloginwithsecurityadmin2
+GO
+
+alter server role securityadmin add member sp_helplogin_loginwithusermemberofdbowner
 GO
 
 use sp_helplogins_db1
@@ -122,6 +131,25 @@ GO
 EXEC sp_helplogins
 GO
 
+-- we can query for the login which is currently connected 
+-- to the session and we WILL BE able to see the user for 
+-- that login
+-- ignore_columns 2
+EXEC sp_helplogins 'testloginwithsecurityadmin'
+GO
+
+-- HOWEVER if we explicitly query for other logins with users, 
+-- the corresponding users should not be visible
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+
+-- but if we query for superuser the logins and its users should be visible
+-- but only from the databases that this user has access to
+-- ignore_columns 2
+EXEC sp_helplogins 'jdbc_user'
+GO
+
 -- tsql user=testloginwithsecurityadmin2 password=12345678
 -- since this login is a member of securityadmin, it will be able to call the proc
 -- it will see all logins and since it also has db_securityadmin in sp_helplogins_db1
@@ -176,4 +204,32 @@ GO
 
 -- ignore_columns 2
 EXEC sp_helplogins ' '
+GO
+
+-- tsql user=sp_helplogin_loginwithusermemberofdbowner password=12345678
+-- since this login is a member of securityadmin, it will be able to call the proc
+-- it will see all logins and since it also has db_owner in master
+-- it will also see all the users in that database
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+
+-- and also it will be able to see users for which it calls
+-- the proc explicitly
+-- ignore_columns 2
+EXEC sp_helplogins 'jdbc_user'
+GO
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
+GO
+
+-- tsql user=justanotherloginwithsecad password=12345678
+-- since it is a member of securityadmin, it will be able to call the proc
+-- and since it is also member of db_accessadmin in master db,
+-- it can view the users in master db
+-- ignore_columns 2
+EXEC sp_helplogins
+GO
+-- ignore_columns 2
+EXEC sp_helplogins 'sp_helplogins_testlogin'
 GO

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -570,4 +570,5 @@ test_conv_int_to_varbinary_binary_before_17_5_or_16_9
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+z_sp_helplogins
 weak-binding

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -573,4 +573,5 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+z_sp_helplogins
 weak-binding

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -573,4 +573,5 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+z_sp_helplogins
 weak-binding

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -573,5 +573,4 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT-before-16_4
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
-z_sp_helplogins
 weak-binding

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -604,4 +604,5 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+z_sp_helplogins
 weak-binding

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -611,4 +611,5 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+z_sp_helplogins
 weak-binding

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -625,4 +625,5 @@ babel_test_numeric_int8_oper
 MONEY_OBJECT
 money_smallmoney
 money_smallmoney_bit_dep_obj_before_17_6
+z_sp_helplogins
 weak-binding


### PR DESCRIPTION
Currently, there are certain issues with sp_helplogins -
1. db_owner is not treated as a special role with special priv leading to incorrect results
2. Using INTs instead of BIGINTs as the intermediate value for SIDs since we are converting it to binary and size of the intermediate type matters
3. Filter for the second result was missing from SQL for when loginname is not null.

And removed the branching to merge the if..else

Cherry-pick - https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/dd8e1b8928c8c3e37f2e79d9824de1155ab36e2c
Original PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3918


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).