### PR TITLE
Fix column-level permissions loss during ALTER VIEW operations

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -70,6 +70,7 @@
 #include "utils/plancache.h"
 #include "utils/ps_status.h"
 #include "utils/queryenvironment.h"
+#include "utils/catcache.h"
 #include "utils/rel.h"
 #include "utils/relcache.h"
 #include "utils/snapmgr.h"
@@ -147,6 +148,8 @@ static void set_pgtype_byval(List *name, bool byval);
 static void pltsql_proc_get_oid_proname_proacl(AlterFunctionStmt *stmt, ParseState *pstate, Oid *oid, Acl **acl, bool *isSameFunc, bool is_proc);
 static Acl *get_old_view_acl(Oid oldViewOid);
 static void pg_class_update_acl(Oid newViewOid, Acl *oldViewAcl);
+static List *get_old_view_column_acls(Oid oldViewOid);
+static void restore_view_column_acls(Oid newViewOid, List *column_acls);
 static bool pltsql_truncate_identifier(char *ident, int len, bool warn);
 static Name pltsql_cstr_to_name(char *s, int len);
 extern void pltsql_add_guc_plan(CachedPlanSource *plansource);
@@ -186,6 +189,12 @@ static int isolation_to_int(char *isolation_level);
 static void bbf_set_tran_isolation(char *new_isolation_level_str);
 static void gen_command_grant_revoke_priv_to_role(StringInfo query, const char *rolename,
 							bool is_grant, Oid login_oid);
+
+typedef struct ColumnAclInfo
+{
+    char       *attname;   /* Column name */
+    Acl        *acl;       /* ACL for the column */
+} ColumnAclInfo;
 
 typedef struct {
 	int oid;
@@ -2941,6 +2950,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					ObjectAddress address, originalView;
 					Oid oldViewOid;
 					Acl *oldViewAcl = NULL;
+					List *oldColumnAcls = NIL;
 					bool isCompleteQuery = (context != PROCESS_UTILITY_SUBCOMMAND);
 					bool needCleanup;
 			
@@ -2992,6 +3002,9 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 						{
 							/* Save ACL before dropping the view */
 							oldViewAcl = get_old_view_acl(oldViewOid);
+
+							/* Save column ACLs before dropping the view */
+							oldColumnAcls = get_old_view_column_acls(oldViewOid);
 							CacheInvalidateRelcacheByRelid(oldViewOid);
 			
 							/* Drop the old view */
@@ -3030,6 +3043,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 
 							/* Update ACL info */
 							pg_class_update_acl(address.objectId, oldViewAcl);
+							restore_view_column_acls(address.objectId, oldColumnAcls);
 
 							if(oldViewAcl != NULL)
 								pfree(oldViewAcl);
@@ -5184,6 +5198,111 @@ pg_class_update_acl(Oid newViewOid, Acl *oldViewAcl)
 	ReleaseSysCache(classtup);
 	heap_freetuple(newtup);
 	table_close(pg_class_rel, RowExclusiveLock);
+}
+
+static List *
+get_old_view_column_acls(Oid oldViewOid)
+{
+	CatCList *catlist;
+	List *column_acls = NIL;
+	int i;
+
+	catlist = SearchSysCacheList1(ATTNUM, ObjectIdGetDatum(oldViewOid));
+
+	for (i = 0; i < catlist->n_members; i++)
+	{
+		HeapTuple tuple = &catlist->members[i]->tuple;
+		Form_pg_attribute att = (Form_pg_attribute) GETSTRUCT(tuple);
+		Datum aclDatum;
+		bool isNull;
+		ColumnAclInfo *info;
+
+		/* Skip system columns */
+		if (att->attnum <= InvalidAttrNumber)
+			continue;
+
+		aclDatum = SysCacheGetAttr(ATTNUM, tuple, 
+								Anum_pg_attribute_attacl, &isNull);
+
+		info = (ColumnAclInfo *) palloc0(sizeof(ColumnAclInfo));
+		info->attname = pstrdup(NameStr(att->attname));
+		info->acl = isNull ? NULL : DatumGetAclPCopy(aclDatum);
+
+		column_acls = lappend(column_acls, info);
+	}
+
+	ReleaseCatCacheList(catlist);
+	return column_acls;
+}
+
+static void
+restore_view_column_acls(Oid newViewOid, List *column_acls)
+{
+	ListCell *lc;
+	
+	foreach(lc, column_acls)
+	{
+		ColumnAclInfo *info = (ColumnAclInfo *) lfirst(lc);
+		Relation pg_attribute_rel;
+		HeapTuple attTup = NULL;
+		CatCList *catlist;
+		bool found = false;
+		Datum values[Natts_pg_attribute];
+		bool nulls[Natts_pg_attribute];
+		bool replaces[Natts_pg_attribute];
+		HeapTuple newTuple;
+		
+		catlist = SearchSysCacheList1(ATTNUM, ObjectIdGetDatum(newViewOid));
+		
+		/* Search for case-insensitive match */
+		for (int i = 0; i < catlist->n_members; i++)
+		{
+			HeapTuple  tuple = &catlist->members[i]->tuple;
+			Form_pg_attribute att = (Form_pg_attribute) GETSTRUCT(tuple);
+			
+			/* Skip system columns */
+			if (att->attnum <= InvalidAttrNumber)
+				continue;
+				
+			/* Case-insensitive comparison */
+			if (pg_strcasecmp(NameStr(att->attname), info->attname) == 0)
+			{
+				attTup = SearchSysCacheCopy2(ATTNUM,
+										ObjectIdGetDatum(newViewOid),
+										Int16GetDatum(att->attnum));
+				found = true;
+				break;
+			}
+		}
+		
+		ReleaseCatCacheList(catlist);
+		
+		if (!found || !HeapTupleIsValid(attTup))
+			continue;
+		
+		/* Update the ACL */
+		pg_attribute_rel = table_open(AttributeRelationId, RowExclusiveLock);
+		
+		memset(values, 0, sizeof(values));
+		memset(nulls, false, sizeof(nulls));
+		memset(replaces, false, sizeof(replaces));
+		
+		if (info->acl != NULL)
+			values[Anum_pg_attribute_attacl - 1] = PointerGetDatum(info->acl);
+		else
+			nulls[Anum_pg_attribute_attacl - 1] = true;
+			
+		replaces[Anum_pg_attribute_attacl - 1] = true;
+		
+		newTuple = heap_modify_tuple(attTup, RelationGetDescr(pg_attribute_rel),
+								values, nulls, replaces);
+								
+		CatalogTupleUpdate(pg_attribute_rel, &newTuple->t_self, newTuple);
+		heap_freetuple(newTuple);
+		heap_freetuple(attTup);
+		
+		table_close(pg_attribute_rel, RowExclusiveLock);
+	}
 }
 
 /*

--- a/test/JDBC/expected/alter-view-acl.out
+++ b/test/JDBC/expected/alter-view-acl.out
@@ -116,6 +116,9 @@ GO
 CREATE TABLE test_schema.base_table (id INT PRIMARY KEY, name VARCHAR(50), email VARCHAR(100));
 GO
 
+CREATE TABLE test_schema.base_table1 ( id INT PRIMARY KEY, name VARCHAR(50), email VARCHAR(100), age INT, salary DECIMAL(10,2) );
+GO
+
 INSERT INTO test_schema.base_table VALUES (1, 'John', 'john@test.com'), (2, 'Jane', 'jane@test.com');
 GO
 ~~ROW COUNT: 2~~
@@ -125,6 +128,9 @@ GO
 CREATE VIEW test_schema.test_view as select * from test_schema.base_table
 GO
 
+CREATE VIEW test_schema.colacl_view1 as select 1 as a, 2 as b, 3 as c;
+GO
+
 -- Verify view_owner can select from view
 SELECT * FROM test_schema.test_view;
 GO
@@ -132,6 +138,107 @@ GO
 int#!#varchar#!#varchar
 1#!#John#!#john@test.com
 2#!#Jane#!#jane@test.com
+~~END~~
+
+
+SELECT * FROM test_schema.colacl_view1;
+GO
+~~START~~
+int#!#int#!#int
+1#!#2#!#3
+~~END~~
+
+
+-- Create view with 3 columns
+CREATE VIEW test_schema.test_view1 AS 
+SELECT id, name, email FROM test_schema.base_table1;
+GO
+
+-- Grant permissions
+GRANT SELECT ON test_schema.test_view1(id, name) TO view_user;
+GO
+
+-- psql
+-- Print initial permissions
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view1' AND
+    COLUMN_NAME IN ('id', 'name')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
+GO
+~~START~~
+name#!#name#!#varchar
+test_view1#!#id#!#INSERT
+test_view1#!#id#!#INSERT
+test_view1#!#id#!#REFERENCES
+test_view1#!#id#!#SELECT
+test_view1#!#id#!#SELECT
+test_view1#!#id#!#SELECT
+test_view1#!#id#!#UPDATE
+test_view1#!#id#!#UPDATE
+test_view1#!#name#!#INSERT
+test_view1#!#name#!#INSERT
+test_view1#!#name#!#REFERENCES
+test_view1#!#name#!#SELECT
+test_view1#!#name#!#SELECT
+test_view1#!#name#!#SELECT
+test_view1#!#name#!#UPDATE
+test_view1#!#name#!#UPDATE
+~~END~~
+
+
+-- tsql user=view_owner_login password=12345678
+-- Alter view to have 4+ columns
+ALTER VIEW test_schema.test_view1 AS
+SELECT 
+    id,
+    name AS "NAME" , -- Same name as existing column, different case
+    email,
+    age,
+    salary,
+    UPPER(name) AS new_column
+FROM 
+    test_schema.base_table1;
+GO
+
+-- psql
+-- Print permissions after alteration
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view1' AND
+    COLUMN_NAME IN ('id', 'NAME')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
+GO
+~~START~~
+name#!#name#!#varchar
+test_view1#!#NAME#!#INSERT
+test_view1#!#NAME#!#INSERT
+test_view1#!#NAME#!#REFERENCES
+test_view1#!#NAME#!#SELECT
+test_view1#!#NAME#!#SELECT
+test_view1#!#NAME#!#SELECT
+test_view1#!#NAME#!#UPDATE
+test_view1#!#NAME#!#UPDATE
+test_view1#!#id#!#INSERT
+test_view1#!#id#!#INSERT
+test_view1#!#id#!#REFERENCES
+test_view1#!#id#!#SELECT
+test_view1#!#id#!#SELECT
+test_view1#!#id#!#SELECT
+test_view1#!#id#!#UPDATE
+test_view1#!#id#!#UPDATE
 ~~END~~
 
 
@@ -148,6 +255,50 @@ GO
 ~~ERROR (Message: permission denied for view test_view)~~
 
 
+SELECT * FROM test_schema.colacl_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view colacl_view1)~~
+
+
+-- This should succeed (has permissions)
+SELECT id, "NAME" FROM test_schema.test_view1;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+SELECT id, name FROM test_schema.test_view1;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- These should fail (no permissions)
+SELECT email FROM test_schema.test_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view1)~~
+
+
+SELECT age FROM test_schema.test_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view1)~~
+
+
+SELECT new_column FROM test_schema.test_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view1)~~
+
+
 -- tsql user=view_owner_login password=12345678
 -- Grant permission to view_user
 USE view_perm_db;
@@ -155,6 +306,115 @@ GO
 
 GRANT SELECT ON test_schema.test_view TO view_user;
 GO
+
+GRANT SELECT ON test_schema.colacl_view1(a, c) TO view_user;
+GO
+
+CREATE VIEW test_schema.test_view2 (col1, col2, col3) AS
+SELECT id, name, email FROM test_schema.base_table1;
+GO
+
+-- Grant permissions
+GRANT SELECT ON test_schema.test_view2(col1, col2) TO view_user;
+GO
+
+-- psql
+-- Print initial permissions
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view2' AND
+    COLUMN_NAME IN ('col1', 'col2', 'col3')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
+GO
+~~START~~
+name#!#name#!#varchar
+test_view2#!#col1#!#INSERT
+test_view2#!#col1#!#INSERT
+test_view2#!#col1#!#REFERENCES
+test_view2#!#col1#!#SELECT
+test_view2#!#col1#!#SELECT
+test_view2#!#col1#!#SELECT
+test_view2#!#col1#!#UPDATE
+test_view2#!#col1#!#UPDATE
+test_view2#!#col2#!#INSERT
+test_view2#!#col2#!#INSERT
+test_view2#!#col2#!#REFERENCES
+test_view2#!#col2#!#SELECT
+test_view2#!#col2#!#SELECT
+test_view2#!#col2#!#SELECT
+test_view2#!#col2#!#UPDATE
+test_view2#!#col2#!#UPDATE
+test_view2#!#col3#!#INSERT
+test_view2#!#col3#!#INSERT
+test_view2#!#col3#!#REFERENCES
+test_view2#!#col3#!#SELECT
+test_view2#!#col3#!#SELECT
+test_view2#!#col3#!#UPDATE
+test_view2#!#col3#!#UPDATE
+~~END~~
+
+
+-- tsql user=view_owner_login password=12345678
+-- Alter view with explicit column aliases
+ALTER VIEW test_schema.test_view2 (col1, COL2, col3, col4, col5, col6) AS
+SELECT 
+    id,
+    name,
+    email,
+    age,
+    salary,
+    UPPER(name)
+FROM 
+    test_schema.base_table1;
+GO
+
+-- psql
+-- Print permissions after alteration
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view2' AND
+    COLUMN_NAME IN ('col1', 'col2', 'col3')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
+GO
+~~START~~
+name#!#name#!#varchar
+test_view2#!#col1#!#INSERT
+test_view2#!#col1#!#INSERT
+test_view2#!#col1#!#REFERENCES
+test_view2#!#col1#!#SELECT
+test_view2#!#col1#!#SELECT
+test_view2#!#col1#!#SELECT
+test_view2#!#col1#!#UPDATE
+test_view2#!#col1#!#UPDATE
+test_view2#!#col2#!#INSERT
+test_view2#!#col2#!#INSERT
+test_view2#!#col2#!#REFERENCES
+test_view2#!#col2#!#SELECT
+test_view2#!#col2#!#SELECT
+test_view2#!#col2#!#SELECT
+test_view2#!#col2#!#UPDATE
+test_view2#!#col2#!#UPDATE
+test_view2#!#col3#!#INSERT
+test_view2#!#col3#!#INSERT
+test_view2#!#col3#!#REFERENCES
+test_view2#!#col3#!#SELECT
+test_view2#!#col3#!#SELECT
+test_view2#!#col3#!#UPDATE
+test_view2#!#col3#!#UPDATE
+~~END~~
+
 
 -- tsql user=view_user_login password=12345678
 -- Now view_user should be able to select
@@ -171,6 +431,78 @@ int#!#varchar#!#varchar
 ~~END~~
 
 
+SELECT a FROM test_schema.colacl_view1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+--This should fail
+SELECT b FROM test_schema.colacl_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view colacl_view1)~~
+
+
+SELECT c FROM test_schema.colacl_view1;
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT * FROM test_schema.colacl_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view colacl_view1)~~
+
+
+-- These should succeed (has permissions)
+SELECT col1, col2 FROM test_schema.test_view2;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+SELECT col1, COL2 FROM test_schema.test_view2;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+-- These should fail (no permissions)
+SELECT col3 FROM test_schema.test_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view2)~~
+
+SELECT col4 FROM test_schema.test_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view2)~~
+
+SELECT col5 FROM test_schema.test_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view2)~~
+
+SELECT col6 FROM test_schema.test_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for view test_view2)~~
+
+
 -- tsql user=view_owner_login password=12345678
 -- Alter view as view_owner
 USE view_perm_db;
@@ -181,6 +513,9 @@ AS
     SELECT id, name FROM test_schema.base_table;
 GO
 
+ALTER VIEW test_schema.colacl_view1 AS SELECT 2 AS a;
+GO
+
 -- Verify view_owner can still access
 SELECT * FROM test_schema.test_view;
 GO
@@ -188,6 +523,14 @@ GO
 int#!#varchar
 1#!#John
 2#!#Jane
+~~END~~
+
+
+SELECT a FROM test_schema.colacl_view1;
+GO
+~~START~~
+int
+2
 ~~END~~
 
 
@@ -203,6 +546,14 @@ GO
 int#!#varchar
 1#!#John
 2#!#Jane
+~~END~~
+
+
+SELECT a FROM test_schema.colacl_view1;
+GO
+~~START~~
+int
+2
 ~~END~~
 
 
@@ -282,7 +633,19 @@ GO
 DROP VIEW test_schema.test_view;
 GO
 
+DROP VIEW test_schema.colacl_view1;
+GO
+
+DROP VIEW test_schema.test_view1;
+GO
+
+DROP VIEW test_schema.test_view2;
+GO
+
 DROP TABLE test_schema.base_table;
+GO
+
+DROP TABLE test_schema.base_table1;
 GO
 
 DROP SCHEMA test_schema;

--- a/test/JDBC/input/alter/alter-view-acl.mix
+++ b/test/JDBC/input/alter/alter-view-acl.mix
@@ -96,6 +96,9 @@ GO
 CREATE TABLE test_schema.base_table (id INT PRIMARY KEY, name VARCHAR(50), email VARCHAR(100));
 GO
 
+CREATE TABLE test_schema.base_table1 ( id INT PRIMARY KEY, name VARCHAR(50), email VARCHAR(100), age INT, salary DECIMAL(10,2) );
+GO
+
 INSERT INTO test_schema.base_table VALUES (1, 'John', 'john@test.com'), (2, 'Jane', 'jane@test.com');
 GO
 
@@ -103,8 +106,67 @@ GO
 CREATE VIEW test_schema.test_view as select * from test_schema.base_table
 GO
 
+CREATE VIEW test_schema.colacl_view1 as select 1 as a, 2 as b, 3 as c;
+GO
+
 -- Verify view_owner can select from view
 SELECT * FROM test_schema.test_view;
+GO
+
+SELECT * FROM test_schema.colacl_view1;
+GO
+
+-- Create view with 3 columns
+CREATE VIEW test_schema.test_view1 AS 
+SELECT id, name, email FROM test_schema.base_table1;
+GO
+
+-- Grant permissions
+GRANT SELECT ON test_schema.test_view1(id, name) TO view_user;
+GO
+
+-- psql
+-- Print initial permissions
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view1' AND
+    COLUMN_NAME IN ('id', 'name')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
+GO
+
+-- tsql user=view_owner_login password=12345678
+-- Alter view to have 4+ columns
+ALTER VIEW test_schema.test_view1 AS
+SELECT 
+    id,
+    name AS "NAME" , -- Same name as existing column, different case
+    email,
+    age,
+    salary,
+    UPPER(name) AS new_column
+FROM 
+    test_schema.base_table1;
+GO
+
+-- psql
+-- Print permissions after alteration
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view1' AND
+    COLUMN_NAME IN ('id', 'NAME')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
 GO
 
 -- Verify view_user cannot access the view yet
@@ -116,12 +178,87 @@ GO
 SELECT * FROM test_schema.test_view;
 GO
 
+SELECT * FROM test_schema.colacl_view1;
+GO
+
+-- This should succeed (has permissions)
+SELECT id, "NAME" FROM test_schema.test_view1;
+GO
+
+SELECT id, name FROM test_schema.test_view1;
+GO
+
+-- These should fail (no permissions)
+SELECT email FROM test_schema.test_view1;
+GO
+
+SELECT age FROM test_schema.test_view1;
+GO
+
+SELECT new_column FROM test_schema.test_view1;
+GO
+
 -- Grant permission to view_user
 -- tsql user=view_owner_login password=12345678
 USE view_perm_db;
 GO
 
 GRANT SELECT ON test_schema.test_view TO view_user;
+GO
+
+GRANT SELECT ON test_schema.colacl_view1(a, c) TO view_user;
+GO
+
+CREATE VIEW test_schema.test_view2 (col1, col2, col3) AS
+SELECT id, name, email FROM test_schema.base_table1;
+GO
+
+-- Grant permissions
+GRANT SELECT ON test_schema.test_view2(col1, col2) TO view_user;
+GO
+
+-- psql
+-- Print initial permissions
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view2' AND
+    COLUMN_NAME IN ('col1', 'col2', 'col3')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
+GO
+
+-- tsql user=view_owner_login password=12345678
+-- Alter view with explicit column aliases
+ALTER VIEW test_schema.test_view2 (col1, COL2, col3, col4, col5, col6) AS
+SELECT 
+    id,
+    name,
+    email,
+    age,
+    salary,
+    UPPER(name)
+FROM 
+    test_schema.base_table1;
+GO
+
+-- psql
+-- Print permissions after alteration
+SELECT
+    TABLE_NAME, 
+    COLUMN_NAME, 
+    PRIVILEGE_TYPE
+FROM 
+    INFORMATION_SCHEMA.COLUMN_PRIVILEGES
+WHERE 
+    TABLE_NAME = 'test_view2' AND
+    COLUMN_NAME IN ('col1', 'col2', 'col3')
+ORDER BY 
+    COLUMN_NAME, PRIVILEGE_TYPE;
 GO
 
 -- Now view_user should be able to select
@@ -131,6 +268,36 @@ GO
 
 -- This should succeed
 SELECT * FROM test_schema.test_view;
+GO
+
+SELECT a FROM test_schema.colacl_view1;
+GO
+
+--This should fail
+SELECT b FROM test_schema.colacl_view1;
+GO
+
+SELECT c FROM test_schema.colacl_view1;
+GO
+
+SELECT * FROM test_schema.colacl_view1;
+GO
+
+-- These should succeed (has permissions)
+SELECT col1, col2 FROM test_schema.test_view2;
+GO
+
+SELECT col1, COL2 FROM test_schema.test_view2;
+GO
+
+-- These should fail (no permissions)
+SELECT col3 FROM test_schema.test_view2;
+GO
+SELECT col4 FROM test_schema.test_view2;
+GO
+SELECT col5 FROM test_schema.test_view2;
+GO
+SELECT col6 FROM test_schema.test_view2;
 GO
 
 -- Alter view as view_owner
@@ -143,8 +310,14 @@ AS
     SELECT id, name FROM test_schema.base_table;
 GO
 
+ALTER VIEW test_schema.colacl_view1 AS SELECT 2 AS a;
+GO
+
 -- Verify view_owner can still access
 SELECT * FROM test_schema.test_view;
+GO
+
+SELECT a FROM test_schema.colacl_view1;
 GO
 
 -- Verify view_user can still access after alter
@@ -154,6 +327,9 @@ GO
 
 -- This should succeed as permissions are retained
 SELECT * FROM test_schema.test_view;
+GO
+
+SELECT a FROM test_schema.colacl_view1;
 GO
 
 -- Revoke permission to view_user
@@ -213,7 +389,19 @@ GO
 DROP VIEW test_schema.test_view;
 GO
 
+DROP VIEW test_schema.colacl_view1;
+GO
+
+DROP VIEW test_schema.test_view1;
+GO
+
+DROP VIEW test_schema.test_view2;
+GO
+
 DROP TABLE test_schema.base_table;
+GO
+
+DROP TABLE test_schema.base_table1;
 GO
 
 DROP SCHEMA test_schema;


### PR DESCRIPTION
Cherry-Picked from BABEL_5_X_DEV
PR link: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4036
### Description

This PR fixes an issue where column-level permissions were being lost when a view was modified using ALTER VIEW. While view-level ACLs were correctly preserved, column-level ACLs stored in pg_attribute.attacl were not being carried over to the new view definition.

#### Changes:
- Added a `ColumnAclInfo` structure to store column permission information
- `get_old_view_column_acls()` to retrieve column-level ACLs before view alteration
- `restore_view_column_acls()` to restore column-level ACLs after view recreation

### Issues Resolved

BABEL-5936

Signed off: Rahul Parande rparande@amazon.com

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).