### PR TITLE
Support Select top N Percent

### DIFF
--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-epilogue.y.c
@@ -885,10 +885,12 @@ tsql_update_delete_stmt_with_join(Node *n, List *from_clause, Node *where_clause
 	List	   *indirect;
 	SelectStmt *selectstmt;
 	ResTarget  *resTarget;
+	SelectLimit *top_stmt = (SelectLimit *)top_clause;
 
 	/* use queue to go over all join expr and find target table */
 	List	   *queue = list_make1(jexpr);
 	ListCell   *queue_item;
+
 
 	if (IsA(n, DeleteStmt))
 		n_d = (DeleteStmt *) n;
@@ -940,16 +942,19 @@ tsql_update_delete_stmt_with_join(Node *n, List *from_clause, Node *where_clause
 		 */
 		if (n_d)
 		{
+			
+			n_d->limitCount = top_stmt->limitCount;
+			tsql_check_top_percent_support(top_stmt, "DELETE", -1, yyscanner);
 			n_d->usingClause = from_clause;
 			n_d->whereClause = where_clause;
-			n_d->limitCount = top_clause;
 			return (Node *) n_d;
 		}
 		else
 		{
+			n_u->limitCount = top_stmt->limitCount;
+			tsql_check_top_percent_support(top_stmt, "UPDATE", -1, yyscanner);
 			n_u->fromClause = from_clause;
 			n_u->whereClause = where_clause;
-			n_u->limitCount = top_clause;
 			return (Node *) n_u;
 		}
 	}
@@ -975,7 +980,11 @@ tsql_update_delete_stmt_with_join(Node *n, List *from_clause, Node *where_clause
 	selectstmt->fromClause = from_clause;
 	selectstmt->whereClause = where_clause;
 	/* if we end up createing a subquery for JOIN, attach TOP clause to it */
-	selectstmt->limitCount = top_clause;
+	selectstmt->limitCount = top_stmt->limitCount;
+	if (n_d)
+		tsql_check_top_percent_support(top_stmt, "DELETE", -1, yyscanner);
+	else
+		tsql_check_top_percent_support(top_stmt, "UPDATE", -1, yyscanner);
 	/* construct where_clause(subLink) */
 	link = makeNode(SubLink);
 	link->subselect = (Node *) selectstmt;
@@ -1090,7 +1099,7 @@ tsql_update_delete_stmt_from_clause_alias(RangeVar *relation, List *from_clause)
 static Node *
 tsql_insert_output_into_cte_transformation(WithClause *opt_with_clause, Node *opt_top_clause, RangeVar *insert_target,
 										   List *insert_column_list, List *tsql_output_clause, RangeVar *output_target, List *tsql_output_into_target_columns,
-										   InsertStmt *tsql_output_insert_rest, int select_location)
+										   InsertStmt *tsql_output_insert_rest, int select_location, core_yyscan_t yyscanner)
 {
 
 	CommonTableExpr *cte = makeNode(CommonTableExpr);
@@ -1107,6 +1116,7 @@ tsql_insert_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	ListCell   *lc;
 	Node	   *field1;
 	char	   *qualifier = NULL;
+	SelectLimit *top_stmt = (SelectLimit *)opt_top_clause;
 
 	snprintf(ctename, NAMEDATALEN, "internal_output_cte##sys_gen##%p", (void *) i);
 	internal_ctename = pstrdup(ctename);
@@ -1114,7 +1124,8 @@ tsql_insert_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	/* PreparableStmt inside CTE */
 	i->cols = insert_column_list;
 	i->selectStmt = tsql_output_insert_rest->selectStmt;
-	i->limitCount = opt_top_clause;
+	i->limitCount = top_stmt->limitCount;
+	tsql_check_top_percent_support(top_stmt, "INSERT", -1, yyscanner);
 	i->relation = insert_target;
 	i->onConflictClause = NULL;
 	i->returningList = get_transformed_output_list(tsql_output_clause);
@@ -1182,7 +1193,8 @@ tsql_insert_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	}
 
 	/* SelectStmt inside outer InsertStmt */
-	n->limitCount = NULL;
+	n->limitCount = top_stmt->limitCount;
+	tsql_check_top_percent_support(top_stmt, "INSERT", -1, yyscanner);
 	n->targetList = output_list;
 	n->intoClause = NULL;
 	n->fromClause = list_make1(makeRangeVar(NULL, internal_ctename, select_location));
@@ -1243,6 +1255,7 @@ tsql_delete_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	ListCell   *expr;
 	char		col_alias_arr[NAMEDATALEN];
 	char	   *col_alias = NULL;
+	SelectLimit *top_stmt = (SelectLimit *)opt_top_clause;
 
 	snprintf(ctename, NAMEDATALEN, "internal_output_cte##sys_gen##%p", (void *) i);
 	internal_ctename = pstrdup(ctename);
@@ -1262,7 +1275,8 @@ tsql_delete_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	{
 		d->usingClause = from_clause;
 		d->whereClause = where_or_current_clause;
-		d->limitCount = opt_top_clause;
+		d->limitCount = top_stmt->limitCount;
+		tsql_check_top_percent_support(top_stmt, "DELETE", -1, yyscanner);
 	}
 	d->returningList = get_transformed_output_list(tsql_output_clause);
 	d->withClause = opt_with_clause;
@@ -1412,6 +1426,7 @@ tsql_update_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	ListCell   *expr;
 	char		col_alias_arr[NAMEDATALEN];
 	char	   *col_alias = NULL;
+	SelectLimit *top_stmt = (SelectLimit *)opt_top_clause;
 
 	snprintf(ctename, NAMEDATALEN, "internal_output_cte##sys_gen##%p", (void *) i);
 	internal_ctename = pstrdup(ctename);
@@ -1432,7 +1447,8 @@ tsql_update_output_into_cte_transformation(WithClause *opt_with_clause, Node *op
 	{
 		u->fromClause = from_clause;
 		u->whereClause = where_or_current_clause;
-		u->limitCount = opt_top_clause;
+		u->limitCount = top_stmt->limitCount;
+		tsql_check_top_percent_support(top_stmt, "UPDATE", -1, yyscanner);
 	}
 	u->returningList = get_transformed_output_list(tsql_output_clause);
 	u->withClause = opt_with_clause;
@@ -2418,4 +2434,22 @@ check_server_role_and_throw_if_unsupported (const char *serverrole, int position
 				errmsg("Only fixed server role is supported in ALTER SERVER ROLE statement"),
 							parser_errposition(position)));
 	}
+}
+
+/*
+ * Common function to throw error message for UPDATE/DELETE/INSERT TOP N PERCENT support
+ */
+static void
+tsql_check_top_percent_support(SelectLimit *top_clause, const char *dml_stmt_type, int location, core_yyscan_t yyscanner)
+{
+	if (top_clause->limitCount != NULL && top_clause->limitOption == LIMIT_OPTION_PERCENT)
+	{
+		char error_msg[256];
+		snprintf(error_msg, sizeof(error_msg), "%s TOP N PERCENT is not supported yet", dml_stmt_type);
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("%s", error_msg),
+				 parser_errposition(location)));
+	}
+
 }

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-prologue.y.h
@@ -85,7 +85,7 @@ static void tsql_reset_update_delete_globals(void);
 static void tsql_update_delete_stmt_from_clause_alias(RangeVar *relation, List *from_clause);
 static Node *tsql_insert_output_into_cte_transformation(WithClause *opt_with_clause, Node *opt_top_clause, RangeVar *insert_target,
 														List *insert_column_list, List *tsql_output_clause, RangeVar *output_target, List *tsql_output_into_target_columns,
-														InsertStmt *tsql_output_insert_rest, int select_location);
+														InsertStmt *tsql_output_insert_rest, int select_location, core_yyscan_t yyscanner);
 static Node *tsql_delete_output_into_cte_transformation(WithClause *opt_with_clause, Node *opt_top_clause,
 														RangeVar *relation_expr_opt_alias, List *tsql_output_clause, RangeVar *insert_target,
 														List *tsql_output_into_target_columns, List *from_clause, Node *where_or_current_clause,
@@ -99,3 +99,4 @@ static List *get_transformed_output_list(List *tsql_output_clause);
 static bool returning_list_has_column_name(List *existing_colnames, char *current_colname);
 static void tsql_index_nulls_order(List *indexParams, const char *accessMethod);
 static void check_server_role_and_throw_if_unsupported(const char* serverrole, int position, core_yyscan_t yyscanner);
+static void tsql_check_top_percent_support(SelectLimit *top_clause, const char *dml_stmt_type, int location, core_yyscan_t yyscanner);

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -1316,9 +1316,11 @@ tsql_UpdateStmt: opt_with_clause UPDATE opt_top_clause relation_expr_opt_alias
 			returning_clause
 				{
 					UpdateStmt *n = makeNode(UpdateStmt);
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					tsql_reset_update_delete_globals();
 					n->withClause = $1;
-					n->limitCount = $3;
+					n->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "UPDATE", @3, yyscanner);
 					n->relation = $4;
 					n->targetList = $7;
 					n->fromClause = $8;
@@ -1347,7 +1349,9 @@ tsql_UpdateStmt: opt_with_clause UPDATE opt_top_clause relation_expr_opt_alias
 						}
 						else
 						{
-							n->limitCount = $3;
+							SelectLimit *top_stmt = (SelectLimit *)$3;
+							n->limitCount = top_stmt->limitCount;
+							tsql_check_top_percent_support(top_stmt, "UPDATE", @3, yyscanner);
 							n->fromClause = $9;
 							n->whereClause = $10;
 						}
@@ -1503,8 +1507,10 @@ simple_select:
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-
-					n->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					n->targetList = $4;
 					if ($3 != NULL && $4 == NULL)
 						ereport(ERROR,
@@ -1527,9 +1533,11 @@ simple_select:
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					n->distinctClause = $2;
-					n->limitCount = $3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					n->targetList = $4;
 					if ($3 != NULL && $4 == NULL)
 						ereport(ERROR,
@@ -1552,7 +1560,10 @@ simple_select:
 			group_clause having_clause window_clause 
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-					n->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					if ($3 != NULL && $4 == NULL)
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
@@ -1572,7 +1583,10 @@ simple_select:
 			group_clause having_clause window_clause 
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-					n->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					if ($3 != NULL && $4 == NULL)
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
@@ -2264,7 +2278,10 @@ tsql_output_simple_select:
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-					n->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					n->targetList = $4;
 					n->intoClause = $5;
 					n->fromClause = $6;
@@ -2281,8 +2298,11 @@ tsql_output_simple_select:
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					n->distinctClause = $2;
-					n->limitCount = $3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					n->targetList = $4;
 					n->intoClause = $5;
 					n->fromClause = $6;
@@ -2299,7 +2319,10 @@ tsql_output_simple_select:
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
-					n->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					n->intoClause = $5;
 					n->whereClause = $9;
 					n->groupClause = ($10)->list;
@@ -2313,8 +2336,11 @@ tsql_output_simple_select:
 			group_clause having_clause window_clause
 				{
 					SelectStmt *n = makeNode(SelectStmt);
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					n->distinctClause = $2;
-					n->limitCount = $3;
+					n->limitCount = top_stmt->limitCount;
+					if (top_stmt->limitCount != NULL)
+						n->limitOption = top_stmt->limitOption;
 					n->intoClause = $5;
 					n->whereClause = $9;
 					n->groupClause = ($10)->list;
@@ -2666,7 +2692,9 @@ tsql_InsertStmt:
 			opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
 			tsql_output_insert_rest
 				{
-					$10->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					$10->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					$10->relation = $5;
 					$10->onConflictClause = NULL;
 					$10->returningList = NULL;
@@ -2676,7 +2704,9 @@ tsql_InsertStmt:
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_insert_rest
 				{
-					$7->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					$7->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					$7->relation = $5;
 					$7->onConflictClause = NULL;
 					$7->returningList = NULL;
@@ -2686,8 +2716,10 @@ tsql_InsertStmt:
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr DEFAULT TSQL_VALUES
 				{
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					InsertStmt *i = makeNode(InsertStmt);
-					i->limitCount = $3;
+					i->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					i->relation = $5;
 					i->onConflictClause = NULL;
 					i->returningList = NULL;
@@ -2701,12 +2733,14 @@ tsql_InsertStmt:
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
 			 tsql_output_clause tsql_output_insert_rest_no_paren 
 				{
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					if ($11->execStmt)
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
 								 parser_errposition(@10)));
-					$11->limitCount = $3;
+					$11->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					$11->relation = $5;
 					$11->onConflictClause = NULL;
 					$11->returningList = $10;
@@ -2716,12 +2750,15 @@ tsql_InsertStmt:
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause tsql_output_insert_rest_no_paren 
 				{
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					if ($8->execStmt)
 						ereport(ERROR,
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
 								 parser_errposition(@7)));
-					$8->limitCount = $3;
+					
+					$8->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					$8->relation = $5;
 					$8->onConflictClause = NULL;
 					$8->returningList = $7;
@@ -2733,7 +2770,9 @@ tsql_InsertStmt:
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause DEFAULT VALUES
 				{
 					InsertStmt *i = makeNode(InsertStmt);
-					i->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					i->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					i->relation = $5;
 					i->onConflictClause = NULL;
 					i->returningList = $7;
@@ -2753,7 +2792,7 @@ tsql_InsertStmt:
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
 								 parser_errposition(@14)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, $13, $14, 5);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, $13, $14, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_into_target_columns tsql_output_insert_rest
@@ -2763,7 +2802,7 @@ tsql_InsertStmt:
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
 								 parser_errposition(@10)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, $11, 5);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, $11, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_into_target_columns DEFAULT VALUES
@@ -2776,7 +2815,7 @@ tsql_InsertStmt:
 					i->cols = NIL;
 					i->selectStmt = NULL;
 					i->execStmt = NULL;
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, i, 5);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, i, 5, yyscanner);
 				}
 			/* Without OUTPUT target column list */
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
@@ -2787,7 +2826,7 @@ tsql_InsertStmt:
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
 								 parser_errposition(@13)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, NIL, $13, 5);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, NIL, $13, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_insert_rest_no_paren
@@ -2797,7 +2836,7 @@ tsql_InsertStmt:
 								(errcode(ERRCODE_SYNTAX_ERROR),
 								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
 								 parser_errposition(@9)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, $10, 5);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, $10, 5, yyscanner);
 				}
 			/*
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
@@ -2811,7 +2850,7 @@ tsql_InsertStmt:
 					i->cols = NIL;
 					i->selectStmt = NULL;
 					i->execStmt = NULL;
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, i, 5);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, i, 5, yyscanner);
 				}
 			*/
 		;
@@ -3491,7 +3530,9 @@ tsql_DeleteStmt: opt_with_clause DELETE_P opt_top_clause opt_from relation_expr_
 			tsql_opt_table_hint_expr from_clause where_or_current_clause
 				{
 					DeleteStmt *n = makeNode(DeleteStmt);
-					n->limitCount = $3;
+					SelectLimit *top_stmt = (SelectLimit *)$3;
+					n->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "DELETE", @3, yyscanner);
 					n->relation = $5;
 					n->usingClause = $7;
 					n->whereClause = $8;
@@ -3504,9 +3545,11 @@ tsql_DeleteStmt: opt_with_clause DELETE_P opt_top_clause opt_from relation_expr_
 			tsql_opt_table_hint_expr tsql_output_clause from_clause where_or_current_clause
 				{
 					DeleteStmt *n = makeNode(DeleteStmt);
+					SelectLimit *top_stmt = (SelectLimit *)$3;
 					tsql_reset_update_delete_globals();
 					n->relation = $5;
-					n->limitCount = $3;
+					n->limitCount = top_stmt->limitCount;
+					tsql_check_top_percent_support(top_stmt, "DELETE", @3, yyscanner);
 					n->usingClause = $8;
 					n->whereClause = $9;
 					n->returningList = $7;
@@ -3529,8 +3572,20 @@ tsql_DeleteStmt: opt_with_clause DELETE_P opt_top_clause opt_from relation_expr_
 			;
 
 tsql_top_clause:
-			TSQL_TOP '(' a_expr ')'						{ $$ = $3; }
-			| TSQL_TOP I_or_F_const						{ $$ = $2; }
+			TSQL_TOP '(' a_expr ')'						
+				{ 
+					SelectLimit *n = (SelectLimit *) palloc0(sizeof(SelectLimit));
+					n->limitCount = $3;
+					n->limitOption = LIMIT_OPTION_COUNT;
+					$$ = (Node *)n;
+				}
+			| TSQL_TOP I_or_F_const
+				{
+					SelectLimit *n = (SelectLimit *) palloc0(sizeof(SelectLimit));
+					n->limitCount = $2;
+					n->limitOption = LIMIT_OPTION_COUNT;
+					$$ = (Node *)n;
+				}
 			| TSQL_TOP select_with_parens
 				{
 					/*
@@ -3538,71 +3593,81 @@ tsql_top_clause:
 					 * because c_expr (in a_expr) has a rule select_with_parens but we defined the first rule as '(' a_expr ')'.
 					 * In other words, the first rule will be hit only when double parenthesis is used like `SELECT TOP ((select 1)) ...`
 					 */
-					SubLink *n = makeNode(SubLink);
-					n->subLinkType = EXPR_SUBLINK;
-					n->subLinkId = 0;
-					n->testexpr = NULL;
-					n->operName = NIL;
-					n->subselect = $2;
-					n->location = @1;
+					SelectLimit *n = (SelectLimit *) palloc0(sizeof(SelectLimit));
+					SubLink *sublink = makeNode(SubLink);
+
+					sublink->subLinkType = EXPR_SUBLINK;
+					sublink->subLinkId = 0;
+					sublink->testexpr = NULL;
+					sublink->operName = NIL;
+					sublink->subselect = $2;
+					sublink->location = @1;
+
+					n->limitCount = (Node *)sublink;
+					n->limitOption = LIMIT_OPTION_COUNT;
 					$$ = (Node *)n;
 				}
 			| TSQL_TOP '(' a_expr ')' TSQL_PERCENT
 				{
+					SelectLimit *stmt = (SelectLimit *) palloc0(sizeof(SelectLimit));
+
 					if (IsA($3, A_Const))
 					{
 						A_Const* n = (A_Const *)$3;
+
 						if(IsA(&n->val, Integer) && n->val.ival.ival == 100)
 						{
-								$$ = NULL;
+							stmt->limitCount = NULL;
 						}
 						else if(IsA(&n->val, Float) && atof(n->val.fval.fval) == 100.0)
 						{
-								$$ = NULL;
+							stmt->limitCount = NULL;
 						}
 						else
 						{
-							TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_TOP_PERCENT_IN_STMT);
-							ereport(ERROR,
-									(errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("TOP # PERCENT is not yet supported"),
-									parser_errposition(@1)));
+							stmt->limitCount = $3;
+                			stmt->limitOption = LIMIT_OPTION_PERCENT;
 						}
 					}
 					else
 					{
-						TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_TOP_PERCENT_IN_STMT);
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								errmsg("TOP # PERCENT is not yet supported"),
-								parser_errposition(@1)));
+						stmt->limitCount = $3;
+                		stmt->limitOption = LIMIT_OPTION_PERCENT;
 					}
+
+					$$ = (Node *)stmt;
 				}
 			| TSQL_TOP I_or_F_const TSQL_PERCENT
 				{
+					SelectLimit *stmt = (SelectLimit *) palloc0(sizeof(SelectLimit));
 					A_Const* n = (A_Const *)$2;
+
 					if(IsA(&n->val, Integer) && n->val.ival.ival == 100)
 					{
-							$$ = NULL;
+						stmt->limitCount = NULL;
 					}
 					else if(IsA(&n->val, Float) && atof(n->val.fval.fval) == 100.0)
 					{
-							$$ = NULL;
+						stmt->limitCount = NULL;
 					}
 					else
 					{
-						TSQLInstrumentation(INSTR_UNSUPPORTED_TSQL_TOP_PERCENT_IN_STMT);
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								errmsg("TOP # PERCENT is not yet supported"),
-								parser_errposition(@1)));
+						stmt->limitCount = $2;
+                		stmt->limitOption = LIMIT_OPTION_PERCENT;
 					}
+
+					$$ = (Node *)stmt;
 				}
 		;
 
 opt_top_clause:
 				tsql_top_clause { $$ = $1; }
-			| /*EMPTY*/ { $$ = NULL; }
+			| /*EMPTY*/ 
+			{ 
+				SelectLimit *n = (SelectLimit *) palloc0(sizeof(SelectLimit));
+				n->limitCount = NULL;
+				$$ = (Node *)n;
+			}
 		;
 
 /*

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -164,6 +164,9 @@ static SortByNulls unique_constraint_nulls_ordering(ConstrType constraint_type,
 static void transform_pivot_clause(ParseState *pstate, SelectStmt *stmt);
 static void transform_unpivot_clause(ParseState *pstate, SelectStmt *stmt);
 static bool transform_unpivot_clause_recursive(Node **node, List **measure_cols, List **unpivot_src_cols);
+static void transform_tsql_select_statement(ParseState *pstate, SelectStmt *stmt);
+static void transform_percent_clause(ParseState *pstate, SelectStmt *stmt);
+static SelectStmt *handle_group_by_percent_count(SelectStmt *stmt);
 static List* filter_star_targetlist_for_unpivot(ParseState *pstate, SelectStmt *stmt, List **source_cols);
 static bool repair_broken_views(Query *parsetree);
 
@@ -332,7 +335,7 @@ static drop_relation_refcnt_hook_type prev_drop_relation_refcnt_hook = NULL;
 static bbf_get_sysadmin_oid_hook_type prev_bbf_get_sysadmin_oid_hook = NULL;
 static get_bbf_admin_oid_hook_type prev_get_bbf_admin_oid_hook = NULL;
 static transform_pivot_clause_hook_type pre_transform_pivot_clause_hook = NULL;
-static transform_unpivot_clause_hook_type pre_transform_unpivot_clause_hook = NULL;
+static transform_tsql_select_stmt_hook_type pre_transform_tsql_select_stmt_hook = NULL;
 static called_from_tsql_insert_exec_hook_type pre_called_from_tsql_insert_exec_hook = NULL;
 static called_for_tsql_itvf_func_hook_type prev_called_for_tsql_itvf_func_hook = NULL;
 static exec_tsql_cast_value_hook_type pre_exec_tsql_cast_value_hook = NULL;
@@ -533,8 +536,8 @@ InstallExtendedHooks(void)
 	pre_transform_pivot_clause_hook = transform_pivot_clause_hook;
 	transform_pivot_clause_hook = transform_pivot_clause;
 
-	pre_transform_unpivot_clause_hook = transform_unpivot_clause_hook;
-	transform_unpivot_clause_hook = transform_unpivot_clause;
+	pre_transform_tsql_select_stmt_hook = transform_tsql_select_stmt_hook;
+	transform_tsql_select_stmt_hook = transform_tsql_select_statement;
 
 	prev_optimize_explicit_cast_hook = optimize_explicit_cast_hook;
 	optimize_explicit_cast_hook = optimize_explicit_cast;
@@ -660,7 +663,7 @@ UninstallExtendedHooks(void)
 	bbf_get_sysadmin_oid_hook = prev_bbf_get_sysadmin_oid_hook;
 	get_bbf_admin_oid_hook = prev_get_bbf_admin_oid_hook;
 	transform_pivot_clause_hook = pre_transform_pivot_clause_hook;
-	transform_unpivot_clause_hook = pre_transform_unpivot_clause_hook;
+	transform_tsql_select_stmt_hook = pre_transform_tsql_select_stmt_hook;
 	optimize_explicit_cast_hook = prev_optimize_explicit_cast_hook;
 	called_from_tsql_insert_exec_hook = pre_called_from_tsql_insert_exec_hook;
 	called_for_tsql_itvf_func_hook = prev_called_for_tsql_itvf_func_hook;
@@ -1525,6 +1528,7 @@ post_transform_delete(ParseState *pstate, DeleteStmt *stmt, Query *query)
 {
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
+
 
 	/* Handle DELETE TOP */
 	query->limitCount = transformLimitClause(pstate, stmt->limitCount,
@@ -3430,6 +3434,7 @@ pre_transform_insert(ParseState *pstate, InsertStmt *stmt, Query *query)
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
 		return;
+
 
 	query->limitCount = transformLimitClause(pstate, stmt->limitCount,
 											EXPR_KIND_LIMIT, "LIMIT",
@@ -5581,6 +5586,214 @@ transform_pivot_clause(ParseState *pstate, SelectStmt *stmt)
 							  COERCE_EXPLICIT_CALL, 
 							  -1);
 	wrapperSelect_RangeFunction->functions = list_make1(list_make2((Node *) pivot_func, NIL));
+}
+
+/*
+ * Handle GROUP BY case for PERCENT clause transformation
+ *
+ * Creates a subquery to count distinct groups since PostgreSQL doesn't support
+ * COUNT(DISTINCT col1, col2, ...) with multiple columns.
+ *
+ * Transforms the input statement to select only GROUP BY columns, then wraps it
+ * in an outer COUNT(*) query to get the total number of distinct groups.
+ *
+ * Example: SELECT col1, col2 FROM table GROUP BY col1, col2 HAVING condition
+ * Becomes: SELECT COUNT(*) FROM (SELECT col1, col2 FROM table GROUP BY col1, col2 HAVING condition) AS grouped_data
+ */
+static SelectStmt *
+handle_group_by_percent_count(SelectStmt *groupbySelectStmt)
+{
+    /* For GROUP BY queries, we need to count the number of groups */
+    SelectStmt        *outerCountStmt = makeNode(SelectStmt);
+    RangeSubselect    *subselect      = makeNode(RangeSubselect);
+    FuncCall          *countFunc;         /* COUNT function for total rows */
+    ResTarget         *countTarget;       /* Target entry for COUNT result */
+    ListCell          *lc;
+    
+    /* Keep only GROUP BY columns in target list */
+    groupbySelectStmt->targetList = NIL;
+    foreach(lc, groupbySelectStmt->groupClause)
+    {
+        ResTarget *rt = makeNode(ResTarget);
+        rt->name = NULL;
+        rt->indirection = NIL;
+        rt->val = copyObject(lfirst(lc));
+        rt->location = -1;
+        groupbySelectStmt->targetList = lappend(groupbySelectStmt->targetList, rt);
+    }
+    
+    /* Wrap in another COUNT(*) query */
+    subselect->subquery = (Node *) groupbySelectStmt;
+    subselect->alias = makeAlias("grouped_data", NIL);
+    
+    outerCountStmt->fromClause = list_make1(subselect);
+    
+    /* Create COUNT(*) for outer query */
+    countFunc = makeNode(FuncCall);
+    countFunc->funcname = list_make1(makeString("count"));
+    countFunc->args = NIL;
+    countFunc->agg_star = true;
+    countFunc->agg_distinct = false;
+    countFunc->location = -1;
+    
+    countTarget = makeNode(ResTarget);
+    countTarget->name = NULL;
+    countTarget->indirection = NIL;
+    countTarget->val = (Node *) countFunc;
+    countTarget->location = -1;
+    
+    outerCountStmt->targetList = list_make1(countTarget);
+    
+    return outerCountStmt;
+}
+
+/*
+ * Common hook to transform TSQL unpivot and TOP N Percent
+ */
+static void
+transform_tsql_select_statement(ParseState *pstate, SelectStmt *stmt)
+{
+	transform_percent_clause(pstate, stmt);
+	transform_unpivot_clause(pstate, stmt);
+}
+
+/*
+ * Transform T-SQL PERCENT clause in SELECT statements
+ *
+ * Converts "SELECT TOP N PERCENT ..." to "SELECT TOP CEIL((COUNT(*) * N) / 100) ..."
+ * by replacing the limitCount with a calculated expression based on total row count.
+ *
+ * For GROUP BY queries, uses subquery approach to count distinct groups: 
+ * SELECT COUNT(*) FROM (SELECT group_cols FROM table GROUP BY group_cols) AS grouped_data
+ * Function : handle_group_by_percent_count(SelectStmt *groupbySelectStmt) 
+ *
+ * For regular queries, uses simple COUNT(*) from the table.
+ */
+static void 
+transform_percent_clause(ParseState *pstate, SelectStmt *stmt)
+{
+    /* To create inner select count(*) from t for percent */
+    SelectStmt    *totalCountSelectStmt; 
+    
+    /* Variables for building percentage calculation expression */
+    SubLink       *countSublink;     /* Subquery link for wrap select COUNT(*).. */
+    A_Expr        *mulExpr;          /* to multiply N*(select count(*)..) */
+    A_Expr        *divExpr;          /* Division expression to divide by 100 */
+    A_Const       *intConst;         /* Integer constant (100) */
+    FuncCall      *ceilFunc;         /* CEIL function for rounding */
+    
+    /* Check whether TSQL and limit value present */
+	if (sql_dialect != SQL_DIALECT_TSQL || stmt->limitCount == NULL)
+        return;
+    
+    if (stmt->limitOption != LIMIT_OPTION_PERCENT)
+        return;
+    else
+        stmt->limitOption = LIMIT_OPTION_COUNT;
+
+    /* Add validation check for percentage value > 100 */
+    if (IsA(stmt->limitCount, A_Const))
+    {
+        A_Const *const_val = (A_Const *) stmt->limitCount;
+        if (const_val->val.ival.type == T_Integer)
+        {
+            int percent_val = const_val->val.ival.ival;
+            if (percent_val > 100)
+                ereport(ERROR,
+                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                        errmsg("Percent values must be between 0 and 100.")));
+        }
+        else if (const_val->val.fval.type == T_Float)
+        {
+            float8 percent_val = strtod(const_val->val.fval.fval, NULL);
+            if (percent_val > 100.0)
+                ereport(ERROR,
+                        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                        errmsg("Percent values must be between 0 and 100.")));
+        }
+    }
+
+    /* Make a deep copy of the statement for the COUNT query */
+    totalCountSelectStmt = (SelectStmt *) copyObject(stmt);
+    
+    /* Clear limit, offset, and sorting from the copy */
+    totalCountSelectStmt->limitCount = NULL;
+    totalCountSelectStmt->limitOffset = NULL;
+    totalCountSelectStmt->sortClause = NIL;
+    
+    /* 
+    * Since group by with (count(*) in targetList) doesn't return single record 
+    * Hence We will rewrite the totalCountSelectStmt query as - 
+    * select count(*) from (select group_by_columns from t group by col1, col2, ...) as t
+    * instead of (select count(*) from t)
+    */
+    if (stmt->groupClause != NIL)
+    {
+        totalCountSelectStmt = handle_group_by_percent_count(totalCountSelectStmt);
+    }
+    else
+    {
+        FuncCall      *countFunc;       /* COUNT function for total rows */
+        ResTarget     *countTarget;     /* Target entry for COUNT result */
+
+        /* Regular query without GROUP BY - use COUNT(*) */
+        countFunc = makeNode(FuncCall);
+        countFunc->funcname = list_make1(makeString("count"));
+        countFunc->args = NIL;
+        countFunc->agg_star = true;
+        countFunc->agg_distinct = false;
+        countFunc->location = -1;
+        
+        countTarget = makeNode(ResTarget);
+        countTarget->name = NULL;
+        countTarget->indirection = NIL;
+        countTarget->val = (Node *) countFunc;
+        countTarget->location = -1;
+        
+        totalCountSelectStmt->targetList = list_make1(countTarget);
+    }
+	
+	/* Create subquery node to store transformed select count(*).. query */
+	countSublink = makeNode(SubLink);
+	countSublink->subLinkType = EXPR_SUBLINK;
+	countSublink->subselect = (Node *) totalCountSelectStmt;
+	countSublink->location = -1;
+	
+	/* Create multiplication: (COUNT(*) * limitCount) */
+	mulExpr = makeNode(A_Expr);
+	mulExpr->kind = AEXPR_OP;
+	mulExpr->name = list_make1(makeString("*"));
+	mulExpr->lexpr = (Node *) countSublink;
+	mulExpr->rexpr = stmt->limitCount;
+	mulExpr->location = -1;
+	
+	/* Create division: ((COUNT(*) * limitCount) / 100) */
+	divExpr = makeNode(A_Expr);
+	divExpr->kind = AEXPR_OP;
+	divExpr->name = list_make1(makeString("/"));
+	divExpr->lexpr = (Node *) mulExpr;
+	
+	/* Create A_Const for float 100.0 to ensure floating-point division */
+	intConst = makeNode(A_Const);
+	intConst->val.fval.type = T_Float;
+	intConst->val.fval.fval = pstrdup("100.0");
+	intConst->isnull = false;
+	intConst->location = -1;
+	
+	divExpr->rexpr = (Node *) intConst;
+	divExpr->location = -1;
+
+	/* Create CEIL function call-  ceil (((COUNT(*) * limitCount) / 100))  */
+    ceilFunc = makeNode(FuncCall);
+    ceilFunc->funcname = list_make1(makeString("ceil"));
+    ceilFunc->args = list_make1(divExpr);  // Add the division expression as argument
+    ceilFunc->agg_star = false;
+    ceilFunc->agg_distinct = false;
+    ceilFunc->location = -1;
+
+    /* Replace the original limitCount with CEIL function */
+    stmt->limitCount = (Node *) ceilFunc;
+
 }
 
 /*

--- a/test/JDBC/expected/Select_top_N_percent-vu-cleanup.out
+++ b/test/JDBC/expected/Select_top_N_percent-vu-cleanup.out
@@ -1,0 +1,44 @@
+
+-- Cleanup script for TOP PERCENT test cases
+-- Drop dependent objects created in prepare file
+DROP VIEW IF EXISTS jira_babel_1358.top_performers_view;
+GO
+
+DROP FUNCTION IF EXISTS jira_babel_1358.get_top_sales;
+GO
+
+DROP PROCEDURE IF EXISTS jira_babel_1358.get_top_percent_by_category;
+GO
+
+-- Drop test tables created in prepare file
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_scores;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales_second;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales_third;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_scores_second;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_scores_third;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales_large;
+GO
+
+-- Drop cross-schema test table
+DROP TABLE IF EXISTS test_schema2_jira_babel_1358.test_cross_sales;
+GO
+
+-- Drop the test schemas
+DROP SCHEMA IF EXISTS jira_babel_1358;
+GO
+
+DROP SCHEMA IF EXISTS test_schema2_jira_babel_1358;
+GO

--- a/test/JDBC/expected/Select_top_N_percent-vu-prepare.out
+++ b/test/JDBC/expected/Select_top_N_percent-vu-prepare.out
@@ -1,0 +1,242 @@
+
+/*
+ * TOP PERCENT Test Cases Summary
+ * JIRA-BABEL-1358
+ *
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | Basic TOP PERCENT                                | Basic               | Tests 50%, 0%                                 |
+ * |  2  | TOP PERCENT with ties                            | Error Case          | WITH TIES not supported - should throw error  |
+ * |  3  | TOP PERCENT with WHERE                           | Filtering           | Tests 25% and 20.4% with WHERE clause         |
+ * |  4  | TOP PERCENT with NULL values                     | NULL Handling       | Tests 40% with NULL data                      |
+ * |  5  | TOP PERCENT with money data type                 | Data Types          | Tests 50% with money/revenue data             |
+ * |  6  | TOP PERCENT in subquery                          | Subquery            | Tests 50% in nested SELECT                    |
+ * |  7  | TOP PERCENT with GROUP BY                        | Aggregation         | Tests 50% with GROUP BY clause                |
+ * | 7a  | TOP PERCENT with GROUP BY and HAVING             | Aggregation+Filter  | Tests 50% with GROUP BY and HAVING clause     |
+ * |  8  | TOP PERCENT with decimal percentage              | Precision           | Tests 33.33% decimal precision                |
+ * |  9  | TOP PERCENT with DISTINCT                        | Distinct Values     | Tests 50% with DISTINCT                       |
+ * | 10  | TOP PERCENT with JOIN                            | Joins               | Tests 50% with LEFT JOIN                      |
+ * | 11  | TOP 100 PERCENT                                  | Edge Case           | Should return all rows                        |
+ * | 12  | TOP 1 PERCENT                                    | Minimum Case        | Tests minimum percentage                      |
+ * | 13  | TOP 0 PERCENT                                    | Extreme Edge        | Tests zero percentage                         |
+ * | 14  | TOP 0.5 PERCENT                                  | Extreme Decimal     | Tests very small decimal percentage           |
+ * | 15  | TOP PERCENT with PIVOT                           | Advanced            | Tests 50% with PIVOT operation                |
+ * | 16  | TOP PERCENT with UNPIVOT                         | Advanced            | Tests nested 50% and 30% with UNPIVOT         |
+ * | 17  | TOP PERCENT with Window Functions                | Window Functions    | Tests 50% with ROW_NUMBER() and AVG() OVER    |
+ * | 18  | TOP PERCENT with CTEs                            | CTEs                | Tests 50% with Common Table Expressions       |
+ * | 19  | TOP PERCENT with CROSS APPLY                     | Advanced Joins      | Tests 30% with CROSS APPLY                    |
+ * | 20  | TOP PERCENT with Window Functions and Filtering  | Complex Window      | Tests 40% with multiple window functions      |
+ * | 21  | Nested TOP PERCENT                               | Nested              | Tests 25% of 50% (nested percentages)         |
+ * | 22  | TOP PERCENT with Revenue Analysis                | Complex CTE         | Tests 50% with revenue analysis CTE           |
+ * | 23  | TOP PERCENT with Running Totals                  | Running Calculations| Tests 30% with SUM() OVER                     |
+ * | 24  | TOP PERCENT with Complex Joins                   | Complex Joins       | Tests 40% with LEFT JOIN and window functions |
+ * | 25  | Performance test with large table                | Performance         | Tests 10% with large dataset (10K rows)       |
+ * | 26  | Complex performance test with large table        | Complex Performance | Tests 5% with GROUP BY, HAVING, window funcs  |
+ * | 27  | TOP PERCENT with variables and reuse             | Variables           | Tests table variable storage and reuse        |
+ * | 28  | TOP PERCENT with variable percentage             | Variable Percentage | Tests dynamic percentage with @percent_value  |
+ * | 29  | TOP PERCENT in VIEW                              | Dependent Objects   | Tests TOP PERCENT within VIEW definition      |
+ * | 30  | TOP PERCENT in FUNCTION                          | Dependent Objects   | Tests TOP PERCENT in table-valued function    |
+ * | 31  | TOP PERCENT in STORED PROCEDURE                  | Dependent Objects   | Tests TOP PERCENT in stored procedure         |
+ * | 32  | TOP PERCENT with FOR JSON AUTO                   | JSON Output         | Tests 50% with FOR JSON AUTO                  |
+ * | 33  | TOP PERCENT with FOR JSON PATH                   | JSON Output         | Tests 30% with FOR JSON PATH                  |
+ * | 34  | TOP PERCENT with FOR JSON INCLUDE_NULL_VALUES    | JSON Output         | Tests 33% with NULL handling in JSON          |
+ * | 35  | TOP PERCENT with UNION ALL                       | Set Operations      | Tests 30% and 50% with UNION ALL              |
+ * | 36  | TOP PERCENT with UNION                           | Set Operations      | Tests 40% and 60% with UNION (deduplication)  |
+ * | 37  | TOP PERCENT on outside of UNION                  | Set Operations      | Tests 20% applied to UNION result             |
+ * | 38  | TOP PERCENT with cross schema JOIN               | Cross Schema        | Tests 30% with cross-schema LEFT JOIN         |
+ * | 39  | TOP PERCENT with cross schema subquery           | Cross Schema        | Tests 40% with cross-schema subquery          |
+ * | 40  | TOP PERCENT with cross schema CTE                | Cross Schema        | Tests 50% with cross-schema CTE               |
+ * | 41  | UPDATE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 42  | DELETE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 43  | INSERT TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 44  | INSERT with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests INSERT TOP 100% with OUTPUT INTO        |
+ * | 45  | UPDATE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests UPDATE TOP 100% with JOIN               |
+ * | 46  | UPDATE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests UPDATE TOP 100% with OUTPUT INTO        |
+ * | 47  | DELETE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests DELETE TOP 100% with JOIN               |
+ * | 48  | DELETE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests DELETE TOP 100% with OUTPUT INTO        |
+ */
+-- Create schema for TOP PERCENT testing
+CREATE SCHEMA jira_babel_1358;
+GO
+
+
+ -- Create test tables for TOP N PERCENT testing
+CREATE TABLE jira_babel_1358.test_percent_scores (
+    id INT,
+    student_name VARCHAR(50),
+    score DECIMAL(5,2),
+    class_name VARCHAR(50),
+    year INT
+);
+CREATE TABLE jira_babel_1358.test_percent_sales (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    quarter VARCHAR(2)
+);
+GO
+
+
+-- Insert test data for scores
+INSERT INTO jira_babel_1358.test_percent_scores (id, student_name, score, class_name, year) VALUES
+(1, 'John Doe', 95.5, 'Math', 2023),
+(2, 'Jane Smith', 87.3, 'Math', 2023),
+(3, 'Bob Wilson', 92.0, 'Math', 2023),
+(4, 'Alice Brown', 78.5, 'Math', 2023),
+(5, 'Charlie Davis', 88.9, 'Math', 2023),
+(6, 'Eva White', 100.0, 'Physics', 2023),
+(7, 'Frank Black', 100.0, 'Physics', 2023),
+(8, 'George Grey', 0.0, 'Physics', 2023),
+(9, 'Helen Green', NULL, 'Physics', 2023);
+-- Insert test data for sales
+INSERT INTO jira_babel_1358.test_percent_sales (id, product_name, revenue, region, quarter) VALUES
+(1, 'Product A', 10000.00, 'North', 'Q1'),
+(2, 'Product B', 15000.50, 'North', 'Q1'),
+(3, 'Product C', 20000.75, 'North', 'Q1'),
+(4, 'Product D', 5000.25, 'South', 'Q1'),
+(5, 'Product E', 7500.50, 'South', 'Q1'),
+(6, 'Product F', NULL, 'South', 'Q1');
+GO
+~~ROW COUNT: 9~~
+
+~~ROW COUNT: 6~~
+
+
+-- Create a simple large table
+CREATE TABLE jira_babel_1358.test_percent_sales_large (
+    product_name VARCHAR(20),
+    category VARCHAR(20),
+    sales_amount DECIMAL(10,2)
+);
+GO
+
+-- Insert sample data (10,000 rows)
+WITH Numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 
+    FROM Numbers 
+    WHERE n < 10000
+)
+INSERT INTO jira_babel_1358.test_percent_sales_large (product_name, category, sales_amount)
+SELECT 
+    'Product' + CAST((n % 10) AS VARCHAR(2)),
+    CASE (n % 3)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Clothing'
+        ELSE 'Food'
+    END,
+    100 + (n % 900)
+FROM Numbers
+OPTION (MAXRECURSION 10000);
+GO
+~~ROW COUNT: 10000~~
+
+
+
+
+/*
+ * ======================================================================================================================
+ *                                          DEPENDENT OBJECTS TESTS
+ * ======================================================================================================================
+ */
+ -- View 
+CREATE VIEW jira_babel_1358.top_performers_view AS
+    SELECT TOP 20 PERCENT student_name, score, class_name
+    FROM jira_babel_1358.test_percent_scores
+    WHERE score IS NOT NULL
+    ORDER BY score DESC;
+GO
+
+
+-- Function
+CREATE FUNCTION jira_babel_1358.get_top_sales(@percentage FLOAT)
+RETURNS TABLE
+AS
+RETURN (
+    SELECT TOP (@percentage) PERCENT product_name, sales_amount
+    FROM jira_babel_1358.test_percent_sales_large
+    ORDER BY sales_amount DESC
+);
+GO
+
+-- Procedure
+CREATE PROCEDURE jira_babel_1358.get_top_percent_by_category
+    @category VARCHAR(20),
+    @percentage FLOAT
+AS
+BEGIN
+    SELECT COUNT(*) as row_count
+    FROM (
+        SELECT TOP (@percentage) PERCENT *
+        FROM jira_babel_1358.test_percent_sales_large
+        WHERE category = @category
+        ORDER BY sales_amount DESC
+    ) as derived_table;
+END;
+GO
+
+
+-- Create second schema for cross-schema testing
+CREATE SCHEMA test_schema2_jira_babel_1358;
+GO
+
+CREATE TABLE test_schema2_jira_babel_1358.test_cross_sales (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    sales_date DATE
+);
+GO
+
+-- Insert test data for cross-schema testing
+INSERT INTO test_schema2_jira_babel_1358.test_cross_sales (id, product_name, revenue, region, sales_date) VALUES
+(1, 'Cross Product A', 12000.00, 'East', '2023-01-15'),
+(2, 'Cross Product B', 18000.50, 'West', '2023-02-20'),
+(3, 'Cross Product C', 25000.75, 'East', '2023-03-10'),
+(4, 'Cross Product D', 8000.25, 'West', '2023-04-05'),
+(5, 'Cross Product E', 15500.50, 'North', '2023-05-12');
+GO
+~~ROW COUNT: 5~~
+
+
+
+
+/*
+ * Created to test insert into output ..
+ * test case 43-48 
+ */ 
+CREATE TABLE jira_babel_1358.test_percent_scores_second (
+    id INT,
+    student_name VARCHAR(50),
+    score DECIMAL(5,2),
+    class_name VARCHAR(50),
+    year INT
+);
+CREATE TABLE jira_babel_1358.test_percent_sales_second (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    quarter VARCHAR(2)
+);
+GO
+
+
+CREATE TABLE jira_babel_1358.test_percent_scores_third (
+    id INT,
+    student_name VARCHAR(50),
+    score DECIMAL(5,2),
+    class_name VARCHAR(50),
+    year INT
+);
+CREATE TABLE jira_babel_1358.test_percent_sales_third (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    quarter VARCHAR(2)
+);
+GO

--- a/test/JDBC/expected/Select_top_N_percent-vu-verify.out
+++ b/test/JDBC/expected/Select_top_N_percent-vu-verify.out
@@ -1,0 +1,923 @@
+
+
+/*
+ * TOP PERCENT Test Cases Summary
+ * JIRA-BABEL-1358
+ *
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | Basic TOP PERCENT                                | Basic               | Tests 50%, 0%                                 |
+ * |  2  | TOP PERCENT with ties                            | Error Case          | WITH TIES not supported - should throw error  |
+ * |  3  | TOP PERCENT with WHERE                           | Filtering           | Tests 25% and 20.4% with WHERE clause         |
+ * |  4  | TOP PERCENT with NULL values                     | NULL Handling       | Tests 40% with NULL data                      |
+ * |  5  | TOP PERCENT with money data type                 | Data Types          | Tests 50% with money/revenue data             |
+ * |  6  | TOP PERCENT in subquery                          | Subquery            | Tests 50% in nested SELECT                    |
+ * |  7  | TOP PERCENT with GROUP BY                        | Aggregation         | Tests 50% with GROUP BY clause                |
+ * | 7a  | TOP PERCENT with GROUP BY and HAVING             | Aggregation+Filter  | Tests 50% with GROUP BY and HAVING clause     |
+ * |  8  | TOP PERCENT with decimal percentage              | Precision           | Tests 33.33% decimal precision                |
+ * |  9  | TOP PERCENT with DISTINCT                        | Distinct Values     | Tests 50% with DISTINCT                       |
+ * | 10  | TOP PERCENT with JOIN                            | Joins               | Tests 50% with LEFT JOIN                      |
+ * | 11  | TOP 100 PERCENT                                  | Edge Case           | Should return all rows                        |
+ * | 12  | TOP 1 PERCENT                                    | Minimum Case        | Tests minimum percentage                      |
+ * | 13  | TOP 0 PERCENT                                    | Extreme Edge        | Tests zero percentage                         |
+ * | 14  | TOP 0.5 PERCENT                                  | Extreme Decimal     | Tests very small decimal percentage           |
+ * | 15  | TOP PERCENT with PIVOT                           | Advanced            | Tests 50% with PIVOT operation                |
+ * | 16  | TOP PERCENT with UNPIVOT                         | Advanced            | Tests nested 50% and 30% with UNPIVOT         |
+ * | 17  | TOP PERCENT with Window Functions                | Window Functions    | Tests 50% with ROW_NUMBER() and AVG() OVER    |
+ * | 18  | TOP PERCENT with CTEs                            | CTEs                | Tests 50% with Common Table Expressions       |
+ * | 19  | TOP PERCENT with CROSS APPLY                     | Advanced Joins      | Tests 30% with CROSS APPLY                    |
+ * | 20  | TOP PERCENT with Window Functions and Filtering  | Complex Window      | Tests 40% with multiple window functions      |
+ * | 21  | Nested TOP PERCENT                               | Nested              | Tests 25% of 50% (nested percentages)         |
+ * | 22  | TOP PERCENT with Revenue Analysis                | Complex CTE         | Tests 50% with revenue analysis CTE           |
+ * | 23  | TOP PERCENT with Running Totals                  | Running Calculations| Tests 30% with SUM() OVER                     |
+ * | 24  | TOP PERCENT with Complex Joins                   | Complex Joins       | Tests 40% with LEFT JOIN and window functions |
+ * | 25  | Performance test with large table                | Performance         | Tests 10% with large dataset (10K rows)       |
+ * | 26  | Complex performance test with large table        | Complex Performance | Tests 5% with GROUP BY, HAVING, window funcs  |
+ * | 27  | TOP PERCENT with variables and reuse             | Variables           | Tests table variable storage and reuse        |
+ * | 28  | TOP PERCENT with variable percentage             | Variable Percentage | Tests dynamic percentage with @percent_value  |
+ * | 29  | TOP PERCENT in VIEW                              | Dependent Objects   | Tests TOP PERCENT within VIEW definition      |
+ * | 30  | TOP PERCENT in FUNCTION                          | Dependent Objects   | Tests TOP PERCENT in table-valued function    |
+ * | 31  | TOP PERCENT in STORED PROCEDURE                  | Dependent Objects   | Tests TOP PERCENT in stored procedure         |
+ * | 32  | TOP PERCENT with FOR JSON AUTO                   | JSON Output         | Tests 50% with FOR JSON AUTO                  |
+ * | 33  | TOP PERCENT with FOR JSON PATH                   | JSON Output         | Tests 30% with FOR JSON PATH                  |
+ * | 34  | TOP PERCENT with FOR JSON INCLUDE_NULL_VALUES    | JSON Output         | Tests 33% with NULL handling in JSON          |
+ * | 35  | TOP PERCENT with UNION ALL                       | Set Operations      | Tests 30% and 50% with UNION ALL              |
+ * | 36  | TOP PERCENT with UNION                           | Set Operations      | Tests 40% and 60% with UNION (deduplication)  |
+ * | 37  | TOP PERCENT on outside of UNION                  | Set Operations      | Tests 20% applied to UNION result             |
+ * | 38  | TOP PERCENT with cross schema JOIN               | Cross Schema        | Tests 30% with cross-schema LEFT JOIN         |
+ * | 39  | TOP PERCENT with cross schema subquery           | Cross Schema        | Tests 40% with cross-schema subquery          |
+ * | 40  | TOP PERCENT with cross schema CTE                | Cross Schema        | Tests 50% with cross-schema CTE               |
+ * | 41  | UPDATE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 42  | DELETE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 43  | INSERT TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 44  | INSERT with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests INSERT TOP 100% with OUTPUT INTO        |
+ * | 45  | UPDATE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests UPDATE TOP 100% with JOIN               |
+ * | 46  | UPDATE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests UPDATE TOP 100% with OUTPUT INTO        |
+ * | 47  | DELETE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests DELETE TOP 100% with JOIN               |
+ * | 48  | DELETE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests DELETE TOP 100% with OUTPUT INTO        |
+ */
+-- Use the test schema
+-- Tables are in jira_babel_1358 schema
+ -- Test Case 1: Basic TOP PERCENT
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t1;
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT COUNT(*) FROM (SELECT TOP 0 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t2;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test Case 2: TOP PERCENT with ties
+/*
+* It seems currently we don't support "with ties" and thus it will throw the error
+* Expected Output : should return 30% of records
+*/
+SELECT COUNT(*) FROM (SELECT TOP 30 PERCENT WITH TIES * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t3;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Target list missing from TOP clause)~~
+
+
+-- Test Case 3: TOP PERCENT with WHERE clause
+SELECT COUNT(*) FROM (SELECT TOP 25 PERCENT * FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' ORDER BY score DESC) AS t4;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT COUNT(*) FROM (SELECT TOP 20.4 PERCENT * FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' ORDER BY score DESC) AS t5;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Test Case 4: TOP PERCENT with NULL values
+SELECT COUNT(*) FROM (SELECT TOP 40 PERCENT * FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics' ORDER BY score DESC) AS t6;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Test Case 5: TOP PERCENT with money data type
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT * FROM jira_babel_1358.test_percent_sales ORDER BY revenue DESC) AS t7;
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Test Case 6: TOP PERCENT in subquery
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM (
+        SELECT TOP 50 PERCENT *
+        FROM jira_babel_1358.test_percent_scores
+        ORDER BY score DESC
+    ) AS subq
+    WHERE score > 90
+) AS t8;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- Test Case 7: TOP PERCENT with GROUP BY
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT class_name, AVG(score) as avg_score FROM jira_babel_1358.test_percent_scores
+GROUP BY class_name
+ORDER BY avg_score DESC) AS t9;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 7a: TOP PERCENT with GROUP BY and HAVING clause
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT class_name, AVG(score) as avg_score FROM jira_babel_1358.test_percent_scores
+GROUP BY class_name
+HAVING AVG(score) > 80
+ORDER BY avg_score DESC) AS t10;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 8: TOP PERCENT with decimal percentage
+SELECT COUNT(*) FROM (SELECT TOP 33.33 PERCENT *
+FROM jira_babel_1358.test_percent_scores
+ORDER BY score DESC) AS t11;
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Test Case 9: TOP PERCENT with DISTINCT
+SELECT COUNT(*) FROM (SELECT DISTINCT TOP 50 PERCENT class_name
+FROM jira_babel_1358.test_percent_scores
+ORDER BY class_name) AS t12;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Test Case 10: TOP PERCENT with JOIN
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT s.student_name, s.score, t.revenue
+FROM jira_babel_1358.test_percent_scores s
+LEFT JOIN jira_babel_1358.test_percent_sales t ON s.id = t.id
+ORDER BY s.score DESC) AS t13;
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+-- Test Case 11: TOP 100 PERCENT (should return all rows)
+SELECT COUNT(*) FROM (SELECT TOP 100 PERCENT *
+FROM jira_babel_1358.test_percent_scores
+ORDER BY score DESC) AS t14;
+GO
+~~START~~
+int
+9
+~~END~~
+
+
+-- Test Case 12: TOP 1 PERCENT (minimum count case)
+SELECT COUNT(*) FROM (SELECT TOP 1 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t15; 
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 13: TOP 0 PERCENT (Extreme min count case)
+SELECT COUNT(*) FROM (SELECT TOP 0 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t16;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test Case 14: TOP 0.5 PERCENT (Extreme min decimal count case)
+SELECT COUNT(*) FROM (SELECT TOP 0.5 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t17;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 15: TOP PERCENT with PIVOT
+SELECT COUNT(*) FROM (
+    SELECT TOP 50 PERCENT *
+    FROM (
+        SELECT class_name, score, 
+               CASE 
+                   WHEN score >= 90 THEN 'A'
+                   WHEN score >= 80 THEN 'B'
+                   WHEN score >= 70 THEN 'C'
+                   ELSE 'D'
+               END as grade
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+    ) AS SourceTable
+    PIVOT (
+        COUNT(score)
+        FOR grade IN ([A], [B], [C], [D])
+    ) AS PivotTable
+    ORDER BY [A] DESC, [B] DESC
+) AS t18;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 16: TOP PERCENT with UNPIVOT and subquery
+WITH QuarterlyRevenue AS (
+    SELECT TOP 50 PERCENT 
+           region,
+           SUM(CASE WHEN quarter = 'Q1' THEN revenue ELSE 0 END) as Q1_Revenue,
+           SUM(CASE WHEN quarter = 'Q2' THEN revenue ELSE 0 END) as Q2_Revenue
+    FROM jira_babel_1358.test_percent_sales
+    GROUP BY region
+)
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT *
+    FROM QuarterlyRevenue
+    UNPIVOT (
+        revenue FOR quarter IN (Q1_Revenue, Q2_Revenue)
+    ) AS unpvt
+    ORDER BY revenue DESC
+) AS t19;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 17: TOP PERCENT with Window Functions
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM (
+        SELECT TOP 50 PERCENT 
+               student_name,
+               score,
+               class_name,
+               ROW_NUMBER() OVER(PARTITION BY class_name ORDER BY score DESC) as rank_in_class,
+               AVG(score) OVER(PARTITION BY class_name) as class_avg
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+    ) AS ranked_scores
+    WHERE rank_in_class <= 2
+) AS t20;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- Test Case 18: TOP PERCENT with CTEs and Multiple Aggregations
+WITH ClassStats AS (
+    SELECT TOP 50 PERCENT
+        class_name,
+        AVG(score) as avg_score,
+        COUNT(*) as student_count,
+        MAX(score) as max_score
+    FROM jira_babel_1358.test_percent_scores
+    WHERE score IS NOT NULL
+    GROUP BY class_name
+    ORDER BY AVG(score) DESC
+),
+ClassRanking AS (
+    SELECT 
+        class_name,
+        avg_score,
+        RANK() OVER(ORDER BY avg_score DESC) as class_rank
+    FROM ClassStats
+)
+SELECT COUNT(*) FROM (
+    SELECT TOP 50 PERCENT *
+    FROM ClassRanking
+    ORDER BY avg_score DESC
+) AS t21;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 19: TOP PERCENT with CROSS APPLY
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT c.class_name, c.avg_score, s.student_name, s.score
+    FROM (
+        SELECT class_name, AVG(score) as avg_score
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        GROUP BY class_name
+    ) c
+    CROSS APPLY (
+        SELECT TOP 2 student_name, score
+        FROM jira_babel_1358.test_percent_scores s
+        WHERE s.class_name = c.class_name
+        AND score IS NOT NULL
+        ORDER BY score DESC
+    ) s
+    ORDER BY c.avg_score DESC
+) AS t22;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Test Case 20: TOP PERCENT with Window Functions and Filtering
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM (
+        SELECT TOP 40 PERCENT
+               student_name,
+               score,
+               class_name,
+               AVG(score) OVER(PARTITION BY class_name) as class_avg,
+               score - AVG(score) OVER(PARTITION BY class_name) as score_diff,
+               DENSE_RANK() OVER(ORDER BY score DESC) as overall_rank
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+    ) sub
+    WHERE score_diff > 0
+) AS t23;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- Test Case 21: Nested TOP PERCENT with Multiple Levels
+SELECT COUNT(*) FROM (
+    SELECT TOP 25 PERCENT *
+    FROM (
+        SELECT TOP 50 PERCENT
+               student_name,
+               score,
+               class_name,
+               NTILE(4) OVER(ORDER BY score DESC) as quartile
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+    ) sub
+    WHERE quartile = 1
+    ORDER BY score DESC
+) AS t24;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Test Case 22: TOP PERCENT with Revenue Analysis
+WITH RevenueAnalysis AS (
+    SELECT TOP 50 PERCENT
+           region,
+           quarter,
+           revenue,
+           SUM(revenue) OVER(PARTITION BY region) as total_region_revenue,
+           SUM(revenue) OVER(PARTITION BY quarter) as total_quarter_revenue
+    FROM jira_babel_1358.test_percent_sales
+    WHERE revenue IS NOT NULL
+    ORDER BY revenue DESC
+)
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM RevenueAnalysis
+    WHERE revenue > (SELECT AVG(revenue) FROM jira_babel_1358.test_percent_sales WHERE revenue IS NOT NULL)
+) AS t25;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Test Case 23: TOP PERCENT with Running Totals
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT
+           student_name,
+           score,
+           class_name,
+           SUM(score) OVER(PARTITION BY class_name ORDER BY score DESC) as running_total,
+           COUNT(*) OVER(PARTITION BY class_name ORDER BY score DESC) as running_count
+    FROM jira_babel_1358.test_percent_scores
+    WHERE score IS NOT NULL
+    ORDER BY class_name, score DESC
+) AS t26;
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Test Case 24: TOP PERCENT with Complex Joins
+SELECT COUNT(*) FROM (
+    SELECT TOP 40 PERCENT 
+           s.student_name,
+           s.score as student_score,
+           s.class_name,
+           t.revenue as related_revenue,
+           AVG(s.score) OVER(PARTITION BY s.class_name) as class_avg
+    FROM jira_babel_1358.test_percent_scores s
+    LEFT JOIN jira_babel_1358.test_percent_sales t ON t.id = s.id
+    WHERE s.score IS NOT NULL
+    ORDER BY s.score DESC, t.revenue DESC
+) AS t27;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- Test Case 25: Performance test with large table
+select count(*) from ( SELECT TOP 10 PERCENT product_name FROM jira_babel_1358.test_percent_sales_large );
+GO
+~~START~~
+int
+1000
+~~END~~
+
+
+-- Test Case 26: Complex performance test with large table
+SELECT COUNT(*) FROM (
+    SELECT TOP 5 PERCENT 
+           category,
+           AVG(sales_amount) as avg_sales,
+           COUNT(*) as product_count,
+           SUM(sales_amount) as total_sales,
+           RANK() OVER(ORDER BY AVG(sales_amount) DESC) as category_rank
+    FROM jira_babel_1358.test_percent_sales_large
+    WHERE sales_amount > 200
+    GROUP BY category
+    HAVING COUNT(*) > 100
+    ORDER BY avg_sales DESC
+) AS complex_perf_test;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+
+-- Test Case 27: TOP PERCENT with variables and reuse
+DECLARE @top_products TABLE (
+    product_name VARCHAR(20),
+    sales_amount DECIMAL(10,2)
+);
+INSERT INTO @top_products
+SELECT TOP 5 PERCENT product_name, sales_amount 
+FROM jira_babel_1358.test_percent_sales_large 
+ORDER BY sales_amount DESC;
+SELECT COUNT(*) FROM @top_products;
+GO
+~~ROW COUNT: 500~~
+
+~~START~~
+int
+500
+~~END~~
+
+
+-- Test Case 28: TOP PERCENT with variable percentage
+DECLARE @percent_value FLOAT = 15.5;
+SELECT COUNT(*) FROM (
+    SELECT TOP (@percent_value) PERCENT * 
+    FROM jira_babel_1358.test_percent_sales_large 
+    WHERE category = 'Electronics'
+    ORDER BY sales_amount DESC
+) AS variable_percent_test;
+GO
+~~START~~
+int
+517
+~~END~~
+
+
+
+/*
+ * ======================================================================================================================
+ *                                          DEPENDENT OBJECTS TESTS
+ * ======================================================================================================================
+ */
+-- Test Case 29: TOP PERCENT in VIEW
+SELECT COUNT(*) FROM jira_babel_1358.top_performers_view;
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Test Case 30: TOP PERCENT in FUNCTION
+SELECT COUNT(*) FROM jira_babel_1358.get_top_sales(10.5);
+GO
+~~START~~
+int
+1050
+~~END~~
+
+
+-- Test Case 31: TOP PERCENT in STORED PROCEDURE
+EXEC jira_babel_1358.get_top_percent_by_category 'Electronics', 25.0;
+GO
+~~START~~
+int
+834
+~~END~~
+
+
+
+
+/*
+ * ======================================================================================================================
+ *                                          ADDITIONAL COMPLEX Example TESTING
+ * ======================================================================================================================
+ */
+-- Test Case 32: Basic TOP PERCENT with FOR JSON AUTO
+SELECT TOP 50 PERCENT student_name
+FROM jira_babel_1358.test_percent_scores 
+ORDER BY score DESC
+FOR JSON AUTO;
+GO
+~~START~~
+nvarchar
+[{"student_name": "Frank Black"}, {"student_name": "Eva White"}, {"student_name": "John Doe"}, {"student_name": "Bob Wilson"}, {"student_name": "Charlie Davis"}]
+~~END~~
+
+
+-- Test Case 33: TOP PERCENT with FOR JSON PATH
+SELECT TOP 30 PERCENT student_name, score, class_name
+FROM jira_babel_1358.test_percent_scores 
+WHERE score IS NOT NULL
+ORDER BY score DESC
+FOR JSON PATH;
+GO
+~~START~~
+nvarchar
+[{"student_name": "Frank Black", "score": 100.00, "class_name": "Physics"}, {"student_name": "Eva White", "score": 100.00, "class_name": "Physics"}, {"student_name": "John Doe", "score": 95.50, "class_name": "Math"}]
+~~END~~
+
+
+-- Test Case 34: TOP PERCENT with FOR JSON PATH and INCLUDE_NULL_VALUES
+SELECT TOP 33 PERCENT student_name, score, class_name
+FROM jira_babel_1358.test_percent_scores 
+ORDER BY id
+FOR JSON PATH, INCLUDE_NULL_VALUES;
+GO
+~~START~~
+nvarchar
+[{"student_name": "John Doe", "score": 95.50, "class_name": "Math"}, {"student_name": "Jane Smith", "score": 87.30, "class_name": "Math"}, {"student_name": "Bob Wilson", "score": 92.00, "class_name": "Math"}]
+~~END~~
+
+
+
+-- Test Case 35: TOP PERCENT with UNION ALL : 
+/*
+* will fail because of order by issue with subquery (known error)
+* BABEL-4313: Handle ORDER BY clause when inside subquery with UNION and TOP
+* The ORDER BY clause is invalid in views, inline functions, derived tables, 
+* subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.
+*/
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' ORDER BY score DESC
+    UNION ALL
+    SELECT TOP 50 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics' ORDER BY score DESC
+) AS t34;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "UNION")~~
+
+
+-- The above sql query passing without order by clause
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' 
+    UNION ALL
+    SELECT TOP 50 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics'
+) AS t34;
+GO
+~~START~~
+int
+9
+~~END~~
+
+
+-- Test Case 36: TOP PERCENT with UNION (removes duplicates)
+SELECT COUNT(*) FROM (
+    SELECT TOP 40 PERCENT student_name, score FROM jira_babel_1358.test_percent_scores WHERE score > 80
+    UNION
+    SELECT TOP 60 PERCENT student_name, score FROM jira_babel_1358.test_percent_scores WHERE score < 90
+) AS t35;
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+-- Test Case 37: TOP PERCENT on outside of UNION
+SELECT TOP 20 PERCENT * FROM (
+    SELECT student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math'
+    UNION ALL
+    SELECT student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics'
+) AS union_result
+ORDER BY score DESC;
+GO
+~~START~~
+varchar#!#numeric#!#varchar
+Eva White#!#100.00#!#Physics
+Frank Black#!#100.00#!#Physics
+~~END~~
+
+
+
+
+/*
+ * ======================================================================================================================
+ *                                          CROSS SCHEMA TESTING WITH TOP PERCENT
+ * ======================================================================================================================
+ */
+-- Test Case 38: TOP PERCENT with cross schema JOIN
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT 
+           s.student_name, 
+           s.score, 
+           t.revenue
+    FROM jira_babel_1358.test_percent_scores s
+    LEFT JOIN test_schema2_jira_babel_1358.test_cross_sales t ON s.id = t.id
+    WHERE s.score IS NOT NULL
+    ORDER BY s.score DESC
+) AS t39;
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Test Case 39: TOP PERCENT with cross schema subquery
+SELECT COUNT(*) FROM (
+    SELECT TOP 40 PERCENT *
+    FROM jira_babel_1358.test_percent_scores s
+    WHERE s.score > (
+        SELECT AVG(revenue) 
+        FROM test_schema2_jira_babel_1358.test_cross_sales 
+        WHERE revenue IS NOT NULL
+    )
+    ORDER BY s.score DESC
+) AS t41;
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test Case 40: TOP PERCENT with cross schema CTE
+WITH CrossSchemaData AS (
+    SELECT TOP 50 PERCENT 
+           s.student_name,
+           s.score,
+           (SELECT COUNT(*) FROM test_schema2_jira_babel_1358.test_cross_sales WHERE revenue > s.score) as higher_revenue_count
+    FROM jira_babel_1358.test_percent_scores s
+    WHERE s.score IS NOT NULL
+    ORDER BY s.score DESC
+)
+SELECT COUNT(*) FROM CrossSchemaData WHERE higher_revenue_count > 0;
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+
+
+/*
+ * ======================================================================================================================
+ *                                          Update/Delete/Insert TOP N PERCENT ..
+ *                                  Currently, we are not supporting top N Percent for other DMLs
+ *                              Creates BABEL-6059 to track support for TOP N PERCENT for others DMLs
+ *                   Exception: Though, we support top 100 percent as it is being treated as no percent Op is present        
+ * ======================================================================================================================
+ */
+-- Test Case 41: UPDATE TOP N PERCENT (will throw error)
+UPDATE TOP (30) PERCENT jira_babel_1358.test_percent_scores 
+SET score = score + 5 
+WHERE score IS NOT NULL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: UPDATE TOP N PERCENT is not supported yet)~~
+
+
+UPDATE TOP (100) PERCENT jira_babel_1358.test_percent_scores 
+SET score = score + 5 
+WHERE score IS NOT NULL;
+GO
+~~ROW COUNT: 8~~
+
+
+-- Test Case 42: DELETE TOP N PERCENT (will throw error)
+DELETE TOP (60) PERCENT FROM jira_babel_1358.test_percent_scores 
+WHERE score < 80;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: DELETE TOP N PERCENT is not supported yet)~~
+
+
+-- Test Case 43: INSERT TOP N PERCENT (will throw error)
+INSERT TOP (9) PERCENT INTO jira_babel_1358.test_percent_scores (id, student_name, score, class_name, year)
+SELECT id + 200, 'New_' + student_name, score, class_name, 2024
+FROM jira_babel_1358.test_percent_scores
+WHERE score IS NOT NULL
+ORDER BY score DESC;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: INSERT TOP N PERCENT is not supported yet)~~
+
+
+-- Test Case 44: INSERT TOP N PERCENT with OUTPUT INTO
+INSERT INTO jira_babel_1358.test_percent_sales_second
+OUTPUT inserted.*
+INTO jira_babel_1358.test_percent_sales_third
+SELECT TOP 100 PERCENT *
+FROM (
+    SELECT TOP 6 *
+    FROM jira_babel_1358.test_percent_sales
+) AS top_students;
+GO
+~~ROW COUNT: 6~~
+
+
+select count(*) from jira_babel_1358.test_percent_sales_second;
+GO
+~~START~~
+int
+6
+~~END~~
+
+select count(*) from jira_babel_1358.test_percent_sales_third;
+GO
+~~START~~
+int
+6
+~~END~~
+
+
+
+WITH RankedSales AS (
+    SELECT *, 
+           ROW_NUMBER() OVER (PARTITION BY region ORDER BY revenue DESC) as region_rank,
+           DENSE_RANK() OVER (ORDER BY revenue DESC) as overall_rank
+    FROM jira_babel_1358.test_percent_sales 
+    WHERE revenue IS NOT NULL
+),
+TopSales AS (
+    SELECT id, product_name, revenue, region, quarter
+    FROM RankedSales 
+    WHERE region_rank <= 2
+)
+INSERT INTO jira_babel_1358.test_percent_sales_second (id, product_name, revenue, region, quarter)
+OUTPUT inserted.id, inserted.product_name, inserted.revenue, inserted.region, inserted.quarter
+INTO jira_babel_1358.test_percent_sales_third (id, product_name, revenue, region, quarter)
+SELECT TOP 100 PERCENT 
+    id, 
+    product_name, 
+    revenue, 
+    region, 
+    quarter
+FROM TopSales 
+ORDER BY revenue DESC;
+select count(*) from jira_babel_1358.test_percent_sales_second;
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int
+10
+~~END~~
+
+select count(*) from jira_babel_1358.test_percent_sales_third;
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+-- Test Case 45: UPDATE with JOIN and TOP N PERCENT Tests
+UPDATE TOP (100) PERCENT s 
+SET s.score = s.score + 5
+FROM jira_babel_1358.test_percent_scores s
+INNER JOIN jira_babel_1358.test_percent_sales t ON s.id = t.id
+WHERE s.score IS NOT NULL;
+GO
+~~ROW COUNT: 6~~
+
+
+select count(*) from jira_babel_1358.test_percent_scores;
+GO
+~~START~~
+int
+9
+~~END~~
+
+
+
+-- Test Case 46: UPDATE with OUTPUT INTO and TOP N PERCENT
+UPDATE TOP (100) PERCENT jira_babel_1358.test_percent_scores
+SET score = score + 10
+OUTPUT inserted.*
+INTO jira_babel_1358.test_percent_scores_second
+WHERE score < 80;
+GO
+~~ROW COUNT: 1~~
+
+
+select count(*) from jira_babel_1358.test_percent_scores_second;
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+-- Test Case 47: DELETE with JOIN and TOP N PERCENT Tests
+DELETE TOP (100) PERCENT s
+FROM jira_babel_1358.test_percent_scores s
+INNER JOIN jira_babel_1358.test_percent_sales t ON s.id = t.id
+WHERE s.id > 200 OR s.id > 100;
+select count(*) from jira_babel_1358.test_percent_scores;
+GO
+~~START~~
+int
+9
+~~END~~
+
+
+
+-- Test Case 48: DELETE with OUTPUT INTO and TOP N PERCENT
+DELETE TOP (100) PERCENT FROM jira_babel_1358.test_percent_scores
+OUTPUT deleted.id, deleted.student_name, deleted.score, deleted.class_name
+INTO jira_babel_1358.test_percent_sales (id, product_name, revenue, region)
+WHERE score < 85;
+select count(*) from jira_babel_1358.test_percent_scores;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+8
+~~END~~
+

--- a/test/JDBC/expected/babel_top_in_dml.out
+++ b/test/JDBC/expected/babel_top_in_dml.out
@@ -223,14 +223,14 @@ update top (10) percent t4 set b = 100
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TOP # PERCENT is not yet supported)~~
+~~ERROR (Message: UPDATE TOP N PERCENT is not supported yet)~~
 
 
 delete top (10) percent from t4
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: TOP # PERCENT is not yet supported)~~
+~~ERROR (Message: DELETE TOP N PERCENT is not supported yet)~~
 
 
 drop table t
@@ -1249,7 +1249,7 @@ Update on top_with_output_tbl
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 24.340 ms
+Babelfish T-SQL Batch Parsing Time: 0.329 ms
 ~~END~~
 
 
@@ -1276,7 +1276,7 @@ Delete on top_with_output_tbl
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 8.331 ms
+Babelfish T-SQL Batch Parsing Time: 0.103 ms
 ~~END~~
 
 

--- a/test/JDBC/input/top_percent/Select_top_N_percent-vu-cleanup.sql
+++ b/test/JDBC/input/top_percent/Select_top_N_percent-vu-cleanup.sql
@@ -1,0 +1,44 @@
+-- Cleanup script for TOP PERCENT test cases
+
+-- Drop dependent objects created in prepare file
+DROP VIEW IF EXISTS jira_babel_1358.top_performers_view;
+GO
+
+DROP FUNCTION IF EXISTS jira_babel_1358.get_top_sales;
+GO
+
+DROP PROCEDURE IF EXISTS jira_babel_1358.get_top_percent_by_category;
+GO
+
+-- Drop test tables created in prepare file
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_scores;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales_second;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales_third;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_scores_second;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_scores_third;
+GO
+
+DROP TABLE IF EXISTS jira_babel_1358.test_percent_sales_large;
+GO
+
+-- Drop cross-schema test table
+DROP TABLE IF EXISTS test_schema2_jira_babel_1358.test_cross_sales;
+GO
+
+-- Drop the test schemas
+DROP SCHEMA IF EXISTS jira_babel_1358;
+GO
+
+DROP SCHEMA IF EXISTS test_schema2_jira_babel_1358;
+GO

--- a/test/JDBC/input/top_percent/Select_top_N_percent-vu-prepare.sql
+++ b/test/JDBC/input/top_percent/Select_top_N_percent-vu-prepare.sql
@@ -1,0 +1,234 @@
+/*
+ * TOP PERCENT Test Cases Summary
+ * JIRA-BABEL-1358
+ *
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | Basic TOP PERCENT                                | Basic               | Tests 50%, 0%                                 |
+ * |  2  | TOP PERCENT with ties                            | Error Case          | WITH TIES not supported - should throw error  |
+ * |  3  | TOP PERCENT with WHERE                           | Filtering           | Tests 25% and 20.4% with WHERE clause         |
+ * |  4  | TOP PERCENT with NULL values                     | NULL Handling       | Tests 40% with NULL data                      |
+ * |  5  | TOP PERCENT with money data type                 | Data Types          | Tests 50% with money/revenue data             |
+ * |  6  | TOP PERCENT in subquery                          | Subquery            | Tests 50% in nested SELECT                    |
+ * |  7  | TOP PERCENT with GROUP BY                        | Aggregation         | Tests 50% with GROUP BY clause                |
+ * | 7a  | TOP PERCENT with GROUP BY and HAVING             | Aggregation+Filter  | Tests 50% with GROUP BY and HAVING clause     |
+ * |  8  | TOP PERCENT with decimal percentage              | Precision           | Tests 33.33% decimal precision                |
+ * |  9  | TOP PERCENT with DISTINCT                        | Distinct Values     | Tests 50% with DISTINCT                       |
+ * | 10  | TOP PERCENT with JOIN                            | Joins               | Tests 50% with LEFT JOIN                      |
+ * | 11  | TOP 100 PERCENT                                  | Edge Case           | Should return all rows                        |
+ * | 12  | TOP 1 PERCENT                                    | Minimum Case        | Tests minimum percentage                      |
+ * | 13  | TOP 0 PERCENT                                    | Extreme Edge        | Tests zero percentage                         |
+ * | 14  | TOP 0.5 PERCENT                                  | Extreme Decimal     | Tests very small decimal percentage           |
+ * | 15  | TOP PERCENT with PIVOT                           | Advanced            | Tests 50% with PIVOT operation                |
+ * | 16  | TOP PERCENT with UNPIVOT                         | Advanced            | Tests nested 50% and 30% with UNPIVOT         |
+ * | 17  | TOP PERCENT with Window Functions                | Window Functions    | Tests 50% with ROW_NUMBER() and AVG() OVER    |
+ * | 18  | TOP PERCENT with CTEs                            | CTEs                | Tests 50% with Common Table Expressions       |
+ * | 19  | TOP PERCENT with CROSS APPLY                     | Advanced Joins      | Tests 30% with CROSS APPLY                    |
+ * | 20  | TOP PERCENT with Window Functions and Filtering  | Complex Window      | Tests 40% with multiple window functions      |
+ * | 21  | Nested TOP PERCENT                               | Nested              | Tests 25% of 50% (nested percentages)         |
+ * | 22  | TOP PERCENT with Revenue Analysis                | Complex CTE         | Tests 50% with revenue analysis CTE           |
+ * | 23  | TOP PERCENT with Running Totals                  | Running Calculations| Tests 30% with SUM() OVER                     |
+ * | 24  | TOP PERCENT with Complex Joins                   | Complex Joins       | Tests 40% with LEFT JOIN and window functions |
+ * | 25  | Performance test with large table                | Performance         | Tests 10% with large dataset (10K rows)       |
+ * | 26  | Complex performance test with large table        | Complex Performance | Tests 5% with GROUP BY, HAVING, window funcs  |
+ * | 27  | TOP PERCENT with variables and reuse             | Variables           | Tests table variable storage and reuse        |
+ * | 28  | TOP PERCENT with variable percentage             | Variable Percentage | Tests dynamic percentage with @percent_value  |
+ * | 29  | TOP PERCENT in VIEW                              | Dependent Objects   | Tests TOP PERCENT within VIEW definition      |
+ * | 30  | TOP PERCENT in FUNCTION                          | Dependent Objects   | Tests TOP PERCENT in table-valued function    |
+ * | 31  | TOP PERCENT in STORED PROCEDURE                  | Dependent Objects   | Tests TOP PERCENT in stored procedure         |
+ * | 32  | TOP PERCENT with FOR JSON AUTO                   | JSON Output         | Tests 50% with FOR JSON AUTO                  |
+ * | 33  | TOP PERCENT with FOR JSON PATH                   | JSON Output         | Tests 30% with FOR JSON PATH                  |
+ * | 34  | TOP PERCENT with FOR JSON INCLUDE_NULL_VALUES    | JSON Output         | Tests 33% with NULL handling in JSON          |
+ * | 35  | TOP PERCENT with UNION ALL                       | Set Operations      | Tests 30% and 50% with UNION ALL              |
+ * | 36  | TOP PERCENT with UNION                           | Set Operations      | Tests 40% and 60% with UNION (deduplication)  |
+ * | 37  | TOP PERCENT on outside of UNION                  | Set Operations      | Tests 20% applied to UNION result             |
+ * | 38  | TOP PERCENT with cross schema JOIN               | Cross Schema        | Tests 30% with cross-schema LEFT JOIN         |
+ * | 39  | TOP PERCENT with cross schema subquery           | Cross Schema        | Tests 40% with cross-schema subquery          |
+ * | 40  | TOP PERCENT with cross schema CTE                | Cross Schema        | Tests 50% with cross-schema CTE               |
+ * | 41  | UPDATE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 42  | DELETE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 43  | INSERT TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 44  | INSERT with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests INSERT TOP 100% with OUTPUT INTO        |
+ * | 45  | UPDATE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests UPDATE TOP 100% with JOIN               |
+ * | 46  | UPDATE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests UPDATE TOP 100% with OUTPUT INTO        |
+ * | 47  | DELETE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests DELETE TOP 100% with JOIN               |
+ * | 48  | DELETE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests DELETE TOP 100% with OUTPUT INTO        |
+ */
+
+-- Create schema for TOP PERCENT testing
+CREATE SCHEMA jira_babel_1358;
+GO
+
+ -- Create test tables for TOP N PERCENT testing
+CREATE TABLE jira_babel_1358.test_percent_scores (
+    id INT,
+    student_name VARCHAR(50),
+    score DECIMAL(5,2),
+    class_name VARCHAR(50),
+    year INT
+);
+
+CREATE TABLE jira_babel_1358.test_percent_sales (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    quarter VARCHAR(2)
+);
+GO
+
+-- Insert test data for scores
+INSERT INTO jira_babel_1358.test_percent_scores (id, student_name, score, class_name, year) VALUES
+(1, 'John Doe', 95.5, 'Math', 2023),
+(2, 'Jane Smith', 87.3, 'Math', 2023),
+(3, 'Bob Wilson', 92.0, 'Math', 2023),
+(4, 'Alice Brown', 78.5, 'Math', 2023),
+(5, 'Charlie Davis', 88.9, 'Math', 2023),
+(6, 'Eva White', 100.0, 'Physics', 2023),
+(7, 'Frank Black', 100.0, 'Physics', 2023),
+(8, 'George Grey', 0.0, 'Physics', 2023),
+(9, 'Helen Green', NULL, 'Physics', 2023);
+
+-- Insert test data for sales
+INSERT INTO jira_babel_1358.test_percent_sales (id, product_name, revenue, region, quarter) VALUES
+(1, 'Product A', 10000.00, 'North', 'Q1'),
+(2, 'Product B', 15000.50, 'North', 'Q1'),
+(3, 'Product C', 20000.75, 'North', 'Q1'),
+(4, 'Product D', 5000.25, 'South', 'Q1'),
+(5, 'Product E', 7500.50, 'South', 'Q1'),
+(6, 'Product F', NULL, 'South', 'Q1');
+GO
+
+-- Create a simple large table
+CREATE TABLE jira_babel_1358.test_percent_sales_large (
+    product_name VARCHAR(20),
+    category VARCHAR(20),
+    sales_amount DECIMAL(10,2)
+);
+GO
+
+-- Insert sample data (10,000 rows)
+WITH Numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 
+    FROM Numbers 
+    WHERE n < 10000
+)
+INSERT INTO jira_babel_1358.test_percent_sales_large (product_name, category, sales_amount)
+SELECT 
+    'Product' + CAST((n % 10) AS VARCHAR(2)),
+    CASE (n % 3)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Clothing'
+        ELSE 'Food'
+    END,
+    100 + (n % 900)
+FROM Numbers
+OPTION (MAXRECURSION 10000);
+GO
+
+
+/*
+ * ======================================================================================================================
+ *                                          DEPENDENT OBJECTS TESTS
+ * ======================================================================================================================
+ */
+
+ -- View 
+CREATE VIEW jira_babel_1358.top_performers_view AS
+    SELECT TOP 20 PERCENT student_name, score, class_name
+    FROM jira_babel_1358.test_percent_scores
+    WHERE score IS NOT NULL
+    ORDER BY score DESC;
+GO
+
+
+-- Function
+CREATE FUNCTION jira_babel_1358.get_top_sales(@percentage FLOAT)
+RETURNS TABLE
+AS
+RETURN (
+    SELECT TOP (@percentage) PERCENT product_name, sales_amount
+    FROM jira_babel_1358.test_percent_sales_large
+    ORDER BY sales_amount DESC
+);
+GO
+
+-- Procedure
+CREATE PROCEDURE jira_babel_1358.get_top_percent_by_category
+    @category VARCHAR(20),
+    @percentage FLOAT
+AS
+BEGIN
+    SELECT COUNT(*) as row_count
+    FROM (
+        SELECT TOP (@percentage) PERCENT *
+        FROM jira_babel_1358.test_percent_sales_large
+        WHERE category = @category
+        ORDER BY sales_amount DESC
+    ) as derived_table;
+END;
+GO
+
+
+-- Create second schema for cross-schema testing
+CREATE SCHEMA test_schema2_jira_babel_1358;
+GO
+
+CREATE TABLE test_schema2_jira_babel_1358.test_cross_sales (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    sales_date DATE
+);
+GO
+
+-- Insert test data for cross-schema testing
+INSERT INTO test_schema2_jira_babel_1358.test_cross_sales (id, product_name, revenue, region, sales_date) VALUES
+(1, 'Cross Product A', 12000.00, 'East', '2023-01-15'),
+(2, 'Cross Product B', 18000.50, 'West', '2023-02-20'),
+(3, 'Cross Product C', 25000.75, 'East', '2023-03-10'),
+(4, 'Cross Product D', 8000.25, 'West', '2023-04-05'),
+(5, 'Cross Product E', 15500.50, 'North', '2023-05-12');
+GO
+
+
+/*
+ * Created to test insert into output ..
+ * test case 43-48 
+ */ 
+CREATE TABLE jira_babel_1358.test_percent_scores_second (
+    id INT,
+    student_name VARCHAR(50),
+    score DECIMAL(5,2),
+    class_name VARCHAR(50),
+    year INT
+);
+
+CREATE TABLE jira_babel_1358.test_percent_sales_second (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    quarter VARCHAR(2)
+);
+GO
+
+CREATE TABLE jira_babel_1358.test_percent_scores_third (
+    id INT,
+    student_name VARCHAR(50),
+    score DECIMAL(5,2),
+    class_name VARCHAR(50),
+    year INT
+);
+
+CREATE TABLE jira_babel_1358.test_percent_sales_third (
+    id INT,
+    product_name VARCHAR(50),
+    revenue MONEY,
+    region VARCHAR(50),
+    quarter VARCHAR(2)
+);
+GO

--- a/test/JDBC/input/top_percent/Select_top_N_percent-vu-verify.sql
+++ b/test/JDBC/input/top_percent/Select_top_N_percent-vu-verify.sql
@@ -1,0 +1,638 @@
+/*
+ * TOP PERCENT Test Cases Summary
+ * JIRA-BABEL-1358
+ *
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | Basic TOP PERCENT                                | Basic               | Tests 50%, 0%                                 |
+ * |  2  | TOP PERCENT with ties                            | Error Case          | WITH TIES not supported - should throw error  |
+ * |  3  | TOP PERCENT with WHERE                           | Filtering           | Tests 25% and 20.4% with WHERE clause         |
+ * |  4  | TOP PERCENT with NULL values                     | NULL Handling       | Tests 40% with NULL data                      |
+ * |  5  | TOP PERCENT with money data type                 | Data Types          | Tests 50% with money/revenue data             |
+ * |  6  | TOP PERCENT in subquery                          | Subquery            | Tests 50% in nested SELECT                    |
+ * |  7  | TOP PERCENT with GROUP BY                        | Aggregation         | Tests 50% with GROUP BY clause                |
+ * | 7a  | TOP PERCENT with GROUP BY and HAVING             | Aggregation+Filter  | Tests 50% with GROUP BY and HAVING clause     |
+ * |  8  | TOP PERCENT with decimal percentage              | Precision           | Tests 33.33% decimal precision                |
+ * |  9  | TOP PERCENT with DISTINCT                        | Distinct Values     | Tests 50% with DISTINCT                       |
+ * | 10  | TOP PERCENT with JOIN                            | Joins               | Tests 50% with LEFT JOIN                      |
+ * | 11  | TOP 100 PERCENT                                  | Edge Case           | Should return all rows                        |
+ * | 12  | TOP 1 PERCENT                                    | Minimum Case        | Tests minimum percentage                      |
+ * | 13  | TOP 0 PERCENT                                    | Extreme Edge        | Tests zero percentage                         |
+ * | 14  | TOP 0.5 PERCENT                                  | Extreme Decimal     | Tests very small decimal percentage           |
+ * | 15  | TOP PERCENT with PIVOT                           | Advanced            | Tests 50% with PIVOT operation                |
+ * | 16  | TOP PERCENT with UNPIVOT                         | Advanced            | Tests nested 50% and 30% with UNPIVOT         |
+ * | 17  | TOP PERCENT with Window Functions                | Window Functions    | Tests 50% with ROW_NUMBER() and AVG() OVER    |
+ * | 18  | TOP PERCENT with CTEs                            | CTEs                | Tests 50% with Common Table Expressions       |
+ * | 19  | TOP PERCENT with CROSS APPLY                     | Advanced Joins      | Tests 30% with CROSS APPLY                    |
+ * | 20  | TOP PERCENT with Window Functions and Filtering  | Complex Window      | Tests 40% with multiple window functions      |
+ * | 21  | Nested TOP PERCENT                               | Nested              | Tests 25% of 50% (nested percentages)         |
+ * | 22  | TOP PERCENT with Revenue Analysis                | Complex CTE         | Tests 50% with revenue analysis CTE           |
+ * | 23  | TOP PERCENT with Running Totals                  | Running Calculations| Tests 30% with SUM() OVER                     |
+ * | 24  | TOP PERCENT with Complex Joins                   | Complex Joins       | Tests 40% with LEFT JOIN and window functions |
+ * | 25  | Performance test with large table                | Performance         | Tests 10% with large dataset (10K rows)       |
+ * | 26  | Complex performance test with large table        | Complex Performance | Tests 5% with GROUP BY, HAVING, window funcs  |
+ * | 27  | TOP PERCENT with variables and reuse             | Variables           | Tests table variable storage and reuse        |
+ * | 28  | TOP PERCENT with variable percentage             | Variable Percentage | Tests dynamic percentage with @percent_value  |
+ * | 29  | TOP PERCENT in VIEW                              | Dependent Objects   | Tests TOP PERCENT within VIEW definition      |
+ * | 30  | TOP PERCENT in FUNCTION                          | Dependent Objects   | Tests TOP PERCENT in table-valued function    |
+ * | 31  | TOP PERCENT in STORED PROCEDURE                  | Dependent Objects   | Tests TOP PERCENT in stored procedure         |
+ * | 32  | TOP PERCENT with FOR JSON AUTO                   | JSON Output         | Tests 50% with FOR JSON AUTO                  |
+ * | 33  | TOP PERCENT with FOR JSON PATH                   | JSON Output         | Tests 30% with FOR JSON PATH                  |
+ * | 34  | TOP PERCENT with FOR JSON INCLUDE_NULL_VALUES    | JSON Output         | Tests 33% with NULL handling in JSON          |
+ * | 35  | TOP PERCENT with UNION ALL                       | Set Operations      | Tests 30% and 50% with UNION ALL              |
+ * | 36  | TOP PERCENT with UNION                           | Set Operations      | Tests 40% and 60% with UNION (deduplication)  |
+ * | 37  | TOP PERCENT on outside of UNION                  | Set Operations      | Tests 20% applied to UNION result             |
+ * | 38  | TOP PERCENT with cross schema JOIN               | Cross Schema        | Tests 30% with cross-schema LEFT JOIN         |
+ * | 39  | TOP PERCENT with cross schema subquery           | Cross Schema        | Tests 40% with cross-schema subquery          |
+ * | 40  | TOP PERCENT with cross schema CTE                | Cross Schema        | Tests 50% with cross-schema CTE               |
+ * | 41  | UPDATE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 42  | DELETE TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 43  | INSERT TOP N PERCENT                             | Error Case          | Should throw error - not supported            |
+ * | 44  | INSERT with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests INSERT TOP 100% with OUTPUT INTO        |
+ * | 45  | UPDATE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests UPDATE TOP 100% with JOIN               |
+ * | 46  | UPDATE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests UPDATE TOP 100% with OUTPUT INTO        |
+ * | 47  | DELETE with JOIN and TOP N PERCENT               | JOIN with DML       | Tests DELETE TOP 100% with JOIN               |
+ * | 48  | DELETE with OUTPUT INTO and TOP N PERCENT        | OUTPUT INTO         | Tests DELETE TOP 100% with OUTPUT INTO        |
+ */
+
+-- Use the test schema
+-- Tables are in jira_babel_1358 schema
+
+ -- Test Case 1: Basic TOP PERCENT
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t1;
+GO
+
+SELECT COUNT(*) FROM (SELECT TOP 0 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t2;
+GO
+
+-- Test Case 2: TOP PERCENT with ties
+/*
+* It seems currently we don't support "with ties" and thus it will throw the error
+* Expected Output : should return 30% of records
+*/
+SELECT COUNT(*) FROM (SELECT TOP 30 PERCENT WITH TIES * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t3;
+GO
+
+-- Test Case 3: TOP PERCENT with WHERE clause
+SELECT COUNT(*) FROM (SELECT TOP 25 PERCENT * FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' ORDER BY score DESC) AS t4;
+GO
+
+SELECT COUNT(*) FROM (SELECT TOP 20.4 PERCENT * FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' ORDER BY score DESC) AS t5;
+GO
+
+-- Test Case 4: TOP PERCENT with NULL values
+SELECT COUNT(*) FROM (SELECT TOP 40 PERCENT * FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics' ORDER BY score DESC) AS t6;
+GO
+
+-- Test Case 5: TOP PERCENT with money data type
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT * FROM jira_babel_1358.test_percent_sales ORDER BY revenue DESC) AS t7;
+GO
+
+-- Test Case 6: TOP PERCENT in subquery
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM (
+        SELECT TOP 50 PERCENT *
+        FROM jira_babel_1358.test_percent_scores
+        ORDER BY score DESC
+    ) AS subq
+    WHERE score > 90
+) AS t8;
+GO
+
+-- Test Case 7: TOP PERCENT with GROUP BY
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT class_name, AVG(score) as avg_score FROM jira_babel_1358.test_percent_scores
+GROUP BY class_name
+ORDER BY avg_score DESC) AS t9;
+GO
+
+-- Test Case 7a: TOP PERCENT with GROUP BY and HAVING clause
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT class_name, AVG(score) as avg_score FROM jira_babel_1358.test_percent_scores
+GROUP BY class_name
+HAVING AVG(score) > 80
+ORDER BY avg_score DESC) AS t10;
+GO
+
+-- Test Case 8: TOP PERCENT with decimal percentage
+SELECT COUNT(*) FROM (SELECT TOP 33.33 PERCENT *
+FROM jira_babel_1358.test_percent_scores
+ORDER BY score DESC) AS t11;
+GO
+
+-- Test Case 9: TOP PERCENT with DISTINCT
+SELECT COUNT(*) FROM (SELECT DISTINCT TOP 50 PERCENT class_name
+FROM jira_babel_1358.test_percent_scores
+ORDER BY class_name) AS t12;
+GO
+
+-- Test Case 10: TOP PERCENT with JOIN
+SELECT COUNT(*) FROM (SELECT TOP 50 PERCENT s.student_name, s.score, t.revenue
+FROM jira_babel_1358.test_percent_scores s
+LEFT JOIN jira_babel_1358.test_percent_sales t ON s.id = t.id
+ORDER BY s.score DESC) AS t13;
+GO
+
+-- Test Case 11: TOP 100 PERCENT (should return all rows)
+SELECT COUNT(*) FROM (SELECT TOP 100 PERCENT *
+FROM jira_babel_1358.test_percent_scores
+ORDER BY score DESC) AS t14;
+GO
+
+-- Test Case 12: TOP 1 PERCENT (minimum count case)
+SELECT COUNT(*) FROM (SELECT TOP 1 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t15; 
+GO
+
+-- Test Case 13: TOP 0 PERCENT (Extreme min count case)
+SELECT COUNT(*) FROM (SELECT TOP 0 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t16;
+GO
+
+-- Test Case 14: TOP 0.5 PERCENT (Extreme min decimal count case)
+SELECT COUNT(*) FROM (SELECT TOP 0.5 PERCENT * FROM jira_babel_1358.test_percent_scores ORDER BY score DESC) AS t17;
+GO
+
+-- Test Case 15: TOP PERCENT with PIVOT
+SELECT COUNT(*) FROM (
+    SELECT TOP 50 PERCENT *
+    FROM (
+        SELECT class_name, score, 
+               CASE 
+                   WHEN score >= 90 THEN 'A'
+                   WHEN score >= 80 THEN 'B'
+                   WHEN score >= 70 THEN 'C'
+                   ELSE 'D'
+               END as grade
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+    ) AS SourceTable
+    PIVOT (
+        COUNT(score)
+        FOR grade IN ([A], [B], [C], [D])
+    ) AS PivotTable
+    ORDER BY [A] DESC, [B] DESC
+) AS t18;
+GO
+
+-- Test Case 16: TOP PERCENT with UNPIVOT and subquery
+WITH QuarterlyRevenue AS (
+    SELECT TOP 50 PERCENT 
+           region,
+           SUM(CASE WHEN quarter = 'Q1' THEN revenue ELSE 0 END) as Q1_Revenue,
+           SUM(CASE WHEN quarter = 'Q2' THEN revenue ELSE 0 END) as Q2_Revenue
+    FROM jira_babel_1358.test_percent_sales
+    GROUP BY region
+)
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT *
+    FROM QuarterlyRevenue
+    UNPIVOT (
+        revenue FOR quarter IN (Q1_Revenue, Q2_Revenue)
+    ) AS unpvt
+    ORDER BY revenue DESC
+) AS t19;
+GO
+
+-- Test Case 17: TOP PERCENT with Window Functions
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM (
+        SELECT TOP 50 PERCENT 
+               student_name,
+               score,
+               class_name,
+               ROW_NUMBER() OVER(PARTITION BY class_name ORDER BY score DESC) as rank_in_class,
+               AVG(score) OVER(PARTITION BY class_name) as class_avg
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+    ) AS ranked_scores
+    WHERE rank_in_class <= 2
+) AS t20;
+GO
+
+-- Test Case 18: TOP PERCENT with CTEs and Multiple Aggregations
+WITH ClassStats AS (
+    SELECT TOP 50 PERCENT
+        class_name,
+        AVG(score) as avg_score,
+        COUNT(*) as student_count,
+        MAX(score) as max_score
+    FROM jira_babel_1358.test_percent_scores
+    WHERE score IS NOT NULL
+    GROUP BY class_name
+    ORDER BY AVG(score) DESC
+),
+ClassRanking AS (
+    SELECT 
+        class_name,
+        avg_score,
+        RANK() OVER(ORDER BY avg_score DESC) as class_rank
+    FROM ClassStats
+)
+SELECT COUNT(*) FROM (
+    SELECT TOP 50 PERCENT *
+    FROM ClassRanking
+    ORDER BY avg_score DESC
+) AS t21;
+GO
+
+-- Test Case 19: TOP PERCENT with CROSS APPLY
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT c.class_name, c.avg_score, s.student_name, s.score
+    FROM (
+        SELECT class_name, AVG(score) as avg_score
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        GROUP BY class_name
+    ) c
+    CROSS APPLY (
+        SELECT TOP 2 student_name, score
+        FROM jira_babel_1358.test_percent_scores s
+        WHERE s.class_name = c.class_name
+        AND score IS NOT NULL
+        ORDER BY score DESC
+    ) s
+    ORDER BY c.avg_score DESC
+) AS t22;
+GO
+
+-- Test Case 20: TOP PERCENT with Window Functions and Filtering
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM (
+        SELECT TOP 40 PERCENT
+               student_name,
+               score,
+               class_name,
+               AVG(score) OVER(PARTITION BY class_name) as class_avg,
+               score - AVG(score) OVER(PARTITION BY class_name) as score_diff,
+               DENSE_RANK() OVER(ORDER BY score DESC) as overall_rank
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+    ) sub
+    WHERE score_diff > 0
+) AS t23;
+GO
+
+-- Test Case 21: Nested TOP PERCENT with Multiple Levels
+SELECT COUNT(*) FROM (
+    SELECT TOP 25 PERCENT *
+    FROM (
+        SELECT TOP 50 PERCENT
+               student_name,
+               score,
+               class_name,
+               NTILE(4) OVER(ORDER BY score DESC) as quartile
+        FROM jira_babel_1358.test_percent_scores
+        WHERE score IS NOT NULL
+        ORDER BY score DESC
+    ) sub
+    WHERE quartile = 1
+    ORDER BY score DESC
+) AS t24;
+GO
+
+-- Test Case 22: TOP PERCENT with Revenue Analysis
+WITH RevenueAnalysis AS (
+    SELECT TOP 50 PERCENT
+           region,
+           quarter,
+           revenue,
+           SUM(revenue) OVER(PARTITION BY region) as total_region_revenue,
+           SUM(revenue) OVER(PARTITION BY quarter) as total_quarter_revenue
+    FROM jira_babel_1358.test_percent_sales
+    WHERE revenue IS NOT NULL
+    ORDER BY revenue DESC
+)
+SELECT COUNT(*) FROM (
+    SELECT *
+    FROM RevenueAnalysis
+    WHERE revenue > (SELECT AVG(revenue) FROM jira_babel_1358.test_percent_sales WHERE revenue IS NOT NULL)
+) AS t25;
+GO
+
+-- Test Case 23: TOP PERCENT with Running Totals
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT
+           student_name,
+           score,
+           class_name,
+           SUM(score) OVER(PARTITION BY class_name ORDER BY score DESC) as running_total,
+           COUNT(*) OVER(PARTITION BY class_name ORDER BY score DESC) as running_count
+    FROM jira_babel_1358.test_percent_scores
+    WHERE score IS NOT NULL
+    ORDER BY class_name, score DESC
+) AS t26;
+GO
+
+-- Test Case 24: TOP PERCENT with Complex Joins
+SELECT COUNT(*) FROM (
+    SELECT TOP 40 PERCENT 
+           s.student_name,
+           s.score as student_score,
+           s.class_name,
+           t.revenue as related_revenue,
+           AVG(s.score) OVER(PARTITION BY s.class_name) as class_avg
+    FROM jira_babel_1358.test_percent_scores s
+    LEFT JOIN jira_babel_1358.test_percent_sales t ON t.id = s.id
+    WHERE s.score IS NOT NULL
+    ORDER BY s.score DESC, t.revenue DESC
+) AS t27;
+GO
+
+-- Test Case 25: Performance test with large table
+select count(*) from ( SELECT TOP 10 PERCENT product_name FROM jira_babel_1358.test_percent_sales_large );
+GO
+
+-- Test Case 26: Complex performance test with large table
+SELECT COUNT(*) FROM (
+    SELECT TOP 5 PERCENT 
+           category,
+           AVG(sales_amount) as avg_sales,
+           COUNT(*) as product_count,
+           SUM(sales_amount) as total_sales,
+           RANK() OVER(ORDER BY AVG(sales_amount) DESC) as category_rank
+    FROM jira_babel_1358.test_percent_sales_large
+    WHERE sales_amount > 200
+    GROUP BY category
+    HAVING COUNT(*) > 100
+    ORDER BY avg_sales DESC
+) AS complex_perf_test;
+GO
+
+-- Test Case 27: TOP PERCENT with variables and reuse
+DECLARE @top_products TABLE (
+    product_name VARCHAR(20),
+    sales_amount DECIMAL(10,2)
+);
+
+INSERT INTO @top_products
+SELECT TOP 5 PERCENT product_name, sales_amount 
+FROM jira_babel_1358.test_percent_sales_large 
+ORDER BY sales_amount DESC;
+
+SELECT COUNT(*) FROM @top_products;
+GO
+
+-- Test Case 28: TOP PERCENT with variable percentage
+DECLARE @percent_value FLOAT = 15.5;
+SELECT COUNT(*) FROM (
+    SELECT TOP (@percent_value) PERCENT * 
+    FROM jira_babel_1358.test_percent_sales_large 
+    WHERE category = 'Electronics'
+    ORDER BY sales_amount DESC
+) AS variable_percent_test;
+GO
+
+/*
+ * ======================================================================================================================
+ *                                          DEPENDENT OBJECTS TESTS
+ * ======================================================================================================================
+ */
+
+-- Test Case 29: TOP PERCENT in VIEW
+SELECT COUNT(*) FROM jira_babel_1358.top_performers_view;
+GO
+
+-- Test Case 30: TOP PERCENT in FUNCTION
+SELECT COUNT(*) FROM jira_babel_1358.get_top_sales(10.5);
+GO
+
+-- Test Case 31: TOP PERCENT in STORED PROCEDURE
+EXEC jira_babel_1358.get_top_percent_by_category 'Electronics', 25.0;
+GO
+
+
+/*
+ * ======================================================================================================================
+ *                                          ADDITIONAL COMPLEX Example TESTING
+ * ======================================================================================================================
+ */
+
+-- Test Case 32: Basic TOP PERCENT with FOR JSON AUTO
+SELECT TOP 50 PERCENT student_name
+FROM jira_babel_1358.test_percent_scores 
+ORDER BY score DESC
+FOR JSON AUTO;
+GO
+
+-- Test Case 33: TOP PERCENT with FOR JSON PATH
+SELECT TOP 30 PERCENT student_name, score, class_name
+FROM jira_babel_1358.test_percent_scores 
+WHERE score IS NOT NULL
+ORDER BY score DESC
+FOR JSON PATH;
+GO
+
+-- Test Case 34: TOP PERCENT with FOR JSON PATH and INCLUDE_NULL_VALUES
+SELECT TOP 33 PERCENT student_name, score, class_name
+FROM jira_babel_1358.test_percent_scores 
+ORDER BY id
+FOR JSON PATH, INCLUDE_NULL_VALUES;
+GO
+
+
+-- Test Case 35: TOP PERCENT with UNION ALL : 
+/*
+* will fail because of order by issue with subquery (known error)
+* BABEL-4313: Handle ORDER BY clause when inside subquery with UNION and TOP
+* The ORDER BY clause is invalid in views, inline functions, derived tables, 
+* subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.
+*/
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' ORDER BY score DESC
+    UNION ALL
+    SELECT TOP 50 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics' ORDER BY score DESC
+) AS t34;
+GO
+
+-- The above sql query passing without order by clause
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math' 
+    UNION ALL
+    SELECT TOP 50 student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics'
+) AS t34;
+GO
+
+-- Test Case 36: TOP PERCENT with UNION (removes duplicates)
+SELECT COUNT(*) FROM (
+    SELECT TOP 40 PERCENT student_name, score FROM jira_babel_1358.test_percent_scores WHERE score > 80
+    UNION
+    SELECT TOP 60 PERCENT student_name, score FROM jira_babel_1358.test_percent_scores WHERE score < 90
+) AS t35;
+GO
+
+-- Test Case 37: TOP PERCENT on outside of UNION
+SELECT TOP 20 PERCENT * FROM (
+    SELECT student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Math'
+    UNION ALL
+    SELECT student_name, score, class_name FROM jira_babel_1358.test_percent_scores WHERE class_name = 'Physics'
+) AS union_result
+ORDER BY score DESC;
+GO
+
+
+/*
+ * ======================================================================================================================
+ *                                          CROSS SCHEMA TESTING WITH TOP PERCENT
+ * ======================================================================================================================
+ */
+
+-- Test Case 38: TOP PERCENT with cross schema JOIN
+SELECT COUNT(*) FROM (
+    SELECT TOP 30 PERCENT 
+           s.student_name, 
+           s.score, 
+           t.revenue
+    FROM jira_babel_1358.test_percent_scores s
+    LEFT JOIN test_schema2_jira_babel_1358.test_cross_sales t ON s.id = t.id
+    WHERE s.score IS NOT NULL
+    ORDER BY s.score DESC
+) AS t39;
+GO
+
+-- Test Case 39: TOP PERCENT with cross schema subquery
+SELECT COUNT(*) FROM (
+    SELECT TOP 40 PERCENT *
+    FROM jira_babel_1358.test_percent_scores s
+    WHERE s.score > (
+        SELECT AVG(revenue) 
+        FROM test_schema2_jira_babel_1358.test_cross_sales 
+        WHERE revenue IS NOT NULL
+    )
+    ORDER BY s.score DESC
+) AS t41;
+GO
+
+-- Test Case 40: TOP PERCENT with cross schema CTE
+WITH CrossSchemaData AS (
+    SELECT TOP 50 PERCENT 
+           s.student_name,
+           s.score,
+           (SELECT COUNT(*) FROM test_schema2_jira_babel_1358.test_cross_sales WHERE revenue > s.score) as higher_revenue_count
+    FROM jira_babel_1358.test_percent_scores s
+    WHERE s.score IS NOT NULL
+    ORDER BY s.score DESC
+)
+SELECT COUNT(*) FROM CrossSchemaData WHERE higher_revenue_count > 0;
+GO
+
+
+/*
+ * ======================================================================================================================
+ *                                          Update/Delete/Insert TOP N PERCENT ..
+ *                                  Currently, we are not supporting top N Percent for other DMLs
+ *                              Creates BABEL-6059 to track support for TOP N PERCENT for others DMLs
+ *                   Exception: Though, we support top 100 percent as it is being treated as no percent Op is present        
+ * ======================================================================================================================
+ */
+
+-- Test Case 41: UPDATE TOP N PERCENT (will throw error)
+UPDATE TOP (30) PERCENT jira_babel_1358.test_percent_scores 
+SET score = score + 5 
+WHERE score IS NOT NULL;
+GO
+
+UPDATE TOP (100) PERCENT jira_babel_1358.test_percent_scores 
+SET score = score + 5 
+WHERE score IS NOT NULL;
+GO
+
+-- Test Case 42: DELETE TOP N PERCENT (will throw error)
+DELETE TOP (60) PERCENT FROM jira_babel_1358.test_percent_scores 
+WHERE score < 80;
+GO
+
+-- Test Case 43: INSERT TOP N PERCENT (will throw error)
+INSERT TOP (9) PERCENT INTO jira_babel_1358.test_percent_scores (id, student_name, score, class_name, year)
+SELECT id + 200, 'New_' + student_name, score, class_name, 2024
+FROM jira_babel_1358.test_percent_scores
+WHERE score IS NOT NULL
+ORDER BY score DESC;
+GO
+
+-- Test Case 44: INSERT TOP N PERCENT with OUTPUT INTO
+INSERT INTO jira_babel_1358.test_percent_sales_second
+OUTPUT inserted.*
+INTO jira_babel_1358.test_percent_sales_third
+SELECT TOP 100 PERCENT *
+FROM (
+    SELECT TOP 6 *
+    FROM jira_babel_1358.test_percent_sales
+) AS top_students;
+GO
+
+select count(*) from jira_babel_1358.test_percent_sales_second;
+GO
+select count(*) from jira_babel_1358.test_percent_sales_third;
+GO
+
+WITH RankedSales AS (
+    SELECT *, 
+           ROW_NUMBER() OVER (PARTITION BY region ORDER BY revenue DESC) as region_rank,
+           DENSE_RANK() OVER (ORDER BY revenue DESC) as overall_rank
+    FROM jira_babel_1358.test_percent_sales 
+    WHERE revenue IS NOT NULL
+),
+TopSales AS (
+    SELECT id, product_name, revenue, region, quarter
+    FROM RankedSales 
+    WHERE region_rank <= 2
+)
+INSERT INTO jira_babel_1358.test_percent_sales_second (id, product_name, revenue, region, quarter)
+OUTPUT inserted.id, inserted.product_name, inserted.revenue, inserted.region, inserted.quarter
+INTO jira_babel_1358.test_percent_sales_third (id, product_name, revenue, region, quarter)
+SELECT TOP 100 PERCENT 
+    id, 
+    product_name, 
+    revenue, 
+    region, 
+    quarter
+FROM TopSales 
+ORDER BY revenue DESC;
+
+select count(*) from jira_babel_1358.test_percent_sales_second;
+GO
+select count(*) from jira_babel_1358.test_percent_sales_third;
+GO
+
+-- Test Case 45: UPDATE with JOIN and TOP N PERCENT Tests
+UPDATE TOP (100) PERCENT s 
+SET s.score = s.score + 5
+FROM jira_babel_1358.test_percent_scores s
+INNER JOIN jira_babel_1358.test_percent_sales t ON s.id = t.id
+WHERE s.score IS NOT NULL;
+GO
+
+select count(*) from jira_babel_1358.test_percent_scores;
+GO
+
+
+-- Test Case 46: UPDATE with OUTPUT INTO and TOP N PERCENT
+UPDATE TOP (100) PERCENT jira_babel_1358.test_percent_scores
+SET score = score + 10
+OUTPUT inserted.*
+INTO jira_babel_1358.test_percent_scores_second
+WHERE score < 80;
+GO
+
+select count(*) from jira_babel_1358.test_percent_scores_second;
+GO
+
+-- Test Case 47: DELETE with JOIN and TOP N PERCENT Tests
+DELETE TOP (100) PERCENT s
+FROM jira_babel_1358.test_percent_scores s
+INNER JOIN jira_babel_1358.test_percent_sales t ON s.id = t.id
+WHERE s.id > 200 OR s.id > 100;
+
+select count(*) from jira_babel_1358.test_percent_scores;
+GO
+
+-- Test Case 48: DELETE with OUTPUT INTO and TOP N PERCENT
+DELETE TOP (100) PERCENT FROM jira_babel_1358.test_percent_scores
+OUTPUT deleted.id, deleted.student_name, deleted.score, deleted.class_name
+INTO jira_babel_1358.test_percent_sales (id, product_name, revenue, region)
+WHERE score < 85;
+
+select count(*) from jira_babel_1358.test_percent_scores;
+GO

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -645,3 +645,4 @@ alter-function-with-weak-view
 mathematical_func_tests
 alter-table-null-notnull
 ascii_function
+Select_top_N_percent


### PR DESCRIPTION
### Description
This PR implements comprehensive support for SELECT TOP N PERCENT syntax in Babelfish, addressing JIRA-BABEL-1358. The implementation adds percentage-based row limiting functionality to align with SQL Server behavior.

### Problem
Babelfish previously only supported SELECT TOP N (fixed count) but lacked support for SELECT TOP N PERCENT (percentage-based limiting), which is a commonly used SQL Server feature for selecting a percentage of rows from result sets.

### Related Links -
Engine Link - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/624

### Solution

**Core Changes**

- [ ] **1. Grammar Extensions ( gram-tsql-rule.y)**
- Updated Grammer to support Percent Operator
- Also changed return type of tsql_top_clause node to selectLimit to match its behavior with postgres.

- [ ] **2. Parser Updates ( gram-tsql-epilogue.y.c)**
- Added a new field in LimitOption enum **"LIMIT_OPTION_PERCENT"** to represent Percent Op in TSQL.

- [ ] **3. Hook Implementation ( hooks.c)**
- Added error handling for unsupported UPDATE/DELETE/INSERT TOP N PERCENT
- Handled top N Percent by rewriting N -> select count(*) from parent_query
- handled group by by rewriting N -> select count(*) from (select groupby_cols from parent_query group by groupby_cols )

### Test Coverage
1. 43+ test cases covering all scenarios
2. Basic percentage operations (50%, 25%, 0%, 100%)
3. Edge cases (0.5%, 33.33% decimal precision)
4. Complex queries (JOINs, CTEs, window functions, subqueries)
5. FOR JSON integration 
6. Dependent Objects Test Case
7. UNION operations
8. Cross-schema functionality 
9. Error cases for UPDATE/DELETE TOP N PERCENT
10. Update/Delete/insert + Output clause
11.  Complex Update/Delete/insert top 100 percent



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).