### PR TITLE
Fix permission checks for views in Planner phase for cross-db cases

### DIFF
--- a/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
+++ b/contrib/babelfishpg_tsql/src/bbf_parallel_query.c
@@ -99,7 +99,7 @@ bbf_ExecInitParallelPlan(EState *estate, ParallelContext *pcxt, bool estimate)
 				/* getRTEPermissionInfo would return valid perfInfo, error will be raised otherwise */
 				perminfo = getRTEPermissionInfo(estate->es_plannedstmt->permInfos, rte);
 				/* probably (re)do perm check */
-				if (!ExecCheckOneRelPerms_wrapper(perminfo))
+				if (!ExecCheckOneRelPerms(perminfo))
 				{
 					aclcheck_error(ACLCHECK_NO_PRIV,
 									get_relkind_objtype(get_rel_relkind(perminfo->relid)),

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4958,27 +4958,10 @@ update_rte_perms_info_walker(Node *node, void *context)
 					}
 				}
 			}
-
-			if (rte->rtekind == RTE_SUBQUERY)
-				update_rte_perms_info_walker((Node *) rte->subquery, NULL);
 		}
-
-		/* Recurse into subquery-in-WITH */
-		foreach(l, qry->cteList)
-		{
-			CommonTableExpr *cte = (CommonTableExpr *) lfirst(l);
-
-			update_rte_perms_info_walker(cte->ctequery, NULL);
-		}
-
-		/* If there are sublinks, search for them and process their RTEs */
-		if (qry->hasSubLinks)
-			query_tree_walker(qry, update_rte_perms_info_walker, NULL,
-							QTW_IGNORE_RC_SUBQUERIES);
-		return false;
+		return query_tree_walker(qry, update_rte_perms_info_walker, NULL, 0);
 	}
-	return expression_tree_walker(node, update_rte_perms_info_walker,
-								  NULL);
+	return expression_tree_walker(node, update_rte_perms_info_walker, NULL);
 }
 
 static PlannedStmt *

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4912,11 +4912,83 @@ print_pltsql_function_arguments(StringInfo buf, HeapTuple proctup,
 	return argsprinted;
 }
 
+/*
+ * update_rte_perms_info_walker
+ *		Recursively scan a query or expression tree and set the checkAsUser
+ *		field to corresponding TSQL login in RTEPermissionInfos of view RTEs of Query.
+ */
+static bool
+update_rte_perms_info_walker(Node *node, void *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Query))
+	{
+		ListCell   *l;
+		Query	*qry = (Query *) node;
+
+		foreach(l, qry->rtable)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
+
+			if (rte->rtekind == RTE_SUBQUERY && get_rel_relkind(rte->relid) == RELKIND_VIEW)
+			{
+				Oid nspid = get_rel_namespace(rte->relid);
+
+				if (OidIsValid(nspid))
+				{
+					char *physical_schemaname = NULL;
+					RTEPermissionInfo *perminfo = NULL;
+
+					physical_schemaname = get_namespace_name(nspid);
+					perminfo = getRTEPermissionInfo(qry->rteperminfos, rte);
+
+					if (physical_schemaname && !is_shared_schema(physical_schemaname))
+					{
+						if (OidIsValid(perminfo->checkAsUser))
+						{
+							Oid loginId = get_login_for_user(perminfo->checkAsUser, physical_schemaname);
+							if (OidIsValid(loginId))
+								perminfo->checkAsUser = loginId;
+						}
+						else
+							perminfo->checkAsUser = GetSessionUserId();
+						pfree(physical_schemaname);
+					}
+				}
+			}
+
+			if (rte->rtekind == RTE_SUBQUERY)
+				update_rte_perms_info_walker((Node *) rte->subquery, NULL);
+		}
+
+		/* Recurse into subquery-in-WITH */
+		foreach(l, qry->cteList)
+		{
+			CommonTableExpr *cte = (CommonTableExpr *) lfirst(l);
+
+			update_rte_perms_info_walker(cte->ctequery, NULL);
+		}
+
+		/* If there are sublinks, search for them and process their RTEs */
+		if (qry->hasSubLinks)
+			query_tree_walker(qry, update_rte_perms_info_walker, NULL,
+							QTW_IGNORE_RC_SUBQUERIES);
+		return false;
+	}
+	return expression_tree_walker(node, update_rte_perms_info_walker,
+								  NULL);
+}
+
 static PlannedStmt *
 pltsql_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt *plan;
 	PLtsql_execstate *estate = NULL;
+
+	if (sql_dialect == SQL_DIALECT_TSQL && IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
+		update_rte_perms_info_walker((Node *) parse, NULL);
 
 	if (pltsql_explain_analyze)
 	{

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4932,7 +4932,7 @@ update_rte_perms_info_walker(Node *node, void *context)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
 
-			if (get_rel_relkind(rte->relid) == RELKIND_VIEW)
+			if (rte->perminfoindex != 0 && get_rel_relkind(rte->relid) == RELKIND_VIEW)
 			{
 				Oid nspid = get_rel_namespace(rte->relid);
 

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4987,7 +4987,7 @@ pltsql_planner_hook(Query *parse, const char *query_string, int cursorOptions, P
 	PlannedStmt *plan;
 	PLtsql_execstate *estate = NULL;
 
-	if (sql_dialect == SQL_DIALECT_TSQL && IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
+	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
 		update_rte_perms_info_walker((Node *) parse, NULL);
 
 	if (pltsql_explain_analyze)

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4932,7 +4932,7 @@ update_rte_perms_info_walker(Node *node, void *context)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
 
-			if (rte->rtekind == RTE_SUBQUERY && get_rel_relkind(rte->relid) == RELKIND_VIEW)
+			if (get_rel_relkind(rte->relid) == RELKIND_VIEW)
 			{
 				Oid nspid = get_rel_namespace(rte->relid);
 


### PR DESCRIPTION
Commit e2d4ef8de86 - "Fix security checks in selectivity estimation functions." introduced the permission checks on view in the planner phase. In Babelfish there is permission specific logic which is implemented in executor_hook to support the query on cross-db views. While implementing cross-db view query support, We assumed that permission checks always happens at executor. After mentioned community changes that assumption got brocken and cross-db view queries throwing errors of insufficient privileges.

This commit fixes above issue by adding same logic for supporting cross-db view query to pre-planning phase using pltsql_planner_hook. It is basically walking through whole query tree and inserts checkAsUser field for all the view RTE, so that permission check on views always happens on TSQL login to support cross-db usecases.

Issues Resolved: BABEL-6035
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).