### PR TITLE
Remove duplicate installations from CI (#4017)

### DIFF
--- a/.github/composite-actions/install-and-run-dotnet/action.yml
+++ b/.github/composite-actions/install-and-run-dotnet/action.yml
@@ -7,8 +7,6 @@ runs:
   - name: Install MSSQL Tools
     id: install-mssql-tools
     run: |
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-        curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
         sudo apt-get update
         sudo apt-get install mssql-tools18 unixodbc-dev
         echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
@@ -20,11 +18,6 @@ runs:
     if: always() && steps.install-mssql-tools.outcome == 'success'
     run: | 
       cd ~
-      # Remove existing repositories
-      sudo rm /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/msprod*.list /etc/apt/sources.list.d/mssql*.list
-      wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-      echo "Y" | sudo dpkg -i packages-microsoft-prod.deb
-      rm packages-microsoft-prod.deb
       sudo apt-get clean
       sudo apt-get update
       sudo apt-get install -y apt-transport-https

--- a/.github/composite-actions/install-and-run-python/action.yml
+++ b/.github/composite-actions/install-and-run-python/action.yml
@@ -14,8 +14,6 @@ runs:
       id: configure-python-environment
       if: always() && steps.install-python.outcome == 'success'
       run: |
-        cd ~
-        curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
         cd ~/work/babelfish_extensions/babelfish_extensions/test/python
         mkdir sqltoolsservice
         cd sqltoolsservice

--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -5,8 +5,16 @@ runs:
     - name: Install Dependencies
       run: |
         sudo apt clean && sudo apt-get update --fix-missing -y
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+        # Clean up any existing Microsoft repository configurations to avoid conflicts
+        sudo rm -f /etc/apt/sources.list.d/msprod.list
+        sudo rm -f /etc/apt/sources.list.d/packages-microsoft-com-prod.list
+        sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
+        sudo rm -f /usr/share/keyrings/microsoft-prod.gpg
+        
+        # Download and install Microsoft's GPG key properly
+        wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+        # Add Microsoft repository with proper GPG key configuration
+        echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" | sudo tee /etc/apt/sources.list.d/msprod.list
         sudo apt-get update --fix-missing -y
         sudo apt-get install gcc-9 uuid-dev openjdk-21-jre libicu-dev libxml2-dev openssl libssl-dev python3-dev libossp-uuid-dev libpq-dev pkg-config g++ build-essential bison mssql-tools unixodbc-dev libsybdb5 freetds-dev freetds-common gdal-bin libgdal-dev libgeos-dev gdb libkrb5-dev
         sudo apt install -y ccache

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Configure Python environment
         run: |
           cd ~
-          curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           cd ~/work/babelfish_extensions/babelfish_extensions/test/python
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
           pip3 install pyodbc pymssql pytest pytest-xdist antlr4-python3-runtime==4.13.2


### PR DESCRIPTION
There are duplicate installations in CI which causes problem.


(cherry picked from commit 3d7dd95e37efc4cbfb9e43e0c0c1fac2a38b3e01)

### Description

Cherry-pick from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4017
### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).