### PR TITLE
Solving Crash in FOR JSON AUTO/PATH

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1639,7 +1639,7 @@ buildJsonEntry(int nestLevel, char* tableAlias, TargetEntry* te)
 	sprintf(nest, "%d", nestLevel);
 	// Adding JSONAUTOALIAS prevents us from modifying
 	// a column more than once
-	if(!strcmp(te->resname, "\?column\?")) {
+	if(te->resname == NULL || !strcmp(te->resname, "\?column\?")) {
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					errmsg("column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table")));
@@ -1659,10 +1659,23 @@ static void modifyColumnEntries(List* targetList, forjson_table **tableInfoArr, 
 	int i = 0;
 	int currMax = 0;
 	ListCell* lc;
+	
 	foreach(lc, targetList) {
-		TargetEntry* te = castNode(TargetEntry, lfirst(lc));
-		int oid = te->resorigtbl;
-		String* s = castNode(String, lfirst(list_nth_cell(colnameAlias->colnames, i)));
+		TargetEntry* te;
+		int oid;
+		String *s;
+
+		// Add null check for target entry
+		if (!lc || !lfirst(lc))
+			continue;
+		
+		te = castNode(TargetEntry, lfirst(lc));
+
+		if(te->resjunk)
+			continue;
+
+		oid = te->resorigtbl;
+		s = castNode(String, lfirst(list_nth_cell(colnameAlias->colnames, i)));
 		if(te->expr != NULL && nodeTag(te->expr) == T_SubLink) {
 			SubLink *sl = castNode(SubLink, te->expr);
 			if(sl->subselect != NULL && nodeTag(sl->subselect) == T_Query) {

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -496,8 +496,8 @@ tsql_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_values)
 
 		colname = NameStr(att->attname);
 
-		if (!strcmp(colname, "\?column\?")) /* When column name or alias is
-											 * not provided */
+		/* When column name or alias is not provided */
+		if (!colname || !strcmp(colname, "\?column\?") || colname[0] == '\0')
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/test/JDBC/expected/forjson-vu-verify.out
+++ b/test/JDBC/expected/forjson-vu-verify.out
@@ -155,3 +155,47 @@ nvarchar
 [{"Id": 5, "Age": 10, "Country": "USA"}, {"Id": 4, "Age": 20}, {"Id": 1, "Age": 25, "Country": "India"}, {"Id": 3, "Age": 30, "Country": "India"}, {"Id": 2, "Age": 40, "Country": "USA"}]
 ~~END~~
 
+
+/* 
+ * Found a crash in FOR JSON PATH 
+ * If the colname is empty, then system is crashing which needs handling
+ */
+--Empty column test
+select id as '', firstname as '' from forjson_vu_t_people for json path
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table)~~
+
+select id as '' from forjson_vu_t_people for json path, INCLUDE_NULL_VALUES
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table)~~
+
+select id as '', firstname as '' from forjson_vu_t_people for json auto
+GO
+~~START~~
+nvarchar
+[{"": 1, "": "Divya"}, {"": 2}, {"": 3, "": "Tom"}, {"": 4, "": "Kane"}]
+~~END~~
+
+select id as '' from forjson_vu_t_people for json auto, INCLUDE_NULL_VALUES
+GO
+~~START~~
+nvarchar
+[{"": 1}, {"": 2}, {"": 3}, {"": 4}]
+~~END~~
+
+select 1+1 as '' from forjson_vu_t_people for json path
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table)~~
+

--- a/test/JDBC/expected/forjsonauto-vu-cleanup.out
+++ b/test/JDBC/expected/forjsonauto-vu-cleanup.out
@@ -40,6 +40,15 @@ GO
 DROP VIEW forjson_vu_v_14
 GO
 
+DROP PROCEDURE forjson_vu_v_resjunk_orderby_groupby
+GO
+
+DROP PROCEDURE forjson_vu_v_resjunk_window_functions
+GO
+
+DROP PROCEDURE forjson_vu_p_resjunk_groupby_having_orderby
+GO
+
 DROP PROCEDURE forjson_vu_p_1
 GO
 
@@ -93,6 +102,9 @@ go
 
 drop trigger forjson_vu_trigger_2;
 go
+ 
+DROP FUNCTION dbo.forjson_auto_test_diff_cases_fn;
+GO
 
 DROP TABLE forjson_auto_vu_t_users
 GO
@@ -110,4 +122,12 @@ DROP TABLE forjson_auto_vu_t_times
 GO
 
 DROP TABLE t50
+GO
+
+DROP TABLE forjson_auto_test_diff_cases;
+DROP TABLE forjson_test_nested_1;
+DROP TABLE forjson_test_nested_2;
+DROP TABLE forjson_test_unicode;
+DROP TABLE forjson_test_orderby;
+DROP TABLE forjson_test_groupby;
 GO

--- a/test/JDBC/expected/forjsonauto-vu-prepare.out
+++ b/test/JDBC/expected/forjsonauto-vu-prepare.out
@@ -4,11 +4,21 @@ CREATE TABLE forjson_auto_vu_t_orders ([Id] int, [userid] int, [productid] int, 
 CREATE TABLE forjson_auto_vu_t_products ([Id] int, [name] varchar(50), [price] varchar (25));
 CREATE TABLE forjson_auto_vu_t_sales ([Id] int, [price] varchar(25), [totalSales] int);
 CREATE TABLE forjson_auto_vu_t_times ([Id] int, [date] Date);
+CREATE TABLE forjson_test_nested_1 (id int, [data] varchar(50));
+CREATE TABLE forjson_test_nested_2 (id int, [ref_id] int);
+CREATE TABLE forjson_test_unicode (id int, [column_标] varchar(50));
+CREATE TABLE forjson_test_orderby (id int, value int, name varchar(50));
+CREATE TABLE forjson_test_groupby (category varchar(20), product varchar(50), quantity int, price decimal(10,2));
 INSERT INTO forjson_auto_vu_t_users VALUES (1, 'j', 'o', 'testemail'), (1, 'e', 'l', 'testemail2');
 INSERT INTO forjson_auto_vu_t_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
 INSERT INTO forjson_auto_vu_t_products VALUES (1, 'A', 20), (1, 'B', 30);
 INSERT INTO forjson_auto_vu_t_sales VALUES (1, 20, 50), (2, 30, 100);
 INSERT INTO forjson_auto_vu_t_times VALUES (1, '2023-11-26'), (2, '2023-11-27');
+INSERT INTO forjson_test_nested_1 VALUES (1, NULL), (2, 'test');
+INSERT INTO forjson_test_nested_2 VALUES (1, 1), (2, NULL);
+INSERT INTO forjson_test_unicode VALUES (1, 'unicode data');
+INSERT INTO forjson_test_orderby VALUES (1, 20, 'Apple'), (2, 10, 'Banana'), (3, 30, 'Cherry'), (4, 15, 'Date'), (5, 25, 'Elderberry');
+INSERT INTO forjson_test_groupby VALUES ('Fruit', 'Apple', 10, 2.50), ('Fruit', 'Banana', 15, 1.75);
 GO
 ~~ROW COUNT: 2~~
 
@@ -17,6 +27,16 @@ GO
 ~~ROW COUNT: 2~~
 
 ~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 5~~
 
 ~~ROW COUNT: 2~~
 
@@ -281,4 +301,67 @@ CREATE PROCEDURE forjson_vu_p_15 AS
         SET @json_string = (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) 
         select U.id, U.firstname, @json_string as details from forjson_auto_vu_t_users U for json auto
 END
+GO
+
+-- FOR JSON AUTO + orderby + groupby
+CREATE PROCEDURE forjson_vu_v_resjunk_orderby_groupby AS
+SELECT (
+    SELECT P.price, 
+           COUNT(*) as product_count, 
+           SUM(O.quantity) as total_quantity
+    FROM forjson_auto_vu_t_orders O
+    JOIN forjson_auto_vu_t_products P ON P.Id = O.productid
+    GROUP BY P.price
+    ORDER BY SUM(O.quantity) DESC
+    FOR JSON AUTO
+) AS json_data;
+GO
+
+-- FOR JSON AUTO + window function
+CREATE PROCEDURE forjson_vu_v_resjunk_window_functions AS
+SELECT (
+    SELECT U.Id, U.firstname, P.name, P.price,
+           ROW_NUMBER() OVER(PARTITION BY P.price ORDER BY O.quantity DESC) as quantity_rank
+    FROM forjson_auto_vu_t_users U
+    JOIN forjson_auto_vu_t_orders O ON U.Id = O.userid
+    JOIN forjson_auto_vu_t_products P ON P.Id = O.productid
+    ORDER BY P.price, quantity_rank
+    FOR JSON AUTO
+) AS json_data;
+GO
+
+-- Stored procedure with GROUP BY, HAVING and ORDER BY
+CREATE PROCEDURE forjson_vu_p_resjunk_groupby_having_orderby AS
+BEGIN
+    SELECT P.price,
+           COUNT(*) as product_count,
+           SUM(O.quantity) as total_quantity
+    FROM forjson_auto_vu_t_orders O
+    JOIN forjson_auto_vu_t_products P ON P.Id = O.productid
+    GROUP BY P.price
+    HAVING COUNT(*) >= 1
+    ORDER BY SUM(O.quantity) DESC
+    FOR JSON AUTO;
+END;
+GO
+
+
+
+/*--------------- Found some incorrect cases which needs to be handled in future ------------------- */
+/*
+* CASE 1: FOR JSON AUTO + Function
+*/
+CREATE TABLE forjson_auto_test_diff_cases ( EmployeeId INT, Salary INT);
+INSERT INTO forjson_auto_test_diff_cases (EmployeeId, Salary) VALUES(1, 75000),(2, 85000)
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE FUNCTION dbo.forjson_auto_test_diff_cases_fn(@DepartmentId INT)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT  e.EmployeeId FROM forjson_auto_test_diff_cases e
+);
 GO

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -256,3 +256,202 @@ nvarchar
 
 ~~ROW COUNT: 1~~
 
+
+
+/* BABEL-5910 - Crash inside strcmp(), under buildJsonEntry() */
+-- Should fail gracefully with proper error message rather than crash
+SELECT 1+2 , firstname as [NULL] FROM forjson_auto_vu_t_users FOR JSON AUTO;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column expressions and data sources without names or aliases cannot be formatted as JSON text using FOR JSON clause. Add alias to the unnamed column or table)~~
+
+
+select 1+2 as 'a' for json auto;
+GO
+~~ERROR (Code: 13600)~~
+
+~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+
+
+select NULL as [NULL] from forjson_auto_vu_t_users for json auto;
+GO
+~~START~~
+nvarchar
+[{}, {}, {}]
+~~END~~
+
+
+-- empty result set
+SELECT * FROM forjson_auto_vu_t_users WHERE 1=0 FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+~~END~~
+
+
+-- NULL testing
+SELECT n1.id as "outer.id", 
+       n1.data as "outer.data", 
+       n2.id as "inner.id", 
+       n2.ref_id as "inner.ref_id" 
+FROM forjson_test_nested_1 n1 
+LEFT JOIN forjson_test_nested_2 n2 ON n1.id = n2.id 
+FOR JSON AUTO, INCLUDE_NULL_VALUES;
+GO
+~~START~~
+nvarchar
+[{"outer.id": 2, "outer.data": "test", "n2": [{"inner.id": 2, "inner.ref_id": null}]}, {"outer.id": 1, "outer.data": null, "n2": [{"inner.id": 1, "inner.ref_id": 1}]}]
+~~END~~
+
+
+--Special Unicode characters in column names
+SELECT id as "parent.id", 
+       column_标 as "parent.子.data" 
+FROM forjson_test_unicode 
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"parent.id": 1, "parent.子.data": "unicode data"}]
+~~END~~
+
+
+-- long alias name test check
+SELECT id as "ThisIsAnExtremelyLongColumnNameThatExceedsTheNormalLimitForColumnNamesInMostDatabaseSystemsIncludingPostgreSQLAndShouldTriggerOurHashKeyTruncationWarningWithoutCrashing.id"
+FROM forjson_auto_vu_t_users
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"ThisIsAnExtremelyLongCo": 1}, {"ThisIsAnExtremelyLongCo": 1}, {"ThisIsAnExtremelyLongCo": 1}]
+~~END~~
+
+
+-- ORDER BY with calculation - creates resjunk column
+SELECT id, name, value FROM forjson_test_orderby ORDER BY value * 2 DESC FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"id": 3, "name": "Cherry", "value": 30}, {"id": 5, "name": "Elderberry", "value": 25}, {"id": 1, "name": "Apple", "value": 20}, {"id": 4, "name": "Date", "value": 15}, {"id": 2, "name": "Banana", "value": 10}]
+~~END~~
+
+
+-- ORDER BY with multiple expressions - creates multiple resjunk columns
+SELECT id, name, value FROM forjson_test_orderby ORDER BY SUBSTRING(name, 1, 1), value DESC FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"id": 1, "name": "Apple", "value": 20}, {"id": 2, "name": "Banana", "value": 10}, {"id": 3, "name": "Cherry", "value": 30}, {"id": 4, "name": "Date", "value": 15}, {"id": 5, "name": "Elderberry", "value": 25}]
+~~END~~
+
+
+-- Simple GROUP BY - creates resjunk columns
+SELECT category, SUM(quantity) as total_quantity, AVG(price) as avg_price FROM forjson_test_groupby GROUP BY category FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"category": "Fruit", "total_quantity": 25, "avg_price": 2.125000}]
+~~END~~
+
+
+-- GROUP BY with HAVING - creates resjunk columns with filtering
+SELECT category, COUNT(*) as product_count, SUM(quantity) as total_quantity FROM forjson_test_groupby GROUP BY category
+HAVING SUM(quantity) > 20 FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"category": "Fruit", "product_count": 2, "total_quantity": 25}]
+~~END~~
+
+
+-- This creates multiple resjunk columns of various types
+SELECT category, 
+       COUNT(*) as product_count, 
+       SUM(quantity) as total_quantity,
+       MAX(price) as max_price,
+       MIN(price) as min_price
+FROM forjson_test_groupby
+GROUP BY category
+ORDER BY SUM(quantity * price) DESC
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"category": "Fruit", "product_count": 2, "total_quantity": 25, "max_price": 2.50, "min_price": 1.75}]
+~~END~~
+
+
+-- Test 13: Window functions - create resjunk columns
+SELECT id, 
+       value,
+       ROW_NUMBER() OVER(ORDER BY value) as row_num,
+       RANK() OVER(ORDER BY value) as rank_val
+FROM forjson_test_orderby
+ORDER BY id
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"id": 1, "value": 20, "row_num": 3, "rank_val": 3}, {"id": 2, "value": 10, "row_num": 1, "rank_val": 1}, {"id": 3, "value": 30, "row_num": 5, "rank_val": 5}, {"id": 4, "value": 15, "row_num": 2, "rank_val": 2}, {"id": 5, "value": 25, "row_num": 4, "rank_val": 4}]
+~~END~~
+
+
+-- For Version Upgrade Test
+EXECUTE forjson_vu_v_resjunk_orderby_groupby;
+GO
+~~START~~
+nvarchar
+[{"price": "30", "product_count": 2, "total_quantity": 11}, {"price": "20", "product_count": 2, "total_quantity": 11}]
+~~END~~
+
+
+EXECUTE forjson_vu_v_resjunk_window_functions;
+GO
+~~START~~
+nvarchar
+[{"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 2}, {"Id": 1, "firstname": "j", "p": [{"name": "A", "price": "20"}], "quantity_rank": 3}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 4}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 5}, {"Id": 1, "firstname": "j", "p": [{"name": "A", "price": "20"}], "quantity_rank": 6}, {"Id": 1, "firstname": "j", "p": [{"name": "B", "price": "30"}], "quantity_rank": 1}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 2}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 3}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 4}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 5}, {"Id": 1, "firstname": "j", "p": [{"name": "B", "price": "30"}], "quantity_rank": 6}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 1}]
+~~END~~
+
+
+EXECUTE forjson_vu_p_resjunk_groupby_having_orderby;
+GO
+~~START~~
+nvarchar
+[{"price": "30", "product_count": 2, "total_quantity": 11}, {"price": "20", "product_count": 2, "total_quantity": 11}]
+~~END~~
+
+
+
+
+/* ----------- Found Incorrect cases with needs to be handled in future  -------------- */
+/*
+ *  Condition : Only Function in the query
+ *  Expected Output: should not throw any error
+ *  Actual Output: throws incorrect error message
+ */ 
+SELECT  b.EmployeeId
+FROM dbo.forjson_auto_test_diff_cases_fn(1) as b
+FOR JSON AUTO;
+GO
+~~ERROR (Code: 13600)~~
+
+~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+
+
+
+/*
+ *  Condition : FUNCTION + RELATION
+ *  Actual Output: Treats Function as relation and gives incorrect output
+ *  Expected Output: should treat function and relation as separate and provides different
+ *                   nesting key and level for both
+ */ 
+SELECT  b.EmployeeId, a.salary
+FROM dbo.forjson_auto_test_diff_cases_fn(1) as b, forjson_auto_test_diff_cases a
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"EmployeeId": 1, "salary": 75000}, {"EmployeeId": 1, "salary": 85000}, {"EmployeeId": 2, "salary": 75000}, {"EmployeeId": 2, "salary": 85000}]
+~~END~~
+

--- a/test/JDBC/input/forjson/forjson-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjson-vu-verify.sql
@@ -61,3 +61,19 @@ GO
 -- Test for all parser rules
 SELECT * FROM forjson_vu_v_order_by
 GO
+
+/* 
+ * Found a crash in FOR JSON PATH 
+ * If the colname is empty, then system is crashing which needs handling
+ */
+--Empty column test
+select id as '', firstname as '' from forjson_vu_t_people for json path
+GO
+select id as '' from forjson_vu_t_people for json path, INCLUDE_NULL_VALUES
+GO
+select id as '', firstname as '' from forjson_vu_t_people for json auto
+GO
+select id as '' from forjson_vu_t_people for json auto, INCLUDE_NULL_VALUES
+GO
+select 1+1 as '' from forjson_vu_t_people for json path
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
@@ -40,6 +40,15 @@ GO
 DROP VIEW forjson_vu_v_14
 GO
 
+DROP PROCEDURE forjson_vu_v_resjunk_orderby_groupby
+GO
+
+DROP PROCEDURE forjson_vu_v_resjunk_window_functions
+GO
+
+DROP PROCEDURE forjson_vu_p_resjunk_groupby_having_orderby
+GO
+
 DROP PROCEDURE forjson_vu_p_1
 GO
 
@@ -93,6 +102,9 @@ go
 
 drop trigger forjson_vu_trigger_2;
 go
+ 
+DROP FUNCTION dbo.forjson_auto_test_diff_cases_fn;
+GO
 
 DROP TABLE forjson_auto_vu_t_users
 GO
@@ -110,4 +122,12 @@ DROP TABLE forjson_auto_vu_t_times
 GO
 
 DROP TABLE t50
+GO
+
+DROP TABLE forjson_auto_test_diff_cases;
+DROP TABLE forjson_test_nested_1;
+DROP TABLE forjson_test_nested_2;
+DROP TABLE forjson_test_unicode;
+DROP TABLE forjson_test_orderby;
+DROP TABLE forjson_test_groupby;
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
@@ -3,12 +3,22 @@ CREATE TABLE forjson_auto_vu_t_orders ([Id] int, [userid] int, [productid] int, 
 CREATE TABLE forjson_auto_vu_t_products ([Id] int, [name] varchar(50), [price] varchar (25));
 CREATE TABLE forjson_auto_vu_t_sales ([Id] int, [price] varchar(25), [totalSales] int);
 CREATE TABLE forjson_auto_vu_t_times ([Id] int, [date] Date);
+CREATE TABLE forjson_test_nested_1 (id int, [data] varchar(50));
+CREATE TABLE forjson_test_nested_2 (id int, [ref_id] int);
+CREATE TABLE forjson_test_unicode (id int, [column_标] varchar(50));
+CREATE TABLE forjson_test_orderby (id int, value int, name varchar(50));
+CREATE TABLE forjson_test_groupby (category varchar(20), product varchar(50), quantity int, price decimal(10,2));
 
 INSERT INTO forjson_auto_vu_t_users VALUES (1, 'j', 'o', 'testemail'), (1, 'e', 'l', 'testemail2');
 INSERT INTO forjson_auto_vu_t_orders VALUES (1, 1, 1, 5, '2023-06-25'), (2, 1, 1, 6, '2023-06-25');
 INSERT INTO forjson_auto_vu_t_products VALUES (1, 'A', 20), (1, 'B', 30);
 INSERT INTO forjson_auto_vu_t_sales VALUES (1, 20, 50), (2, 30, 100);
 INSERT INTO forjson_auto_vu_t_times VALUES (1, '2023-11-26'), (2, '2023-11-27');
+INSERT INTO forjson_test_nested_1 VALUES (1, NULL), (2, 'test');
+INSERT INTO forjson_test_nested_2 VALUES (1, 1), (2, NULL);
+INSERT INTO forjson_test_unicode VALUES (1, 'unicode data');
+INSERT INTO forjson_test_orderby VALUES (1, 20, 'Apple'), (2, 10, 'Banana'), (3, 30, 'Cherry'), (4, 15, 'Date'), (5, 25, 'Elderberry');
+INSERT INTO forjson_test_groupby VALUES ('Fruit', 'Apple', 10, 2.50), ('Fruit', 'Banana', 15, 1.75);
 GO
 
 CREATE VIEW forjson_vu_v_1 AS 
@@ -263,4 +273,65 @@ CREATE PROCEDURE forjson_vu_p_15 AS
         SET @json_string = (select P.price, O.productId from forjson_auto_vu_t_orders O JOIN forjson_auto_vu_t_products P ON (P.id = O.productid) for json auto) 
         select U.id, U.firstname, @json_string as details from forjson_auto_vu_t_users U for json auto
 END
+GO
+
+-- FOR JSON AUTO + orderby + groupby
+CREATE PROCEDURE forjson_vu_v_resjunk_orderby_groupby AS
+SELECT (
+    SELECT P.price, 
+           COUNT(*) as product_count, 
+           SUM(O.quantity) as total_quantity
+    FROM forjson_auto_vu_t_orders O
+    JOIN forjson_auto_vu_t_products P ON P.Id = O.productid
+    GROUP BY P.price
+    ORDER BY SUM(O.quantity) DESC
+    FOR JSON AUTO
+) AS json_data;
+GO
+
+-- FOR JSON AUTO + window function
+CREATE PROCEDURE forjson_vu_v_resjunk_window_functions AS
+SELECT (
+    SELECT U.Id, U.firstname, P.name, P.price,
+           ROW_NUMBER() OVER(PARTITION BY P.price ORDER BY O.quantity DESC) as quantity_rank
+    FROM forjson_auto_vu_t_users U
+    JOIN forjson_auto_vu_t_orders O ON U.Id = O.userid
+    JOIN forjson_auto_vu_t_products P ON P.Id = O.productid
+    ORDER BY P.price, quantity_rank
+    FOR JSON AUTO
+) AS json_data;
+GO
+
+-- Stored procedure with GROUP BY, HAVING and ORDER BY
+CREATE PROCEDURE forjson_vu_p_resjunk_groupby_having_orderby AS
+BEGIN
+    SELECT P.price,
+           COUNT(*) as product_count,
+           SUM(O.quantity) as total_quantity
+    FROM forjson_auto_vu_t_orders O
+    JOIN forjson_auto_vu_t_products P ON P.Id = O.productid
+    GROUP BY P.price
+    HAVING COUNT(*) >= 1
+    ORDER BY SUM(O.quantity) DESC
+    FOR JSON AUTO;
+END;
+GO
+
+
+/*--------------- Found some incorrect cases which needs to be handled in future ------------------- */
+
+/*
+* CASE 1: FOR JSON AUTO + Function
+*/
+CREATE TABLE forjson_auto_test_diff_cases ( EmployeeId INT, Salary INT);
+INSERT INTO forjson_auto_test_diff_cases (EmployeeId, Salary) VALUES(1, 75000),(2, 85000)
+GO
+
+CREATE FUNCTION dbo.forjson_auto_test_diff_cases_fn(@DepartmentId INT)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT  e.EmployeeId FROM forjson_auto_test_diff_cases e
+);
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -90,3 +90,116 @@ GO
 
 INSERT INTO forjson_auto_vu_t_users VALUES (1, 'e', 'o', 'testemail3')
 go
+
+/* BABEL-5910 - Crash inside strcmp(), under buildJsonEntry() */
+
+-- Should fail gracefully with proper error message rather than crash
+SELECT 1+2 , firstname as [NULL] FROM forjson_auto_vu_t_users FOR JSON AUTO;
+GO
+
+select 1+2 as 'a' for json auto;
+GO
+
+select NULL as [NULL] from forjson_auto_vu_t_users for json auto;
+GO
+
+-- empty result set
+SELECT * FROM forjson_auto_vu_t_users WHERE 1=0 FOR JSON AUTO;
+GO
+
+-- NULL testing
+SELECT n1.id as "outer.id", 
+       n1.data as "outer.data", 
+       n2.id as "inner.id", 
+       n2.ref_id as "inner.ref_id" 
+FROM forjson_test_nested_1 n1 
+LEFT JOIN forjson_test_nested_2 n2 ON n1.id = n2.id 
+FOR JSON AUTO, INCLUDE_NULL_VALUES;
+GO
+
+--Special Unicode characters in column names
+SELECT id as "parent.id", 
+       column_标 as "parent.子.data" 
+FROM forjson_test_unicode 
+FOR JSON AUTO;
+GO
+
+-- long alias name test check
+SELECT id as "ThisIsAnExtremelyLongColumnNameThatExceedsTheNormalLimitForColumnNamesInMostDatabaseSystemsIncludingPostgreSQLAndShouldTriggerOurHashKeyTruncationWarningWithoutCrashing.id"
+FROM forjson_auto_vu_t_users
+FOR JSON AUTO;
+GO
+
+-- ORDER BY with calculation - creates resjunk column
+SELECT id, name, value FROM forjson_test_orderby ORDER BY value * 2 DESC FOR JSON AUTO;
+GO
+
+-- ORDER BY with multiple expressions - creates multiple resjunk columns
+SELECT id, name, value FROM forjson_test_orderby ORDER BY SUBSTRING(name, 1, 1), value DESC FOR JSON AUTO;
+GO
+
+-- Simple GROUP BY - creates resjunk columns
+SELECT category, SUM(quantity) as total_quantity, AVG(price) as avg_price FROM forjson_test_groupby GROUP BY category FOR JSON AUTO;
+GO
+
+-- GROUP BY with HAVING - creates resjunk columns with filtering
+SELECT category, COUNT(*) as product_count, SUM(quantity) as total_quantity FROM forjson_test_groupby GROUP BY category
+HAVING SUM(quantity) > 20 FOR JSON AUTO;
+GO
+
+-- This creates multiple resjunk columns of various types
+SELECT category, 
+       COUNT(*) as product_count, 
+       SUM(quantity) as total_quantity,
+       MAX(price) as max_price,
+       MIN(price) as min_price
+FROM forjson_test_groupby
+GROUP BY category
+ORDER BY SUM(quantity * price) DESC
+FOR JSON AUTO;
+GO
+
+-- Test 13: Window functions - create resjunk columns
+SELECT id, 
+       value,
+       ROW_NUMBER() OVER(ORDER BY value) as row_num,
+       RANK() OVER(ORDER BY value) as rank_val
+FROM forjson_test_orderby
+ORDER BY id
+FOR JSON AUTO;
+GO
+
+-- For Version Upgrade Test
+EXECUTE forjson_vu_v_resjunk_orderby_groupby;
+GO
+
+EXECUTE forjson_vu_v_resjunk_window_functions;
+GO
+
+EXECUTE forjson_vu_p_resjunk_groupby_having_orderby;
+GO
+
+
+/* ----------- Found Incorrect cases with needs to be handled in future  -------------- */
+
+/*
+ *  Condition : Only Function in the query
+ *  Expected Output: should not throw any error
+ *  Actual Output: throws incorrect error message
+ */ 
+SELECT  b.EmployeeId
+FROM dbo.forjson_auto_test_diff_cases_fn(1) as b
+FOR JSON AUTO;
+GO
+
+
+/*
+ *  Condition : FUNCTION + RELATION
+ *  Actual Output: Treats Function as relation and gives incorrect output
+ *  Expected Output: should treat function and relation as separate and provides different
+ *                   nesting key and level for both
+ */ 
+SELECT  b.EmployeeId, a.salary
+FROM dbo.forjson_auto_test_diff_cases_fn(1) as b, forjson_auto_test_diff_cases a
+FOR JSON AUTO;
+GO


### PR DESCRIPTION
### Description
Bug Description: A crash has been identified in the FOR JSON AUTO implementation, specifically in the pl_handler.c file. The crash occurs within the strcmp() function called from the buildJsonEntry() function when processing column names.

### Root Cause:

The code fails to check if entries in the target list are marked as "resjunk" (which should be skipped during processing).
There's no validation to ensure column names are not NULL before processing.

### Issues Resolved
BABEL-5910

### Test Scenarios Covered
Use case based -
Boundary conditions -
Arbitrary inputs -
Negative test cases -


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).