### PR TITLE
Fix permission checks for views in Planner phase for cross-db cases

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4912,11 +4912,67 @@ print_pltsql_function_arguments(StringInfo buf, HeapTuple proctup,
 	return argsprinted;
 }
 
+/*
+ * update_rte_perms_info_walker
+ *		Recursively scan a query or expression tree and set the checkAsUser
+ *		field to corresponding TSQL login in RTEPermissionInfos of view RTEs of Query.
+ */
+static bool
+update_rte_perms_info_walker(Node *node, void *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Query))
+	{
+		ListCell   *l;
+		Query	*qry = (Query *) node;
+
+		foreach(l, qry->rtable)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
+
+			if (rte->rtekind == RTE_SUBQUERY && get_rel_relkind(rte->relid) == RELKIND_VIEW)
+			{
+				Oid nspid = get_rel_namespace(rte->relid);
+
+				if (OidIsValid(nspid))
+				{
+					char *physical_schemaname = NULL;
+					RTEPermissionInfo *perminfo = NULL;
+
+					physical_schemaname = get_namespace_name(nspid);
+					perminfo = getRTEPermissionInfo(qry->rteperminfos, rte);
+
+					if (physical_schemaname && !is_shared_schema(physical_schemaname))
+					{
+						if (OidIsValid(perminfo->checkAsUser))
+						{
+							Oid loginId = get_login_for_user(perminfo->checkAsUser, physical_schemaname);
+							if (OidIsValid(loginId))
+								perminfo->checkAsUser = loginId;
+						}
+						else
+							perminfo->checkAsUser = GetSessionUserId();
+					}
+					if (physical_schemaname)
+						pfree(physical_schemaname);
+				}
+			}
+		}
+		return query_tree_walker(qry, update_rte_perms_info_walker, NULL, 0);
+	}
+	return expression_tree_walker(node, update_rte_perms_info_walker, NULL);
+}
+
 static PlannedStmt *
 pltsql_planner_hook(Query *parse, const char *query_string, int cursorOptions, ParamListInfo boundParams)
 {
 	PlannedStmt *plan;
 	PLtsql_execstate *estate = NULL;
+
+	if (IS_TDS_CLIENT() && !InSecurityRestrictedOperation())
+		update_rte_perms_info_walker((Node *) parse, NULL);
 
 	if (pltsql_explain_analyze)
 	{

--- a/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CROSS-DB-vu-verify.out
@@ -1992,3 +1992,127 @@ nvarchar
 This is correct: master.dbo.sp_test_babel_5448_1
 ~~END~~
 
+
+-- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
+-- CASE: cross-db views inside subquery/cte
+-- Cross-database view access with different users
+-- user should have access
+USE master;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+~~END~~
+
+
+SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS derived ORDER BY id;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+~~END~~
+
+
+SELECT * FROM (SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS inner_derived) AS outer_derived ORDER BY id;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+~~END~~
+
+
+WITH cte AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT * FROM cte ORDER BY id;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+~~END~~
+
+
+WITH cte1 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2), cte2 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT c1.id, c2.id as id2 FROM cte1 c1 JOIN cte2 c2 ON c1.id = c2.id ORDER BY c1.id;
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT d1.id, d2.id as id2 FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d1 JOIN my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d2 ON d1.id = d2.id ORDER BY d1.id;
+GO
+~~START~~
+int#!#int
+~~END~~
+
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v1 WHERE id IN (SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v2 WHERE v2.id > 1) ORDER BY id;
+GO
+~~START~~
+int#!#int#!#varchar#!#varchar
+~~END~~
+
+
+SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 UNION SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+~~START~~
+int
+~~END~~
+
+
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+-- user should not have access
+USE master;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS derived ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+SELECT * FROM (SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS inner_derived) AS outer_derived ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+WITH cte AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT * FROM cte ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+WITH cte1 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2), cte2 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT c1.id, c2.id as id2 FROM cte1 c1 JOIN cte2 c2 ON c1.id = c2.id ORDER BY c1.id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+SELECT d1.id, d2.id as id2 FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d1 JOIN my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d2 ON d1.id = d2.id ORDER BY d1.id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v1 WHERE id IN (SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v2 WHERE v2.id > 1) ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+
+
+SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 UNION SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view babel_cross_db_vu_prepare_v2)~~
+

--- a/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
+++ b/test/JDBC/input/ownership/BABEL-CROSS-DB-vu-verify.mix
@@ -943,3 +943,63 @@ SELECT db_name()
 GO
 EXECUTE dbo.sp_test_babel_5448_3;
 GO
+
+-- CASE: cross-db views inside subquery/cte
+-- Cross-database view access with different users
+-- user should have access
+-- tsql user=babel_cross_db_vu_prepare_l1 password=12345678
+USE master;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+
+SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS derived ORDER BY id;
+GO
+
+SELECT * FROM (SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS inner_derived) AS outer_derived ORDER BY id;
+GO
+
+WITH cte AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT * FROM cte ORDER BY id;
+GO
+
+WITH cte1 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2), cte2 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT c1.id, c2.id as id2 FROM cte1 c1 JOIN cte2 c2 ON c1.id = c2.id ORDER BY c1.id;
+GO
+
+SELECT d1.id, d2.id as id2 FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d1 JOIN my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d2 ON d1.id = d2.id ORDER BY d1.id;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v1 WHERE id IN (SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v2 WHERE v2.id > 1) ORDER BY id;
+GO
+
+SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 UNION SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+
+-- user should not have access
+-- tsql user=babel_cross_db_vu_prepare_l2 password=12345678
+USE master;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO
+
+SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS derived ORDER BY id;
+GO
+
+SELECT * FROM (SELECT * FROM (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) AS inner_derived) AS outer_derived ORDER BY id;
+GO
+
+WITH cte AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT * FROM cte ORDER BY id;
+GO
+
+WITH cte1 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2), cte2 AS (SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2) SELECT c1.id, c2.id as id2 FROM cte1 c1 JOIN cte2 c2 ON c1.id = c2.id ORDER BY c1.id;
+GO
+
+SELECT d1.id, d2.id as id2 FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d1 JOIN my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 d2 ON d1.id = d2.id ORDER BY d1.id;
+GO
+
+SELECT * FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v1 WHERE id IN (SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 v2 WHERE v2.id > 1) ORDER BY id;
+GO
+
+SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 UNION SELECT id FROM my_babel_cross_db_vu_prepare_db1.babel_cross_db_vu_prepare_s2.babel_cross_db_vu_prepare_v2 ORDER BY id;
+GO


### PR DESCRIPTION
### Description

Commit e2d4ef8de86 - "Fix security checks in selectivity estimation functions." introduced the permission checks on view in the planner phase. In Babelfish there is permission specific logic which is implemented in executor_hook to support the query on cross-db views. While implementing cross-db view query support, We assumed that permission checks always happens at executor. After mentioned community changes that assumption got brocken and cross-db view queries throwing errors of insufficient privileges.

This commit fixes above issue by adding same logic for supporting cross-db view query to pre-planning phase using pltsql_planner_hook. It is basically walking through whole query tree and inserts checkAsUser field for all the view RTE, so that permission check on views always happens on TSQL login to support cross-db usecases.

Issues Resolved: BABEL-6035
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).