### PR TITLE
[Part 2][For 16+ rel] Fix permission checks for views in Planner phase for cross-db cases

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4885,7 +4885,7 @@ update_rte_perms_info_walker(Node *node, void *context)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(l);
 
-			if (rte->rtekind == RTE_SUBQUERY && get_rel_relkind(rte->relid) == RELKIND_VIEW)
+			if (rte->perminfoindex != 0 && get_rel_relkind(rte->relid) == RELKIND_VIEW)
 			{
 				Oid nspid = get_rel_namespace(rte->relid);
 


### PR DESCRIPTION
### Description

This commit removes condition to check subquery for applying the checkAsUser logic to support cross-db access. By removing, it we are matching with community change which just checks the relkind of RTE and do the permission check if it is view, it is not matter whether RTE is of type SUBQUERY or RELATION kind.

Issues Resolved: BABEL-6035
Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).