### PR TITLE
fix for DB user drop query when granted some permission (#3789)

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -4108,6 +4108,49 @@ remove_entry_from_bbf_schema_perms(const char *schema_name,
 	table_close(bbf_schema_rel, RowExclusiveLock);
 }
 
+/* Removes all rows for babelfish database user from the catalog BABELFISH_SCHEMA_PERMISSIONS when a user is dropped. */
+void
+remove_user_entry_from_bbf_schema_perms(Oid user_oid)
+{
+	Relation		bbf_schema_rel;
+	HeapTuple		tuple_bbf_schema;
+	ScanKeyData		scanKey[1];
+	SysScanDesc		scan;
+	const char		*user_name = NULL;
+
+	/* Return if the Oid is invalid */
+	if (!OidIsValid(user_oid))
+		return;
+
+	user_name = GetUserNameFromId(user_oid, true);
+
+	bbf_schema_rel = table_open(get_bbf_schema_perms_oid(),
+									RowExclusiveLock);
+
+	ScanKeyEntryInitialize(&scanKey[0], 0,
+				Anum_bbf_schema_perms_grantee,
+				BTEqualStrategyNumber,
+				InvalidOid,
+				tsql_get_database_or_server_collation_oid_internal(false),
+				F_TEXTEQ,
+				CStringGetTextDatum(user_name));
+
+	scan = systable_beginscan(bbf_schema_rel,
+				get_bbf_schema_perms_idx_oid(),
+				true, NULL, 1, scanKey);
+
+	tuple_bbf_schema = systable_getnext(scan);
+	/* Multiple entries can be there */
+	while (HeapTupleIsValid(tuple_bbf_schema))
+	{
+		/* Delete the entry */
+		CatalogTupleDelete(bbf_schema_rel, &tuple_bbf_schema->t_self);
+		tuple_bbf_schema = systable_getnext(scan);
+	}
+
+	systable_endscan(scan);
+	table_close(bbf_schema_rel, RowExclusiveLock);
+}
 /*
  * Add an entry to BABELFISH_SCHEMA_PERMISSIONS table, if it doesn't exist already.
  * If exists, updates the PERMISSION column in the table.

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -378,6 +378,7 @@ extern void add_entry_to_bbf_schema_perms(const char *schema_name, const char *o
 extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
 extern void update_privileges_of_object(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant);
 extern void remove_entry_from_bbf_schema_perms(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
+extern void remove_user_entry_from_bbf_schema_perms(Oid user_oid);
 extern void add_or_update_object_in_bbf_schema(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant, const char *func_args);
 extern void clean_up_bbf_schema_permissions(const char *schema_name, const char *object_name, bool is_schema);
 extern void grant_perms_to_objects_in_schema(const char *schema_name, int permission, const char *grantee);

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4075,6 +4075,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									pfree(rolspec->rolename);
 
 									rolspec->rolename = user_name;
+									bbf_shdep_drop_owned_dependent_acl((Oid) role_oid, DROP_CASCADE);
 								}
 							}
 							else

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -19,6 +19,7 @@
 #include "access/xact.h"
 #include "catalog/binary_upgrade.h"
 #include "catalog/catalog.h"
+#include "catalog/pg_shdepend.h"
 #include "catalog/dependency.h"
 #include "catalog/heap.h"
 #include "catalog/indexing.h"
@@ -58,6 +59,7 @@
 #include "pltsql.h"
 #include "dbcmds.h"
 #include "utils/guc.h"
+#include "catalog/pg_default_acl.h"
 
 #include <ctype.h>
 
@@ -3312,4 +3314,128 @@ drop_db_owner_related_roles(Oid roleid, const char* rolname)
 		pfree(query.data);
 		pfree(obj_rolname);
 	}
+}
+
+/* 
+ * Function bbf_shdep_drop_owned_dependent_acl() is being forked from pg function shdepDropOwned()
+ * Check if the object is grantor of any permission, if yes then do not allow to drop the user.
+ * If not grantor, revoke the permissions from an object present in Dependent ACL list within the same database.
+ */
+void
+bbf_shdep_drop_owned_dependent_acl(Oid roleid, DropBehavior behavior)
+{
+	Relation			sdepRel;
+	ScanKeyData 		key[2];
+	SysScanDesc 		scan;
+	HeapTuple			tuple;
+	bool				user_is_grantor = false;
+
+	sdepRel = table_open(SharedDependRelationId, RowExclusiveLock);
+
+	/* Doesn't work for pinned objects */
+	if (IsPinnedObject(AuthIdRelationId, roleid))
+	{
+		ObjectAddress obj;
+		obj.classId = AuthIdRelationId;
+		obj.objectId = roleid;
+		obj.objectSubId = 0;
+		ereport(ERROR,
+				(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+				 errmsg("cannot drop objects owned by %s because they are "
+						"required by the database system",
+						getObjectDescription(&obj, false))));
+	}
+
+	ScanKeyInit(&key[0],
+				Anum_pg_shdepend_refclassid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(AuthIdRelationId));
+
+	ScanKeyInit(&key[1],
+				Anum_pg_shdepend_refobjid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(roleid));
+
+	scan = systable_beginscan(sdepRel, SharedDependReferenceIndexId, true,
+							  NULL, 2, key);
+
+	while ((tuple = systable_getnext(scan)) != NULL)
+	{
+		Form_pg_shdepend sdepForm = (Form_pg_shdepend) GETSTRUCT(tuple);
+		/*
+		 * We only operate on shared objects and objects in the current
+		 * database
+		 */
+		if (sdepForm->dbid != MyDatabaseId &&
+			sdepForm->dbid != InvalidOid)
+			break;
+
+		if (sdepForm->deptype != SHARED_DEPENDENCY_ACL)
+			break;
+
+		/*
+			* Dependencies on role grants are recorded using
+			* SHARED_DEPENDENCY_ACL, but unlike a regular ACL list
+			* which stores all permissions for a particular object in
+			* a single ACL array, there's a separate catalog row for
+			* each grant - so removing the grant just means removing
+			* the entire row.
+			*/
+		if (sdepForm->classid != AuthMemRelationId)
+		{
+
+			if (sdepForm->classid != DefaultAclRelationId)
+			{
+				HeapTuple		tup;
+				bool			isNull;
+				Datum			aclDatum;
+				Acl				*old_acl = NULL;
+				Oid relOid =	sdepForm->objid;
+				int cacheid =	get_object_catcache_oid(sdepForm->classid);
+
+				tup = SearchSysCache1(cacheid, ObjectIdGetDatum(relOid));
+				if (!HeapTupleIsValid(tuple))
+					elog(ERROR, "cache lookup failed for relation %u", relOid);
+
+				aclDatum = SysCacheGetAttr(cacheid, tup, get_object_attnum_acl(sdepForm->classid),
+										&isNull);
+				if (!isNull)
+				{
+					/* 
+						* Check if the current user is grantor for any permission in current object acl
+						* If yes then do not allow to drop the user
+						*/
+					const AclItem *acldat;
+					old_acl = DatumGetAclPCopy(aclDatum);
+					acldat = ACL_DAT(old_acl);
+
+					for (int i = 0; i < ACL_NUM(old_acl); i++)
+					{
+						const AclItem *ai = &acldat[i];
+
+						/* no need to remove if grantor */
+						if (ai->ai_grantor == roleid)
+							user_is_grantor = true;
+					}
+				}
+
+				ReleaseSysCache(tup);
+				if (!old_acl)
+					pfree(old_acl);
+			}
+			if (!user_is_grantor)
+			{
+				RemoveRoleFromObjectACL(roleid,
+										sdepForm->classid,
+										sdepForm->objid);
+			}
+		}
+	}
+
+	/* Update the catalog after deleting the user if user is not grantor. */
+	if (!user_is_grantor)
+		remove_user_entry_from_bbf_schema_perms(roleid);
+
+	systable_endscan(scan);
+	table_close(sdepRel, RowExclusiveLock);
 }

--- a/contrib/babelfishpg_tsql/src/rolecmds.h
+++ b/contrib/babelfishpg_tsql/src/rolecmds.h
@@ -90,5 +90,6 @@ extern bool is_grantee_role_db_owner(GrantRoleStmt *stmt);
 extern void change_object_owner_if_db_owner(void);
 extern char* get_obj_role(const char *rolname);
 extern void grant_revoke_role_to_login(const char* login, const char *role_name, const char *grantor, bool is_grant);
+extern void bbf_shdep_drop_owned_dependent_acl(Oid roleoids, DropBehavior behavior);
 
 #endif

--- a/test/JDBC/expected/BABEL-ROLE.out
+++ b/test/JDBC/expected/BABEL-ROLE.out
@@ -783,6 +783,48 @@ GO
 DROP DATABASE db1
 GO
 
+--Drop user when user has some permissions
+create database mydb
+go
+use mydb
+go
+create login babel_role_login with password = '123'
+go
+create user babel_role_user for login babel_role_login
+go
+create table t_role(a int)
+go
+grant select on t_role to babel_role_user
+go
+drop user babel_role_user
+go
+drop login babel_role_login
+go
+drop table t_role
+go
+use master
+GO
+drop database mydb
+GO
+-- Case: when user is granted with some permissions over schema
+create schema role_sch1
+go
+create login babel_role_login with password = '123'
+go
+create user babel_role_user for login babel_role_login
+go
+grant select on schema::sch1 to babel_role_user
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "sch1" does not exist)~~
+
+drop user babel_role_user
+go
+drop login babel_role_login
+go
+drop schema role_sch1
+go
 -- Check if catalog is cleaned up
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext

--- a/test/JDBC/expected/restrict_drop_user_role.out
+++ b/test/JDBC/expected/restrict_drop_user_role.out
@@ -1,4 +1,22 @@
 -- tsql
+create login l1 with password = '123'
+go
+create user u1 for login l1
+go
+create schema sch authorization u1
+go
+create login l2 with password = '123'
+go
+create user u2 for login l2
+go
+create login l3 with password = '123'
+go
+create user u3 for login l3
+go
+create table grant_tbl(a int)
+go
+grant select on grant_tbl to u2 with grant option
+go
 create login no_priv_login1 with password = '12345678'
 go
 
@@ -34,6 +52,73 @@ go
 
 use master
 go
+-- tsql user=l1 password=123
+-- case-0 - user is owner of an object 
+create table sch.t1(a int)
+go
+-- tsql
+drop user u1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "master_u1" cannot be dropped because some objects depend on it)~~
+
+-- tsql user=l1 password=123
+drop table sch.t1
+go
+drop schema sch
+go
+-- terminate-tsql-conn user=l1 password=123
+
+-- psql 
+select * from sys.BABELFISH_SCHEMA_PERMISSIONS;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+1#!#dbo#!#grant_tbl#!#2#!#master_u2#!#r#!#<NULL>#!#<NULL>
+~~END~~
+
+-- tsql user=l2 password=123
+-- case: User is grantor of permission  
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+grant select on grant_tbl to u3
+go
+-- terminate-tsql-conn user=l2 password=123
+
+-- tsql 
+-- Not able to drop the user since u2 is grantor of permission on grant_tbl to u3
+drop user u2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "master_u2" cannot be dropped because some objects depend on it)~~
+
+drop table grant_tbl
+go
+-- Able to drop since we dropped the table grant_tbl
+drop user u2
+go
+drop login l2
+go
+drop user u3
+go
+drop login l3
+go
+
+-- psql 
+-- the catalog get updated
+select * from sys.BABELFISH_SCHEMA_PERMISSIONS;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+~~END~~
+
 
 -- tsql user=no_priv_login1 password=12345678
 -- case-1 - when current user is guest
@@ -338,6 +423,12 @@ drop login no_priv_login3
 go
 
 drop database restrict_user_db1
+go
+
+drop user u1
+go
+
+drop login l1
 go
 
 -- tsql

--- a/test/JDBC/expected/single_db/restrict_drop_user_role.out
+++ b/test/JDBC/expected/single_db/restrict_drop_user_role.out
@@ -1,4 +1,22 @@
 -- tsql
+create login l1 with password = '123'
+go
+create user u1 for login l1
+go
+create schema sch authorization u1
+go
+create login l2 with password = '123'
+go
+create user u2 for login l2
+go
+create login l3 with password = '123'
+go
+create user u3 for login l3
+go
+create table grant_tbl(a int)
+go
+grant select on grant_tbl to u2 with grant option
+go
 create login no_priv_login1 with password = '12345678'
 go
 
@@ -34,6 +52,73 @@ go
 
 use master
 go
+-- tsql user=l1 password=123
+-- case-0 - user is owner of an object 
+create table sch.t1(a int)
+go
+-- tsql
+drop user u1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "master_u1" cannot be dropped because some objects depend on it)~~
+
+-- tsql user=l1 password=123
+drop table sch.t1
+go
+drop schema sch
+go
+-- terminate-tsql-conn user=l1 password=123
+
+-- psql 
+select * from sys.BABELFISH_SCHEMA_PERMISSIONS;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+1#!#dbo#!#grant_tbl#!#2#!#master_u2#!#r#!#<NULL>#!#<NULL>
+~~END~~
+
+-- tsql user=l2 password=123
+-- case: User is grantor of permission  
+select current_user;
+go
+~~START~~
+varchar
+u2
+~~END~~
+
+grant select on grant_tbl to u3
+go
+-- terminate-tsql-conn user=l2 password=123
+
+-- tsql 
+-- Not able to drop the user since u2 is grantor of permission on grant_tbl to u3
+drop user u2
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: role "master_u2" cannot be dropped because some objects depend on it)~~
+
+drop table grant_tbl
+go
+-- Able to drop since we dropped the table grant_tbl
+drop user u2
+go
+drop login l2
+go
+drop user u3
+go
+drop login l3
+go
+
+-- psql 
+-- the catalog get updated
+select * from sys.BABELFISH_SCHEMA_PERMISSIONS;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+~~END~~
+
 
 -- tsql user=no_priv_login1 password=12345678
 -- case-1 - when current user is guest
@@ -338,6 +423,12 @@ drop login no_priv_login3
 go
 
 drop database restrict_user_db1
+go
+
+drop user u1
+go
+
+drop login l1
 go
 
 -- tsql

--- a/test/JDBC/input/BABEL-ROLE.sql
+++ b/test/JDBC/input/BABEL-ROLE.sql
@@ -475,6 +475,44 @@ GO
 DROP DATABASE db1
 GO
 
+--Drop user when user has some permissions
+create database mydb
+go
+use mydb
+go
+create login babel_role_login with password = '123'
+go
+create user babel_role_user for login babel_role_login
+go
+create table t_role(a int)
+go
+grant select on t_role to babel_role_user
+go
+drop user babel_role_user
+go
+drop login babel_role_login
+go
+drop table t_role
+go
+use master
+GO
+drop database mydb
+GO
+-- Case: when user is granted with some permissions over schema
+create schema role_sch1
+go
+create login babel_role_login with password = '123'
+go
+create user babel_role_user for login babel_role_login
+go
+grant select on schema::sch1 to babel_role_user
+go
+drop user babel_role_user
+go
+drop login babel_role_login
+go
+drop schema role_sch1
+go
 -- Check if catalog is cleaned up
 SELECT rolname, type, orig_username, database_name
 FROM sys.babelfish_authid_user_ext

--- a/test/JDBC/input/restrict_drop_user_role.mix
+++ b/test/JDBC/input/restrict_drop_user_role.mix
@@ -1,5 +1,23 @@
 -- single_db_mode_expected
 -- tsql
+create login l1 with password = '123'
+go
+create user u1 for login l1
+go
+create schema sch authorization u1
+go
+create login l2 with password = '123'
+go
+create user u2 for login l2
+go
+create login l3 with password = '123'
+go
+create user u3 for login l3
+go
+create table grant_tbl(a int)
+go
+grant select on grant_tbl to u2 with grant option
+go
 create login no_priv_login1 with password = '12345678'
 go
 
@@ -34,6 +52,51 @@ create user no_priv_user1 for login no_priv_login1
 go
 
 use master
+go
+-- case-0 - user is owner of an object 
+-- tsql user=l1 password=123
+create table sch.t1(a int)
+go
+-- tsql
+drop user u1
+go
+-- tsql user=l1 password=123
+drop table sch.t1
+go
+drop schema sch
+go
+-- terminate-tsql-conn user=l1 password=123
+
+-- psql 
+select * from sys.BABELFISH_SCHEMA_PERMISSIONS;
+go
+-- case: User is grantor of permission  
+-- tsql user=l2 password=123
+select current_user;
+go
+grant select on grant_tbl to u3
+go
+-- terminate-tsql-conn user=l2 password=123
+
+-- tsql 
+-- Not able to drop the user since u2 is grantor of permission on grant_tbl to u3
+drop user u2
+go
+drop table grant_tbl
+go
+-- Able to drop since we dropped the table grant_tbl
+drop user u2
+go
+drop login l2
+go
+drop user u3
+go
+drop login l3
+go
+
+-- psql 
+-- the catalog get updated
+select * from sys.BABELFISH_SCHEMA_PERMISSIONS;
 go
 
 -- case-1 - when current user is guest
@@ -223,6 +286,12 @@ drop login no_priv_login3
 go
 
 drop database restrict_user_db1
+go
+
+drop user u1
+go
+
+drop login l1
 go
 
 -- 3.5 - Try dropping user created for another database


### PR DESCRIPTION
Cherry-picked from :https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3789
### Description

Problem : If a user having some permissions over an object then we are not able to drop the user, which is not same as TSQL behaviour.Note:  in postgres we can't drop a role before dropping it's dependencies.
Fix: we have to remove the grants(permission) given to the user via shared_dependency_acl before dropping the user.

- Added a check if user is grantor of some permissions then it can't be dropped. 
- After dropping the user remove the entries corresponding to that user from schema permission catalog.
- To implement we have created a new function bbf_shdep_drop_owned_dependent_acl (forked from pg function shdepDropOwned).

### Issues Resolved
[BABEL-3026]

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).