### PR TITLE
[OSS-ONLY] Fix dotnet installation failures in GitHub Actions (#4010)

### DIFF
--- a/.github/composite-actions/install-and-run-dotnet/action.yml
+++ b/.github/composite-actions/install-and-run-dotnet/action.yml
@@ -20,9 +20,13 @@ runs:
     if: always() && steps.install-mssql-tools.outcome == 'success'
     run: | 
       cd ~
+      # Remove existing repositories
+      sudo rm /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/msprod*.list /etc/apt/sources.list.d/mssql*.list
       wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-      sudo dpkg -i packages-microsoft-prod.deb
+      echo "Y" | sudo dpkg -i packages-microsoft-prod.deb
       rm packages-microsoft-prod.deb
+      sudo apt-get clean
+      sudo apt-get update
       sudo apt-get install -y apt-transport-https
       sudo apt-get install -y dotnet-sdk-8.0
       sudo apt-get install -y apt-transport-https


### PR DESCRIPTION
### Description
This commit fixes dotnet installation failures in GitHub Actions by cleaning up all existing repository sources to avoid conflicts during package installation. 


Signed-off-by: Sumit Jaiswal [sumiji@amazon.com](mailto:sumiji@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).