### PR TITLE
Fix view repair crash caused by comments at start SQL definition

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -7028,7 +7028,7 @@ repair_broken_view_recursive(Oid viewOid, List *visitedViews)
 			rawstmt->stmt_location = -1;
 			rawstmt->stmt_len = 0;
 			
-			query = parse_analyze_fixedparams(rawstmt, viewdef, NULL, 0, NULL);
+			query = parse_analyze_fixedparams(rawstmt, stmt_sql->sqlstmt->query, NULL, 0, NULL);
 		}
 		PG_FINALLY();
 		{

--- a/test/JDBC/expected/weak-binding-vu-verify.out
+++ b/test/JDBC/expected/weak-binding-vu-verify.out
@@ -378,9 +378,9 @@ GO
 
 SELECT * FROM view_test.weak_view_complex1;
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot change name of view column "name" to "est")~~
+~~START~~
+varchar#!#int#!#int
+~~END~~
 
 
 SELECT * FROM view_test.weak_view_complex2;
@@ -569,6 +569,9 @@ on
 ~~END~~
 
 
+-- Create a weak binding view for binary data
+-- test comment 1
+-- test comment 2
 CREATE VIEW view_test.weak_binary_view AS
 SELECT id, binary_data FROM view_test.binary_test_table;
 GO

--- a/test/JDBC/input/views/weak-binding-vu-verify.sql
+++ b/test/JDBC/input/views/weak-binding-vu-verify.sql
@@ -378,6 +378,9 @@ GO
 SELECT set_config('babelfishpg_tsql.weak_view_binding', 'true', false);
 GO
 
+-- Create a weak binding view for binary data
+-- test comment 1
+-- test comment 2
 CREATE VIEW view_test.weak_binary_view AS
 SELECT id, binary_data FROM view_test.binary_test_table;
 GO


### PR DESCRIPTION
### Description

The view repair mechanism was crashing when processing view definitions containing comments at start of the SQL definition.
This happens during the `parse_analyze_fixedparams` call in `repair_broken_view_recursive`, specifically in the `pre_transform_target_entry` function where a memory access violation occurs.

This fix:
Uses ANTLR-processed SQL text for parsing instead of raw view definition (`stmt_sql->sqlstmt->query`), where `stmt_sql` is result of ANTLR parser for the original viewdef

### Issues Resolved
None

Signed off by: Rahul Parande [rparande@amazon.com]
### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).