### PR TITLE
SET DATEFIRST should only accept integer arguments

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -6057,6 +6057,31 @@ makeSetStatement(TSqlParser::Set_statementContext *ctx, tsqlBuilder &builder)
 			}
 			else
 			{
+				// We add a check for DATEFIRST to only accept valid input
+				if (pg_strcasecmp("DATEFIRST", val.c_str()) == 0)
+				{
+					if(ctx->set_special()->constant_LOCAL_ID() && ctx->set_special()->constant_LOCAL_ID()->constant())
+					{
+						std::string datefirst_value = ::getFullText(ctx->set_special()->constant_LOCAL_ID()->constant());
+						char *datefirst_val = pstrdup(datefirst_value.c_str());
+						
+						// Non integral values and strings are not a valid input
+						if (strchr(datefirst_val, '.') || strchr(datefirst_val, '\''))
+						{
+							ereport(ERROR,
+								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+									errmsg("SET DATEFIRST option requires integer parameter.")));
+						}
+								
+						pfree(datefirst_val);
+					}
+					else
+					{
+						ereport(ERROR,
+							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+								errmsg("SET DATEFIRST option requires integer parameter.")));
+					}
+				}
 				// We get here for other SET options that do not fall under set_on_off_option or special_variable, like DATEFORMAT
 				return makeSQL(ctx);
 			}

--- a/test/JDBC/expected/Datetime_system_functions.out
+++ b/test/JDBC/expected/Datetime_system_functions.out
@@ -9628,10 +9628,9 @@ BEGIN CATCH
     SELECT 'PASS: SET DATEFIRST rejected non-integer value 1.5' AS NonIntegerTest;
 END CATCH
 GO
-~~START~~
-varchar
-FAIL: SET DATEFIRST accepted non-integer value 1.5
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
 
 
 
@@ -10153,7 +10152,7 @@ GO
 
 ~~START~~
 varchar
-FAIL: us_english did not set expected DATEFIRST value
+PASS: us_english sets DATEFIRST to 7 (Sunday)
 ~~END~~
 
 ~~WARNING (Code: 0)~~

--- a/test/JDBC/expected/sys-datefirst.out
+++ b/test/JDBC/expected/sys-datefirst.out
@@ -1,3 +1,12 @@
+-- Default value
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
 SELECT * FROM sys.datefirst()
 GO
 ~~START~~
@@ -22,5 +31,316 @@ GO
 ~~START~~
 int
 3
+~~END~~
+
+
+
+-- Integral Value
+-- inbound value (1-7)
+SET datefirst 2
+GO
+SELECT @@datefirst
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SET DATEFIRST 3
+GO
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SET DATEFIRST 4
+GO
+SELECT @@datefirst
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+DECLARE @i INT = 5
+SET DATEFIRST @i
+GO
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+SET DATEFIRST 6
+GO
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+6
+~~END~~
+
+
+-- edge point values 
+declare @i int = 1
+SET datefirst @i
+GO
+SELECT @@datefirst
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SET datefirst 7
+GO
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- out of bound values
+SET DATEFIRST 8
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 8 is outside the valid range for parameter "babelfishpg_tsql.datefirst" (1 .. 7))~~
+
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+SET DATEFIRST 23
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 23 is outside the valid range for parameter "babelfishpg_tsql.datefirst" (1 .. 7))~~
+
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+SET DATEFIRST 0
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 0 is outside the valid range for parameter "babelfishpg_tsql.datefirst" (1 .. 7))~~
+
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+DECLARE @i INT = -4
+SET DATEFIRST @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: -4 is outside the valid range for parameter "babelfishpg_tsql.datefirst" (1 .. 7))~~
+
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+SET DATEFIRST -55
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: -55 is outside the valid range for parameter "babelfishpg_tsql.datefirst" (1 .. 7))~~
+
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+
+
+-- Non Integral Value
+-- inbound values
+SET DATEFIRST 3.5
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET datefirst 5.68
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST 1.23
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST 6.999
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+-- edge point values
+SET DATEFIRST 1.00
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+SET DATEFIRST 7.00
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- out of bound values
+SET DATEFIRST 7.01
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST 59.0974
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST 0.99
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST -2.34
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST -65.045
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+-- arbitrary values
+SET DATEFIRST 'one'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST '4'
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST "three"
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST "2"
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SET DATEFIRST option requires integer parameter.)~~
+
+
+SET DATEFIRST NULL
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "NULL")~~
+
+
+-- should throw integer parameter required error
+DECLARE @i decimal(10,2) = 2.35
+SET DATEFIRST @i
+GO
+
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+DECLARE @i varchar = '4'
+SET DATEFIRST @i
+GO
+
+SELECT @@DATEFIRST
+GO
+~~START~~
+int
+4
 ~~END~~
 

--- a/test/JDBC/input/functions/sys-datefirst.sql
+++ b/test/JDBC/input/functions/sys-datefirst.sql
@@ -1,3 +1,7 @@
+-- Default value
+SELECT @@DATEFIRST
+GO
+
 SELECT * FROM sys.datefirst()
 GO
 
@@ -8,4 +12,151 @@ SELECT @@datefirst
 GO
 
 SELECT sys.datefirst()
+GO
+
+
+-- Integral Value
+-- inbound value (1-7)
+SET datefirst 2
+GO
+SELECT @@datefirst
+GO
+
+SET DATEFIRST 3
+GO
+SELECT @@DATEFIRST
+GO
+
+SET DATEFIRST 4
+GO
+SELECT @@datefirst
+GO
+
+DECLARE @i INT = 5
+SET DATEFIRST @i
+GO
+SELECT @@DATEFIRST
+GO
+
+SET DATEFIRST 6
+GO
+SELECT @@DATEFIRST
+GO
+
+-- edge point values 
+declare @i int = 1
+SET datefirst @i
+GO
+SELECT @@datefirst
+GO
+
+SET datefirst 7
+GO
+SELECT @@DATEFIRST
+GO
+
+-- out of bound values
+SET DATEFIRST 8
+GO
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+
+SET DATEFIRST 23
+GO
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+
+SET DATEFIRST 0
+GO
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+
+DECLARE @i INT = -4
+SET DATEFIRST @i
+GO
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+
+SET DATEFIRST -55
+GO
+-- Invalid value not updated
+SELECT @@DATEFIRST
+GO
+
+
+
+-- Non Integral Value
+-- inbound values
+SET DATEFIRST 3.5
+GO
+
+SET datefirst 5.68
+GO
+
+SET DATEFIRST 1.23
+GO
+
+SET DATEFIRST 6.999
+GO
+
+-- edge point values
+SET DATEFIRST 1.00
+GO
+SELECT @@DATEFIRST
+GO
+
+SET DATEFIRST 7.00
+GO
+SELECT @@DATEFIRST
+GO
+
+-- out of bound values
+SET DATEFIRST 7.01
+GO
+
+SET DATEFIRST 59.0974
+GO
+
+SET DATEFIRST 0.99
+GO
+
+SET DATEFIRST -2.34
+GO
+
+SET DATEFIRST -65.045
+GO
+
+-- arbitrary values
+SET DATEFIRST 'one'
+GO
+
+SET DATEFIRST '4'
+GO
+
+SET DATEFIRST "three"
+GO
+
+SET DATEFIRST "2"
+GO
+
+SET DATEFIRST NULL
+GO
+
+-- should throw integer parameter required error
+DECLARE @i decimal(10,2) = 2.35
+SET DATEFIRST @i
+GO
+
+SELECT @@DATEFIRST
+GO
+
+DECLARE @i varchar = '4'
+SET DATEFIRST @i
+GO
+
+SELECT @@DATEFIRST
 GO


### PR DESCRIPTION
This commit enables the check that allows only integral values to be set as a DATEFIRST values

### 1. Issues
Previously, customer could use non integral values to set the value of `DATEFIRST` 
```
1> SET DATEFIRST 6.5
2> GO
1> SELECT @@DATEFIRST
2> GO

datefirst  
-----------
          6
```
This is not an expected behavior

### 2. Changes made to fix the issue:
To fix this issue we added a check to only allow integral values to be used to set the value of `DATEFIRST`
```
1> SET DATEFIRST 6.5
2> GO
Msg 2743, Level 16, State 3, Server EC2AMAZ-GOMIGPU, Line 1
SET DATEFIRST option requires integer parameter.
```

Authored-by: Jaspal Singh ijaspals@amazon.com
Signed-off-by: Jaspal Singh ijaspals@amazon.com

### Issues Resolved

BABEL-5841

cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4044

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).