### PR TITLE
Handling empty string for isnumeric()

### DIFF
--- a/contrib/babelfishpg_common/src/babelfishpg_common.c
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.c
@@ -222,6 +222,8 @@ get_common_utility_plugin(void)
 		common_utility_plugin_var.initializeToDefaultTime = &initializeToDefaultTime;
 		common_utility_plugin_var.roundoff_datetime = &roundoff_datetime;
 		common_utility_plugin_var.UpdateToNextDayHelper = &UpdateToNextDayHelper;
+		common_utility_plugin_var.isEmptyOrWhitespace = &isEmptyOrWhitespace;
+
 	}
 	return &common_utility_plugin_var;
 }

--- a/contrib/babelfishpg_common/src/babelfishpg_common.h
+++ b/contrib/babelfishpg_common/src/babelfishpg_common.h
@@ -69,6 +69,7 @@ typedef struct common_utility_plugin
 	bool		(*is_tsql_tinyint_datatype) (Oid oid);
 	bool		(*is_tsql_money_datatype) (Oid oid);
 	bool		(*is_tsql_smallmoney_datatype) (Oid oid);
+	bool		(*isEmptyOrWhitespace) (const char *str);
 	
 	Datum		(*datetime_in_str) (char *str, Node *escontext);
 	Datum		(*datetime2sqlvariant) (PG_FUNCTION_ARGS);

--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2223,6 +2223,26 @@ isnumeric(PG_FUNCTION_ARGS)
 			PG_RETURN_INT32(1);
 	}
 
+	/* Get the string representation from input datum. */
+	if (argtypeid == TEXTOID)
+	{
+		value_str = text_to_cstring(PG_GETARG_TEXT_P(0));
+	}
+	else
+	{
+		Oid typoutput;
+		bool typisvarlena;
+		getTypeOutputInfo(argtypeid, &typoutput, &typisvarlena);
+		value_str = OidOutputFunctionCall(typoutput, PG_GETARG_DATUM(0));
+	}
+
+	/* Handling empty string. */
+	if ((*common_utility_plugin_ptr->isEmptyOrWhitespace)(value_str))
+	{
+		pfree(value_str);
+		PG_RETURN_INT32(0);
+	}
+
 	/* Get or initialize the cached data. */
 	my_extra = (IsNumericIOData *) fcinfo->flinfo->fn_extra;
 	if (my_extra == NULL)
@@ -2252,19 +2272,6 @@ isnumeric(PG_FUNCTION_ARGS)
 		fmgr_info_cxt(numeric_typiofunc,
 					&my_extra->numeric_inputproc,
 					fcinfo->flinfo->fn_mcxt);
-	}
-
-	/* Get the string representation from input datum. */
-	if (argtypeid == TEXTOID)
-	{
-		value_str = text_to_cstring(PG_GETARG_TEXT_P(0));
-	}
-	else
-	{
-		Oid typoutput;
-		bool typisvarlena;
-		getTypeOutputInfo(argtypeid, &typoutput, &typisvarlena);
-		value_str = OidOutputFunctionCall(typoutput, PG_GETARG_DATUM(0));
 	}
 
 	/* Try to perform the conversion to numeric. */

--- a/test/JDBC/expected/BABEL-5129-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5129-vu-verify.out
@@ -115,7 +115,7 @@ SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
 GO
 ~~START~~
 int#!#int#!#int
-1#!#0#!#0
+0#!#0#!#0
 ~~END~~
 
 
@@ -126,7 +126,7 @@ SELECT ISNUMERIC(@nv), LEN(@nv), DATALENGTH(@nv)
 GO
 ~~START~~
 int#!#int#!#int
-1#!#0#!#0
+0#!#0#!#0
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_isnumeric-vu-verify.out
+++ b/test/JDBC/expected/babel_isnumeric-vu-verify.out
@@ -229,7 +229,7 @@ select isnumeric(' ')
 GO
 ~~START~~
 int
-1
+0
 ~~END~~
 
 select isnumeric('1 .1234')
@@ -720,5 +720,375 @@ GO
 ~~START~~
 int
 1
+~~END~~
+
+
+
+-- Testing empty string 
+-- string datatypes
+select isnumeric('')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric('    ')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(cast('' as varchar))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+
+select isnumeric(cast('' as char))
+go  
+select isnumeric(cast('' as nchar))
+go
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(cast('' as nvarchar(max)))
+go
+~~START~~
+int
+0
+~~END~~
+
+           
+select isnumeric(cast('' as nvarchar(1)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(cast('' as varchar(1)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(N'')
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(cast('' as nvarchar))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(N'123')
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- binary/varbinary
+select isnumeric(cast('' as binary))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(cast('' as varbinary))
+go
+~~START~~
+int
+0
+~~END~~
+
+ 
+select isnumeric(cast('' as binary(1)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- Exact numerics 
+select isnumeric(cast('' as bigint))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('' as tinyint))
+go
+~~START~~
+int
+1
+~~END~~
+
+          
+select isnumeric(cast('' as smallint))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('' as int))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- money/smallmoney (Monetary values)
+select isnumeric(cast('' as money))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('' as smallmoney))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- real/float (Approximate)
+select isnumeric(cast('' as real))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('' as float))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- decimal/numeric (Fixed precision)
+select isnumeric(cast('' as numeric))
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An empty or space-only string cannot be converted into numeric/decimal data type)~~
+
+
+select isnumeric(cast('' as decimal))
+go
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An empty or space-only string cannot be converted into numeric/decimal data type)~~
+
+
+select isnumeric(cast('' as text))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- text/ntext
+select isnumeric(cast(12234555 as text))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('12234555' as text))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('' as ntext))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- xml
+select isnumeric(cast('' as xml))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- bit
+select isnumeric(cast('' as bit))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- large input values
+select isnumeric(1234567812345678123456781234567812345678)
+Go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast(1234567812345678123456781234567812345678 as text))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- misc tests
+select isnumeric(cast(24 as varbinary))
+Go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(cast('24' as varbinary))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- time/date/smalldatetime/datetime/datetime2/datetimeoffset
+DECLARE @inputString date = '2016-12-21';
+DECLARE @inputEmptyString date = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+DECLARE @inputEmptyString smalldatetime = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+DECLARE @inputEmptyString time(4) = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+DECLARE @inputString datetime = '2006-01-02 15:04:05'
+DECLARE @inputEmptyString datetime = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+go
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+DECLARE @inputEmptyString datetimeoffset(4) = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+DECLARE @inputEmptyString datetime2(4) = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+-- sql_variant
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant);
+DECLARE @inputEmptyString sql_variant = '';
+SELECT isnumeric(CAST(@inputString AS VARCHAR(50))), isnumeric(CAST(@inputEmptyString AS VARCHAR(50)))
+GO
+~~START~~
+int#!#int
+0#!#0
+~~END~~
+
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+DECLARE @inputEmptyString sql_variant = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+~~START~~
+int#!#int
+0#!#0
 ~~END~~
 

--- a/test/JDBC/expected/babel_isnumeric.out
+++ b/test/JDBC/expected/babel_isnumeric.out
@@ -284,7 +284,7 @@ select isnumeric(' ')
 GO
 ~~START~~
 int
-1
+0
 ~~END~~
 
 select isnumeric('1 .1234')

--- a/test/JDBC/expected/parallel_query/babel_isnumeric.out
+++ b/test/JDBC/expected/parallel_query/babel_isnumeric.out
@@ -284,7 +284,7 @@ select isnumeric(' ')
 GO
 ~~START~~
 int
-1
+0
 ~~END~~
 
 select isnumeric('1 .1234')

--- a/test/JDBC/input/babel_isnumeric-vu-verify.sql
+++ b/test/JDBC/input/babel_isnumeric-vu-verify.sql
@@ -287,3 +287,161 @@ GO
 -- Test with computed expressions
 select isnumeric(CAST(POWER(10, 3) AS varchar(50)))
 GO
+
+-- Testing empty string 
+
+-- string datatypes
+select isnumeric('')
+go
+
+select isnumeric('    ')
+go
+
+select isnumeric(cast('' as varchar))
+go
+
+select isnumeric(cast('' as char))
+go  
+
+select isnumeric(cast('' as nchar))
+go
+
+select isnumeric(cast('' as nvarchar(max)))
+go
+           
+select isnumeric(cast('' as nvarchar(1)))
+go
+
+select isnumeric(cast('' as varchar(1)))
+go
+
+select isnumeric(N'')
+go
+
+select isnumeric(cast('' as nvarchar))
+go
+
+select isnumeric(N'123')
+go
+
+-- binary/varbinary
+select isnumeric(cast('' as binary))
+go
+
+select isnumeric(cast('' as varbinary))
+go
+ 
+select isnumeric(cast('' as binary(1)))
+go
+
+-- Exact numerics 
+select isnumeric(cast('' as bigint))
+go
+
+select isnumeric(cast('' as tinyint))
+go
+          
+select isnumeric(cast('' as smallint))
+go
+
+select isnumeric(cast('' as int))
+go
+
+-- money/smallmoney (Monetary values)
+select isnumeric(cast('' as money))
+go
+
+select isnumeric(cast('' as smallmoney))
+go
+
+-- real/float (Approximate)
+select isnumeric(cast('' as real))
+go
+
+select isnumeric(cast('' as float))
+go
+
+-- decimal/numeric (Fixed precision)
+select isnumeric(cast('' as numeric))
+go
+
+select isnumeric(cast('' as decimal))
+go
+
+select isnumeric(cast('' as text))
+go
+
+-- text/ntext
+select isnumeric(cast(12234555 as text))
+go
+
+select isnumeric(cast('12234555' as text))
+go
+
+select isnumeric(cast('' as ntext))
+go
+
+-- xml
+select isnumeric(cast('' as xml))
+go
+
+-- bit
+select isnumeric(cast('' as bit))
+GO
+
+-- large input values
+select isnumeric(1234567812345678123456781234567812345678)
+Go
+
+select isnumeric(cast(1234567812345678123456781234567812345678 as text))
+go
+
+-- misc tests
+select isnumeric(cast(24 as varbinary))
+Go
+
+select isnumeric(cast('24' as varbinary))
+GO
+
+-- time/date/smalldatetime/datetime/datetime2/datetimeoffset
+DECLARE @inputString date = '2016-12-21';
+DECLARE @inputEmptyString date = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+
+
+DECLARE @inputString smalldatetime = '1955-12-13 12:43:10';
+DECLARE @inputEmptyString smalldatetime = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+
+DECLARE @inputString time(4) = '12:10:05.1237';
+DECLARE @inputEmptyString time(4) = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+
+DECLARE @inputString datetime = '2006-01-02 15:04:05'
+DECLARE @inputEmptyString datetime = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+go
+
+DECLARE @inputString datetimeoffset(4) = '1968-10-23 12:45:37.1234 +10:0';
+DECLARE @inputEmptyString datetimeoffset(4) = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+
+DECLARE @inputString datetime2(4) = '1968-10-23 12:45:37.1237';
+DECLARE @inputEmptyString datetime2(4) = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO
+
+-- sql_variant
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant);
+DECLARE @inputEmptyString sql_variant = '';
+SELECT isnumeric(CAST(@inputString AS VARCHAR(50))), isnumeric(CAST(@inputEmptyString AS VARCHAR(50)))
+GO
+
+DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' AS sql_variant)
+DECLARE @inputEmptyString sql_variant = '';
+select isnumeric(@inputString), isnumeric(@inputEmptyString);
+GO


### PR DESCRIPTION
### Description

Previously, in ISNUMERIC() we were converting the empty string input to money/smallmoney and returning the result as 1 in babelfish. This commit adds explicit handling for empty strings in ISNUMERIC() to return 0, ensuring compatibility with T-SQL behavior.

Cherry-pick PR : [#4094](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4094)

Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)

### Issues Resolved

BABEL-6082

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).