### PR TITLE
Fix valgrind unitialized variable issue in pltsql_update_identity_insert_sequence

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -5675,7 +5675,7 @@ pltsql_update_identity_insert_sequence(PLtsql_expr *expr)
 			Oid			seqid = InvalidOid;
 			SPITupleTable *tuptable = SPI_tuptable;
 			uint64		n_processed = SPI_processed;
-			bool		is_cross_db;
+			bool		is_cross_db = false;
 			char	   *schema_name = NULL;
 			HeapTuple	schema_tuple;
 			Oid			current_user_id = InvalidOid;


### PR DESCRIPTION
### Description

Initialize the variable is_cross_db during declaration to fix valgrind uninitialized variable issue

```
==00:01:46:57.201 29256== VALGRINDERROR-BEGIN
==00:01:46:57.201 29256== Conditional jump or move depends on uninitialised value(s)
==00:01:46:57.201 29256==    at 0x12D40B51: pltsql_update_identity_insert_sequence (pl_exec.c:5577)
==00:01:46:57.201 29256==    by 0x12D3F33F: exec_stmt_execsql (pl_exec.c:5022)
==00:01:46:57.201 29256==    by 0x12D34964: dispatch_stmt (iterative_exec.c:670)
==00:01:46:57.201 29256==    by 0x12D36034: dispatch_stmt_handle_error (iterative_exec.c:1305)
```

### Issues Resolved

BABEL-5946

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).