### PR TITLE
Support subqueries, values, CTEs in FOR JSON AUTO.

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1534,11 +1534,14 @@ handleForJsonAuto(Query *wrapperQuery)
 		}
 	}
 
-	ereport(ERROR,
-			(errcode(ERRCODE_UNDEFINED_TABLE),
-			errmsg("FOR JSON AUTO requires at least one table for "
-				"generating JSON objects. Use FOR JSON PATH or add a FROM"
-				" clause with a table name.")));
+	if (validSrcCnt == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				errmsg("FOR JSON AUTO requires at least one table for "
+					"generating JSON objects. Use FOR JSON PATH or add a FROM"
+					" clause with a table name.")));
+	else
+		Assert(false);
 	return true;
 }
 
@@ -1672,6 +1675,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 	int			varlevelsup;	/* Variable's nesting level */
 	int			varattno;	/* Variable's attribute number */
 	RangeTblEntry *matched_src = NULL;	/* Source RTE matched by variable */
+	bool matched_src_CTE_is_recursive = false;
 	char	   *matched_src_alias;
 	StringInfoData full_src_path;	/* Accumulated source path for hash key */
 	char	   *hashed_full_src_path;
@@ -1737,12 +1741,13 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 		cur_te = outermost_te;
 		curQuery = origQuery;
 		at_outermost = true;
+		matched_src_CTE_is_recursive = false;
 
 		while (nodeTag(cur_te->expr) == T_Var)
 		{
 			cur_var = castNode(Var, cur_te->expr);
-			varno = cur_var->varno;
-			varattno = cur_var->varattno;
+			varno = cur_var->varno; // index to the source in current layer's rtable
+			varattno = cur_var->varattno; // index to target in next layer's targetList (in current layer source)
 			matched_src = list_nth(curQuery->rtable, varno-1);
 
 			/* Build full source path for unique identification */
@@ -1750,15 +1755,27 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 				appendStringInfo(&full_src_path, ".");
 			appendStringInfo(&full_src_path, "%s", matched_src->eref->aliasname);
 
+			/*
+			 * if outermost CTE:
+			 * 	  => only do unwrapping when alias is set
+			 * if we reach inner CTE:
+			 *    => we already decided to do unwrapping, keep unwrapping. inner CTE's alias is
+			 *       set or not doesn't affect the unwrapping decision.
+			 */
 			if (matched_src->rtekind == RTE_CTE && (matched_src->alias != NULL || !at_outermost))
 			{
-				/* Navigate into CTE definition */
+				/* get info in the CTE from ctelist (which cannot get from RTE_CTE) */
 				cteHashEntry = (CtenameIdx *) hash_search(ctename_idx_hash,
 														  matched_src->ctename,
 														  HASH_FIND,
 														  &found);
 				Assert(found);
 				cteEntry = (CommonTableExpr *) list_nth(origQuery->cteList, cteHashEntry->idx_in_ctelist);
+				if (cteEntry->cterecursive)
+				{
+					matched_src_CTE_is_recursive = true;
+					break;
+				}
 				curQuery = castNode(Query, cteEntry->ctequery);
 				cur_te = (TargetEntry *) list_nth(curQuery->targetList, varattno-1);
 			}
@@ -1775,7 +1792,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 				at_outermost = false;
 		}
 
-		/* Handle nested subqueries with FOR JSON AUTO */
+		/* Handle nested FOR JSON AUTO in sub-select in target entry */
 		if (nodeTag(cur_te->expr) == T_SubLink)
 		{
 			sl = castNode(SubLink, cur_te->expr);
@@ -1797,8 +1814,17 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 		if (nodeTag(cur_te->expr) == T_Var) {
 			varlevelsup = cur_var->varlevelsup;
 
-			/* Don't use source alias for functions or outer source */
-			if (varlevelsup > 0 || matched_src->rtekind == RTE_FUNCTION)
+			/*
+			 * Don't use source alias for functions or outer source
+			 * 1. if T_Var is referencing from outer sources
+			 * 2. if source is a RTE_FUNCTION
+			 * 3. if source is a RTE_CTE after the previous unwrapping loop
+			 *    - either this CTE is at outermost layer w/o an alias assigned
+			 *      => we want to use this CTE's ctename as JSON nesting key
+			 *    - or this CTE is a recursive CTE
+			 *      => we don't want to use this CTE's ctename as JSON nesting key
+			 */
+			if (varlevelsup > 0 || matched_src->rtekind == RTE_FUNCTION || (matched_src->rtekind == RTE_CTE && matched_src_CTE_is_recursive))
 				outermost_te = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermost_te);
 
 			else
@@ -1819,7 +1845,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 				else
 				{
 					/* Create new hash entry with incremented nest level */
-					if (curMaxUsedJsonLevel == 1 && !nestingLevel1Used) // case 1
+					if (curMaxUsedJsonLevel == 1 && !nestingLevel1Used)
 						nestingLevel1Used = true;
 					else
 						curMaxUsedJsonLevel++;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -102,6 +102,8 @@
 
 #include "access/xact.h"
 
+#define FORJSON_INITIAL_HASH_SIZE 64
+
 extern int  escape_hatch_set_transaction_isolation_level;
 extern bool pltsql_recursive_triggers;
 extern bool restore_tsql_tabletype;
@@ -1739,7 +1741,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias, JsonAutoContext *j
 		cteHashCtl.entrysize = sizeof(CtenameIdx);
 		cteHashCtl.hcxt = CurrentMemoryContext;
 		ctenameIdxHash = hash_create("ctenameIdxHash",
-									 64, // initial allocation size
+									 FORJSON_INITIAL_HASH_SIZE,
 									 &cteHashCtl,
 									 HASH_ELEM | HASH_STRINGS);
 
@@ -1764,7 +1766,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias, JsonAutoContext *j
 	rteJSONHashCtl.entrysize = sizeof(RTEAliasEntry);
 	rteJSONHashCtl.hcxt = CurrentMemoryContext;
 	RTEAliasNestHash = hash_create("RTEAliasNestHash",
-								   64, // initial allocation size
+								   FORJSON_INITIAL_HASH_SIZE,
 								   &rteJSONHashCtl,
 								   HASH_ELEM | HASH_STRINGS);
 
@@ -1936,10 +1938,10 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias, JsonAutoContext *j
 																&found);
 					Assert(!found);
 					strcpy(rteHashEntry->alias_name, hashedFullSrcPath);
-					pfree(hashedFullSrcPath);
 					rteHashEntry->json_nest_level = curMaxUsedJsonLevel;
 					outermostTargetEntry = buildJsonEntry(rteHashEntry->json_nest_level, matchedSrcAlias, outermostTargetEntry);
 				}
+				pfree(hashedFullSrcPath);
 			}
 		}
 		else

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -32,6 +32,7 @@
 #include "catalog/pg_default_acl.h"
 #include "catalog/pg_shdepend.h"
 #include "commands/createas.h"
+#include "catalog/pg_namespace.h"
 #include "commands/dbcommands.h"
 #include "commands/defrem.h"
 #include "commands/extension.h"
@@ -189,21 +190,30 @@ static void bbf_set_tran_isolation(char *new_isolation_level_str);
 static void gen_command_grant_revoke_priv_to_role(StringInfo query, const char *rolename,
 							bool is_grant, Oid login_oid);
 
-typedef struct CtenameIdx {
+typedef struct CtenameIdx
+{
 	char ctename[NAMEDATALEN];
 	int idx_in_ctelist;
 } CtenameIdx;
-typedef struct RTEAliasEntry {
+typedef struct RTEAliasEntry
+{
 	char alias_name[NAMEDATALEN];
 	int json_nest_level;
 } RTEAliasEntry;
 
-static bool handleForJsonAuto(Query *query);
+typedef struct JsonAutoContext
+{
+	List *cteList;
+	HTAB *ctenameIdxHash;
+} JsonAutoContext;
+
+static bool handleForJsonAuto(Query *query, JsonAutoContext *jsonAutoCtx);
 static bool isJsonAuto(List* target);
-static bool check_json_auto_walker(Node *node, ParseState *pstate);
+void checkForJsonAuto(Query *query);
+static bool jsonAutoWalker(Node *node, JsonAutoContext *jsonAutoCtx);
 static TargetEntry* buildJsonEntry(int nestLevel, char* tableAlias, TargetEntry* te);
 static char *string_to_fixed_hash(const char *input);
-static void modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias);
+static void modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias, JsonAutoContext *jsonAutoCtx);
 extern bool pltsql_ansi_defaults;
 extern bool pltsql_quoted_identifier;
 extern bool pltsql_concat_null_yields_null;
@@ -1059,7 +1069,7 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
 
-	(void) check_json_auto_walker((Node*) query, pstate);
+	checkForJsonAuto(query);
 
 	if (query->commandType == CMD_INSERT)
 	{
@@ -1477,13 +1487,16 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
  * handleForJsonAuto - Process FOR JSON AUTO queries
  * 
  * @param wrapperQuery: The outer query containing FOR JSON AUTO clause
+ * @param jsonAutoCtx: Context for processing FOR JSON AUTO clause
+ *        ->cteList: cteList set in the tree walker
+ *        ->ctenameIdxHashFromOuterQuery: Hash table containing CTE names and their indices.
  * @return: true if it's a FOR JSON AUTO query, false if not
  * 
  * Validates that the query has at least one valid source table and processes
  * the target columns for JSON nesting. Follows MSSQL behavior by reporting
  * "at least one table" error when no valid sources are found.
  *
- * Valid source types: RTE_RELATION, RTE_SUBQUERY, RTE_CTE
+ * Valid source types: RTE_RELATION, RTE_SUBQUERY, RTE_CTE, user-defined RTE_FUNCTION
  * Source validity determined by single-source testing without inner sources:
  *   - Returns "at least one table" error: invalid source
  *   - No error: valid source
@@ -1492,7 +1505,7 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
  * CTEs may exist in ctelist but not be referenced in the actual query.
  */
 static bool
-handleForJsonAuto(Query *wrapperQuery)
+handleForJsonAuto(Query *wrapperQuery, JsonAutoContext *jsonAutoCtx)
 {
 	Query			   *origQuery;
 	List			   *wrapperTarget = wrapperQuery->targetList;
@@ -1501,7 +1514,7 @@ handleForJsonAuto(Query *wrapperQuery)
 	ListCell		   *lc;
 	Alias			   *wrapperRteAlias;
 	RangeTblEntry	   *wrapperRte = NULL;
-	int					validSrcCnt = 0;	/* Count of valid source tables */
+	bool				hasValidSrc = false;
 
 	if (!isJsonAuto(wrapperTarget))
 		return false;
@@ -1525,27 +1538,58 @@ handleForJsonAuto(Query *wrapperQuery)
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
 			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_SUBQUERY || rte->rtekind == RTE_CTE)
 			{
-				validSrcCnt++;
-				break; // as long as valid source >= 1 , we should do modifyColumnEntries
+				hasValidSrc = true;
+				break;
 			}
-			// TODO: check RTE_FUNCTION, and other RTEKinds
-		}
+			else if (rte->rtekind == RTE_FUNCTION)
+			{
+				RangeTblFunction	   *rteFunc;
+				FuncExpr			   *funcExpr;
+				HeapTuple				procTuple;
+				Form_pg_proc			procForm;
+				bool					isSystemFunction = false;
+				Oid						funcId;
+				Oid						sysNamespaceOid;
 
-		if (validSrcCnt > 0)
-		{
-			modifyColumnEntries(origQuery, wrapperRteAlias);
-			return true;
+				/* Get the first function from the RTE_FUNCTION */
+				if (rte->functions && list_length(rte->functions) > 0)
+				{
+					rteFunc = (RangeTblFunction *) linitial(rte->functions);
+					funcExpr = (FuncExpr *) rteFunc->funcexpr;
+					funcId = funcExpr->funcid;
+
+					/* Look up function info to check namespace */
+					procTuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcId));
+					if (HeapTupleIsValid(procTuple))
+					{
+						procForm = (Form_pg_proc) GETSTRUCT(procTuple);
+						sysNamespaceOid = get_namespace_oid("sys", true);
+						if (procForm->pronamespace == PG_CATALOG_NAMESPACE ||
+							(OidIsValid(sysNamespaceOid) && procForm->pronamespace == sysNamespaceOid))
+							isSystemFunction = true;
+						ReleaseSysCache(procTuple);
+
+						/* Only user-defined functions count as valid sources */
+						if (!isSystemFunction)
+						{
+							hasValidSrc = true;
+							break;
+						}
+					}
+				}
+			}
 		}
 	}
 
-	if (validSrcCnt == 0)
+	if (hasValidSrc)
+		modifyColumnEntries(origQuery, wrapperRteAlias, jsonAutoCtx);
+	else
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_TABLE),
 				errmsg("FOR JSON AUTO requires at least one table for "
 					"generating JSON objects. Use FOR JSON PATH or add a FROM"
 					" clause with a table name.")));
-	else
-		Assert(false);
+
 	return true;
 }
 
@@ -1613,6 +1657,9 @@ string_to_fixed_hash(const char *input)
  * 
  * @param origQuery: The original query to process (without FOR JSON AUTO wrapper)
  * @param wrapperRteAlias: Alias information from wrapper query
+ * @param jsonAutoCtx: Context for processing FOR JSON AUTO clause
+ *        ->cteList: cteList set in the tree walker
+ *        ->ctenameIdxHashFromOuterQuery: Hash table containing CTE names and their indices.
  * 
  * Analyzes each target entry to assign appropriate JSON nesting keys and levels.
  * Transforms target entry names to include JSON nesting information in the format:
@@ -1651,9 +1698,8 @@ string_to_fixed_hash(const char *input)
  * table names in different contexts, ensuring proper nesting separation.
  */
 static void
-modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
+modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias, JsonAutoContext *jsonAutoCtx)
 {
-	// TODO: 1. move variables to its used scope
 
 	/* JSON nesting variables */
 	char			   *curMaxUsedJsonKey = "temp";	/* Current nesting key for non-source entries */
@@ -1664,10 +1710,11 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 	int					targetIterIdx = 0;
 
 	/* CTE processing variables */
-	HTAB			   *ctenameIdxHash;	/* CTE name-to-index mapping */
+	HTAB			   *ctenameIdxHash = jsonAutoCtx->ctenameIdxHash;	/* CTE name-to-index mapping */
 	ListCell		   *cteLc;
 	CommonTableExpr	   *cteEntry;
 	CtenameIdx		   *cteHashEntry;
+	List			   *cteList = jsonAutoCtx->cteList;
 	HASHCTL				cteHashCtl;
 	int					cteIdx = 0;
 
@@ -1681,20 +1728,23 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 	List			   *origTargetList = origQuery->targetList;
 	ListCell		   *lc;
 
-	/* Initialize CTE name-to-index hash table */
-	memset(&cteHashCtl, 0, sizeof(cteHashCtl));
-	cteHashCtl.keysize = NAMEDATALEN;
-	cteHashCtl.entrysize = sizeof(CtenameIdx);
-	cteHashCtl.hcxt = CurrentMemoryContext;
-	ctenameIdxHash = hash_create("ctenameIdxHash",
-								 64, // initial allocation size
-								 &cteHashCtl,
-								 HASH_ELEM | HASH_STRINGS);
-
-	/* Populate CTE name-to-index hash table */
-	if (origQuery->cteList != NULL)
+	/*
+	 * If ctenameIdxHash hasn't been initialized yet, initialize it if we
+	 * have cteList.
+	 */
+	if (ctenameIdxHash == NULL && cteList != NULL)
 	{
-		foreach(cteLc, origQuery->cteList)
+		memset(&cteHashCtl, 0, sizeof(cteHashCtl));
+		cteHashCtl.keysize = NAMEDATALEN;
+		cteHashCtl.entrysize = sizeof(CtenameIdx);
+		cteHashCtl.hcxt = CurrentMemoryContext;
+		ctenameIdxHash = hash_create("ctenameIdxHash",
+									 64, // initial allocation size
+									 &cteHashCtl,
+									 HASH_ELEM | HASH_STRINGS);
+
+		/* Populate CTE name-to-index hash table */
+		foreach(cteLc, cteList)
 		{
 			cteEntry = (CommonTableExpr *) lfirst(cteLc);
 			cteHashEntry = (CtenameIdx *) hash_search(ctenameIdxHash,
@@ -1749,6 +1799,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 			continue;
 
 		outermostTargetEntry = castNode(TargetEntry, lfirst(lc));
+
 		if (outermostTargetEntry->resjunk)
 			continue;
 
@@ -1794,7 +1845,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 														  HASH_FIND,
 														  &found);
 				Assert(found);
-				cteEntry = (CommonTableExpr *) list_nth(origQuery->cteList, cteHashEntry->idx_in_ctelist);
+				cteEntry = (CommonTableExpr *) list_nth(cteList, cteHashEntry->idx_in_ctelist);
 				if (cteEntry->cterecursive)
 				{
 					matchedSrcCTEIsRecursive = true;
@@ -1817,15 +1868,17 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 				atOutermostLayer = false;
 		}
 
-		/* Handle sub-select in target entry */
 		if (nodeTag(curTargetEntry->expr) == T_SubLink)
 		{
 			sl = castNode(SubLink, curTargetEntry->expr);
 			if(sl->subselect != NULL && nodeTag(sl->subselect) == T_Query)
 			{
-				if(handleForJsonAuto(castNode(Query, sl->subselect)))
+				if (isJsonAuto(((Query *)sl->subselect)->targetList))
 				{
-					/* Wrap subquery result in JSON coercion */
+					/*
+					 * Because this SubLink FOR JSON AUTO still needs to be processed 
+					 * by postgres, we need to convert the type from NVARCHAR to json.
+					 */
 					iocoerce = makeNode(CoerceViaIO);
 					iocoerce->arg = (Expr*) sl;
 					iocoerce->resulttype = TypenameGetTypid("json");
@@ -1900,25 +1953,41 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 	}
 
 	/* Cleanup hash tables */
-	hash_destroy(ctenameIdxHash);
 	hash_destroy(RTEAliasNestHash);
 }
 
-static bool check_json_auto_walker(Node *node, ParseState *pstate)
+void checkForJsonAuto(Query *query)
+{
+	JsonAutoContext *jsonAutoCtx;
+	if (query == NULL) return;
+
+	jsonAutoCtx = (JsonAutoContext *) palloc(sizeof(JsonAutoContext));
+	jsonAutoCtx->cteList = NULL;
+	jsonAutoCtx->ctenameIdxHash = NULL;
+
+	jsonAutoWalker((Node *)query, jsonAutoCtx);
+
+	hash_destroy(jsonAutoCtx->ctenameIdxHash);
+	pfree(jsonAutoCtx);
+	return;
+}
+
+static bool jsonAutoWalker(Node *node, JsonAutoContext *jsonAutoCtx)
 {
 	if (node == NULL)
 		return false;
 	if (IsA(node, Query)) {
-		if(handleForJsonAuto((Query*) node))
-			return true;
-		else {
-			return query_tree_walker((Query*) node,
-								 check_json_auto_walker,
-								 (void *) pstate, 0);
-		}
+
+		if (((Query *)node)->cteList != NULL)
+			jsonAutoCtx->cteList = ((Query *)node)->cteList;
+
+		// First walk inner queries recursively to handle nested FOR JSON AUTO
+		query_tree_walker((Query*) node, jsonAutoWalker, (void *) jsonAutoCtx, 0);
+
+		// Then check if this layer has FOR JSON AUTO and handle it
+		return handleForJsonAuto((Query*) node, jsonAutoCtx);
 	}
-	return expression_tree_walker(node, check_json_auto_walker,
-								  (void *) pstate);
+	return expression_tree_walker(node, jsonAutoWalker, (void *) jsonAutoCtx);
 }
 
 static bool

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -76,6 +76,9 @@
 #include "utils/syscache.h"
 #include "utils/varlena.h"
 #include "utils/guc.h"
+#include "utils/hsearch.h"
+
+#include "common/hashfn.h"
 
 #include "analyzer.h"
 #include "catalog.h"
@@ -186,18 +189,21 @@ static void bbf_set_tran_isolation(char *new_isolation_level_str);
 static void gen_command_grant_revoke_priv_to_role(StringInfo query, const char *rolename,
 							bool is_grant, Oid login_oid);
 
-typedef struct {
-	int oid;
-	char *alias;
-	int nestLevel;
-} forjson_table;
+typedef struct CtenameIdx {
+	char ctename[NAMEDATALEN];
+	int idx_in_ctelist;
+} CtenameIdx;
+typedef struct RTEAliasEntry {
+	char alias_name[NAMEDATALEN];
+	int json_nest_level;
+} RTEAliasEntry;
 
-static bool handleForJsonAuto(Query *query, forjson_table **tableInfoArr, int numTables);
+static bool handleForJsonAuto(Query *query);
 static bool isJsonAuto(List* target);
 static bool check_json_auto_walker(Node *node, ParseState *pstate);
 static TargetEntry* buildJsonEntry(int nestLevel, char* tableAlias, TargetEntry* te);
-static void modifyColumnEntries(List* targetList, forjson_table **tableInfoArr, int numTables, Alias *colnameAlias, bool isCve);
-
+static char *string_to_fixed_hash(const char *input);
+static void modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias);
 extern bool pltsql_ansi_defaults;
 extern bool pltsql_quoted_identifier;
 extern bool pltsql_concat_null_yields_null;
@@ -1052,7 +1058,7 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
-	
+
 	(void) check_json_auto_walker((Node*) query, pstate);
 
 	if (query->commandType == CMD_INSERT)
@@ -1467,140 +1473,72 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 	}
 }
 
+/**
+ * handleForJsonAuto - Process FOR JSON AUTO queries
+ * 
+ * @param wrapperQuery: The outer query containing FOR JSON AUTO clause
+ * @return: true if it's a FOR JSON AUTO query, false if not
+ * 
+ * Validates that the query has at least one valid source table and processes
+ * the target columns for JSON nesting. Follows MSSQL behavior by reporting
+ * "at least one table" error when no valid sources are found.
+ *
+ * Valid source types: RTE_RELATION, RTE_SUBQUERY, RTE_CTE
+ * Source validity determined by single-source testing without inner sources:
+ *   - Returns "at least one table" error: invalid source
+ *   - No error: valid source
+ * 
+ * Note: Only considers CTEs actually used in rtable, not just those in ctelist.
+ * CTEs may exist in ctelist but not be referenced in the actual query.
+ */
 static bool
-handleForJsonAuto(Query *query, forjson_table **tableInfoArr, int numTables)
+handleForJsonAuto(Query *wrapperQuery)
 {
-	Query* subq;
-	List* target = query->targetList;
-	List* rtable;
-	List* subqRtable;
-	ListCell* lc;
-	ListCell* lc2;
-	RangeTblEntry* rte;
-	RangeTblEntry* subqRte;
-	RangeTblEntry* queryRte;
-	Alias *colnameAlias;
-	int newTables = 0;
-	int currTables = numTables;
-	
-	if(!isJsonAuto(target))
+	Query	   *origQuery;
+	List	   *wrapperTarget = wrapperQuery->targetList;
+	List	   *wrapperRtable;
+	List	   *origqRtable;
+	ListCell   *lc;
+	int 		validSrcCnt = 0;	/* Count of valid source tables */
+	Alias	   *wrapperRteAlias;
+	RangeTblEntry *wrapperRte = NULL;
+
+	if (!isJsonAuto(wrapperTarget))
 		return false;
 
-	// Modify query to be of the form "JSONAUTOALIAS.[nest_level].[table_alias]" 
-	rtable = (List*) query->rtable;
-	if(rtable != NULL && list_length(rtable) > 0) {
-		rte = linitial_node(RangeTblEntry, rtable);
-		if(rte != NULL) {
-			subq = (Query*) rte->subquery;
-			if(subq != NULL && (subq->cteList == NULL || list_length(subq->cteList) == 0)) {
-				subqRtable = (List*) subq->rtable;
-				if(subqRtable != NULL && list_length(subqRtable) > 0) {
-					forjson_table **tempArr;
-					foreach(lc, subqRtable) {
-						subqRte = castNode(RangeTblEntry, lfirst(lc));
-						if(subqRte->rtekind == RTE_RELATION) {
-							newTables++;
-						} else if(subqRte->rtekind == RTE_SUBQUERY) {
-							ereport(ERROR,
-									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-										errmsg("sub-select and values for json auto are not currently supported.")));
-						}
-					}
+	wrapperRtable = (List *) wrapperQuery->rtable;
+	if (wrapperRtable != NULL && list_length(wrapperRtable) > 0)
+		wrapperRte = linitial_node(RangeTblEntry, wrapperRtable);
 
-					if(numTables + newTables == 0) {
-						ereport(ERROR,
-									(errcode(ERRCODE_UNDEFINED_TABLE),
-										errmsg("FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.")));
-					}
+	Assert(wrapperRtable != NULL && wrapperRte != NULL);
 
-					tempArr = palloc((numTables + newTables) * sizeof(forjson_table));
-					for(int j = 0; j < numTables; j++) {
-						tempArr[j] = tableInfoArr[j];
-					}
-					tableInfoArr = tempArr;
-					tempArr = NULL;
-					queryRte = linitial_node(RangeTblEntry, query->rtable);
-					colnameAlias = (Alias*) queryRte->eref;
+	wrapperRteAlias = (Alias *)wrapperRte->eref;
+	origQuery = wrapperRte->subquery;
 
-					foreach(lc, subqRtable) {
-						subqRte = castNode(RangeTblEntry, lfirst(lc));
-						if(subqRte->rtekind == RTE_RELATION) {
-							forjson_table *table = palloc(sizeof(forjson_table));
-							Alias* a = (Alias*) subqRte->eref;
-							table->oid = subqRte->relid;
-							table->nestLevel = -1;
-							table->alias = a->aliasname;
-							tableInfoArr[currTables] = table;
-							currTables++;
-						}
-					}
-					numTables = numTables + newTables;
-					modifyColumnEntries(subq->targetList, tableInfoArr, numTables, colnameAlias, false);
-					return true;
-				}
-			} else if(subq->cteList != NULL && list_length(subq->cteList) > 0) {
-				Query* ctequery;
-				CommonTableExpr* cte;
-				forjson_table **tempArr;
-				foreach(lc, subq->cteList) {
-					cte = castNode(CommonTableExpr, lfirst(lc));
-					ctequery = (Query*) cte->ctequery;
-					foreach(lc2, ctequery->rtable) {
-						subqRte = castNode(RangeTblEntry, lfirst(lc2));
-						if(subqRte->rtekind == RTE_RELATION)
-							newTables++;
-					}
-				}
+	/* Count valid sources in original query */
+	origqRtable = (List *)origQuery->rtable;
+	if (origqRtable != NULL && list_length(origqRtable) > 0)
+	{
+		foreach(lc, origqRtable)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_SUBQUERY ||
+				rte->rtekind == RTE_CTE)
+				validSrcCnt++;
+		}
 
-				if(newTables == 0) {
-					forjson_table *table = palloc(sizeof(forjson_table));
-					tempArr = palloc((numTables + 1) * sizeof(forjson_table));
-					table->oid = 0;
-					table->nestLevel = -1;
-					table->alias = "cteplaceholder";
-					tempArr[numTables] = table;
-					newTables++;
-				} else {
-					tempArr = palloc((numTables + newTables) * sizeof(forjson_table));
-				}
-
-				for(int j = 0; j < numTables; j++) {
-					tempArr[j] = tableInfoArr[j];
-				}
-
-				tableInfoArr = tempArr;
-				tempArr = NULL;
-				numTables = numTables + newTables;
-				queryRte = linitial_node(RangeTblEntry, query->rtable);
-				colnameAlias = (Alias*) queryRte->eref;
-
-				foreach(lc, subq->cteList) {
-					cte = castNode(CommonTableExpr, lfirst(lc));
-					ctequery = (Query*) cte->ctequery;
-					foreach(lc2, ctequery->rtable) {
-						subqRte = castNode(RangeTblEntry, lfirst(lc2));
-						if(subqRte->rtekind == RTE_RELATION) {
-							forjson_table *table = palloc(sizeof(forjson_table));
-							Alias* a = (Alias*) subqRte->eref;
-							table->oid = subqRte->relid;
-							table->nestLevel = -1;
-							table->alias = a->aliasname;
-							tableInfoArr[currTables] = table;
-							currTables++;
-						}
-					}
-				}
-
-				modifyColumnEntries(subq->targetList, tableInfoArr, numTables, colnameAlias, true);
-				
-				return true;
-			}
+		if (validSrcCnt > 0)
+		{
+			modifyColumnEntries(origQuery, wrapperRteAlias);
+			return true;
 		}
 	}
 
 	ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_TABLE),
-					errmsg("FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.")));
+			(errcode(ERRCODE_UNDEFINED_TABLE),
+			errmsg("FOR JSON AUTO requires at least one table for "
+				"generating JSON objects. Use FOR JSON PATH or add a FROM"
+				" clause with a table name.")));
 	return true;
 }
 
@@ -1654,62 +1592,263 @@ buildJsonEntry(int nestLevel, char* tableAlias, TargetEntry* te)
 	return te;
 }
 
-static void modifyColumnEntries(List* targetList, forjson_table **tableInfoArr, int numTables, Alias *colnameAlias, bool isCve)
+static char *
+string_to_fixed_hash(const char *input)
 {
-	int i = 0;
-	int currMax = 0;
-	ListCell* lc;
-	
-	foreach(lc, targetList) {
-		TargetEntry* te;
-		int oid;
-		String *s;
+	Datum hash_val = hash_any_extended((unsigned char *)input, strlen(input), 0);
+	char *result = palloc(17); // 16 hex chars + null terminator
+	snprintf(result, 17, "%016lx", DatumGetUInt64(hash_val));
+	return result;
+}
 
+/**
+ * modifyColumnEntries - Determine JSON nesting structure for target columns
+ * 
+ * @param origQuery: The original query to process (without FOR JSON AUTO wrapper)
+ * @param wrapperRteAlias: Alias information from wrapper query
+ * 
+ * Analyzes each target entry to assign appropriate JSON nesting keys and levels.
+ * Transforms target entry names to include JSON nesting information in the format:
+ * "JSONAUTOALIAS.[nest_level].[nest_key].[colname]"
+ * 
+ * Algorithm Overview:
+ * 1. Build two hash tables:
+ *    - CTE lookup (ctename -> index in ctelist)
+ *    - alias-to-level mapping (assigned JSON nesting level for an alias)
+ * 2. For each target entry:
+ *    - If T_Var: use matched source's alias as JSON nesting key, assign next unused
+ *                JSON nesting level to it and store in hash so that later columns
+ *                referencing the same source can know the correct JSON nesting level to use.
+ *    - Other types of target entry: assign current max used JSON nesting
+ *                key and level to this target entry.
+ * 3. Handle special cases:
+ *    - If source is a RTE_FUNCTION, do not use its alias; instead we use
+ *      current max used JSON nesting key and level.
+ *    - If outermost source RTE is RTE_CTE and it's assigned an alias, we need
+ *      to unwrap recursively.
+ * 
+ * Recursive Unwrapping Algorithm:
+ * Follows variable references (varno and varattno in T_Var) to match outer target to
+ * inner target and get matched inner source recursively until reaching stop conditions:
+ * - Outermost RTE is not a CTE
+ * - Outermost CTE has no alias assigned  
+ * - Current target entry is not a T_Var
+ * - Inner RTE is not RTE_CTE or RTE_SUBQUERY
+ *
+ * JSON Nesting Level Logic:
+ * - Level 1: root level, initially unused, will be assigned to first unique source alias
+ * - Level N+1: Each additional unique source alias
+ *
+ * Hash Key Strategy:
+ * Uses full source path (e.g., "cte1.table1", "cte2.table1") to distinguish identical
+ * table names in different contexts, ensuring proper nesting separation.
+ */
+static void
+modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
+{
+	HTAB	   *ctename_idx_hash;	/* CTE name-to-index mapping */
+	HASHCTL		cte_ct;
+	ListCell   *cte_lc;
+	int			cte_idx = 0;
+	CommonTableExpr *cteEntry;
+	CtenameIdx *cteHashEntry;
+	int			targetIterIdx = 0;
+	int 		curMaxUsedJsonLevel = 1;	/* Current maximum JSON nesting level */
+	char	   *curMaxUsedJsonKey = "temp";	/* Current nesting key for non-source entries */
+	bool 		nestingLevel1Used = false;	/* Whether level 1 has been assigned */
+	List	   *origTgtList = origQuery->targetList;
+	HTAB	   *RTEAliasNestHash;	/* RTE alias-to-nesting-level mapping */
+	HASHCTL		rteJsonCt;
+	bool		found;
+	ListCell   *lc;
+	RTEAliasEntry *rteHashEntry;
+	TargetEntry *outermost_te;	/* Original target entry to modify */
+	TargetEntry *cur_te;	/* Current target during unwrapping */
+	String	   *colnameStr;
+	SubLink    *sl;
+	CoerceViaIO *iocoerce;
+	Var		   *cur_var = NULL;	/* Current variable node */
+	int			varno;	/* Variable's range table index */
+	int			varlevelsup;	/* Variable's nesting level */
+	int			varattno;	/* Variable's attribute number */
+	RangeTblEntry *matched_src = NULL;	/* Source RTE matched by variable */
+	char	   *matched_src_alias;
+	StringInfoData full_src_path;	/* Accumulated source path for hash key */
+	char	   *hashed_full_src_path;
+	Query	   *curQuery;	/* Current query context during unwrapping */
+	bool		at_outermost = true;
+
+	initStringInfo(&full_src_path);
+
+	/* Build CTE name-to-index hash table */
+	memset(&cte_ct, 0, sizeof(cte_ct));
+	cte_ct.keysize = NAMEDATALEN;
+	cte_ct.entrysize = sizeof(CtenameIdx);
+	cte_ct.hcxt = CurrentMemoryContext;
+	ctename_idx_hash = hash_create("ctename_idx_hash",
+								 256,
+								 &cte_ct,
+								 HASH_ELEM | HASH_STRINGS);
+
+	if (origQuery->cteList != NULL)
+	{
+		foreach(cte_lc, origQuery->cteList)
+		{
+			cteEntry = (CommonTableExpr *) lfirst(cte_lc);
+			cteHashEntry = (CtenameIdx *) hash_search(ctename_idx_hash,
+													  cteEntry->ctename,
+													  HASH_ENTER,
+													  &found);
+			Assert(!found);
+			strcpy(cteHashEntry->ctename, cteEntry->ctename);
+			cteHashEntry->idx_in_ctelist = cte_idx;
+			cte_idx++;
+		}
+	}
+
+	/* Build RTE alias-to-nesting-level hash table */
+	memset(&rteJsonCt, 0, sizeof(rteJsonCt));
+	rteJsonCt.keysize = NAMEDATALEN;
+	rteJsonCt.entrysize = sizeof(RTEAliasEntry);
+	rteJsonCt.hcxt = CurrentMemoryContext;
+	RTEAliasNestHash = hash_create("RTEAliasNestHash",
+								   256,
+								   &rteJsonCt,
+								   HASH_ELEM | HASH_STRINGS);
+
+	/* Process each target entry to determine JSON nesting structure */
+	foreach(lc, origTgtList)
+	{
 		// Add null check for target entry
 		if (!lc || !lfirst(lc))
 			continue;
-		
-		te = castNode(TargetEntry, lfirst(lc));
 
-		if(te->resjunk)
+		outermost_te = castNode(TargetEntry, lfirst(lc));
+		if (outermost_te->resjunk)
 			continue;
 
-		oid = te->resorigtbl;
-		s = castNode(String, lfirst(list_nth_cell(colnameAlias->colnames, i)));
-		if(te->expr != NULL && nodeTag(te->expr) == T_SubLink) {
-			SubLink *sl = castNode(SubLink, te->expr);
-			if(sl->subselect != NULL && nodeTag(sl->subselect) == T_Query) {
-				if(handleForJsonAuto(castNode(Query, sl->subselect), tableInfoArr, numTables)) {
-					CoerceViaIO *iocoerce = makeNode(CoerceViaIO);
+		if (outermost_te->expr == NULL)
+			continue;
+
+		colnameStr = castNode(String, lfirst(list_nth_cell(wrapperRteAlias->colnames, targetIterIdx)));
+
+		/* Recursively unwrap CTE/subquery chains to find ultimate source */
+		resetStringInfo(&full_src_path);
+		cur_te = outermost_te;
+		curQuery = origQuery;
+		at_outermost = true;
+
+		while (nodeTag(cur_te->expr) == T_Var)
+		{
+			cur_var = castNode(Var, cur_te->expr);
+			varno = cur_var->varno;
+			varattno = cur_var->varattno;
+			matched_src = list_nth(curQuery->rtable, varno-1);
+
+			/* Build full source path for unique identification */
+			if (full_src_path.len != 0)
+				appendStringInfo(&full_src_path, ".");
+			appendStringInfo(&full_src_path, "%s", matched_src->eref->aliasname);
+
+			if (matched_src->rtekind == RTE_CTE && (matched_src->alias != NULL || !at_outermost))
+			{
+				/* Navigate into CTE definition */
+				cteHashEntry = (CtenameIdx *) hash_search(ctename_idx_hash,
+														  matched_src->ctename,
+														  HASH_FIND,
+														  &found);
+				Assert(found);
+				cteEntry = (CommonTableExpr *) list_nth(origQuery->cteList, cteHashEntry->idx_in_ctelist);
+				curQuery = castNode(Query, cteEntry->ctequery);
+				cur_te = (TargetEntry *) list_nth(curQuery->targetList, varattno-1);
+			}
+			else if (!at_outermost && matched_src->rtekind == RTE_SUBQUERY)
+			{
+				/* Navigate into subquery */
+				curQuery = matched_src->subquery;
+				cur_te = (TargetEntry *) list_nth(curQuery->targetList, varattno-1);
+			}
+			else
+				break;
+
+			if (at_outermost)
+				at_outermost = false;
+		}
+
+		/* Handle nested subqueries with FOR JSON AUTO */
+		if (nodeTag(cur_te->expr) == T_SubLink)
+		{
+			sl = castNode(SubLink, cur_te->expr);
+			if(sl->subselect != NULL && nodeTag(sl->subselect) == T_Query)
+			{
+				if(handleForJsonAuto(castNode(Query, sl->subselect)))
+				{
+					/* Wrap subquery result in JSON coercion */
+					iocoerce = makeNode(CoerceViaIO);
 					iocoerce->arg = (Expr*) sl;
 					iocoerce->resulttype = TypenameGetTypid("json");
 					iocoerce->resultcollid = 0;
 					iocoerce->coerceformat = COERCE_EXPLICIT_CAST;
-					buildJsonEntry(1, "temp", te);
-					s->sval = te->resname;
-					te->expr = (Expr*) iocoerce;
-					continue;
+					cur_te->expr = (Expr*) iocoerce;
 				}
 			}
 		}
-		for(int j = 0; j < numTables; j++) {
-			if(tableInfoArr[j]->oid == oid) {
-				// build entry
-				if(tableInfoArr[j]->nestLevel == -1) {
-					currMax++;
-					tableInfoArr[j]->nestLevel = currMax;
+
+		if (nodeTag(cur_te->expr) == T_Var) {
+			varlevelsup = cur_var->varlevelsup;
+
+			/* Don't use source alias for functions or outer source */
+			if (varlevelsup > 0 || matched_src->rtekind == RTE_FUNCTION)
+				outermost_te = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermost_te);
+
+			else
+			{
+				/* Use full path as hash key to handle duplicate table names */
+				hashed_full_src_path = string_to_fixed_hash(full_src_path.data);
+				matched_src_alias = matched_src->eref->aliasname;
+
+				rteHashEntry = (RTEAliasEntry *)hash_search(RTEAliasNestHash,
+															hashed_full_src_path,
+															HASH_FIND,
+															&found);
+				if (found)
+				{
+					// Use existing nest level from hash
+					outermost_te = buildJsonEntry(rteHashEntry->json_nest_level, matched_src_alias, outermost_te);
 				}
-				te = buildJsonEntry(tableInfoArr[j]->nestLevel, tableInfoArr[j]->alias, te);
-				s->sval = te->resname;
-				break;
-			} else if(!isCve && oid == 0 && j == numTables - 1) {
-				te = buildJsonEntry(1, "temp", te);
-				s->sval = te->resname;
-				break;
+				else
+				{
+					/* Create new hash entry with incremented nest level */
+					if (curMaxUsedJsonLevel == 1 && !nestingLevel1Used) // case 1
+						nestingLevel1Used = true;
+					else
+						curMaxUsedJsonLevel++;
+					curMaxUsedJsonKey = matched_src_alias;
+					rteHashEntry = (RTEAliasEntry *)hash_search(RTEAliasNestHash,
+															hashed_full_src_path,
+															HASH_ENTER,
+															&found);
+					Assert(!found);
+					strcpy(rteHashEntry->alias_name, hashed_full_src_path);
+					pfree(hashed_full_src_path);
+					rteHashEntry->json_nest_level = curMaxUsedJsonLevel;
+					outermost_te = buildJsonEntry(rteHashEntry->json_nest_level, matched_src_alias, outermost_te);
+				}
 			}
 		}
-		i++;
+		else
+		{
+			/* Non-variable expressions use current max level/key */
+			outermost_te = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermost_te);
+		}
+
+		colnameStr->sval = outermost_te->resname;
+		targetIterIdx++;
 	}
+
+	/* Cleanup hash tables */
+	hash_destroy(ctename_idx_hash);
+	hash_destroy(RTEAliasNestHash);
 }
 
 static bool check_json_auto_walker(Node *node, ParseState *pstate)
@@ -1717,7 +1856,7 @@ static bool check_json_auto_walker(Node *node, ParseState *pstate)
 	if (node == NULL)
 		return false;
 	if (IsA(node, Query)) {
-		if(handleForJsonAuto((Query*) node, NULL, 0))
+		if(handleForJsonAuto((Query*) node))
 			return true;
 		else {
 			return query_tree_walker((Query*) node,

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1802,6 +1802,7 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias, JsonAutoContext *j
 
 		outermostTargetEntry = castNode(TargetEntry, lfirst(lc));
 
+		/* junk node - won't appear in the final result */
 		if (outermostTargetEntry->resjunk)
 			continue;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1494,14 +1494,14 @@ pltsql_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
 static bool
 handleForJsonAuto(Query *wrapperQuery)
 {
-	Query	   *origQuery;
-	List	   *wrapperTarget = wrapperQuery->targetList;
-	List	   *wrapperRtable;
-	List	   *origqRtable;
-	ListCell   *lc;
-	int 		validSrcCnt = 0;	/* Count of valid source tables */
-	Alias	   *wrapperRteAlias;
-	RangeTblEntry *wrapperRte = NULL;
+	Query			   *origQuery;
+	List			   *wrapperTarget = wrapperQuery->targetList;
+	List			   *wrapperRtable;
+	List			   *origqRtable;
+	ListCell		   *lc;
+	Alias			   *wrapperRteAlias;
+	RangeTblEntry	   *wrapperRte = NULL;
+	int					validSrcCnt = 0;	/* Count of valid source tables */
 
 	if (!isJsonAuto(wrapperTarget))
 		return false;
@@ -1514,6 +1514,7 @@ handleForJsonAuto(Query *wrapperQuery)
 
 	wrapperRteAlias = (Alias *)wrapperRte->eref;
 	origQuery = wrapperRte->subquery;
+	Assert(origQuery != NULL);
 
 	/* Count valid sources in original query */
 	origqRtable = (List *)origQuery->rtable;
@@ -1522,9 +1523,12 @@ handleForJsonAuto(Query *wrapperQuery)
 		foreach(lc, origqRtable)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_SUBQUERY ||
-				rte->rtekind == RTE_CTE)
+			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_SUBQUERY || rte->rtekind == RTE_CTE)
+			{
 				validSrcCnt++;
+				break; // as long as valid source >= 1 , we should do modifyColumnEntries
+			}
+			// TODO: check RTE_FUNCTION, and other RTEKinds
 		}
 
 		if (validSrcCnt > 0)
@@ -1649,153 +1653,174 @@ string_to_fixed_hash(const char *input)
 static void
 modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 {
-	HTAB	   *ctename_idx_hash;	/* CTE name-to-index mapping */
-	HASHCTL		cte_ct;
-	ListCell   *cte_lc;
-	int			cte_idx = 0;
-	CommonTableExpr *cteEntry;
-	CtenameIdx *cteHashEntry;
-	int			targetIterIdx = 0;
-	int 		curMaxUsedJsonLevel = 1;	/* Current maximum JSON nesting level */
-	char	   *curMaxUsedJsonKey = "temp";	/* Current nesting key for non-source entries */
-	bool 		nestingLevel1Used = false;	/* Whether level 1 has been assigned */
-	List	   *origTgtList = origQuery->targetList;
-	HTAB	   *RTEAliasNestHash;	/* RTE alias-to-nesting-level mapping */
-	HASHCTL		rteJsonCt;
-	bool		found;
-	ListCell   *lc;
-	RTEAliasEntry *rteHashEntry;
-	TargetEntry *outermost_te;	/* Original target entry to modify */
-	TargetEntry *cur_te;	/* Current target during unwrapping */
-	String	   *colnameStr;
-	SubLink    *sl;
-	CoerceViaIO *iocoerce;
-	Var		   *cur_var = NULL;	/* Current variable node */
-	int			varno;	/* Variable's range table index */
-	int			varlevelsup;	/* Variable's nesting level */
-	int			varattno;	/* Variable's attribute number */
-	RangeTblEntry *matched_src = NULL;	/* Source RTE matched by variable */
-	bool matched_src_CTE_is_recursive = false;
-	char	   *matched_src_alias;
-	StringInfoData full_src_path;	/* Accumulated source path for hash key */
-	char	   *hashed_full_src_path;
-	Query	   *curQuery;	/* Current query context during unwrapping */
-	bool		at_outermost = true;
+	// TODO: 1. move variables to its used scope
 
-	initStringInfo(&full_src_path);
+	/* JSON nesting variables */
+	char			   *curMaxUsedJsonKey = "temp";	/* Current nesting key for non-source entries */
+	int					curMaxUsedJsonLevel = 1;	/* Current maximum JSON nesting level */
+	bool				nestingLevel1Used = false;	/* Whether level 1 has been assigned */
 
-	/* Build CTE name-to-index hash table */
-	memset(&cte_ct, 0, sizeof(cte_ct));
-	cte_ct.keysize = NAMEDATALEN;
-	cte_ct.entrysize = sizeof(CtenameIdx);
-	cte_ct.hcxt = CurrentMemoryContext;
-	ctename_idx_hash = hash_create("ctename_idx_hash",
-								 256,
-								 &cte_ct,
+	/* Target entries iteration index */
+	int					targetIterIdx = 0;
+
+	/* CTE processing variables */
+	HTAB			   *ctenameIdxHash;	/* CTE name-to-index mapping */
+	ListCell		   *cteLc;
+	CommonTableExpr	   *cteEntry;
+	CtenameIdx		   *cteHashEntry;
+	HASHCTL				cteHashCtl;
+	int					cteIdx = 0;
+
+	/* Alias-to-level mapping variables */
+	HTAB			   *RTEAliasNestHash;	/* RTE alias-to-nesting-level mapping */
+	RTEAliasEntry	   *rteHashEntry;
+	HASHCTL				rteJSONHashCtl;
+	bool				found;
+
+	/* target entry iteration variables */
+	List			   *origTargetList = origQuery->targetList;
+	ListCell		   *lc;
+
+	/* Initialize CTE name-to-index hash table */
+	memset(&cteHashCtl, 0, sizeof(cteHashCtl));
+	cteHashCtl.keysize = NAMEDATALEN;
+	cteHashCtl.entrysize = sizeof(CtenameIdx);
+	cteHashCtl.hcxt = CurrentMemoryContext;
+	ctenameIdxHash = hash_create("ctenameIdxHash",
+								 64, // initial allocation size
+								 &cteHashCtl,
 								 HASH_ELEM | HASH_STRINGS);
 
+	/* Populate CTE name-to-index hash table */
 	if (origQuery->cteList != NULL)
 	{
-		foreach(cte_lc, origQuery->cteList)
+		foreach(cteLc, origQuery->cteList)
 		{
-			cteEntry = (CommonTableExpr *) lfirst(cte_lc);
-			cteHashEntry = (CtenameIdx *) hash_search(ctename_idx_hash,
+			cteEntry = (CommonTableExpr *) lfirst(cteLc);
+			cteHashEntry = (CtenameIdx *) hash_search(ctenameIdxHash,
 													  cteEntry->ctename,
 													  HASH_ENTER,
 													  &found);
 			Assert(!found);
 			strcpy(cteHashEntry->ctename, cteEntry->ctename);
-			cteHashEntry->idx_in_ctelist = cte_idx;
-			cte_idx++;
+			cteHashEntry->idx_in_ctelist = cteIdx;
+			cteIdx++;
 		}
 	}
 
-	/* Build RTE alias-to-nesting-level hash table */
-	memset(&rteJsonCt, 0, sizeof(rteJsonCt));
-	rteJsonCt.keysize = NAMEDATALEN;
-	rteJsonCt.entrysize = sizeof(RTEAliasEntry);
-	rteJsonCt.hcxt = CurrentMemoryContext;
+	/* Initialize RTE alias-to-nesting-level hash table */
+	memset(&rteJSONHashCtl, 0, sizeof(rteJSONHashCtl));
+	rteJSONHashCtl.keysize = NAMEDATALEN;
+	rteJSONHashCtl.entrysize = sizeof(RTEAliasEntry);
+	rteJSONHashCtl.hcxt = CurrentMemoryContext;
 	RTEAliasNestHash = hash_create("RTEAliasNestHash",
-								   256,
-								   &rteJsonCt,
+								   64, // initial allocation size
+								   &rteJSONHashCtl,
 								   HASH_ELEM | HASH_STRINGS);
 
 	/* Process each target entry to determine JSON nesting structure */
-	foreach(lc, origTgtList)
+	foreach(lc, origTargetList)
 	{
+		/* variables for each target entry iteration */
+		TargetEntry		   *outermostTargetEntry;	/* Original target entry to modify */
+		TargetEntry		   *curTargetEntry;	/* Current target during unwrapping */
+		String			   *colnameStr;
+		RangeTblEntry	   *matchedSrc = NULL;	/* Source RTE matched by variable */
+		char			   *matchedSrcAlias;
+		char			   *hashedFullSrcPath;
+		Query			   *curQuery;	/* Current query context during unwrapping */
+		StringInfoData		fullSrcPath;	/* Accumulated source path for hash key */
+		bool				matchedSrcCTEIsRecursive = false;
+		bool				atOutermostLayer = true; // at outermost layer or not when unwrapping
+
+		/* T_SubLink target entry variables */
+		SubLink			   *sl;
+		CoerceViaIO		   *iocoerce;
+
+		/* T_Var target entry variables */
+		Var				   *curVar = NULL;	/* Current variable node */
+		int					varNo;	/* Variable's range table index */
+		int					varLevelsUp;	/* Variable's nesting level */
+		int					varAttNo;	/* Variable's attribute number */
+
+		initStringInfo(&fullSrcPath);
 		// Add null check for target entry
 		if (!lc || !lfirst(lc))
 			continue;
 
-		outermost_te = castNode(TargetEntry, lfirst(lc));
-		if (outermost_te->resjunk)
+		outermostTargetEntry = castNode(TargetEntry, lfirst(lc));
+		if (outermostTargetEntry->resjunk)
 			continue;
 
-		if (outermost_te->expr == NULL)
+		if (outermostTargetEntry->expr == NULL)
 			continue;
 
+		/* The wrapperQuery's view of column references from this origQuery will need to be updated too */
 		colnameStr = castNode(String, lfirst(list_nth_cell(wrapperRteAlias->colnames, targetIterIdx)));
 
-		/* Recursively unwrap CTE/subquery chains to find ultimate source */
-		resetStringInfo(&full_src_path);
-		cur_te = outermost_te;
+		/* Set up initial state for recursive unwrapping */
+		curTargetEntry = outermostTargetEntry;
 		curQuery = origQuery;
-		at_outermost = true;
-		matched_src_CTE_is_recursive = false;
+		atOutermostLayer = true;
+		matchedSrcCTEIsRecursive = false;
 
-		while (nodeTag(cur_te->expr) == T_Var)
+		/* Recursively unwrap CTE/subquery chains to find ultimate source */
+		while (nodeTag(curTargetEntry->expr) == T_Var)
 		{
-			cur_var = castNode(Var, cur_te->expr);
-			varno = cur_var->varno; // index to the source in current layer's rtable
-			varattno = cur_var->varattno; // index to target in next layer's targetList (in current layer source)
-			matched_src = list_nth(curQuery->rtable, varno-1);
+			/* Update T_Var variables when we goto inner T_Var */
+			curVar = castNode(Var, curTargetEntry->expr);
+			varNo = curVar->varno; // index to the source in current layer's rtable
+			varAttNo = curVar->varattno; // index to target in next layer's targetList (in current layer source)
+			matchedSrc = list_nth(curQuery->rtable, varNo-1);
 
-			/* Build full source path for unique identification */
-			if (full_src_path.len != 0)
-				appendStringInfo(&full_src_path, ".");
-			appendStringInfo(&full_src_path, "%s", matched_src->eref->aliasname);
+			/* Keep appending src's alias when unwrapping for unique identification */
+			if (fullSrcPath.len != 0)
+				appendStringInfo(&fullSrcPath, ".");
+			appendStringInfo(&fullSrcPath, "%s", matchedSrc->eref->aliasname);
 
 			/*
-			 * if outermost CTE:
+			 * If outermost CTE:
 			 * 	  => only do unwrapping when alias is set
-			 * if we reach inner CTE:
+			 * If we reach inner CTE:
 			 *    => we already decided to do unwrapping, keep unwrapping. inner CTE's alias is
 			 *       set or not doesn't affect the unwrapping decision.
+			 * For recursive CTE, we don't unwrap it.
 			 */
-			if (matched_src->rtekind == RTE_CTE && (matched_src->alias != NULL || !at_outermost))
+			if (matchedSrc->rtekind == RTE_CTE && (matchedSrc->alias != NULL || !atOutermostLayer))
 			{
 				/* get info in the CTE from ctelist (which cannot get from RTE_CTE) */
-				cteHashEntry = (CtenameIdx *) hash_search(ctename_idx_hash,
-														  matched_src->ctename,
+				cteHashEntry = (CtenameIdx *) hash_search(ctenameIdxHash,
+														  matchedSrc->ctename,
 														  HASH_FIND,
 														  &found);
 				Assert(found);
 				cteEntry = (CommonTableExpr *) list_nth(origQuery->cteList, cteHashEntry->idx_in_ctelist);
 				if (cteEntry->cterecursive)
 				{
-					matched_src_CTE_is_recursive = true;
+					matchedSrcCTEIsRecursive = true;
 					break;
 				}
 				curQuery = castNode(Query, cteEntry->ctequery);
-				cur_te = (TargetEntry *) list_nth(curQuery->targetList, varattno-1);
+				curTargetEntry = (TargetEntry *) list_nth(curQuery->targetList, varAttNo-1);
 			}
-			else if (!at_outermost && matched_src->rtekind == RTE_SUBQUERY)
+			/* We only unwrap RTE_SUBQUERY when it's at inner layers */
+			else if (!atOutermostLayer && matchedSrc->rtekind == RTE_SUBQUERY)
 			{
 				/* Navigate into subquery */
-				curQuery = matched_src->subquery;
-				cur_te = (TargetEntry *) list_nth(curQuery->targetList, varattno-1);
+				curQuery = matchedSrc->subquery;
+				curTargetEntry = (TargetEntry *) list_nth(curQuery->targetList, varAttNo-1);
 			}
 			else
 				break;
 
-			if (at_outermost)
-				at_outermost = false;
+			if (atOutermostLayer)
+				atOutermostLayer = false;
 		}
 
-		/* Handle nested FOR JSON AUTO in sub-select in target entry */
-		if (nodeTag(cur_te->expr) == T_SubLink)
+		/* Handle sub-select in target entry */
+		if (nodeTag(curTargetEntry->expr) == T_SubLink)
 		{
-			sl = castNode(SubLink, cur_te->expr);
+			sl = castNode(SubLink, curTargetEntry->expr);
 			if(sl->subselect != NULL && nodeTag(sl->subselect) == T_Query)
 			{
 				if(handleForJsonAuto(castNode(Query, sl->subselect)))
@@ -1806,13 +1831,14 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 					iocoerce->resulttype = TypenameGetTypid("json");
 					iocoerce->resultcollid = 0;
 					iocoerce->coerceformat = COERCE_EXPLICIT_CAST;
-					cur_te->expr = (Expr*) iocoerce;
+					curTargetEntry->expr = (Expr*) iocoerce;
 				}
 			}
 		}
 
-		if (nodeTag(cur_te->expr) == T_Var) {
-			varlevelsup = cur_var->varlevelsup;
+		/* If final matched target is a T_Var, we might want ot use matchedSrc's alias as JSON nesting key */
+		if (nodeTag(curTargetEntry->expr) == T_Var) {
+			varLevelsUp = curVar->varlevelsup;
 
 			/*
 			 * Don't use source alias for functions or outer source
@@ -1824,23 +1850,24 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 			 *    - or this CTE is a recursive CTE
 			 *      => we don't want to use this CTE's ctename as JSON nesting key
 			 */
-			if (varlevelsup > 0 || matched_src->rtekind == RTE_FUNCTION || (matched_src->rtekind == RTE_CTE && matched_src_CTE_is_recursive))
-				outermost_te = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermost_te);
+			if (varLevelsUp > 0 || matchedSrc->rtekind == RTE_FUNCTION ||
+				(matchedSrc->rtekind == RTE_CTE && matchedSrcCTEIsRecursive))
+				outermostTargetEntry = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermostTargetEntry);
 
 			else
 			{
 				/* Use full path as hash key to handle duplicate table names */
-				hashed_full_src_path = string_to_fixed_hash(full_src_path.data);
-				matched_src_alias = matched_src->eref->aliasname;
+				hashedFullSrcPath = string_to_fixed_hash(fullSrcPath.data);
+				matchedSrcAlias = matchedSrc->eref->aliasname;
 
 				rteHashEntry = (RTEAliasEntry *)hash_search(RTEAliasNestHash,
-															hashed_full_src_path,
+															hashedFullSrcPath,
 															HASH_FIND,
 															&found);
 				if (found)
 				{
 					// Use existing nest level from hash
-					outermost_te = buildJsonEntry(rteHashEntry->json_nest_level, matched_src_alias, outermost_te);
+					outermostTargetEntry = buildJsonEntry(rteHashEntry->json_nest_level, matchedSrcAlias, outermostTargetEntry);
 				}
 				else
 				{
@@ -1849,31 +1876,31 @@ modifyColumnEntries(Query *origQuery, Alias *wrapperRteAlias)
 						nestingLevel1Used = true;
 					else
 						curMaxUsedJsonLevel++;
-					curMaxUsedJsonKey = matched_src_alias;
+					curMaxUsedJsonKey = matchedSrcAlias;
 					rteHashEntry = (RTEAliasEntry *)hash_search(RTEAliasNestHash,
-															hashed_full_src_path,
-															HASH_ENTER,
-															&found);
+																hashedFullSrcPath,
+																HASH_ENTER,
+																&found);
 					Assert(!found);
-					strcpy(rteHashEntry->alias_name, hashed_full_src_path);
-					pfree(hashed_full_src_path);
+					strcpy(rteHashEntry->alias_name, hashedFullSrcPath);
+					pfree(hashedFullSrcPath);
 					rteHashEntry->json_nest_level = curMaxUsedJsonLevel;
-					outermost_te = buildJsonEntry(rteHashEntry->json_nest_level, matched_src_alias, outermost_te);
+					outermostTargetEntry = buildJsonEntry(rteHashEntry->json_nest_level, matchedSrcAlias, outermostTargetEntry);
 				}
 			}
 		}
 		else
 		{
 			/* Non-variable expressions use current max level/key */
-			outermost_te = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermost_te);
+			outermostTargetEntry = buildJsonEntry(curMaxUsedJsonLevel, curMaxUsedJsonKey, outermostTargetEntry);
 		}
 
-		colnameStr->sval = outermost_te->resname;
+		colnameStr->sval = outermostTargetEntry->resname;
 		targetIterIdx++;
 	}
 
 	/* Cleanup hash tables */
-	hash_destroy(ctename_idx_hash);
+	hash_destroy(ctenameIdxHash);
 	hash_destroy(RTEAliasNestHash);
 }
 

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -374,6 +374,12 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 					// insert new array into existing obj for nest
 					sprintf(hashKey, "%d", num - 1);
 					hashEntry = (JsonbEntry *) hash_search(jsonbHash, hashKey, HASH_FIND, &found);
+					if (!found)
+						ereport(ERROR,
+							(errcode(ERRCODE_INTERNAL_ERROR)),
+							errmsg("Cannot find parent level: queries with"
+								" some missing intermediate levels in output"
+								" are not supported yet.)"));
 					current = hashEntry->value;
 					insert_existing_json_to_obj(current, hashEntry->parent, &(nestedVal->val.object.pairs[0].value), hashEntry->idx, parts[2]);
 				}

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -230,8 +230,6 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 
 		colval = heap_getattr(tuple, i + 1, tupdesc, &isnull);
 
-		if (isnull && !include_null_values)
-			continue;
 
 		/*
 		 * Below is a workaround for is_tsql_x_datatype() which does not work
@@ -251,7 +249,7 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 		 * datatypes in different namespaces but with the same name. Examples:
 		 * bigint, int, etc.
 		 */
-		if (tsql_datatype_oid == datatype_oid)
+		if (tsql_datatype_oid == datatype_oid && (!isnull || include_null_values))
 		{
 			/* binary datatypes are not supported */
 			if (strcmp(typename, "binary") == 0 ||
@@ -312,9 +310,15 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 		}
 		
 		// Check for NULL
-		if (isnull && include_null_values)	{
-			value = palloc(sizeof(JsonbValue));
-			value->type=jbvNull;
+		if (isnull)
+		{
+			if (include_null_values)
+			{
+				value = palloc(sizeof(JsonbValue));
+				value->type=jbvNull;
+			}
+			else
+				value = NULL;
 		}
 		else	{
 			/*
@@ -339,8 +343,8 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 		parts = determine_parts(colname, &num);
 		if(strcmp(parts[0], "JSONAUTOALIAS") != 0) {
 			ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							errmsg("sub-select and values for json auto are not currently supported.")));
+						(errcode(ERRCODE_INTERNAL_ERROR),
+							errmsg("FOR JSON AUTO: Column '%s' was not properly processed by the analyzer stage", colname)));
 		}
 		colname = remove_index_and_alias(colname);
 		nestedVal = value;
@@ -351,6 +355,24 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 
 		maxDepth = (num > maxDepth) ? num : maxDepth;
 
+		/*
+		 * Null value handling for JSON nesting structure creation:
+		 *
+		 * When processing null values where num > 1 and the hash for this nesting level
+		 * doesn't exist, we must create the hash structure to allow sub-levels to append
+		 * to this layer.
+		 *
+		 * nestedVal can be NULL in cases where (isnull && !include_null_values). We still
+		 * pass NULL here to ensure JSON nesting layer structures are generated when needed.
+		 *
+		 * When nestedVal == NULL, the only required action is checking if the hashEntry
+		 * for this JSON nesting level exists, and creating it if missing. All other
+		 * processing blocks should skip NULL cases:
+		 *
+		 * - insert_existing_json_to_obj(): Skip when nestedVal == NULL
+		 * - create_json_array(): Should create empty [{}] (jbvArray->jbvObject with 0 pairs)
+		 * - When num == 1: Skip inserting the pair in jsonbRow if nestedVal == NULL
+		 */
 		if (num > 1)	{
 			hashKey = parts[1];
 
@@ -360,9 +382,13 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 			if (hashEntry)	{
 				// function call
 				current = hashEntry->value;
-				insert_existing_json_to_obj(current, hashEntry->parent, nestedVal, hashEntry->idx, colname);
+				if (nestedVal != NULL)
+					insert_existing_json_to_obj(current, hashEntry->parent, nestedVal, hashEntry->idx, colname);
 				pfree(hashKey);
-			} else {
+			}
+			else
+			{
+				/* create hashEntry for this layer (hashKey == "<nesting_level>") */
 				hashEntry = (JsonbEntry *) hash_search(jsonbHash, (void *) hashKey, HASH_ENTER, NULL);
 				strlcpy(hashEntry->path, hashKey, NAMEDATALEN);
 				nestedVal = create_json_array(parts[2], colname, nestedVal, &hashEntry->idx);
@@ -382,6 +408,11 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 								"intermediate nesting keys in the JSON hierarchy."
 								" This pattern is not currently supported."));
 					current = hashEntry->value;
+					/*
+					 * nestedVal->val.object.pairs[0].value points to value of jsonbPair <nesting_key, jbvArray of this layer>
+					 * for example, we created nesting level 3 from create_json_array(): {"o": [{"a": 1}]},
+					 * nestedVal->val.object.pairs[0].value points to                          ↑
+					 */
 					insert_existing_json_to_obj(current, hashEntry->parent, &(nestedVal->val.object.pairs[0].value), hashEntry->idx, parts[2]);
 				}
 				else	{
@@ -400,7 +431,9 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 				jsonbRow->val.object.nPairs++;
 				}
 		}
-		else {
+		/* num == 1 && nestedVal != NULL */
+		else if (nestedVal != NULL)
+		{
 			// Increment nPairs in the row if it isnt inserted into an already existing json object.
 			jsonbRow->val.object.nPairs++;
 
@@ -871,15 +904,23 @@ create_json_array(char *arrayKey, char* pairKey, JsonbValue* pairVal, int *idx)
 	jsonbArray->val.array.elems = (JsonbValue *) palloc(sizeof(JsonbValue));
 
 	// Create pair to hold key and value
-	innerPair = palloc(sizeof(JsonbPair));
-	innerPair->key = *innerKey;
-	innerPair->value = *pairVal;
 
 	innerObj = palloc(sizeof(JsonbValue));
 	innerObj->type = jbvObject;
-	innerObj->val.object.nPairs = 1;
-	innerObj->val.object.pairs = palloc(sizeof(JsonbPair));
-	innerObj->val.object.pairs[innerObj->val.object.nPairs - 1] = *innerPair;
+	if (pairVal != NULL)
+	{
+		innerPair = palloc(sizeof(JsonbPair));
+		innerPair->key = *innerKey;
+		innerPair->value = *pairVal;
+		innerObj->val.object.nPairs = 1;
+		innerObj->val.object.pairs = palloc(sizeof(JsonbPair));
+		innerObj->val.object.pairs[innerObj->val.object.nPairs - 1] = *innerPair;
+	}
+	else
+	{
+		innerObj->val.object.nPairs = 0;
+		innerObj->val.object.pairs = NULL;
+	}
 	
 	jsonbArray->val.array.elems[0] = *innerObj;
 

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -377,9 +377,10 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 					if (!found)
 						ereport(ERROR,
 							(errcode(ERRCODE_INTERNAL_ERROR)),
-							errmsg("Cannot find parent level: queries with"
-								" some missing intermediate levels in output"
-								" are not supported yet.)"));
+							errmsg("FOR JSON AUTO limitation: Your query has"
+								" produced empty result subsets that skip "
+								"intermediate nesting keys in the JSON hierarchy."
+								" This pattern is not currently supported."));
 					current = hashEntry->value;
 					insert_existing_json_to_obj(current, hashEntry->parent, &(nestedVal->val.object.pairs[0].value), hashEntry->idx, parts[2]);
 				}

--- a/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forjson.c
@@ -344,7 +344,8 @@ tsql_auto_row_to_json(JsonbValue* jsonbArray, Datum record, bool include_null_va
 		if(strcmp(parts[0], "JSONAUTOALIAS") != 0) {
 			ereport(ERROR,
 						(errcode(ERRCODE_INTERNAL_ERROR),
-							errmsg("FOR JSON AUTO: Column '%s' was not properly processed by the analyzer stage", colname)));
+							errmsg("An unexpected error occurred while processing JSON data."
+								" Unable to process column '%s' for JSON conversion", colname)));
 		}
 		colname = remove_index_and_alias(colname);
 		nestedVal = value;

--- a/test/JDBC/expected/forjson-escape-vu-verify.out
+++ b/test/JDBC/expected/forjson-escape-vu-verify.out
@@ -176,11 +176,13 @@ nvarchar
 SELECT ID, child.child_col as json_query_parent_col 
 from 
   (select ID ,JSON_QUERY(EmployeeDetails,'$.contact') as child_col from babel_5112_test5 ) child
+WHERE ID = 1
 FOR JSON AUTO;
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+~~START~~
+nvarchar
+[{"ID": 1, "json_query_parent_col": {"email": "naruto@example.com", "phone": "123-456-7890"}}]
+~~END~~
 
 
 -- FAIL (KNOWN CASE)
@@ -237,16 +239,17 @@ nvarchar
 
 
 --FAIL (KNOWN CASE)
-select * from (
+select MIN(test_union) as min_test_union from (
     SELECT JSON_QUERY(EmployeeDetails, '$.skills') as test_union FROM babel_5112_test7
     UNION 
     SELECT JSON_QUERY(EmployeeDetails, '$.contact') as test_union FROM babel_5112_test7
 ) as union_query
 FOR JSON AUTO;
 go
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+~~START~~
+nvarchar
+[{"min_test_union": "[\"C++\"]"}]
+~~END~~
 
 
 

--- a/test/JDBC/expected/forjson-escape-vu-verify.out
+++ b/test/JDBC/expected/forjson-escape-vu-verify.out
@@ -332,9 +332,8 @@ FOR JSON AUTO;
 GO
 ~~START~~
 nvarchar
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+[{"ID": 1, "employee_info": {"name": "Naruto"}}, {"ID": 2, "employee_info": {"name": "Sasuke"}}]
+~~END~~
 
 
 SELECT 

--- a/test/JDBC/expected/forjsonauto-before-16_5-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-before-16_5-vu-verify.out
@@ -148,9 +148,10 @@ nvarchar
 
 EXECUTE forjson_vu_p_5
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+~~START~~
+nvarchar
+[{"Val": 1, "y": [{"ValY": 1}]}]
+~~END~~
 
 
 EXECUTE forjson_vu_p_6

--- a/test/JDBC/expected/forjsonauto-before-16_5-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-before-16_5-vu-verify.out
@@ -176,7 +176,7 @@ GO
 nvarchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+~~ERROR (Message: invalid input syntax for type integer: "[{"max": 1}]")~~
 
 
 EXECUTE forjson_vu_p_9

--- a/test/JDBC/expected/forjsonauto-vu-cleanup.out
+++ b/test/JDBC/expected/forjsonauto-vu-cleanup.out
@@ -131,3 +131,13 @@ DROP TABLE forjson_test_unicode;
 DROP TABLE forjson_test_orderby;
 DROP TABLE forjson_test_groupby;
 GO
+
+DROP TABLE IF EXISTS forjsonauto_t_categories;
+DROP TABLE IF EXISTS forjsonauto_t_customers;
+DROP TABLE IF EXISTS forjsonauto_t_orders;
+DROP TABLE IF EXISTS forjsonauto_t_products;
+DROP TABLE IF EXISTS forjsonauto_t_order_details;
+DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_warehouses;
+DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_suppliers;
+DROP SCHEMA IF EXISTS forjsonauto_t_inventory_schema;
+GO

--- a/test/JDBC/expected/forjsonauto-vu-cleanup.out
+++ b/test/JDBC/expected/forjsonauto-vu-cleanup.out
@@ -140,4 +140,5 @@ DROP TABLE IF EXISTS forjsonauto_t_order_details;
 DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_warehouses;
 DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_suppliers;
 DROP SCHEMA IF EXISTS forjsonauto_t_inventory_schema;
+DROP TABLE IF EXISTS JsonTable;
 GO

--- a/test/JDBC/expected/forjsonauto-vu-prepare.out
+++ b/test/JDBC/expected/forjsonauto-vu-prepare.out
@@ -377,6 +377,7 @@ CREATE TABLE forjsonauto_t_order_details (OrderDetailID INT PRIMARY KEY, OrderID
 CREATE SCHEMA forjsonauto_t_inventory_schema;
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID INT PRIMARY KEY, SupplierName NVARCHAR(100), ContactPerson NVARCHAR(50), Phone NVARCHAR(20), Country NVARCHAR(50), Rating INT, CreatedDate DATETIME DEFAULT GETDATE());
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID INT PRIMARY KEY, WarehouseName NVARCHAR(100), Location NVARCHAR(100), Capacity INT, SupplierID INT, OperationalStatus NVARCHAR(20), LastInspectionDate DATETIME);
+CREATE TABLE JsonTable (ID INT IDENTITY(1,1) PRIMARY KEY, JsonData NVARCHAR(MAX));
 INSERT INTO forjsonauto_t_categories (CategoryID, CategoryName, Description, ParentCategoryID) VALUES (1, 'Beverages', 'Soft drinks, coffees, teas', NULL), (2, 'Coffee', 'Various coffee brands', 1), (3, 'Tea', 'Various tea brands', 1), (4, 'Electronics', 'Electronic equipment', NULL), (5, 'Computers', 'Computer equipment', 4);
 INSERT INTO forjsonauto_t_customers (CustomerID, CompanyName, ContactName, ContactTitle, Region, Country, Phone) VALUES ('ALFKI', 'Alfreds Inc', 'Maria Anders', 'Sales Rep', 'WA', 'USA', '030-0074321'), ('BERGS', 'Berglunds snabbköp', 'Christina Berglund', 'Administrator', NULL, 'Sweden', '0921-12 34 65'), ('CONSH', 'Consolidated Holdings', 'Elizabeth Brown', 'Sales Manager', 'LA', 'USA', '(171) 555-2282');
 INSERT INTO forjsonauto_t_orders (OrderID, CustomerID, OrderDate, ShipAddress, ShipCity, ShipCountry, TotalAmount, Status) VALUES (10248, 'ALFKI', '2023-07-04', '23 Tsawassen Blvd.', 'Seattle', 'USA', 440.00, 'Shipped'), (10249, 'BERGS', '2023-07-05', 'Luisenstr. 48', 'Mannheim', 'Germany', 1863.40, 'Pending'), (10250, 'CONSH', '2023-07-06', 'Berkeley Gardens', 'London', 'UK', 1552.60, 'Delivered');
@@ -384,6 +385,12 @@ INSERT INTO forjsonauto_t_products (ProductID, ProductName, UnitPrice, CategoryI
 INSERT INTO forjsonauto_t_order_details (OrderDetailID, OrderID, ProductID, Quantity, UnitPrice, Discount) VALUES (1, 10248, 1, 12, 18.00, 0.00), (2, 10248, 2, 10, 19.00, 0.05), (3, 10249, 3, 5, 1200.00, 0.00), (4, 10250, 1, 20, 18.00, 0.10), (5, 10250, 4, 15, 10.00, 0.00);
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID, SupplierName, ContactPerson, Phone, Country, Rating) VALUES (1, 'Global Supply Co', 'John Smith', '+1-555-1234', 'USA', 5), (2, 'Euro Logistics', 'Maria Garcia', '+34-612-345678', 'Spain', 4), (3, 'Asia Trade Ltd', 'Chen Wei', '+86-138-12345678', 'China', 3), (4, 'Nordic Solutions', 'Erik Larsson', '+46-70-1234567', 'Sweden', 5);
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID, WarehouseName, Location, Capacity, SupplierID, OperationalStatus, LastInspectionDate) VALUES (101, 'Seattle Distribution Center', 'Seattle, WA', 50000, 1, 'Active', '2023-06-15'), (102, 'Madrid Storage Facility', 'Madrid, Spain', 35000, 2, 'Active', '2023-07-01'), (103, 'Shanghai Warehouse', 'Shanghai, China', 75000, 3, 'Maintenance', '2023-05-20'), (104, 'Stockholm Hub', 'Stockholm, Sweden', 40000, 4, 'Active', '2023-07-10'), (105, 'Backup Seattle Facility', 'Tacoma, WA', 25000, 1, 'Inactive', '2023-04-30');
+INSERT INTO JsonTable (JsonData)
+VALUES 
+    ((SELECT CustomerID, CompanyName, ContactName, Country, Phone 
+      FROM forjsonauto_t_customers 
+      WHERE CustomerID = 'ALFKI' 
+      FOR JSON AUTO));
 GO
 ~~ROW COUNT: 5~~
 
@@ -398,4 +405,6 @@ GO
 ~~ROW COUNT: 4~~
 
 ~~ROW COUNT: 5~~
+
+~~ROW COUNT: 1~~
 

--- a/test/JDBC/expected/forjsonauto-vu-prepare.out
+++ b/test/JDBC/expected/forjsonauto-vu-prepare.out
@@ -365,3 +365,37 @@ RETURN
     SELECT  e.EmployeeId FROM forjson_auto_test_diff_cases e
 );
 GO
+
+
+
+
+CREATE TABLE forjsonauto_t_categories (CategoryID INT PRIMARY KEY, CategoryName NVARCHAR(50), Description NVARCHAR(200), ParentCategoryID INT, CreatedDate DATETIME DEFAULT GETDATE());
+CREATE TABLE forjsonauto_t_customers (CustomerID NCHAR(5) PRIMARY KEY, CompanyName NVARCHAR(100), ContactName NVARCHAR(100), ContactTitle NVARCHAR(50), Region NVARCHAR(50), Country NVARCHAR(50), Phone NVARCHAR(20), IsActive BIT DEFAULT 1);
+CREATE TABLE forjsonauto_t_orders (OrderID INT PRIMARY KEY, CustomerID NCHAR(5), OrderDate DATETIME, ShipAddress NVARCHAR(100), ShipCity NVARCHAR(50), ShipCountry NVARCHAR(50), TotalAmount MONEY, Status NVARCHAR(20));
+CREATE TABLE forjsonauto_t_products (ProductID INT PRIMARY KEY, ProductName NVARCHAR(100), UnitPrice MONEY, CategoryID INT, UnitsInStock INT, Discontinued BIT DEFAULT 0, LastUpdated DATETIME DEFAULT GETDATE());
+CREATE TABLE forjsonauto_t_order_details (OrderDetailID INT PRIMARY KEY, OrderID INT, ProductID INT, Quantity INT, UnitPrice MONEY, Discount DECIMAL(3,2) DEFAULT 0.00);
+CREATE SCHEMA forjsonauto_t_inventory_schema;
+CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID INT PRIMARY KEY, SupplierName NVARCHAR(100), ContactPerson NVARCHAR(50), Phone NVARCHAR(20), Country NVARCHAR(50), Rating INT, CreatedDate DATETIME DEFAULT GETDATE());
+CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID INT PRIMARY KEY, WarehouseName NVARCHAR(100), Location NVARCHAR(100), Capacity INT, SupplierID INT, OperationalStatus NVARCHAR(20), LastInspectionDate DATETIME);
+INSERT INTO forjsonauto_t_categories (CategoryID, CategoryName, Description, ParentCategoryID) VALUES (1, 'Beverages', 'Soft drinks, coffees, teas', NULL), (2, 'Coffee', 'Various coffee brands', 1), (3, 'Tea', 'Various tea brands', 1), (4, 'Electronics', 'Electronic equipment', NULL), (5, 'Computers', 'Computer equipment', 4);
+INSERT INTO forjsonauto_t_customers (CustomerID, CompanyName, ContactName, ContactTitle, Region, Country, Phone) VALUES ('ALFKI', 'Alfreds Inc', 'Maria Anders', 'Sales Rep', 'WA', 'USA', '030-0074321'), ('BERGS', 'Berglunds snabbköp', 'Christina Berglund', 'Administrator', NULL, 'Sweden', '0921-12 34 65'), ('CONSH', 'Consolidated Holdings', 'Elizabeth Brown', 'Sales Manager', 'LA', 'USA', '(171) 555-2282');
+INSERT INTO forjsonauto_t_orders (OrderID, CustomerID, OrderDate, ShipAddress, ShipCity, ShipCountry, TotalAmount, Status) VALUES (10248, 'ALFKI', '2023-07-04', '23 Tsawassen Blvd.', 'Seattle', 'USA', 440.00, 'Shipped'), (10249, 'BERGS', '2023-07-05', 'Luisenstr. 48', 'Mannheim', 'Germany', 1863.40, 'Pending'), (10250, 'CONSH', '2023-07-06', 'Berkeley Gardens', 'London', 'UK', 1552.60, 'Delivered');
+INSERT INTO forjsonauto_t_products (ProductID, ProductName, UnitPrice, CategoryID, UnitsInStock) VALUES (1, 'Chai', 18.00, 3, 39), (2, 'Coffee Beans', 19.00, 2, 17), (3, 'Laptop', 1200.00, 5, 10), (4, 'Green Tea', 10.00, 3, 25);
+INSERT INTO forjsonauto_t_order_details (OrderDetailID, OrderID, ProductID, Quantity, UnitPrice, Discount) VALUES (1, 10248, 1, 12, 18.00, 0.00), (2, 10248, 2, 10, 19.00, 0.05), (3, 10249, 3, 5, 1200.00, 0.00), (4, 10250, 1, 20, 18.00, 0.10), (5, 10250, 4, 15, 10.00, 0.00);
+INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID, SupplierName, ContactPerson, Phone, Country, Rating) VALUES (1, 'Global Supply Co', 'John Smith', '+1-555-1234', 'USA', 5), (2, 'Euro Logistics', 'Maria Garcia', '+34-612-345678', 'Spain', 4), (3, 'Asia Trade Ltd', 'Chen Wei', '+86-138-12345678', 'China', 3), (4, 'Nordic Solutions', 'Erik Larsson', '+46-70-1234567', 'Sweden', 5);
+INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID, WarehouseName, Location, Capacity, SupplierID, OperationalStatus, LastInspectionDate) VALUES (101, 'Seattle Distribution Center', 'Seattle, WA', 50000, 1, 'Active', '2023-06-15'), (102, 'Madrid Storage Facility', 'Madrid, Spain', 35000, 2, 'Active', '2023-07-01'), (103, 'Shanghai Warehouse', 'Shanghai, China', 75000, 3, 'Maintenance', '2023-05-20'), (104, 'Stockholm Hub', 'Stockholm, Sweden', 40000, 4, 'Active', '2023-07-10'), (105, 'Backup Seattle Facility', 'Tacoma, WA', 25000, 1, 'Inactive', '2023-04-30');
+GO
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 5~~
+
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 5~~
+

--- a/test/JDBC/expected/forjsonauto-vu-prepare.out
+++ b/test/JDBC/expected/forjsonauto-vu-prepare.out
@@ -367,24 +367,68 @@ RETURN
 GO
 
 
-
-
 CREATE TABLE forjsonauto_t_categories (CategoryID INT PRIMARY KEY, CategoryName NVARCHAR(50), Description NVARCHAR(200), ParentCategoryID INT, CreatedDate DATETIME DEFAULT GETDATE());
+GO
+
 CREATE TABLE forjsonauto_t_customers (CustomerID NCHAR(5) PRIMARY KEY, CompanyName NVARCHAR(100), ContactName NVARCHAR(100), ContactTitle NVARCHAR(50), Region NVARCHAR(50), Country NVARCHAR(50), Phone NVARCHAR(20), IsActive BIT DEFAULT 1);
+GO
+
 CREATE TABLE forjsonauto_t_orders (OrderID INT PRIMARY KEY, CustomerID NCHAR(5), OrderDate DATETIME, ShipAddress NVARCHAR(100), ShipCity NVARCHAR(50), ShipCountry NVARCHAR(50), TotalAmount MONEY, Status NVARCHAR(20));
+GO
+
 CREATE TABLE forjsonauto_t_products (ProductID INT PRIMARY KEY, ProductName NVARCHAR(100), UnitPrice MONEY, CategoryID INT, UnitsInStock INT, Discontinued BIT DEFAULT 0, LastUpdated DATETIME DEFAULT GETDATE());
+GO
+
 CREATE TABLE forjsonauto_t_order_details (OrderDetailID INT PRIMARY KEY, OrderID INT, ProductID INT, Quantity INT, UnitPrice MONEY, Discount DECIMAL(3,2) DEFAULT 0.00);
+GO
+
 CREATE SCHEMA forjsonauto_t_inventory_schema;
+GO
+
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID INT PRIMARY KEY, SupplierName NVARCHAR(100), ContactPerson NVARCHAR(50), Phone NVARCHAR(20), Country NVARCHAR(50), Rating INT, CreatedDate DATETIME DEFAULT GETDATE());
+GO
+
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID INT PRIMARY KEY, WarehouseName NVARCHAR(100), Location NVARCHAR(100), Capacity INT, SupplierID INT, OperationalStatus NVARCHAR(20), LastInspectionDate DATETIME);
+GO
+
 CREATE TABLE JsonTable (ID INT IDENTITY(1,1) PRIMARY KEY, JsonData NVARCHAR(MAX));
+GO
+
 INSERT INTO forjsonauto_t_categories (CategoryID, CategoryName, Description, ParentCategoryID) VALUES (1, 'Beverages', 'Soft drinks, coffees, teas', NULL), (2, 'Coffee', 'Various coffee brands', 1), (3, 'Tea', 'Various tea brands', 1), (4, 'Electronics', 'Electronic equipment', NULL), (5, 'Computers', 'Computer equipment', 4);
+GO
+~~ROW COUNT: 5~~
+
+
 INSERT INTO forjsonauto_t_customers (CustomerID, CompanyName, ContactName, ContactTitle, Region, Country, Phone) VALUES ('ALFKI', 'Alfreds Inc', 'Maria Anders', 'Sales Rep', 'WA', 'USA', '030-0074321'), ('BERGS', 'Berglunds snabbköp', 'Christina Berglund', 'Administrator', NULL, 'Sweden', '0921-12 34 65'), ('CONSH', 'Consolidated Holdings', 'Elizabeth Brown', 'Sales Manager', 'LA', 'USA', '(171) 555-2282');
+GO
+~~ROW COUNT: 3~~
+
+
 INSERT INTO forjsonauto_t_orders (OrderID, CustomerID, OrderDate, ShipAddress, ShipCity, ShipCountry, TotalAmount, Status) VALUES (10248, 'ALFKI', '2023-07-04', '23 Tsawassen Blvd.', 'Seattle', 'USA', 440.00, 'Shipped'), (10249, 'BERGS', '2023-07-05', 'Luisenstr. 48', 'Mannheim', 'Germany', 1863.40, 'Pending'), (10250, 'CONSH', '2023-07-06', 'Berkeley Gardens', 'London', 'UK', 1552.60, 'Delivered');
+GO
+~~ROW COUNT: 3~~
+
+
 INSERT INTO forjsonauto_t_products (ProductID, ProductName, UnitPrice, CategoryID, UnitsInStock) VALUES (1, 'Chai', 18.00, 3, 39), (2, 'Coffee Beans', 19.00, 2, 17), (3, 'Laptop', 1200.00, 5, 10), (4, 'Green Tea', 10.00, 3, 25);
+GO
+~~ROW COUNT: 4~~
+
+
 INSERT INTO forjsonauto_t_order_details (OrderDetailID, OrderID, ProductID, Quantity, UnitPrice, Discount) VALUES (1, 10248, 1, 12, 18.00, 0.00), (2, 10248, 2, 10, 19.00, 0.05), (3, 10249, 3, 5, 1200.00, 0.00), (4, 10250, 1, 20, 18.00, 0.10), (5, 10250, 4, 15, 10.00, 0.00);
+GO
+~~ROW COUNT: 5~~
+
+
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID, SupplierName, ContactPerson, Phone, Country, Rating) VALUES (1, 'Global Supply Co', 'John Smith', '+1-555-1234', 'USA', 5), (2, 'Euro Logistics', 'Maria Garcia', '+34-612-345678', 'Spain', 4), (3, 'Asia Trade Ltd', 'Chen Wei', '+86-138-12345678', 'China', 3), (4, 'Nordic Solutions', 'Erik Larsson', '+46-70-1234567', 'Sweden', 5);
+GO
+~~ROW COUNT: 4~~
+
+
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID, WarehouseName, Location, Capacity, SupplierID, OperationalStatus, LastInspectionDate) VALUES (101, 'Seattle Distribution Center', 'Seattle, WA', 50000, 1, 'Active', '2023-06-15'), (102, 'Madrid Storage Facility', 'Madrid, Spain', 35000, 2, 'Active', '2023-07-01'), (103, 'Shanghai Warehouse', 'Shanghai, China', 75000, 3, 'Maintenance', '2023-05-20'), (104, 'Stockholm Hub', 'Stockholm, Sweden', 40000, 4, 'Active', '2023-07-10'), (105, 'Backup Seattle Facility', 'Tacoma, WA', 25000, 1, 'Inactive', '2023-04-30');
+GO
+~~ROW COUNT: 5~~
+
+
 INSERT INTO JsonTable (JsonData)
 VALUES 
     ((SELECT CustomerID, CompanyName, ContactName, Country, Phone 
@@ -392,19 +436,5 @@ VALUES
       WHERE CustomerID = 'ALFKI' 
       FOR JSON AUTO));
 GO
-~~ROW COUNT: 5~~
-
-~~ROW COUNT: 3~~
-
-~~ROW COUNT: 3~~
-
-~~ROW COUNT: 4~~
-
-~~ROW COUNT: 5~~
-
-~~ROW COUNT: 4~~
-
-~~ROW COUNT: 5~~
-
 ~~ROW COUNT: 1~~
 

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -1376,6 +1376,26 @@ nvarchar
 ~~END~~
 
 
+-- outer query w/o FOR JSON AUTO + inner query w/ FOR JSON AUTO
+WITH customer_orders AS (
+    SELECT c.CustomerID, c.CompanyName, o.OrderID, o.TotalAmount
+    FROM forjsonauto_t_customers c
+    JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
+)
+SELECT subquery_result.aa
+FROM (
+    SELECT co.CompanyName, co.OrderID, co.TotalAmount
+    FROM customer_orders co
+      where co.OrderID = 10248
+    FOR JSON AUTO
+) AS subquery_result(aa)
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "o": [{"OrderID": 10248, "TotalAmount": 440.0000}]}]
+~~END~~
+
+
 ---------------------------------------- Different types of Targets (in SELECT_clause) ----------------------------------------
 -- subquery as target (nest_level > 1)
 SELECT c.CompanyName, 
@@ -1695,5 +1715,84 @@ GO
 ~~START~~
 nvarchar
 [{"CustomerID": "ALFKI", "o": [{"o": [{"customerID": "ALFKI", "total_order_count": 1}]}]}]
+~~END~~
+
+
+-- only NULL-value columns in level 1
+WITH high_value_orders AS (
+    SELECT o.CustomerID,
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT
+    hvo.CustomerID,
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"c": [{"CustomerID": "ALFKI", "o": [{"customerID": "ALFKI", "total_order_count": 1}]}]}]
+~~END~~
+
+
+-- NULL-value columns in level 1 with “INCLUDE_NULL_VALUES”
+WITH high_value_orders AS (
+    SELECT o.CustomerID,
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT
+    hvo.CustomerID,
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO, INCLUDE_NULL_VALUES;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": null, "c": [{"CustomerID": "ALFKI", "o": [{"customerID": "ALFKI", "total_order_count": 1}]}], "customerID": null}]
+~~END~~
+
+
+-- SELECT FROM a table which value is a result of FOR JSON AUTO
+SELECT * FROM JsonTable;
+GO
+~~START~~
+int#!#nvarchar
+1#!#[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc", "ContactName": "Maria Anders", "Country": "USA", "Phone": "030-0074321"}]
 ~~END~~
 

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -176,7 +176,7 @@ GO
 nvarchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+~~ERROR (Message: invalid input syntax for type integer: "[{"max": 1}]")~~
 
 
 EXECUTE forjson_vu_p_9
@@ -435,9 +435,10 @@ SELECT  b.EmployeeId
 FROM dbo.forjson_auto_test_diff_cases_fn(1) as b
 FOR JSON AUTO;
 GO
-~~ERROR (Code: 13600)~~
-
-~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+~~START~~
+nvarchar
+[{"EmployeeId": 1}, {"EmployeeId": 2}]
+~~END~~
 
 
 
@@ -652,6 +653,59 @@ GO
 ~~START~~
 nvarchar
 [{"ProductName": "Coffee Beans", "c": [{"CategoryName": "Coffee", "product_sales_analysis": [{"od": [{"cu": [{"CustomerID": "ALFKI", "CategoryName": "Coffee", "analyzed_product": "Coffee Beans"}], "Quantity": 10, "UnitPrice": 19.0000, "line_total": 190.0000}], "OrderID": 10248}]}]}]
+~~END~~
+
+
+-- nested FOR JSON AUTO in subquery at outer query's FROM_clause
+WITH SalesData AS (
+    SELECT * FROM (VALUES
+        (1, 'East', '2023-01', 1000),
+        (1, 'East', '2023-02', 1200),
+        (2, 'West', '2023-01', 800),
+        (2, 'West', '2023-02', 900)
+    ) AS v(RegionId, RegionName, Period, Sales)
+)
+SELECT
+    v.RegionId,
+    v.RegionName,
+    (
+        SELECT
+            sd.Period,
+            sd.Sales,
+            sd.Sales * 0.15 as Commission,
+            (
+                SELECT TOP 1 t.TargetValue
+                FROM (VALUES
+                    ('East', 1100),
+                    ('West', 850)
+                ) t(Region, TargetValue)
+                WHERE t.Region = v.RegionName
+            ) as MonthlyTarget,
+            CASE
+                WHEN sd.Sales >= (
+                    SELECT TOP 1 t.TargetValue
+                    FROM (VALUES
+                        ('East', 1100),
+                        ('West', 850)
+                    ) t(Region, TargetValue)
+                    WHERE t.Region = v.RegionName
+                ) THEN 'Achieved'
+                ELSE 'Not Achieved'
+            END as TargetStatus
+        FROM SalesData sd
+        WHERE sd.RegionId = v.RegionId
+        FOR JSON AUTO
+    ) as MonthlyPerformance
+FROM (VALUES
+    (1, 'East'),
+    (2, 'West')
+) v(RegionId, RegionName)
+WHERE v.RegionId = 1
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"RegionId": 1, "RegionName": "East", "MonthlyPerformance": [{"Sales": 1000, "Period": "2023-01", "Commission": 150.00, "TargetStatus": "Not Achieved", "MonthlyTarget": 1100}, {"Sales": 1200, "Period": "2023-02", "Commission": 180.00, "TargetStatus": "Achieved", "MonthlyTarget": 1100}]}]
 ~~END~~
 
 
@@ -1547,13 +1601,13 @@ LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
 LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
 LEFT JOIN forjsonauto_t_products p ON od.ProductID = p.ProductID AND p.UnitPrice > 100
 WHERE c.CustomerID = 'ALFKI'
+AND od.OrderDetailID = 1
 FOR JSON AUTO;
 GO
 ~~START~~
 nvarchar
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: FOR JSON AUTO limitation: Your query has produced empty result subsets that skip intermediate nesting keys in the JSON hierarchy. This pattern is not currently supported.)~~
+[{"CustomerID": "ALFKI", "o": [{"OrderID": 10248, "p": [{"od": [{"OrderDetailID": 1}]}]}]}]
+~~END~~
 
 
 -- base tables LEFT JOIN with multiple NULL intermediate levels
@@ -1576,7 +1630,7 @@ FOR JSON AUTO;
 GO
 ~~START~~
 nvarchar
-[{"CustomerID": "ALFKI", "o": [{"OrderID": 10248}, {"OrderID": 10248}]}]
+[{"CustomerID": "ALFKI", "o": [{"OrderID": 10248, "p": [{"cat": [{"s": [{"w": [{}]}]}]}]}, {"OrderID": 10248, "p": [{"cat": [{"s": [{"w": [{}]}]}]}]}]}]
 ~~END~~
 
 
@@ -1601,13 +1655,13 @@ LEFT JOIN (
     WHERE s.Rating > 4
 ) supplier_info ON expensive_products.CategoryID = supplier_info.Rating
 WHERE c.CustomerID = 'ALFKI'
+AND od.OrderDetailID = 1
 FOR JSON AUTO;
 GO
 ~~START~~
 nvarchar
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: FOR JSON AUTO limitation: Your query has produced empty result subsets that skip intermediate nesting keys in the JSON hierarchy. This pattern is not currently supported.)~~
+[{"CustomerID": "ALFKI", "o": [{"OrderID": 10248, "expensive_products": [{"supplier_info": [{"od": [{"OrderDetailID": 1}]}]}]}]}]
+~~END~~
 
 
 -- CTE LEFT JOIN with NULL intermediate levels
@@ -1640,7 +1694,6 @@ FOR JSON AUTO;
 GO
 ~~START~~
 nvarchar
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: FOR JSON AUTO limitation: Your query has produced empty result subsets that skip intermediate nesting keys in the JSON hierarchy. This pattern is not currently supported.)~~
+[{"CustomerID": "ALFKI", "o": [{"o": [{"customerID": "ALFKI", "total_order_count": 1}]}]}]
+~~END~~
 

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -148,9 +148,10 @@ nvarchar
 
 EXECUTE forjson_vu_p_5
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: sub-select and values for json auto are not currently supported.)~~
+~~START~~
+nvarchar
+[{"Val": 1, "y": [{"ValY": 1}]}]
+~~END~~
 
 
 EXECUTE forjson_vu_p_6
@@ -410,7 +411,7 @@ EXECUTE forjson_vu_v_resjunk_window_functions;
 GO
 ~~START~~
 nvarchar
-[{"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 2}, {"Id": 1, "firstname": "j", "p": [{"name": "A", "price": "20"}], "quantity_rank": 3}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 4}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 5}, {"Id": 1, "firstname": "j", "p": [{"name": "A", "price": "20"}], "quantity_rank": 6}, {"Id": 1, "firstname": "j", "p": [{"name": "B", "price": "30"}], "quantity_rank": 1}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 2}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 3}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 4}, {"Id": 1, "firstname": "e", "p": [{"name": "B", "price": "30"}], "quantity_rank": 5}, {"Id": 1, "firstname": "j", "p": [{"name": "B", "price": "30"}], "quantity_rank": 6}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20"}], "quantity_rank": 1}]
+[{"Id": 1, "firstname": "j", "p": [{"name": "A", "price": "20", "quantity_rank": 3}, {"name": "A", "price": "20", "quantity_rank": 6}, {"name": "B", "price": "30", "quantity_rank": 1}, {"name": "B", "price": "30", "quantity_rank": 6}]}, {"Id": 1, "firstname": "e", "p": [{"name": "A", "price": "20", "quantity_rank": 1}, {"name": "A", "price": "20", "quantity_rank": 2}, {"name": "A", "price": "20", "quantity_rank": 4}, {"name": "A", "price": "20", "quantity_rank": 5}, {"name": "B", "price": "30", "quantity_rank": 2}, {"name": "B", "price": "30", "quantity_rank": 3}, {"name": "B", "price": "30", "quantity_rank": 4}, {"name": "B", "price": "30", "quantity_rank": 5}]}]
 ~~END~~
 
 
@@ -454,4 +455,1064 @@ GO
 nvarchar
 [{"EmployeeId": 1, "salary": 75000}, {"EmployeeId": 1, "salary": 85000}, {"EmployeeId": 2, "salary": 75000}, {"EmployeeId": 2, "salary": 85000}]
 ~~END~~
+
+
+
+---------------------------------------- Subqueries (in FROM_clause) ----------------------------------------
+-- Single subquery
+SELECT sub.CustomerID, sub.CompanyName
+FROM (
+    SELECT CustomerID, CompanyName
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+) AS sub
+WHERE sub.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc"}]
+~~END~~
+
+
+-- Multiple subqueries with JOIN
+SELECT sub1.CustomerID, sub1.CompanyName, sub2.TotalAmount
+FROM (
+    SELECT CustomerID, CompanyName
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+) AS sub1
+JOIN (
+    SELECT CustomerID, TotalAmount
+    FROM forjsonauto_t_orders
+    WHERE TotalAmount > 500
+) AS sub2
+ON sub1.CustomerID = sub2.CustomerID
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "CONSH", "CompanyName": "Consolidated Holdings", "sub2": [{"TotalAmount": 1552.6000}]}]
+~~END~~
+
+
+-- Multiple subqueries referencing same base table
+SELECT o1.OrderID, o1.CustomerID, o1.TotalAmount, o2.AvgAmount
+FROM (
+    SELECT OrderID, CustomerID, TotalAmount
+    FROM forjsonauto_t_orders
+    WHERE TotalAmount > 1000
+) AS o1
+JOIN (
+    SELECT CustomerID, AVG(TotalAmount) AS AvgAmount
+    FROM forjsonauto_t_orders
+    GROUP BY CustomerID
+) AS o2
+ON o1.CustomerID = o2.CustomerID
+WHERE o1.CustomerID = 'BERGS'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"OrderID": 10249, "CustomerID": "BERGS", "TotalAmount": 1863.4000, "o2": [{"AvgAmount": 1863.4000}]}]
+~~END~~
+
+
+-- UNION subqueries
+SELECT combined.CustomerID, combined.Source
+FROM (
+    SELECT CustomerID, 'Active' as Source
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+    UNION ALL
+    SELECT CustomerID, 'International' as Source
+    FROM forjsonauto_t_customers
+    WHERE Country != 'USA'
+) AS combined
+WHERE combined.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "Source": "Active"}]
+~~END~~
+
+
+-- Two-level nesting subqueries
+SELECT outer_sub.CustomerID, outer_sub.OrderCount
+FROM (
+    SELECT sub.CustomerID, COUNT(*) as OrderCount
+    FROM (
+        SELECT CustomerID, OrderID
+        FROM forjsonauto_t_orders
+        WHERE TotalAmount > 200
+    ) AS sub
+    GROUP BY sub.CustomerID
+) AS outer_sub
+WHERE outer_sub.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "OrderCount": 1}]
+~~END~~
+
+
+-- Three-level nesting subqueries
+SELECT final.CategoryName, final.ProductCount
+FROM (
+    SELECT level2.CategoryName, COUNT(*) as ProductCount
+    FROM (
+        SELECT level1.CategoryName, level1.ProductName
+        FROM (
+            SELECT c.CategoryName, p.ProductName, p.UnitPrice
+            FROM forjsonauto_t_categories c
+            JOIN forjsonauto_t_products p ON c.CategoryID = p.CategoryID
+        ) AS level1
+        WHERE level1.UnitPrice > 15
+    ) AS level2
+    GROUP BY level2.CategoryName
+) AS final
+WHERE final.CategoryName = 'Coffee'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CategoryName": "Coffee", "ProductCount": 1}]
+~~END~~
+
+
+-- Correlated subqueries in FROM_clause
+SELECT
+    c.CustomerID,
+    c.CompanyName,
+    c.Country, 
+    order_stats.total_orders,
+    order_stats.avg_order_value
+FROM forjsonauto_t_customers c
+CROSS APPLY (
+    SELECT
+        COUNT(*) as total_orders, 
+        AVG(TotalAmount) as avg_order_value
+    FROM forjsonauto_t_orders o
+    WHERE o.CustomerID = c.CustomerID
+) order_stats
+WHERE order_stats.total_orders > 0
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc", "Country": "USA", "order_stats": [{"total_orders": 1, "avg_order_value": 440.0000}]}]
+~~END~~
+
+
+-- Correlated subqueries in SELECT_clause
+SELECT p.ProductName,
+       c.CategoryName,
+       (SELECT COUNT(*)
+        FROM forjsonauto_t_orders o
+        WHERE o.TotalAmount > p.UnitPrice
+       ) as HigherValueOrderCount
+FROM forjsonauto_t_products p
+JOIN forjsonauto_t_categories c ON p.CategoryID = c.CategoryID
+WHERE p.ProductName = 'Coffee Beans'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"ProductName": "Coffee Beans", "c": [{"CategoryName": "Coffee", "HigherValueOrderCount": 3}]}]
+~~END~~
+
+
+-- Correlated subqueries in SELECT_clause + nested FOR JSON AUTO (inner correlated subquery reference to outer query’s sources)
+SELECT
+    p.ProductName,
+    c.CategoryName,
+    (SELECT
+        o.OrderID,
+        od.Quantity,
+        od.UnitPrice,
+        (od.Quantity * od.UnitPrice) as line_total,
+        cu.CustomerID,
+        p.ProductName as analyzed_product,
+        c.CategoryName
+    FROM forjsonauto_t_order_details od
+    JOIN forjsonauto_t_orders o ON od.OrderID = o.OrderID
+    JOIN forjsonauto_t_customers cu ON o.CustomerID = cu.CustomerID
+    WHERE od.ProductID = p.ProductID
+    AND od.Quantity >= 10
+    FOR JSON AUTO
+    ) as product_sales_analysis
+FROM forjsonauto_t_products p
+JOIN forjsonauto_t_categories c ON p.CategoryID = c.CategoryID
+WHERE p.ProductName = 'Coffee Beans'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"ProductName": "Coffee Beans", "c": [{"CategoryName": "Coffee", "product_sales_analysis": [{"od": [{"cu": [{"CustomerID": "ALFKI", "CategoryName": "Coffee", "analyzed_product": "Coffee Beans"}], "Quantity": 10, "UnitPrice": 19.0000, "line_total": 190.0000}], "OrderID": 10248}]}]}]
+~~END~~
+
+
+---------------------------------------- VALUES (in FROM_clause) ----------------------------------------
+-- VALUES with Mixed Data Types
+SELECT v.product_name, v.price, v.in_stock, v.launch_date
+FROM (VALUES 
+    ('New Coffee', 25.50, 1, '2024-01-15'),
+    ('Premium Tea', 18.75, 0, '2024-02-20'),
+    ('Energy Drink', 3.99, 1, '2024-03-10')
+) AS v(product_name, price, in_stock, launch_date)
+WHERE v.product_name = 'New Coffee'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"product_name": "New Coffee", "price": 25.50, "in_stock": 1, "launch_date": "2024-01-15"}]
+~~END~~
+
+
+-- VALUES with NULL Values
+SELECT v.customer_id, v.region, v.phone
+FROM (VALUES 
+    ('ALFKI', 'WA', '030-0074321'),
+    ('BERGS', NULL, '0921-12 34 65'),
+    ('NEWCO', 'CA', NULL)
+) AS v(customer_id, region, phone)
+WHERE v.customer_id = 'BERGS'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"customer_id": "BERGS", "phone": "0921-12 34 65"}]
+~~END~~
+
+
+-- VALUES Joined with Existing Tables
+SELECT c.CompanyName, v.priority, v.discount_rate
+FROM forjsonauto_t_customers c
+JOIN (VALUES 
+    ('ALFKI', 1, 0.10),
+    ('BERGS', 2, 0.15),
+    ('CONSH', 3, 0.05)
+) AS v(customer_id, priority, discount_rate) 
+ON c.CustomerID = v.customer_id
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "v": [{"priority": 1, "discount_rate": 0.10}]}]
+~~END~~
+
+
+-- VALUES with Aggregation
+SELECT
+    v.category,
+    COUNT(*) as item_count,
+    AVG(v.score) as avg_score
+FROM (VALUES 
+    ('Electronics', 85),
+    ('Electronics', 92),
+    ('Beverages', 78),
+    ('Beverages', 88),
+    ('Beverages', 95)
+) AS v(category, score)
+WHERE v.category = 'Beverages'
+GROUP BY v.category
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"category": "Beverages", "item_count": 3, "avg_score": 87}]
+~~END~~
+
+
+-- VALUES in Subquery
+SELECT
+    c.companyname,
+    c.country
+FROM forjsonauto_t_customers c
+JOIN (
+    VALUES
+      ('ALFKI'),
+      ('BERGS')
+) AS v(customer_id) ON c.customerid = v.customer_id
+WHERE c.companyname = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"companyname": "Alfreds Inc", "country": "USA"}]
+~~END~~
+
+
+---------------------------------------- CTEs (in FROM_clause) ----------------------------------------
+-- Single CTE (only base table reference)
+WITH usa_customers
+AS (
+    SELECT
+        CustomerID, 
+        CompanyName, 
+        Country
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+)
+SELECT
+    CustomerID,
+    CompanyName
+FROM usa_customers
+WHERE CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc"}]
+~~END~~
+
+
+-- single CTE (only base table reference, nest_level > 1)
+WITH usa_customers AS (
+    SELECT 
+        CustomerID, 
+        CompanyName, 
+        Country
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+)
+SELECT 
+    o.OrderID,
+    u.CustomerID,
+    u.CompanyName
+FROM forjsonauto_t_orders o
+JOIN usa_customers u ON o.CustomerID = u.CustomerID
+WHERE o.OrderID = 10248
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"OrderID": 10248, "forjsonauto_t_customers": [{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc"}]}]
+~~END~~
+
+
+-- two CTEs (only base table references)
+WITH 
+  cte AS (
+    SELECT CustomerID, CompanyName 
+    FROM forjsonauto_t_customers
+  ),
+  cte2 AS (
+    SELECT CustomerID, OrderID 
+    FROM forjsonauto_t_orders
+  ) 
+SELECT C.CustomerID, O.OrderID
+FROM cte C
+JOIN cte2 O
+ON (C.CustomerID = O.CustomerID)
+WHERE C.CustomerID = 'ALFKI'
+FOR JSON AUTO
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "forjsonauto_t_orders": [{"OrderID": 10248}]}]
+~~END~~
+
+
+-- two CTEs (w/ same source aliases inside each)
+WITH high_value_orders AS (
+    SELECT o.CustomerID, 
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT 
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'BERGS'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "BERGS", "o": [{"customerID": "BERGS", "o": [{"customerID": "BERGS", "total_order_count": 1}]}]}]
+~~END~~
+
+
+-- two CTEs (w/ subquery inside CTEs)
+WITH 
+  cte AS (
+    SELECT CustomerID, CompanyName 
+    FROM (
+      SELECT CustomerID, CompanyName, Country
+      FROM forjsonauto_t_customers
+      WHERE Country = 'USA'
+    ) AS usa_customers
+  ),
+  cte2 AS (
+    SELECT CustomerID, OrderID, TotalAmount
+    FROM (
+      SELECT CustomerID, OrderID, TotalAmount, OrderDate
+      FROM forjsonauto_t_orders
+      WHERE TotalAmount > 400
+    ) AS large_orders
+  ) 
+SELECT C.CustomerID, C.CompanyName, O.OrderID, O.TotalAmount
+FROM cte C
+JOIN cte2 O ON (C.CustomerID = O.CustomerID)
+WHERE C.CustomerID = 'ALFKI'
+FOR JSON AUTO
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc", "forjsonauto_t_orders": [{"OrderID": 10248, "TotalAmount": 440.0000}]}]
+~~END~~
+
+
+-- values (with or without alias) inside CTE
+WITH priority_customers AS (
+    SELECT v.customer_id, v.priority_level, v.discount_rate
+    FROM (VALUES 
+        ('ALFKI', 'Gold', 0.15),
+        ('BERGS', 'Silver', 0.10),
+        ('CONSH', 'Platinum', 0.20)
+    ) AS v(customer_id, priority_level, discount_rate)
+)
+SELECT pc.customer_id, pc.priority_level, pc.discount_rate
+FROM priority_customers pc
+WHERE pc.customer_id = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"customer_id": "ALFKI", "priority_level": "Gold", "discount_rate": 0.15}]
+~~END~~
+
+
+-- assign alias for CTE => NO new JSON nesting level
+WITH 
+    cte AS (SELECT 1 AS Id), 
+    cte2 AS (SELECT 1 AS Id)
+SELECT U.Id, O.Id
+FROM cte U
+LEFT JOIN cte2 O ON (U.Id = O.Id)
+FOR JSON AUTO
+GO
+~~START~~
+nvarchar
+[{"Id": 1, "Id": 1}]
+~~END~~
+
+
+-- NO alias for simple 1 layer CTE
+WITH
+    cte AS(SELECT 1 AS Id), 
+    cte2 AS(SELECT 1 AS Id2)
+SELECT Id , Id2
+FROM cte 
+LEFT JOIN cte2 ON (cte.Id = cte2.Id2)
+FOR JSON AUTO
+GO
+~~START~~
+nvarchar
+[{"Id": 1, "cte2": [{"Id2": 1}]}]
+~~END~~
+
+
+
+
+-- CTE created from temp table
+CREATE TABLE #temp_sales (
+    SalesID INT,
+    CustomerID NCHAR(5),
+    SalesAmount MONEY,
+    SalesDate DATETIME
+);
+INSERT INTO #temp_sales VALUES
+(1, 'ALFKI', 500.00, '2023-07-01'),
+(2, 'BERGS', 750.00, '2023-07-02'),
+(3, 'CONSH', 300.00, '2023-07-03'),
+(4, 'ALFKI', 400.00, '2023-07-04');
+WITH sales_summary AS (
+    SELECT 
+        CustomerID,
+        COUNT(*) as TransactionCount,
+        SUM(SalesAmount) as TotalSales,
+        AVG(SalesAmount) as AvgSales
+    FROM #temp_sales
+    GROUP BY CustomerID
+)
+SELECT ss.CustomerID, ss.TransactionCount, ss.TotalSales, ss.AvgSales
+FROM sales_summary ss
+WHERE ss.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "TransactionCount": 2, "TotalSales": 900.0000, "AvgSales": 450.0000}]
+~~END~~
+
+
+-- Nested CTE: wo-w, wo-wo (outer cte w/o alias + inner cte w/ alias, outer cte w/o alias + inner cte w/o alias)
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 1
+),
+cte2 AS (
+    SELECT cte_inner.Country, cte_inner.order_count, cat.CategoryName
+    FROM cte_inner
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 1
+)
+SELECT c.CompanyName, cte1.Country, cte1.productname, cte2.Country, cte2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 ON c.Country = cte1.Country
+JOIN cte2 ON c.Country = cte2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "cte1": [{"Country": "USA", "productname": "Chai", "cte2": [{"Country": "USA", "categoryname": "Beverages"}]}]}]
+~~END~~
+
+
+-- Nested CTE: w-w, w-wo (outer cte w/o alias + inner cte w/ alias, outer cte w/o alias + inner cte w/o alias) (target entry w/ alias) (two column of inner source put in same layer)
+WITH cte_inner AS (
+    SELECT
+        Country,
+        COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT
+        cin.Country,
+        cin.order_count as odc,
+        p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 2
+),
+cte2 AS (
+    SELECT
+        cte_inner.Country,
+        cte_inner.order_count,
+        cat.CategoryName
+    FROM cte_inner
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 2
+)
+SELECT
+    c.CompanyName,
+    c1.Country,
+    c1.productname,
+    c2.Country,
+    c2.categoryname,
+    c1.Country,
+    c1.odc
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "forjsonauto_t_customers": [{"Country": "USA", "p": [{"productname": "Coffee Beans", "forjsonauto_t_customers": [{"Country": "USA", "cat": [{"categoryname": "Coffee", "odc": 2}]}]}], "Country": "USA"}]}]
+~~END~~
+
+
+-- Nested CTE: w-w, w-wo (outer cte w/ alias + inner cte w/ alias, outer cte w/ alias + inner cte w/o alias) accessing by ctename
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 3
+),
+cte2 AS (
+    SELECT cte_inner.Country, cte_inner.order_count, cat.CategoryName
+    FROM cte_inner
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 5
+)
+SELECT c.CompanyName, cte1.Country, cte1.productname, c2.Country, c2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid reference to FROM-clause entry for table "cte1")~~
+
+
+-- Nested CTE: w-w, wo-w (outer cte w/ alias + inner cte w/ alias, outer cte w/o alias + inner cte w/ alias)
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 4
+),
+cte2 AS (
+    SELECT cin.Country, cin.order_count, cat.CategoryName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 3
+)
+SELECT c.CompanyName, cte1.Country, cte1.productname, c2.Country, c2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 ON c.Country = cte1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "cte1": [{"Country": "USA", "productname": "Green Tea", "forjsonauto_t_customers": [{"Country": "USA", "cat": [{"categoryname": "Tea"}]}]}]}]
+~~END~~
+
+
+-- Nested CTE: w-subq, wo-subq (outer cte w/alias + inner subq w/ alias, outer cte w/oalias + inner subq w/ alias)
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, sub.ProductName
+    FROM cte_inner cin
+    JOIN
+    (SELECT
+         ProductName
+     FROM forjsonauto_t_products 
+     WHERE ProductID = 1) sub ON 1=1
+),
+cte2 AS (
+    SELECT cte_inner.Country, cte_inner.order_count, cat_sub.CategoryName
+    FROM cte_inner
+    JOIN
+    (SELECT
+         CategoryName
+     FROM forjsonauto_t_categories
+     WHERE CategoryID = 1) cat_sub ON 1=1
+)
+SELECT c.CompanyName, c1.Country, c1.productname, c2.Country, c2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "forjsonauto_t_customers": [{"Country": "USA", "forjsonauto_t_products": [{"productname": "Chai", "forjsonauto_t_customers": [{"Country": "USA", "forjsonauto_t_categories": [{"categoryname": "Beverages"}]}]}]}]}]
+~~END~~
+
+
+-- alias for inner target entry, and at innermost layer, it doesn’t have a valid source
+WITH cte_inner AS (
+    SELECT Country1, COUNT(*) as order_count
+    FROM (SELECT 'USA' as Country1) sub
+    GROUP BY Country1
+),
+cte1 AS (
+    SELECT cin.Country1 as c1C, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 2
+)
+SELECT c.CompanyName, c1.c1C, c1.productname, c1.order_count
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.c1C
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "c1C": "USA", "p": [{"productname": "Coffee Beans", "order_count": 1}]}]
+~~END~~
+
+
+-- CTE with multiple-level long alias names (for checking if our hash can handle large full_src_path)
+WITH cte_inner_inner AS (
+    SELECT
+          forjsonauto_t_customers_aaaaaa.Country,
+          forjsonauto_t_orders_aaaaaa.OrderID
+      FROM forjsonauto_t_customers forjsonauto_t_customers_aaaaaa 
+      JOIN forjsonauto_t_orders forjsonauto_t_orders_aaaaaa
+      ON forjsonauto_t_customers_aaaaaa.CustomerID = forjsonauto_t_orders_aaaaaa.CustomerID
+),
+cte_inner AS (
+    SELECT
+        cte_inner_inner_123456789012345.Country,
+        cte_inner_inner_123456789012345.OrderID
+    FROM cte_inner_inner cte_inner_inner_123456789012345
+),
+cte1 AS (
+    SELECT
+        cin12345678901234567890.Country,
+        cin12345678901234567890.OrderID
+    FROM cte_inner cin12345678901234567890
+)
+SELECT
+    c.CompanyName,
+    c123456789012345678901234567890.Country,
+    c123456789012345678901234567890.OrderID
+FROM forjsonauto_t_customers c
+JOIN cte1 c123456789012345678901234567890 ON c.Country = c123456789012345678901234567890.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "forjsonauto_t_customers_aaaaaa": [{"Country": "USA", "forjsonauto_t_orders_aaaaaa": [{"OrderID": 10248}, {"OrderID": 10250}]}]}]
+~~END~~
+
+
+---------------------------------------- Different types of Targets (in SELECT_clause) ----------------------------------------
+-- subquery as target (nest_level > 1)
+SELECT c.CompanyName, 
+       o.OrderID,
+       (SELECT COUNT(*) 
+        FROM forjsonauto_t_orders o2 
+        WHERE o2.CustomerID = c.CustomerID
+       ) as OrderCount
+FROM forjsonauto_t_customers c
+JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "o": [{"OrderID": 10248, "OrderCount": 1}]}]
+~~END~~
+
+
+-- Operator Expression as target (nest_level > 1)
+SELECT 
+    c.CategoryName,
+    p.ProductName, 
+    p.UnitPrice * 2 AS doubled_price,
+    p.UnitsInStock + 10 AS adjusted_stock,
+    p.UnitPrice - 5 AS discounted_price
+FROM forjsonauto_t_categories c
+JOIN forjsonauto_t_products p ON c.CategoryID = p.CategoryID
+WHERE c.CategoryID = 2
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CategoryName": "Coffee", "p": [{"ProductName": "Coffee Beans", "doubled_price": 38.0000, "adjusted_stock": 27, "discounted_price": 14.0000}]}]
+~~END~~
+
+
+-- Const Expression as target (nesting level > 1)
+SELECT 
+    cat.CategoryName,
+    p.ProductName,
+    'Premium' AS product_tier,
+    0.15 AS commission_rate,
+    'Active' AS status,
+    2024 AS catalog_year
+FROM forjsonauto_t_categories cat
+JOIN forjsonauto_t_products p ON cat.CategoryID = p.CategoryID
+WHERE cat.CategoryID = 2
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CategoryName": "Coffee", "p": [{"ProductName": "Coffee Beans", "product_tier": "Premium", "commission_rate": 0.15, "status": "Active", "catalog_year": 2024}]}]
+~~END~~
+
+
+-- Function Expression as target (nest_level > 1)
+SELECT 
+    c.CompanyName,
+    o.TotalAmount, 
+    CAST('2023-01-01 12:00:00' AS DATETIME) AS time
+FROM forjsonauto_t_customers c
+JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "o": [{"TotalAmount": 440.0000, "time": "2023-01-01T12:00:00"}]}]
+~~END~~
+
+
+-- Coalesce Expression as target (nesting level > 1)
+SELECT 
+    s.SupplierName,
+    w.WarehouseName,
+    COALESCE(w.LastInspectionDate, '1900-01-01') as InspectionDate
+FROM forjsonauto_t_inventory_schema.forjsonauto_t_suppliers s
+INNER JOIN forjsonauto_t_inventory_schema.forjsonauto_t_warehouses w ON s.SupplierID = w.SupplierID
+WHERE w.WarehouseID = 101
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"SupplierName": "Global Supply Co", "w": [{"WarehouseName": "Seattle Distribution Center", "InspectionDate": "2023-06-15T00:00:00"}]}]
+~~END~~
+
+
+-- CASE WHEN as target (nest_level > 1)
+SELECT 
+    cust.CompanyName,
+    o.TotalAmount,
+    CASE
+        WHEN o.TotalAmount > 1500 THEN 'High Value'
+        WHEN o.TotalAmount > 500 THEN 'Medium Value' 
+        ELSE 'Low Value'
+    END as OrderCategory
+FROM forjsonauto_t_customers cust
+INNER JOIN forjsonauto_t_orders o ON cust.CustomerID = o.CustomerID
+WHERE o.Status = 'Shipped'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CompanyName": "Alfreds Inc", "o": [{"TotalAmount": 440.0000, "OrderCategory": "Low Value"}]}]
+~~END~~
+
+
+---------------------------------------- Cases should return error ----------------------------------------
+-- FOR JSON AUTO without any base table
+SELECT 
+    ss.value AS category,
+    'Active' AS status
+FROM STRING_SPLIT('Electronics,Premium,Popular', ',') ss
+FOR JSON AUTO;
+GO
+~~ERROR (Code: 13600)~~
+
+~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+
+
+-- nested FOR JSON AUTO, inner one doesn't have any base table
+SELECT 
+    p.ProductID,
+    p.ProductName,
+    (SELECT 
+         p.UnitPrice AS price,
+         'Active' AS status,
+         ss.value AS category_tag
+     FROM STRING_SPLIT('Electronics,Premium,Popular', ',') ss
+     FOR JSON AUTO
+    ) AS product_json
+FROM forjsonauto_t_products p
+WHERE p.CategoryID = 4
+FOR JSON AUTO;
+GO
+~~ERROR (Code: 13600)~~
+
+~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+
+
+---------------------------------------- sources valid for FOR JSON AUTO (test if only contain certain RTEKind as source will make MSSQL return "NO TABLE" error) ----------------------------------------
+-- single RTE_RELATION as source
+SELECT
+    CustomerID,
+    CompanyName
+FROM forjsonauto_t_customers
+WHERE CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc"}]
+~~END~~
+
+
+-- single RTE_SUBQUERY as source w/o inner sources
+SELECT
+    sub.id,
+    sub.name 
+FROM
+    (SELECT
+        1 as id,
+        'test' as name
+    ) AS sub 
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"id": 1, "name": "test"}]
+~~END~~
+
+
+-- single RTE_FUNCTION as source w/o inner sources
+SELECT s.value 
+FROM STRING_SPLIT('apple,banana,cherry', ',') AS s 
+FOR JSON AUTO;
+GO
+~~ERROR (Code: 13600)~~
+
+~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+
+
+-- single RTE_CTE as source w/o inner sources
+WITH cte
+AS (SELECT
+        1 as id,
+        'test' as name
+    )
+SELECT
+    cte.id,
+    cte.name
+FROM cte
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"id": 1, "name": "test"}]
+~~END~~
+
+
+-- one cte in ctelist but no RTE_CTE in rtable
+WITH 
+    unused_cte AS (SELECT 1 as id, 'test' as name)
+SELECT f.value 
+FROM STRING_SPLIT('apple,banana,cherry', ',') AS f
+FOR JSON AUTO;
+GO
+~~ERROR (Code: 13600)~~
+
+~~ERROR (Message: FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.)~~
+
+
+---------------------------------------- JSON structure with missing intermediate layers in output ----------------------------------------
+-- base tables LEFT JOIN with 1 NULL intermediate levels
+SELECT 
+    c.CustomerID,
+    o.OrderID,
+    p.ProductName,
+    od.OrderDetailID
+FROM forjsonauto_t_customers c
+LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID 
+LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
+LEFT JOIN forjsonauto_t_products p ON od.ProductID = p.ProductID AND p.UnitPrice > 100
+WHERE c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find parent level: queries with some missing intermediate levels in output are not supported yet.))~~
+
+
+-- base tables LEFT JOIN with multiple NULL intermediate levels
+SELECT 
+    c.CustomerID,
+    o.OrderID,
+    p.ProductName,
+    cat.CategoryName,
+    s.SupplierName,
+    w.WarehouseID
+FROM forjsonauto_t_customers c
+LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID 
+LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
+LEFT JOIN forjsonauto_t_products p ON od.ProductID = p.ProductID AND p.UnitPrice > 100
+LEFT JOIN forjsonauto_t_categories cat ON p.CategoryID = cat.CategoryID AND cat.ParentCategoryID IS NULL
+LEFT JOIN forjsonauto_t_inventory_schema.forjsonauto_t_suppliers s ON cat.CategoryID = s.Rating
+LEFT JOIN forjsonauto_t_inventory_schema.forjsonauto_t_warehouses w ON s.SupplierID = w.SupplierID
+WHERE c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"CustomerID": "ALFKI", "o": [{"OrderID": 10248}, {"OrderID": 10248}]}]
+~~END~~
+
+
+-- subquery LEFT JOIN with NULL intermediate levels
+SELECT 
+    c.CustomerID,
+    o.OrderID,
+    expensive_products.ProductName,
+    supplier_info.SupplierName,
+    od.OrderDetailID
+FROM forjsonauto_t_customers c
+LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID 
+LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
+LEFT JOIN (
+    SELECT p.ProductID, p.ProductName, p.CategoryID
+    FROM forjsonauto_t_products p
+    WHERE p.UnitPrice > 100
+) expensive_products ON od.ProductID = expensive_products.ProductID
+LEFT JOIN (
+    SELECT s.SupplierID, s.SupplierName, s.Rating
+    FROM forjsonauto_t_inventory_schema.forjsonauto_t_suppliers s
+    WHERE s.Rating > 4
+) supplier_info ON expensive_products.CategoryID = supplier_info.Rating
+WHERE c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find parent level: queries with some missing intermediate levels in output are not supported yet.))~~
+
+
+-- CTE LEFT JOIN with NULL intermediate levels
+WITH high_value_orders AS (
+    SELECT o.CustomerID, 
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT 
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find parent level: queries with some missing intermediate levels in output are not supported yet.))~~
 

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -1194,6 +1194,134 @@ nvarchar
 ~~END~~
 
 
+
+
+
+-- direct reference Recursive CTEs
+WITH category_hierarchy AS (
+    SELECT CategoryID, CategoryName, 0 as Level
+    FROM forjsonauto_t_categories
+    WHERE ParentCategoryID IS NULL
+    UNION ALL
+    SELECT c.CategoryID, c.CategoryName, ch.Level + 1
+    FROM forjsonauto_t_categories c
+    INNER JOIN category_hierarchy ch ON c.ParentCategoryID = ch.CategoryID
+)
+SELECT
+    p.ProductName,
+    c.CompanyName,
+    ch.CategoryName,
+    ch.Level
+FROM category_hierarchy ch
+LEFT JOIN forjsonauto_t_products p ON ch.CategoryID = p.CategoryID
+LEFT JOIN forjsonauto_t_order_details od ON p.ProductID = od.ProductID
+LEFT JOIN forjsonauto_t_orders o ON od.OrderID = o.OrderID
+LEFT JOIN forjsonauto_t_customers c ON o.CustomerID = c.CustomerID
+WHERE p.ProductName = 'Laptop'
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"ProductName": "Laptop", "c": [{"CompanyName": "Berglunds snabbköp", "CategoryName": "Computers", "Level": 1}]}]
+~~END~~
+
+
+
+
+-- nested reference Recursive CTE (outer non-recursive CTE w/ alias  +  inner recursive CTE)
+WITH order_tree AS (
+    SELECT
+        orderid,
+        customerid,
+        1 AS depth
+    FROM forjsonauto_t_orders
+    WHERE orderid = 10248
+    UNION ALL
+    SELECT
+        o.orderid,
+        o.customerid,
+        ot.depth + 1
+    FROM forjsonauto_t_orders o
+    INNER JOIN order_tree ot
+    ON o.orderid = ot.orderid + 1
+    WHERE ot.depth < 2 )
+,level2_cte AS (
+    SELECT
+        ot.orderid,
+        c.companyname
+    FROM order_tree ot
+    JOIN forjsonauto_t_customers c
+    ON ot.customerid = c.customerid )
+,level3_cte AS (
+    SELECT
+        l2.orderid,
+        l2.companyname,
+        'Primary' AS ordertype
+    FROM level2_cte l2 )
+SELECT
+    p.productname,
+    l3cte.companyname,
+    l3cte.orderid
+FROM level3_cte l3cte
+JOIN forjsonauto_t_order_details od ON l3cte.orderid = od.orderid
+JOIN forjsonauto_t_products p ON od.productid = p.productid
+WHERE p.productname = 'Chai'
+FOR json auto;
+GO
+~~START~~
+nvarchar
+[{"productname": "Chai", "c": [{"companyname": "Alfreds Inc", "orderid": 10248}]}]
+~~END~~
+
+
+
+
+-- nested reference recursive CTE (outer non-recursive CTE w/o alias  +  inner recursive CTE)
+WITH order_tree AS (
+    SELECT
+        orderid,
+        customerid,
+        1 AS depth
+    FROM forjsonauto_t_orders
+    WHERE orderid = 10248
+    UNION ALL
+    SELECT
+        o.orderid,
+        o.customerid,
+        ot.depth + 1
+    FROM forjsonauto_t_orders o
+    INNER JOIN order_tree ot
+    ON o.orderid = ot.orderid + 1
+    WHERE ot.depth < 2 )
+,level2_cte AS (
+    SELECT
+        ot.orderid,
+        c.companyname
+    FROM order_tree ot
+    JOIN forjsonauto_t_customers c
+    ON ot.customerid = c.customerid )
+,level3_cte AS (
+    SELECT
+        l2.orderid,
+        l2.companyname,
+        'Primary' AS ordertype
+    FROM level2_cte l2 )
+SELECT
+    p.productname,
+    level3_cte.companyname,
+    level3_cte.orderid
+FROM level3_cte
+JOIN forjsonauto_t_order_details od ON level3_cte.orderid = od.orderid
+JOIN forjsonauto_t_products p ON od.productid = p.productid
+WHERE p.productname = 'Chai'
+FOR json auto;
+GO
+~~START~~
+nvarchar
+[{"productname": "Chai", "level3_cte": [{"companyname": "Alfreds Inc", "orderid": 10248}]}]
+~~END~~
+
+
 ---------------------------------------- Different types of Targets (in SELECT_clause) ----------------------------------------
 -- subquery as target (nest_level > 1)
 SELECT c.CompanyName, 
@@ -1425,7 +1553,7 @@ GO
 nvarchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot find parent level: queries with some missing intermediate levels in output are not supported yet.))~~
+~~ERROR (Message: FOR JSON AUTO limitation: Your query has produced empty result subsets that skip intermediate nesting keys in the JSON hierarchy. This pattern is not currently supported.)~~
 
 
 -- base tables LEFT JOIN with multiple NULL intermediate levels
@@ -1479,7 +1607,7 @@ GO
 nvarchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot find parent level: queries with some missing intermediate levels in output are not supported yet.))~~
+~~ERROR (Message: FOR JSON AUTO limitation: Your query has produced empty result subsets that skip intermediate nesting keys in the JSON hierarchy. This pattern is not currently supported.)~~
 
 
 -- CTE LEFT JOIN with NULL intermediate levels
@@ -1514,5 +1642,5 @@ GO
 nvarchar
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Cannot find parent level: queries with some missing intermediate levels in output are not supported yet.))~~
+~~ERROR (Message: FOR JSON AUTO limitation: Your query has produced empty result subsets that skip intermediate nesting keys in the JSON hierarchy. This pattern is not currently supported.)~~
 

--- a/test/JDBC/input/forjson/forjson-escape-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjson-escape-vu-verify.sql
@@ -97,6 +97,7 @@ go
 SELECT ID, child.child_col as json_query_parent_col 
 from 
   (select ID ,JSON_QUERY(EmployeeDetails,'$.contact') as child_col from babel_5112_test5 ) child
+WHERE ID = 1
 FOR JSON AUTO;
 go
 
@@ -135,7 +136,7 @@ FOR JSON PATH;
 go
 
 --FAIL (KNOWN CASE)
-select * from (
+select MIN(test_union) as min_test_union from (
     SELECT JSON_QUERY(EmployeeDetails, '$.skills') as test_union FROM babel_5112_test7
     UNION 
     SELECT JSON_QUERY(EmployeeDetails, '$.contact') as test_union FROM babel_5112_test7

--- a/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
@@ -131,3 +131,13 @@ DROP TABLE forjson_test_unicode;
 DROP TABLE forjson_test_orderby;
 DROP TABLE forjson_test_groupby;
 GO
+
+DROP TABLE IF EXISTS forjsonauto_t_categories;
+DROP TABLE IF EXISTS forjsonauto_t_customers;
+DROP TABLE IF EXISTS forjsonauto_t_orders;
+DROP TABLE IF EXISTS forjsonauto_t_products;
+DROP TABLE IF EXISTS forjsonauto_t_order_details;
+DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_warehouses;
+DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_suppliers;
+DROP SCHEMA IF EXISTS forjsonauto_t_inventory_schema;
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
@@ -140,4 +140,5 @@ DROP TABLE IF EXISTS forjsonauto_t_order_details;
 DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_warehouses;
 DROP TABLE IF EXISTS forjsonauto_t_inventory_schema.forjsonauto_t_suppliers;
 DROP SCHEMA IF EXISTS forjsonauto_t_inventory_schema;
+DROP TABLE IF EXISTS JsonTable;
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
@@ -338,27 +338,57 @@ GO
 
 
 CREATE TABLE forjsonauto_t_categories (CategoryID INT PRIMARY KEY, CategoryName NVARCHAR(50), Description NVARCHAR(200), ParentCategoryID INT, CreatedDate DATETIME DEFAULT GETDATE());
+GO
+
 CREATE TABLE forjsonauto_t_customers (CustomerID NCHAR(5) PRIMARY KEY, CompanyName NVARCHAR(100), ContactName NVARCHAR(100), ContactTitle NVARCHAR(50), Region NVARCHAR(50), Country NVARCHAR(50), Phone NVARCHAR(20), IsActive BIT DEFAULT 1);
+GO
+
 CREATE TABLE forjsonauto_t_orders (OrderID INT PRIMARY KEY, CustomerID NCHAR(5), OrderDate DATETIME, ShipAddress NVARCHAR(100), ShipCity NVARCHAR(50), ShipCountry NVARCHAR(50), TotalAmount MONEY, Status NVARCHAR(20));
+GO
+
 CREATE TABLE forjsonauto_t_products (ProductID INT PRIMARY KEY, ProductName NVARCHAR(100), UnitPrice MONEY, CategoryID INT, UnitsInStock INT, Discontinued BIT DEFAULT 0, LastUpdated DATETIME DEFAULT GETDATE());
+GO
+
 CREATE TABLE forjsonauto_t_order_details (OrderDetailID INT PRIMARY KEY, OrderID INT, ProductID INT, Quantity INT, UnitPrice MONEY, Discount DECIMAL(3,2) DEFAULT 0.00);
+GO
+
 CREATE SCHEMA forjsonauto_t_inventory_schema;
+GO
+
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID INT PRIMARY KEY, SupplierName NVARCHAR(100), ContactPerson NVARCHAR(50), Phone NVARCHAR(20), Country NVARCHAR(50), Rating INT, CreatedDate DATETIME DEFAULT GETDATE());
+GO
+
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID INT PRIMARY KEY, WarehouseName NVARCHAR(100), Location NVARCHAR(100), Capacity INT, SupplierID INT, OperationalStatus NVARCHAR(20), LastInspectionDate DATETIME);
+GO
+
 CREATE TABLE JsonTable (ID INT IDENTITY(1,1) PRIMARY KEY, JsonData NVARCHAR(MAX));
+GO
 
 INSERT INTO forjsonauto_t_categories (CategoryID, CategoryName, Description, ParentCategoryID) VALUES (1, 'Beverages', 'Soft drinks, coffees, teas', NULL), (2, 'Coffee', 'Various coffee brands', 1), (3, 'Tea', 'Various tea brands', 1), (4, 'Electronics', 'Electronic equipment', NULL), (5, 'Computers', 'Computer equipment', 4);
+GO
+
 INSERT INTO forjsonauto_t_customers (CustomerID, CompanyName, ContactName, ContactTitle, Region, Country, Phone) VALUES ('ALFKI', 'Alfreds Inc', 'Maria Anders', 'Sales Rep', 'WA', 'USA', '030-0074321'), ('BERGS', 'Berglunds snabbköp', 'Christina Berglund', 'Administrator', NULL, 'Sweden', '0921-12 34 65'), ('CONSH', 'Consolidated Holdings', 'Elizabeth Brown', 'Sales Manager', 'LA', 'USA', '(171) 555-2282');
+GO
+
 INSERT INTO forjsonauto_t_orders (OrderID, CustomerID, OrderDate, ShipAddress, ShipCity, ShipCountry, TotalAmount, Status) VALUES (10248, 'ALFKI', '2023-07-04', '23 Tsawassen Blvd.', 'Seattle', 'USA', 440.00, 'Shipped'), (10249, 'BERGS', '2023-07-05', 'Luisenstr. 48', 'Mannheim', 'Germany', 1863.40, 'Pending'), (10250, 'CONSH', '2023-07-06', 'Berkeley Gardens', 'London', 'UK', 1552.60, 'Delivered');
+GO
+
 INSERT INTO forjsonauto_t_products (ProductID, ProductName, UnitPrice, CategoryID, UnitsInStock) VALUES (1, 'Chai', 18.00, 3, 39), (2, 'Coffee Beans', 19.00, 2, 17), (3, 'Laptop', 1200.00, 5, 10), (4, 'Green Tea', 10.00, 3, 25);
+GO
+
 INSERT INTO forjsonauto_t_order_details (OrderDetailID, OrderID, ProductID, Quantity, UnitPrice, Discount) VALUES (1, 10248, 1, 12, 18.00, 0.00), (2, 10248, 2, 10, 19.00, 0.05), (3, 10249, 3, 5, 1200.00, 0.00), (4, 10250, 1, 20, 18.00, 0.10), (5, 10250, 4, 15, 10.00, 0.00);
+GO
+
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID, SupplierName, ContactPerson, Phone, Country, Rating) VALUES (1, 'Global Supply Co', 'John Smith', '+1-555-1234', 'USA', 5), (2, 'Euro Logistics', 'Maria Garcia', '+34-612-345678', 'Spain', 4), (3, 'Asia Trade Ltd', 'Chen Wei', '+86-138-12345678', 'China', 3), (4, 'Nordic Solutions', 'Erik Larsson', '+46-70-1234567', 'Sweden', 5);
+GO
+
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID, WarehouseName, Location, Capacity, SupplierID, OperationalStatus, LastInspectionDate) VALUES (101, 'Seattle Distribution Center', 'Seattle, WA', 50000, 1, 'Active', '2023-06-15'), (102, 'Madrid Storage Facility', 'Madrid, Spain', 35000, 2, 'Active', '2023-07-01'), (103, 'Shanghai Warehouse', 'Shanghai, China', 75000, 3, 'Maintenance', '2023-05-20'), (104, 'Stockholm Hub', 'Stockholm, Sweden', 40000, 4, 'Active', '2023-07-10'), (105, 'Backup Seattle Facility', 'Tacoma, WA', 25000, 1, 'Inactive', '2023-04-30');
+GO
+
 INSERT INTO JsonTable (JsonData)
 VALUES 
     ((SELECT CustomerID, CompanyName, ContactName, Country, Phone 
       FROM forjsonauto_t_customers 
       WHERE CustomerID = 'ALFKI' 
       FOR JSON AUTO));
-
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
@@ -345,6 +345,7 @@ CREATE TABLE forjsonauto_t_order_details (OrderDetailID INT PRIMARY KEY, OrderID
 CREATE SCHEMA forjsonauto_t_inventory_schema;
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID INT PRIMARY KEY, SupplierName NVARCHAR(100), ContactPerson NVARCHAR(50), Phone NVARCHAR(20), Country NVARCHAR(50), Rating INT, CreatedDate DATETIME DEFAULT GETDATE());
 CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID INT PRIMARY KEY, WarehouseName NVARCHAR(100), Location NVARCHAR(100), Capacity INT, SupplierID INT, OperationalStatus NVARCHAR(20), LastInspectionDate DATETIME);
+CREATE TABLE JsonTable (ID INT IDENTITY(1,1) PRIMARY KEY, JsonData NVARCHAR(MAX));
 
 INSERT INTO forjsonauto_t_categories (CategoryID, CategoryName, Description, ParentCategoryID) VALUES (1, 'Beverages', 'Soft drinks, coffees, teas', NULL), (2, 'Coffee', 'Various coffee brands', 1), (3, 'Tea', 'Various tea brands', 1), (4, 'Electronics', 'Electronic equipment', NULL), (5, 'Computers', 'Computer equipment', 4);
 INSERT INTO forjsonauto_t_customers (CustomerID, CompanyName, ContactName, ContactTitle, Region, Country, Phone) VALUES ('ALFKI', 'Alfreds Inc', 'Maria Anders', 'Sales Rep', 'WA', 'USA', '030-0074321'), ('BERGS', 'Berglunds snabbköp', 'Christina Berglund', 'Administrator', NULL, 'Sweden', '0921-12 34 65'), ('CONSH', 'Consolidated Holdings', 'Elizabeth Brown', 'Sales Manager', 'LA', 'USA', '(171) 555-2282');
@@ -353,5 +354,11 @@ INSERT INTO forjsonauto_t_products (ProductID, ProductName, UnitPrice, CategoryI
 INSERT INTO forjsonauto_t_order_details (OrderDetailID, OrderID, ProductID, Quantity, UnitPrice, Discount) VALUES (1, 10248, 1, 12, 18.00, 0.00), (2, 10248, 2, 10, 19.00, 0.05), (3, 10249, 3, 5, 1200.00, 0.00), (4, 10250, 1, 20, 18.00, 0.10), (5, 10250, 4, 15, 10.00, 0.00);
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID, SupplierName, ContactPerson, Phone, Country, Rating) VALUES (1, 'Global Supply Co', 'John Smith', '+1-555-1234', 'USA', 5), (2, 'Euro Logistics', 'Maria Garcia', '+34-612-345678', 'Spain', 4), (3, 'Asia Trade Ltd', 'Chen Wei', '+86-138-12345678', 'China', 3), (4, 'Nordic Solutions', 'Erik Larsson', '+46-70-1234567', 'Sweden', 5);
 INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID, WarehouseName, Location, Capacity, SupplierID, OperationalStatus, LastInspectionDate) VALUES (101, 'Seattle Distribution Center', 'Seattle, WA', 50000, 1, 'Active', '2023-06-15'), (102, 'Madrid Storage Facility', 'Madrid, Spain', 35000, 2, 'Active', '2023-07-01'), (103, 'Shanghai Warehouse', 'Shanghai, China', 75000, 3, 'Maintenance', '2023-05-20'), (104, 'Stockholm Hub', 'Stockholm, Sweden', 40000, 4, 'Active', '2023-07-10'), (105, 'Backup Seattle Facility', 'Tacoma, WA', 25000, 1, 'Inactive', '2023-04-30');
+INSERT INTO JsonTable (JsonData)
+VALUES 
+    ((SELECT CustomerID, CompanyName, ContactName, Country, Phone 
+      FROM forjsonauto_t_customers 
+      WHERE CustomerID = 'ALFKI' 
+      FOR JSON AUTO));
 
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
@@ -335,3 +335,23 @@ RETURN
     SELECT  e.EmployeeId FROM forjson_auto_test_diff_cases e
 );
 GO
+
+
+CREATE TABLE forjsonauto_t_categories (CategoryID INT PRIMARY KEY, CategoryName NVARCHAR(50), Description NVARCHAR(200), ParentCategoryID INT, CreatedDate DATETIME DEFAULT GETDATE());
+CREATE TABLE forjsonauto_t_customers (CustomerID NCHAR(5) PRIMARY KEY, CompanyName NVARCHAR(100), ContactName NVARCHAR(100), ContactTitle NVARCHAR(50), Region NVARCHAR(50), Country NVARCHAR(50), Phone NVARCHAR(20), IsActive BIT DEFAULT 1);
+CREATE TABLE forjsonauto_t_orders (OrderID INT PRIMARY KEY, CustomerID NCHAR(5), OrderDate DATETIME, ShipAddress NVARCHAR(100), ShipCity NVARCHAR(50), ShipCountry NVARCHAR(50), TotalAmount MONEY, Status NVARCHAR(20));
+CREATE TABLE forjsonauto_t_products (ProductID INT PRIMARY KEY, ProductName NVARCHAR(100), UnitPrice MONEY, CategoryID INT, UnitsInStock INT, Discontinued BIT DEFAULT 0, LastUpdated DATETIME DEFAULT GETDATE());
+CREATE TABLE forjsonauto_t_order_details (OrderDetailID INT PRIMARY KEY, OrderID INT, ProductID INT, Quantity INT, UnitPrice MONEY, Discount DECIMAL(3,2) DEFAULT 0.00);
+CREATE SCHEMA forjsonauto_t_inventory_schema;
+CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID INT PRIMARY KEY, SupplierName NVARCHAR(100), ContactPerson NVARCHAR(50), Phone NVARCHAR(20), Country NVARCHAR(50), Rating INT, CreatedDate DATETIME DEFAULT GETDATE());
+CREATE TABLE forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID INT PRIMARY KEY, WarehouseName NVARCHAR(100), Location NVARCHAR(100), Capacity INT, SupplierID INT, OperationalStatus NVARCHAR(20), LastInspectionDate DATETIME);
+
+INSERT INTO forjsonauto_t_categories (CategoryID, CategoryName, Description, ParentCategoryID) VALUES (1, 'Beverages', 'Soft drinks, coffees, teas', NULL), (2, 'Coffee', 'Various coffee brands', 1), (3, 'Tea', 'Various tea brands', 1), (4, 'Electronics', 'Electronic equipment', NULL), (5, 'Computers', 'Computer equipment', 4);
+INSERT INTO forjsonauto_t_customers (CustomerID, CompanyName, ContactName, ContactTitle, Region, Country, Phone) VALUES ('ALFKI', 'Alfreds Inc', 'Maria Anders', 'Sales Rep', 'WA', 'USA', '030-0074321'), ('BERGS', 'Berglunds snabbköp', 'Christina Berglund', 'Administrator', NULL, 'Sweden', '0921-12 34 65'), ('CONSH', 'Consolidated Holdings', 'Elizabeth Brown', 'Sales Manager', 'LA', 'USA', '(171) 555-2282');
+INSERT INTO forjsonauto_t_orders (OrderID, CustomerID, OrderDate, ShipAddress, ShipCity, ShipCountry, TotalAmount, Status) VALUES (10248, 'ALFKI', '2023-07-04', '23 Tsawassen Blvd.', 'Seattle', 'USA', 440.00, 'Shipped'), (10249, 'BERGS', '2023-07-05', 'Luisenstr. 48', 'Mannheim', 'Germany', 1863.40, 'Pending'), (10250, 'CONSH', '2023-07-06', 'Berkeley Gardens', 'London', 'UK', 1552.60, 'Delivered');
+INSERT INTO forjsonauto_t_products (ProductID, ProductName, UnitPrice, CategoryID, UnitsInStock) VALUES (1, 'Chai', 18.00, 3, 39), (2, 'Coffee Beans', 19.00, 2, 17), (3, 'Laptop', 1200.00, 5, 10), (4, 'Green Tea', 10.00, 3, 25);
+INSERT INTO forjsonauto_t_order_details (OrderDetailID, OrderID, ProductID, Quantity, UnitPrice, Discount) VALUES (1, 10248, 1, 12, 18.00, 0.00), (2, 10248, 2, 10, 19.00, 0.05), (3, 10249, 3, 5, 1200.00, 0.00), (4, 10250, 1, 20, 18.00, 0.10), (5, 10250, 4, 15, 10.00, 0.00);
+INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_suppliers (SupplierID, SupplierName, ContactPerson, Phone, Country, Rating) VALUES (1, 'Global Supply Co', 'John Smith', '+1-555-1234', 'USA', 5), (2, 'Euro Logistics', 'Maria Garcia', '+34-612-345678', 'Spain', 4), (3, 'Asia Trade Ltd', 'Chen Wei', '+86-138-12345678', 'China', 3), (4, 'Nordic Solutions', 'Erik Larsson', '+46-70-1234567', 'Sweden', 5);
+INSERT INTO forjsonauto_t_inventory_schema.forjsonauto_t_warehouses (WarehouseID, WarehouseName, Location, Capacity, SupplierID, OperationalStatus, LastInspectionDate) VALUES (101, 'Seattle Distribution Center', 'Seattle, WA', 50000, 1, 'Active', '2023-06-15'), (102, 'Madrid Storage Facility', 'Madrid, Spain', 35000, 2, 'Active', '2023-07-01'), (103, 'Shanghai Warehouse', 'Shanghai, China', 75000, 3, 'Maintenance', '2023-05-20'), (104, 'Stockholm Hub', 'Stockholm, Sweden', 40000, 4, 'Active', '2023-07-10'), (105, 'Backup Seattle Facility', 'Tacoma, WA', 25000, 1, 'Inactive', '2023-04-30');
+
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -203,3 +203,828 @@ SELECT  b.EmployeeId, a.salary
 FROM dbo.forjson_auto_test_diff_cases_fn(1) as b, forjson_auto_test_diff_cases a
 FOR JSON AUTO;
 GO
+
+
+---------------------------------------- Subqueries (in FROM_clause) ----------------------------------------
+-- Single subquery
+SELECT sub.CustomerID, sub.CompanyName
+FROM (
+    SELECT CustomerID, CompanyName
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+) AS sub
+WHERE sub.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- Multiple subqueries with JOIN
+SELECT sub1.CustomerID, sub1.CompanyName, sub2.TotalAmount
+FROM (
+    SELECT CustomerID, CompanyName
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+) AS sub1
+JOIN (
+    SELECT CustomerID, TotalAmount
+    FROM forjsonauto_t_orders
+    WHERE TotalAmount > 500
+) AS sub2
+ON sub1.CustomerID = sub2.CustomerID
+FOR JSON AUTO;
+GO
+
+-- Multiple subqueries referencing same base table
+SELECT o1.OrderID, o1.CustomerID, o1.TotalAmount, o2.AvgAmount
+FROM (
+    SELECT OrderID, CustomerID, TotalAmount
+    FROM forjsonauto_t_orders
+    WHERE TotalAmount > 1000
+) AS o1
+JOIN (
+    SELECT CustomerID, AVG(TotalAmount) AS AvgAmount
+    FROM forjsonauto_t_orders
+    GROUP BY CustomerID
+) AS o2
+ON o1.CustomerID = o2.CustomerID
+WHERE o1.CustomerID = 'BERGS'
+FOR JSON AUTO;
+GO
+
+-- UNION subqueries
+SELECT combined.CustomerID, combined.Source
+FROM (
+    SELECT CustomerID, 'Active' as Source
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+    UNION ALL
+    SELECT CustomerID, 'International' as Source
+    FROM forjsonauto_t_customers
+    WHERE Country != 'USA'
+) AS combined
+WHERE combined.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- Two-level nesting subqueries
+SELECT outer_sub.CustomerID, outer_sub.OrderCount
+FROM (
+    SELECT sub.CustomerID, COUNT(*) as OrderCount
+    FROM (
+        SELECT CustomerID, OrderID
+        FROM forjsonauto_t_orders
+        WHERE TotalAmount > 200
+    ) AS sub
+    GROUP BY sub.CustomerID
+) AS outer_sub
+WHERE outer_sub.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- Three-level nesting subqueries
+SELECT final.CategoryName, final.ProductCount
+FROM (
+    SELECT level2.CategoryName, COUNT(*) as ProductCount
+    FROM (
+        SELECT level1.CategoryName, level1.ProductName
+        FROM (
+            SELECT c.CategoryName, p.ProductName, p.UnitPrice
+            FROM forjsonauto_t_categories c
+            JOIN forjsonauto_t_products p ON c.CategoryID = p.CategoryID
+        ) AS level1
+        WHERE level1.UnitPrice > 15
+    ) AS level2
+    GROUP BY level2.CategoryName
+) AS final
+WHERE final.CategoryName = 'Coffee'
+FOR JSON AUTO;
+GO
+
+-- Correlated subqueries in FROM_clause
+SELECT
+    c.CustomerID,
+    c.CompanyName,
+    c.Country, 
+    order_stats.total_orders,
+    order_stats.avg_order_value
+FROM forjsonauto_t_customers c
+CROSS APPLY (
+    SELECT
+        COUNT(*) as total_orders, 
+        AVG(TotalAmount) as avg_order_value
+    FROM forjsonauto_t_orders o
+    WHERE o.CustomerID = c.CustomerID
+) order_stats
+WHERE order_stats.total_orders > 0
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- Correlated subqueries in SELECT_clause
+SELECT p.ProductName,
+       c.CategoryName,
+       (SELECT COUNT(*)
+        FROM forjsonauto_t_orders o
+        WHERE o.TotalAmount > p.UnitPrice
+       ) as HigherValueOrderCount
+FROM forjsonauto_t_products p
+JOIN forjsonauto_t_categories c ON p.CategoryID = c.CategoryID
+WHERE p.ProductName = 'Coffee Beans'
+FOR JSON AUTO;
+GO
+
+-- Correlated subqueries in SELECT_clause + nested FOR JSON AUTO (inner correlated subquery reference to outer query’s sources)
+SELECT
+    p.ProductName,
+    c.CategoryName,
+    (SELECT
+        o.OrderID,
+        od.Quantity,
+        od.UnitPrice,
+        (od.Quantity * od.UnitPrice) as line_total,
+        cu.CustomerID,
+        p.ProductName as analyzed_product,
+        c.CategoryName
+    FROM forjsonauto_t_order_details od
+    JOIN forjsonauto_t_orders o ON od.OrderID = o.OrderID
+    JOIN forjsonauto_t_customers cu ON o.CustomerID = cu.CustomerID
+    WHERE od.ProductID = p.ProductID
+    AND od.Quantity >= 10
+    FOR JSON AUTO
+    ) as product_sales_analysis
+FROM forjsonauto_t_products p
+JOIN forjsonauto_t_categories c ON p.CategoryID = c.CategoryID
+WHERE p.ProductName = 'Coffee Beans'
+FOR JSON AUTO;
+GO
+
+---------------------------------------- VALUES (in FROM_clause) ----------------------------------------
+-- VALUES with Mixed Data Types
+SELECT v.product_name, v.price, v.in_stock, v.launch_date
+FROM (VALUES 
+    ('New Coffee', 25.50, 1, '2024-01-15'),
+    ('Premium Tea', 18.75, 0, '2024-02-20'),
+    ('Energy Drink', 3.99, 1, '2024-03-10')
+) AS v(product_name, price, in_stock, launch_date)
+WHERE v.product_name = 'New Coffee'
+FOR JSON AUTO;
+GO
+
+-- VALUES with NULL Values
+SELECT v.customer_id, v.region, v.phone
+FROM (VALUES 
+    ('ALFKI', 'WA', '030-0074321'),
+    ('BERGS', NULL, '0921-12 34 65'),
+    ('NEWCO', 'CA', NULL)
+) AS v(customer_id, region, phone)
+WHERE v.customer_id = 'BERGS'
+FOR JSON AUTO;
+GO
+
+-- VALUES Joined with Existing Tables
+SELECT c.CompanyName, v.priority, v.discount_rate
+FROM forjsonauto_t_customers c
+JOIN (VALUES 
+    ('ALFKI', 1, 0.10),
+    ('BERGS', 2, 0.15),
+    ('CONSH', 3, 0.05)
+) AS v(customer_id, priority, discount_rate) 
+ON c.CustomerID = v.customer_id
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- VALUES with Aggregation
+SELECT
+    v.category,
+    COUNT(*) as item_count,
+    AVG(v.score) as avg_score
+FROM (VALUES 
+    ('Electronics', 85),
+    ('Electronics', 92),
+    ('Beverages', 78),
+    ('Beverages', 88),
+    ('Beverages', 95)
+) AS v(category, score)
+WHERE v.category = 'Beverages'
+GROUP BY v.category
+FOR JSON AUTO;
+GO
+
+-- VALUES in Subquery
+SELECT
+    c.companyname,
+    c.country
+FROM forjsonauto_t_customers c
+JOIN (
+    VALUES
+      ('ALFKI'),
+      ('BERGS')
+) AS v(customer_id) ON c.customerid = v.customer_id
+WHERE c.companyname = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+---------------------------------------- CTEs (in FROM_clause) ----------------------------------------
+-- Single CTE (only base table reference)
+WITH usa_customers
+AS (
+    SELECT
+        CustomerID, 
+        CompanyName, 
+        Country
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+)
+SELECT
+    CustomerID,
+    CompanyName
+FROM usa_customers
+WHERE CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- single CTE (only base table reference, nest_level > 1)
+WITH usa_customers AS (
+    SELECT 
+        CustomerID, 
+        CompanyName, 
+        Country
+    FROM forjsonauto_t_customers
+    WHERE Country = 'USA'
+)
+SELECT 
+    o.OrderID,
+    u.CustomerID,
+    u.CompanyName
+FROM forjsonauto_t_orders o
+JOIN usa_customers u ON o.CustomerID = u.CustomerID
+WHERE o.OrderID = 10248
+FOR JSON AUTO;
+GO
+
+-- two CTEs (only base table references)
+WITH 
+  cte AS (
+    SELECT CustomerID, CompanyName 
+    FROM forjsonauto_t_customers
+  ),
+  cte2 AS (
+    SELECT CustomerID, OrderID 
+    FROM forjsonauto_t_orders
+  ) 
+SELECT C.CustomerID, O.OrderID
+FROM cte C
+JOIN cte2 O
+ON (C.CustomerID = O.CustomerID)
+WHERE C.CustomerID = 'ALFKI'
+FOR JSON AUTO
+GO
+
+-- two CTEs (w/ same source aliases inside each)
+WITH high_value_orders AS (
+    SELECT o.CustomerID, 
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT 
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'BERGS'
+FOR JSON AUTO;
+GO
+
+-- two CTEs (w/ subquery inside CTEs)
+WITH 
+  cte AS (
+    SELECT CustomerID, CompanyName 
+    FROM (
+      SELECT CustomerID, CompanyName, Country
+      FROM forjsonauto_t_customers
+      WHERE Country = 'USA'
+    ) AS usa_customers
+  ),
+  cte2 AS (
+    SELECT CustomerID, OrderID, TotalAmount
+    FROM (
+      SELECT CustomerID, OrderID, TotalAmount, OrderDate
+      FROM forjsonauto_t_orders
+      WHERE TotalAmount > 400
+    ) AS large_orders
+  ) 
+SELECT C.CustomerID, C.CompanyName, O.OrderID, O.TotalAmount
+FROM cte C
+JOIN cte2 O ON (C.CustomerID = O.CustomerID)
+WHERE C.CustomerID = 'ALFKI'
+FOR JSON AUTO
+GO
+
+-- values (with or without alias) inside CTE
+WITH priority_customers AS (
+    SELECT v.customer_id, v.priority_level, v.discount_rate
+    FROM (VALUES 
+        ('ALFKI', 'Gold', 0.15),
+        ('BERGS', 'Silver', 0.10),
+        ('CONSH', 'Platinum', 0.20)
+    ) AS v(customer_id, priority_level, discount_rate)
+)
+SELECT pc.customer_id, pc.priority_level, pc.discount_rate
+FROM priority_customers pc
+WHERE pc.customer_id = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- assign alias for CTE => NO new JSON nesting level
+WITH 
+    cte AS (SELECT 1 AS Id), 
+    cte2 AS (SELECT 1 AS Id)
+SELECT U.Id, O.Id
+FROM cte U
+LEFT JOIN cte2 O ON (U.Id = O.Id)
+FOR JSON AUTO
+GO
+
+-- NO alias for simple 1 layer CTE
+WITH
+    cte AS(SELECT 1 AS Id), 
+    cte2 AS(SELECT 1 AS Id2)
+SELECT Id , Id2
+FROM cte 
+LEFT JOIN cte2 ON (cte.Id = cte2.Id2)
+FOR JSON AUTO
+GO
+
+-- CTE created from temp table
+CREATE TABLE #temp_sales (
+    SalesID INT,
+    CustomerID NCHAR(5),
+    SalesAmount MONEY,
+    SalesDate DATETIME
+);
+
+INSERT INTO #temp_sales VALUES
+(1, 'ALFKI', 500.00, '2023-07-01'),
+(2, 'BERGS', 750.00, '2023-07-02'),
+(3, 'CONSH', 300.00, '2023-07-03'),
+(4, 'ALFKI', 400.00, '2023-07-04');
+
+WITH sales_summary AS (
+    SELECT 
+        CustomerID,
+        COUNT(*) as TransactionCount,
+        SUM(SalesAmount) as TotalSales,
+        AVG(SalesAmount) as AvgSales
+    FROM #temp_sales
+    GROUP BY CustomerID
+)
+SELECT ss.CustomerID, ss.TransactionCount, ss.TotalSales, ss.AvgSales
+FROM sales_summary ss
+WHERE ss.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- Nested CTE: wo-w, wo-wo (outer cte w/o alias + inner cte w/ alias, outer cte w/o alias + inner cte w/o alias)
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 1
+),
+cte2 AS (
+    SELECT cte_inner.Country, cte_inner.order_count, cat.CategoryName
+    FROM cte_inner
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 1
+)
+SELECT c.CompanyName, cte1.Country, cte1.productname, cte2.Country, cte2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 ON c.Country = cte1.Country
+JOIN cte2 ON c.Country = cte2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- Nested CTE: w-w, w-wo (outer cte w/o alias + inner cte w/ alias, outer cte w/o alias + inner cte w/o alias) (target entry w/ alias) (two column of inner source put in same layer)
+WITH cte_inner AS (
+    SELECT
+        Country,
+        COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT
+        cin.Country,
+        cin.order_count as odc,
+        p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 2
+),
+cte2 AS (
+    SELECT
+        cte_inner.Country,
+        cte_inner.order_count,
+        cat.CategoryName
+    FROM cte_inner
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 2
+)
+SELECT
+    c.CompanyName,
+    c1.Country,
+    c1.productname,
+    c2.Country,
+    c2.categoryname,
+    c1.Country,
+    c1.odc
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- Nested CTE: w-w, w-wo (outer cte w/ alias + inner cte w/ alias, outer cte w/ alias + inner cte w/o alias) accessing by ctename
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 3
+),
+cte2 AS (
+    SELECT cte_inner.Country, cte_inner.order_count, cat.CategoryName
+    FROM cte_inner
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 5
+)
+SELECT c.CompanyName, cte1.Country, cte1.productname, c2.Country, c2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- Nested CTE: w-w, wo-w (outer cte w/ alias + inner cte w/ alias, outer cte w/o alias + inner cte w/ alias)
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 4
+),
+cte2 AS (
+    SELECT cin.Country, cin.order_count, cat.CategoryName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_categories cat ON cat.CategoryID = 3
+)
+SELECT c.CompanyName, cte1.Country, cte1.productname, c2.Country, c2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 ON c.Country = cte1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- Nested CTE: w-subq, wo-subq (outer cte w/alias + inner subq w/ alias, outer cte w/oalias + inner subq w/ alias)
+WITH cte_inner AS (
+    SELECT Country, COUNT(*) as order_count
+    FROM forjsonauto_t_customers 
+    GROUP BY Country
+),
+cte1 AS (
+    SELECT cin.Country, cin.order_count, sub.ProductName
+    FROM cte_inner cin
+    JOIN
+    (SELECT
+         ProductName
+     FROM forjsonauto_t_products 
+     WHERE ProductID = 1) sub ON 1=1
+),
+cte2 AS (
+    SELECT cte_inner.Country, cte_inner.order_count, cat_sub.CategoryName
+    FROM cte_inner
+    JOIN
+    (SELECT
+         CategoryName
+     FROM forjsonauto_t_categories
+     WHERE CategoryID = 1) cat_sub ON 1=1
+)
+SELECT c.CompanyName, c1.Country, c1.productname, c2.Country, c2.categoryname
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.Country
+JOIN cte2 c2 ON c.Country = c2.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- alias for inner target entry, and at innermost layer, it doesn’t have a valid source
+WITH cte_inner AS (
+    SELECT Country1, COUNT(*) as order_count
+    FROM (SELECT 'USA' as Country1) sub
+    GROUP BY Country1
+),
+cte1 AS (
+    SELECT cin.Country1 as c1C, cin.order_count, p.ProductName
+    FROM cte_inner cin
+    JOIN forjsonauto_t_products p ON p.ProductID = 2
+)
+SELECT c.CompanyName, c1.c1C, c1.productname, c1.order_count
+FROM forjsonauto_t_customers c
+JOIN cte1 c1 ON c.Country = c1.c1C
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- CTE with multiple-level long alias names (for checking if our hash can handle large full_src_path)
+WITH cte_inner_inner AS (
+    SELECT
+          forjsonauto_t_customers_aaaaaa.Country,
+          forjsonauto_t_orders_aaaaaa.OrderID
+      FROM forjsonauto_t_customers forjsonauto_t_customers_aaaaaa 
+      JOIN forjsonauto_t_orders forjsonauto_t_orders_aaaaaa
+      ON forjsonauto_t_customers_aaaaaa.CustomerID = forjsonauto_t_orders_aaaaaa.CustomerID
+),
+cte_inner AS (
+    SELECT
+        cte_inner_inner_123456789012345.Country,
+        cte_inner_inner_123456789012345.OrderID
+    FROM cte_inner_inner cte_inner_inner_123456789012345
+),
+cte1 AS (
+    SELECT
+        cin12345678901234567890.Country,
+        cin12345678901234567890.OrderID
+    FROM cte_inner cin12345678901234567890
+)
+SELECT
+    c.CompanyName,
+    c123456789012345678901234567890.Country,
+    c123456789012345678901234567890.OrderID
+FROM forjsonauto_t_customers c
+JOIN cte1 c123456789012345678901234567890 ON c.Country = c123456789012345678901234567890.Country
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+---------------------------------------- Different types of Targets (in SELECT_clause) ----------------------------------------
+-- subquery as target (nest_level > 1)
+SELECT c.CompanyName, 
+       o.OrderID,
+       (SELECT COUNT(*) 
+        FROM forjsonauto_t_orders o2 
+        WHERE o2.CustomerID = c.CustomerID
+       ) as OrderCount
+FROM forjsonauto_t_customers c
+JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- Operator Expression as target (nest_level > 1)
+SELECT 
+    c.CategoryName,
+    p.ProductName, 
+    p.UnitPrice * 2 AS doubled_price,
+    p.UnitsInStock + 10 AS adjusted_stock,
+    p.UnitPrice - 5 AS discounted_price
+FROM forjsonauto_t_categories c
+JOIN forjsonauto_t_products p ON c.CategoryID = p.CategoryID
+WHERE c.CategoryID = 2
+FOR JSON AUTO;
+GO
+
+-- Const Expression as target (nesting level > 1)
+SELECT 
+    cat.CategoryName,
+    p.ProductName,
+    'Premium' AS product_tier,
+    0.15 AS commission_rate,
+    'Active' AS status,
+    2024 AS catalog_year
+FROM forjsonauto_t_categories cat
+JOIN forjsonauto_t_products p ON cat.CategoryID = p.CategoryID
+WHERE cat.CategoryID = 2
+FOR JSON AUTO;
+GO
+
+-- Function Expression as target (nest_level > 1)
+SELECT 
+    c.CompanyName,
+    o.TotalAmount, 
+    CAST('2023-01-01 12:00:00' AS DATETIME) AS time
+FROM forjsonauto_t_customers c
+JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
+WHERE c.CompanyName = 'Alfreds Inc'
+FOR JSON AUTO;
+GO
+
+-- Coalesce Expression as target (nesting level > 1)
+SELECT 
+    s.SupplierName,
+    w.WarehouseName,
+    COALESCE(w.LastInspectionDate, '1900-01-01') as InspectionDate
+FROM forjsonauto_t_inventory_schema.forjsonauto_t_suppliers s
+INNER JOIN forjsonauto_t_inventory_schema.forjsonauto_t_warehouses w ON s.SupplierID = w.SupplierID
+WHERE w.WarehouseID = 101
+FOR JSON AUTO;
+GO
+
+-- CASE WHEN as target (nest_level > 1)
+SELECT 
+    cust.CompanyName,
+    o.TotalAmount,
+    CASE
+        WHEN o.TotalAmount > 1500 THEN 'High Value'
+        WHEN o.TotalAmount > 500 THEN 'Medium Value' 
+        ELSE 'Low Value'
+    END as OrderCategory
+FROM forjsonauto_t_customers cust
+INNER JOIN forjsonauto_t_orders o ON cust.CustomerID = o.CustomerID
+WHERE o.Status = 'Shipped'
+FOR JSON AUTO;
+GO
+
+---------------------------------------- Cases should return error ----------------------------------------
+-- FOR JSON AUTO without any base table
+SELECT 
+    ss.value AS category,
+    'Active' AS status
+FROM STRING_SPLIT('Electronics,Premium,Popular', ',') ss
+FOR JSON AUTO;
+GO
+
+-- nested FOR JSON AUTO, inner one doesn't have any base table
+SELECT 
+    p.ProductID,
+    p.ProductName,
+    (SELECT 
+         p.UnitPrice AS price,
+         'Active' AS status,
+         ss.value AS category_tag
+     FROM STRING_SPLIT('Electronics,Premium,Popular', ',') ss
+     FOR JSON AUTO
+    ) AS product_json
+FROM forjsonauto_t_products p
+WHERE p.CategoryID = 4
+FOR JSON AUTO;
+GO
+
+---------------------------------------- sources valid for FOR JSON AUTO (test if only contain certain RTEKind as source will make MSSQL return "NO TABLE" error) ----------------------------------------
+-- single RTE_RELATION as source
+SELECT
+    CustomerID,
+    CompanyName
+FROM forjsonauto_t_customers
+WHERE CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- single RTE_SUBQUERY as source w/o inner sources
+SELECT
+    sub.id,
+    sub.name 
+FROM
+    (SELECT
+        1 as id,
+        'test' as name
+    ) AS sub 
+FOR JSON AUTO;
+GO
+
+-- single RTE_FUNCTION as source w/o inner sources
+SELECT s.value 
+FROM STRING_SPLIT('apple,banana,cherry', ',') AS s 
+FOR JSON AUTO;
+GO
+
+-- single RTE_CTE as source w/o inner sources
+WITH cte
+AS (SELECT
+        1 as id,
+        'test' as name
+    )
+SELECT
+    cte.id,
+    cte.name
+FROM cte
+FOR JSON AUTO;
+GO
+
+-- one cte in ctelist but no RTE_CTE in rtable
+WITH 
+    unused_cte AS (SELECT 1 as id, 'test' as name)
+SELECT f.value 
+FROM STRING_SPLIT('apple,banana,cherry', ',') AS f
+FOR JSON AUTO;
+GO
+
+---------------------------------------- JSON structure with missing intermediate layers in output ----------------------------------------
+-- base tables LEFT JOIN with 1 NULL intermediate levels
+SELECT 
+    c.CustomerID,
+    o.OrderID,
+    p.ProductName,
+    od.OrderDetailID
+FROM forjsonauto_t_customers c
+LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID 
+LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
+LEFT JOIN forjsonauto_t_products p ON od.ProductID = p.ProductID AND p.UnitPrice > 100
+WHERE c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- base tables LEFT JOIN with multiple NULL intermediate levels
+SELECT 
+    c.CustomerID,
+    o.OrderID,
+    p.ProductName,
+    cat.CategoryName,
+    s.SupplierName,
+    w.WarehouseID
+FROM forjsonauto_t_customers c
+LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID 
+LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
+LEFT JOIN forjsonauto_t_products p ON od.ProductID = p.ProductID AND p.UnitPrice > 100
+LEFT JOIN forjsonauto_t_categories cat ON p.CategoryID = cat.CategoryID AND cat.ParentCategoryID IS NULL
+LEFT JOIN forjsonauto_t_inventory_schema.forjsonauto_t_suppliers s ON cat.CategoryID = s.Rating
+LEFT JOIN forjsonauto_t_inventory_schema.forjsonauto_t_warehouses w ON s.SupplierID = w.SupplierID
+WHERE c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- subquery LEFT JOIN with NULL intermediate levels
+SELECT 
+    c.CustomerID,
+    o.OrderID,
+    expensive_products.ProductName,
+    supplier_info.SupplierName,
+    od.OrderDetailID
+FROM forjsonauto_t_customers c
+LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID 
+LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
+LEFT JOIN (
+    SELECT p.ProductID, p.ProductName, p.CategoryID
+    FROM forjsonauto_t_products p
+    WHERE p.UnitPrice > 100
+) expensive_products ON od.ProductID = expensive_products.ProductID
+LEFT JOIN (
+    SELECT s.SupplierID, s.SupplierName, s.Rating
+    FROM forjsonauto_t_inventory_schema.forjsonauto_t_suppliers s
+    WHERE s.Rating > 4
+) supplier_info ON expensive_products.CategoryID = supplier_info.Rating
+WHERE c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- CTE LEFT JOIN with NULL intermediate levels
+WITH high_value_orders AS (
+    SELECT o.CustomerID, 
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT 
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -790,6 +790,119 @@ WHERE c.CompanyName = 'Alfreds Inc'
 FOR JSON AUTO;
 GO
 
+-- direct reference Recursive CTEs
+WITH category_hierarchy AS (
+
+    SELECT CategoryID, CategoryName, 0 as Level
+    FROM forjsonauto_t_categories
+    WHERE ParentCategoryID IS NULL
+
+    UNION ALL
+
+    SELECT c.CategoryID, c.CategoryName, ch.Level + 1
+    FROM forjsonauto_t_categories c
+    INNER JOIN category_hierarchy ch ON c.ParentCategoryID = ch.CategoryID
+)
+SELECT
+    p.ProductName,
+    c.CompanyName,
+    ch.CategoryName,
+    ch.Level
+FROM category_hierarchy ch
+LEFT JOIN forjsonauto_t_products p ON ch.CategoryID = p.CategoryID
+LEFT JOIN forjsonauto_t_order_details od ON p.ProductID = od.ProductID
+LEFT JOIN forjsonauto_t_orders o ON od.OrderID = o.OrderID
+LEFT JOIN forjsonauto_t_customers c ON o.CustomerID = c.CustomerID
+WHERE p.ProductName = 'Laptop'
+FOR JSON AUTO;
+GO
+
+-- nested reference Recursive CTE (outer non-recursive CTE w/ alias  +  inner recursive CTE)
+WITH order_tree AS (
+    SELECT
+        orderid,
+        customerid,
+        1 AS depth
+    FROM forjsonauto_t_orders
+    WHERE orderid = 10248
+
+    UNION ALL
+
+    SELECT
+        o.orderid,
+        o.customerid,
+        ot.depth + 1
+    FROM forjsonauto_t_orders o
+    INNER JOIN order_tree ot
+    ON o.orderid = ot.orderid + 1
+    WHERE ot.depth < 2 )
+,level2_cte AS (
+    SELECT
+        ot.orderid,
+        c.companyname
+    FROM order_tree ot
+    JOIN forjsonauto_t_customers c
+    ON ot.customerid = c.customerid )
+,level3_cte AS (
+    SELECT
+        l2.orderid,
+        l2.companyname,
+        'Primary' AS ordertype
+    FROM level2_cte l2 )
+SELECT
+    p.productname,
+    l3cte.companyname,
+    l3cte.orderid
+FROM level3_cte l3cte
+JOIN forjsonauto_t_order_details od ON l3cte.orderid = od.orderid
+JOIN forjsonauto_t_products p ON od.productid = p.productid
+WHERE p.productname = 'Chai'
+FOR json auto;
+GO
+
+-- nested reference recursive CTE (outer non-recursive CTE w/o alias  +  inner recursive CTE)
+WITH order_tree AS (
+    SELECT
+        orderid,
+        customerid,
+        1 AS depth
+    FROM forjsonauto_t_orders
+    WHERE orderid = 10248
+
+    UNION ALL
+
+    SELECT
+        o.orderid,
+        o.customerid,
+        ot.depth + 1
+    FROM forjsonauto_t_orders o
+    INNER JOIN order_tree ot
+    ON o.orderid = ot.orderid + 1
+    WHERE ot.depth < 2 )
+,level2_cte AS (
+    SELECT
+        ot.orderid,
+        c.companyname
+    FROM order_tree ot
+    JOIN forjsonauto_t_customers c
+    ON ot.customerid = c.customerid )
+,level3_cte AS (
+    SELECT
+        l2.orderid,
+        l2.companyname,
+        'Primary' AS ordertype
+    FROM level2_cte l2 )
+SELECT
+    p.productname,
+    level3_cte.companyname,
+    level3_cte.orderid
+FROM level3_cte
+JOIN forjsonauto_t_order_details od ON level3_cte.orderid = od.orderid
+JOIN forjsonauto_t_products p ON od.productid = p.productid
+WHERE p.productname = 'Chai'
+FOR json auto;
+GO
+
 ---------------------------------------- Different types of Targets (in SELECT_clause) ----------------------------------------
 -- subquery as target (nest_level > 1)
 SELECT c.CompanyName, 

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -951,6 +951,21 @@ WHERE p.productname = 'Chai'
 FOR json auto;
 GO
 
+-- outer query w/o FOR JSON AUTO + inner query w/ FOR JSON AUTO
+WITH customer_orders AS (
+    SELECT c.CustomerID, c.CompanyName, o.OrderID, o.TotalAmount
+    FROM forjsonauto_t_customers c
+    JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
+)
+SELECT subquery_result.aa
+FROM (
+    SELECT co.CompanyName, co.OrderID, co.TotalAmount
+    FROM customer_orders co
+      where co.OrderID = 10248
+    FOR JSON AUTO
+) AS subquery_result(aa)
+GO
+
 ---------------------------------------- Different types of Targets (in SELECT_clause) ----------------------------------------
 -- subquery as target (nest_level > 1)
 SELECT c.CompanyName, 
@@ -1190,4 +1205,68 @@ LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
 WHERE aco.CustomerID IS NOT NULL
 AND c.CustomerID = 'ALFKI'
 FOR JSON AUTO;
+GO
+
+-- only NULL-value columns in level 1
+WITH high_value_orders AS (
+    SELECT o.CustomerID,
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT
+    hvo.CustomerID,
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO;
+GO
+
+-- NULL-value columns in level 1 with “INCLUDE_NULL_VALUES”
+WITH high_value_orders AS (
+    SELECT o.CustomerID,
+           COUNT(*) as high_order_count,
+           AVG(o.TotalAmount) as avg_high_amount
+    FROM forjsonauto_t_orders o
+    WHERE o.TotalAmount > 1000
+    GROUP BY o.CustomerID
+),
+all_customer_orders AS (
+    SELECT o.CustomerID,
+           o.OrderID,
+           COUNT(*) as total_order_count
+    FROM forjsonauto_t_orders o
+    GROUP BY o.CustomerID, o.OrderID
+)
+SELECT
+    hvo.CustomerID,
+    c.CustomerID,
+    hvo.customerID,
+    aco.customerID,
+    aco.total_order_count
+FROM forjsonauto_t_customers c
+LEFT JOIN high_value_orders hvo ON c.CustomerID = hvo.CustomerID
+LEFT JOIN all_customer_orders aco ON c.CustomerID = aco.CustomerID
+WHERE aco.CustomerID IS NOT NULL
+AND c.CustomerID = 'ALFKI'
+FOR JSON AUTO, INCLUDE_NULL_VALUES;
+GO
+
+-- SELECT FROM a table which value is a result of FOR JSON AUTO
+SELECT * FROM JsonTable;
 GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -357,6 +357,54 @@ WHERE p.ProductName = 'Coffee Beans'
 FOR JSON AUTO;
 GO
 
+-- nested FOR JSON AUTO in subquery at outer query's FROM_clause
+WITH SalesData AS (
+    SELECT * FROM (VALUES
+        (1, 'East', '2023-01', 1000),
+        (1, 'East', '2023-02', 1200),
+        (2, 'West', '2023-01', 800),
+        (2, 'West', '2023-02', 900)
+    ) AS v(RegionId, RegionName, Period, Sales)
+)
+SELECT
+    v.RegionId,
+    v.RegionName,
+    (
+        SELECT
+            sd.Period,
+            sd.Sales,
+            sd.Sales * 0.15 as Commission,
+            (
+                SELECT TOP 1 t.TargetValue
+                FROM (VALUES
+                    ('East', 1100),
+                    ('West', 850)
+                ) t(Region, TargetValue)
+                WHERE t.Region = v.RegionName
+            ) as MonthlyTarget,
+            CASE
+                WHEN sd.Sales >= (
+                    SELECT TOP 1 t.TargetValue
+                    FROM (VALUES
+                        ('East', 1100),
+                        ('West', 850)
+                    ) t(Region, TargetValue)
+                    WHERE t.Region = v.RegionName
+                ) THEN 'Achieved'
+                ELSE 'Not Achieved'
+            END as TargetStatus
+        FROM SalesData sd
+        WHERE sd.RegionId = v.RegionId
+        FOR JSON AUTO
+    ) as MonthlyPerformance
+FROM (VALUES
+    (1, 'East'),
+    (2, 'West')
+) v(RegionId, RegionName)
+WHERE v.RegionId = 1
+FOR JSON AUTO;
+GO
+
 ---------------------------------------- VALUES (in FROM_clause) ----------------------------------------
 -- VALUES with Mixed Data Types
 SELECT v.product_name, v.price, v.in_stock, v.launch_date
@@ -1067,6 +1115,7 @@ LEFT JOIN forjsonauto_t_orders o ON c.CustomerID = o.CustomerID
 LEFT JOIN forjsonauto_t_order_details od ON o.OrderID = od.OrderID
 LEFT JOIN forjsonauto_t_products p ON od.ProductID = p.ProductID AND p.UnitPrice > 100
 WHERE c.CustomerID = 'ALFKI'
+AND od.OrderDetailID = 1
 FOR JSON AUTO;
 GO
 
@@ -1110,6 +1159,7 @@ LEFT JOIN (
     WHERE s.Rating > 4
 ) supplier_info ON expensive_products.CategoryID = supplier_info.Rating
 WHERE c.CustomerID = 'ALFKI'
+AND od.OrderDetailID = 1
 FOR JSON AUTO;
 GO
 


### PR DESCRIPTION
### Description

Support subqueries, values, CTEs in FOR JSON AUTO.

### Issues Resolved
BABEL-5876
BABEL-5877
BABEL-5998
BABEL-6020

### Solution

#### 1. jsonAutoWalker

- Checks for FOR JSON AUTO in the query tree, changed from top-down to bottom-up approach to trigger handleForJsonAuto.
- Passes the jsonAutoContext to reuse the cteList and ctehash. For passing cteList, it's because we cannot reach outermost cteList in inner layer subqueries. For passing ctehash, because it should be the same for the same cteList, we don't want to create them each time a handleForJsonAuto is triggered.

#### 2. handleForJsonAuto

- Unwraps the wrapper JSON query to get the original query.
- Checks if we need to return the "at least one table" error.

#### 3. modifyColumnEntries

- Modifies columns to follow the format "JSONAUTOALIAS.[nesting_level].[nesting_key].[colname]".
- Iterates through target entries; for each target entry and its matched source entry, checks their types to determine whether to use the matched source's alias as the JSON nesting key.
- For RTE_CTE entries, checks if we need to unwrap them to get the inner matched target entry and source entry.

#### 4. tsql_auto_row_to_json 

- Based on the format set in modifyColumnEntries(), constructs the layered JSON structure to accommodate columns at different nesting levels.
- Ensures that even when a middle layer contains only NULL-value columns, its structure is still created so that later layers can append to this layer.


[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**
* **Boundary conditions -**
* **Arbitrary inputs -**
* **Negative test cases -**
* **Minor version upgrade tests -**
* **Major version upgrade tests -**




### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).