### PR TITLE
[BABEL-5957] Adapting to changes in the community for REL_17_6

### DIFF
--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -99,7 +99,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 				/* getRTEPermissionInfo would return valid perfInfo, error will be raised otherwise */
 				perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);
 				/* probably (re)do perm check */
-				if (!ExecCheckOneRelPerms_wrapper(perminfo))
+				if (!ExecCheckOneRelPerms(perminfo))
 				{
 					aclcheck_error(ACLCHECK_NO_PRIV,
 									get_relkind_objtype(get_rel_relkind(perminfo->relid)),


### PR DESCRIPTION
Description
-----------
Community has exposed the function ExecCheckOneRelPerms to other modules. We don't need the original wrapper any more.

See related PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/612

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).