### PR TITLE
Fix rollback to savepoint in TDS TxnMgmtRequest when XID is not assigned to top transaction 

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsxact.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsxact.c
@@ -409,7 +409,7 @@ ProcessTxnMgmtRequest(TDSRequest request)
 				 * ROLLBACK TO SAVEPOINT command.  So if we've rolled back the
 				 * top transaction, send the token.
 				 */
-				if (GetTopTransactionIdIfAny() == InvalidTransactionId)
+				if (!IsTransactionBlock())
 					TdsSendEnvChangeBinary(TDS_ENVID_ROLLBACKTXN, NULL, 0,
 										   &txnId, sizeof(uint64_t));
 				if (req->nextTxn != NULL)

--- a/test/dotnet/ExpectedOutput/TestTransactions.out
+++ b/test/dotnet/ExpectedOutput/TestTransactions.out
@@ -261,3 +261,26 @@
 #D#int
 0
 #Q#DROP TABLE txntable1;
+#Q#CREATE TABLE txntable2 (col1 INT, col2 TEXT);
+#Q#select * from txntable2 order by col1;
+#Q#insert into txntable2 values(1, 'AAA');
+#Q#select * from txntable2;
+#D#int#!#text
+1#!#AAA
+#Q#delete from txntable2;
+#Q#select * from txntable2 order by col1;
+#Q#insert into txntable2 values(1, 'AAA');
+#Q#select * from txntable2;
+#Q#delete from txntable2;
+#Q#select * from txntable2 order by col1;
+#Q#insert into txntable2 values(1, 'AAA');
+#Q#select * from txntable2;
+#D#int#!#text
+1#!#AAA
+#Q#delete from txntable2;
+#Q#select * from txntable2 order by col1;
+#Q#insert into txntable2 values(1, 'AAA');
+#Q#select * from txntable2;
+#D#int#!#text
+1#!#AAA
+#Q#DROP TABLE txntable2;

--- a/test/dotnet/input/Transaction/TestTransactions.txt
+++ b/test/dotnet/input/Transaction/TestTransactions.txt
@@ -187,3 +187,52 @@ txn#!#commit
 
 DROP TABLE txntable1;
 
+CREATE TABLE txntable2 (col1 INT, col2 TEXT);
+
+# begin transaction -> save transaction name -> SELECT -> rollback to savepoint --> INSERT --> commit tran
+txn#!#begin#!#tx1
+txn#!#savepoint#!#sp1
+select * from txntable2 order by col1;
+txn#!#rollback#!#sp1
+insert into txntable2 values(1, 'AAA');
+txn#!#commit$!#tx1
+txn#!#commit$!#tx1
+
+select * from txntable2;
+
+delete from txntable2;
+
+# begin transaction -> save transaction name -> SELECT -> rollback to savepoint --> INSERT --> rollback tran
+txn#!#begin#!#tx1
+txn#!#savepoint#!#sp1
+select * from txntable2 order by col1;
+txn#!#rollback#!#sp1
+insert into txntable2 values(1, 'AAA');
+txn#!#rollback
+
+select * from txntable2;
+
+delete from txntable2;
+
+# begin transaction -> save transaction name -> SELECT -> rollback top level tran --> INSERT --> rollback tran
+txn#!#begin#!#tx1
+txn#!#savepoint#!#sp1
+select * from txntable2 order by col1;
+txn#!#rollback#!#tx1
+insert into txntable2 values(1, 'AAA');
+txn#!#rollback
+
+select * from txntable2;
+
+delete from txntable2;
+
+# begin transaction -> save transaction name -> SELECT -> rollback top level tran --> INSERT --> commit tran
+txn#!#begin#!#tx1
+txn#!#savepoint#!#sp1
+select * from txntable2 order by col1;
+txn#!#rollback#!#tx1
+insert into txntable2 values(1, 'AAA');
+txn#!#commit
+select * from txntable2;
+
+DROP TABLE txntable2;


### PR DESCRIPTION
### Description

Cherry pick of https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4083

In TDS TxnMgmtRequest, after we perform rollback , we check if its was rollback
to savepoint or a complete rollback. In case of compelte rollback we will send a
token back to client while incase of rollback to savepoint we do not. The check
for this relied on top transaction XID being valid if the top transaction is still 
active meaning we did a rollback to savepoint but postgres only assings the  XID
to transaction when it first needs it i.e. lazy assignment. Now for cases where 
top transaction is XID less and we do a rollback to savepoint, the check fails to
detect that top transaction is still active and sends a token back to client anyway
leading to client error "This SqlTransaction has completed; it is no longer usable."

As a fix modify the condition to use IsTransactionBlock() instead of XID

### Issues Resolved

[BABEL-6090]

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).