### PR TITLE
Add quote for grantee identifier in grant_on_function query to support special characters in grantee name

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -4358,11 +4358,11 @@ grant_perms_to_objects_in_schema(const char *schema_name,
 			{
 				priv_name = privilege_to_string(permission);
 				if (strcmp(object_type, OBJ_RELATION) == 0)
-					query = psprintf("GRANT %s ON [%s].[%s] TO %s", priv_name, schema, object_name, grantee);
+					query = psprintf("GRANT %s ON [%s].[%s] TO [%s]", priv_name, schema, object_name, grantee);
 				else if (strcmp(object_type, OBJ_FUNCTION) == 0)
-					query = psprintf("GRANT %s ON FUNCTION [%s].[%s](%s) TO %s", priv_name, schema, object_name, func_args, grantee);
+					query = psprintf("GRANT %s ON FUNCTION [%s].[%s](%s) TO [%s]", priv_name, schema, object_name, func_args, grantee);
 				else if (strcmp(object_type, OBJ_PROCEDURE) == 0)
-					query = psprintf("GRANT %s ON PROCEDURE [%s].[%s](%s) TO %s", priv_name, schema, object_name, func_args, grantee);
+					query = psprintf("GRANT %s ON PROCEDURE [%s].[%s](%s) TO [%s]", priv_name, schema, object_name, func_args, grantee);
 				res = raw_parser(query, RAW_PARSE_DEFAULT);
 				grant = (GrantStmt *) parsetree_nth_stmt(res, 0);
 
@@ -4478,9 +4478,9 @@ exec_internal_grant_on_function(Oid objectId)
 			int     		save_sec_context;
 
 			if (object_type == PROKIND_FUNCTION)
-				query = psprintf("GRANT EXECUTE ON FUNCTION [%s].[%s] TO %s", schema, object_name, grantee);
+				query = psprintf("GRANT EXECUTE ON FUNCTION [%s].[%s] TO [%s]", schema, object_name, grantee);
 			else if (object_type == PROKIND_PROCEDURE)
-				query = psprintf("GRANT EXECUTE ON PROCEDURE [%s].[%s] TO %s", schema, object_name, grantee);
+				query = psprintf("GRANT EXECUTE ON PROCEDURE [%s].[%s] TO [%s]", schema, object_name, grantee);
 			res = raw_parser(query, RAW_PARSE_DEFAULT);
 			grant = (GrantStmt *) parsetree_nth_stmt(res, 0);
 
@@ -6217,9 +6217,9 @@ alter_default_privilege_for_db(char *dbname)
 				{
 					char	*alter_query = NULL;
 					char	*grant_query = NULL;
-					alter_query = psprintf("ALTER DEFAULT PRIVILEGES FOR ROLE %s, %s IN SCHEMA %s GRANT %s ON TABLES TO %s", dbo_user, schema_owner, physical_schema, privilege_to_string(permissions[i]), grantee);
+					alter_query = psprintf("ALTER DEFAULT PRIVILEGES FOR ROLE \"%s\", \"%s\" IN SCHEMA \"%s\" GRANT %s ON TABLES TO \"%s\"", dbo_user, schema_owner, physical_schema, privilege_to_string(permissions[i]), grantee);
 					exec_utility_cmd_helper(alter_query);
-					grant_query = psprintf("GRANT %s ON ALL TABLES IN SCHEMA %s TO %s", privilege_to_string(permissions[i]), physical_schema, grantee);
+					grant_query = psprintf("GRANT %s ON ALL TABLES IN SCHEMA \"%s\" TO \"%s\"", privilege_to_string(permissions[i]), physical_schema, grantee);
 					exec_utility_cmd_helper(grant_query);
 					pfree(alter_query);
 					pfree(grant_query);

--- a/test/JDBC/expected/BABEL-GRANT.out
+++ b/test/JDBC/expected/BABEL-GRANT.out
@@ -16,12 +16,30 @@ GO
 DROP TYPE IF EXISTS type_int;
 GO
 
+DROP USER IF EXISTS [babel-6067-u1];
+GO
+
+IF EXISTS (SELECT * FROM sys.server_principals WHERE name = 'babel-6067-l1')
+BEGIN
+    DROP LOGIN [babel-6067-l1];
+END
+GO
+
 
 ---
 ---  Prepare Objects
 ---
 ---- SCHEMA
 CREATE SCHEMA scm;
+GO
+
+create SCHEMA scm2;
+GO
+
+CREATE LOGIN [babel-6067-l1] WITH PASSWORD = '12345678'
+GO
+
+CREATE USER [babel-6067-u1] FOR LOGIN [babel-6067-l1]
 GO
 
 ---- TABLE
@@ -152,6 +170,13 @@ GRANT UPDATE (a) ON t1 TO guest WITH GRANT OPTION;
 GO
 
 REVOKE GRANT OPTION FOR UPDATE (a) ON t1 FROM guest;
+GO
+
+GRANT SELECT,INSERT,UPDATE,DELETE,EXECUTE ON SCHEMA::scm2 TO [babel-6067-u1];
+GO
+
+-- Validate create procedure grants proc permission to username having hypens like babel-6067-u1
+CREATE PROCEDURE scm2.babel_6067_p1 AS SELECT 'Hello';
 GO
 
 --- 
@@ -423,6 +448,9 @@ GO
 GRANT EXECUTE ON XML SCHEMA COLLECTION::scm TO public;
 GO
 
+GRANT EXECUTE ON scm2.babel_6067_p1 TO [babel-6067-u1];
+GO
+
 
 ---
 ---  Check for supported and unsupported REVOKE syntax
@@ -588,6 +616,9 @@ GO
 
 
 REVOKE EXECUTE ON XML SCHEMA COLLECTION::scm TO public;
+GO
+
+REVOKE EXECUTE ON SCHEMA::scm2 TO [babel-6067-u1];
 GO
 
 
@@ -769,11 +800,16 @@ GO
 ~~ERROR (Message: 'DENY' is not currently supported in Babelfish)~~
 
 
-
 ---
 ---  Clean Up
 ---
+DROP PROCEDURE IF EXISTS scm2.babel_6067_p1;
+GO
+
 DROP SCHEMA scm;
+GO
+
+DROP SCHEMA scm2;
 GO
 
 DROP VIEW IF EXISTS my_view;
@@ -792,4 +828,13 @@ DROP PROCEDURE IF EXISTS my_proc;
 GO
 
 DROP TYPE IF EXISTS type_int;
+GO
+
+DROP USER IF EXISTS [babel-6067-u1];
+GO
+
+IF EXISTS (SELECT * FROM sys.server_principals WHERE name = 'babel-6067-l1')
+BEGIN
+    DROP LOGIN [babel-6067-l1];
+END
 GO

--- a/test/JDBC/expected/GRANT_SCHEMA-before-15_9-16_5-vu-cleanup.out
+++ b/test/JDBC/expected/GRANT_SCHEMA-before-15_9-16_5-vu-cleanup.out
@@ -72,6 +72,9 @@ go
 drop user babel_5172_u2;
 go
 
+drop user [babel_5172-u3];
+go
+
 use master
 go
 
@@ -117,6 +120,9 @@ drop login babel_5172_l1;
 go
 
 drop login babel_5172_l2;
+go
+
+drop login [babel_5172-l3];
 go
 
 drop database babel_5172_db

--- a/test/JDBC/expected/GRANT_SCHEMA-before-15_9-16_5-vu-prepare.out
+++ b/test/JDBC/expected/GRANT_SCHEMA-before-15_9-16_5-vu-prepare.out
@@ -18,6 +18,12 @@ go
 create user babel_5172_u2 for login babel_5172_l2;
 go
 
+create login [babel_5172-l3] with password = '123';
+go
+
+create user [babel_5172-u3] for login [babel_5172-l3];
+go
+
 -- create schema with authorization
 create schema babel_5172_s1 authorization babel_5172_u1
 go
@@ -124,3 +130,11 @@ int
 1
 ~~END~~
 
+
+-- tsql
+use babel_5172_db
+go
+
+-- grant select privilege on the schema with user babel_5172-u3
+grant select, execute on schema::babel_5172_s1 to [babel_5172-u3];
+go

--- a/test/JDBC/expected/GRANT_SCHEMA-before-15_9-16_5-vu-verify.out
+++ b/test/JDBC/expected/GRANT_SCHEMA-before-15_9-16_5-vu-verify.out
@@ -125,6 +125,19 @@ go
 use master
 go
 
+-- tsql user=babel_5172-l3 password=123
+-- objects created by babel_5172_u1 should be accessible
+use babel_5172_db
+go
+
+exec babel_5172_s1.p5;
+go
+~~START~~
+int
+1
+~~END~~
+
+
 -- tsql user=babel_5172_l1 password=123
 -- create new objects using babel_5172_u1 user
 use babel_5172_db
@@ -222,6 +235,10 @@ go
 
 -- revoke select privilege on the schema with user babel_5172_u1
 revoke select, execute on schema::babel_5172_s1 from babel_5172_u2;
+go
+
+-- revoke select privilege on the schema with user babel_5172_u1
+revoke select, execute on schema::babel_5172_s1 from [babel_5172-u3];
 go
 
 use master;
@@ -346,3 +363,22 @@ go
 
 use master
 go
+
+-- tsql user=babel_5172-l3 password=123
+-- no objects should be accessible, since schema privilege is revoked
+use babel_5172_db;
+go
+
+select * from babel_5172_s1.t1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+
+exec babel_5172_s1.p1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for procedure p1)~~
+

--- a/test/JDBC/input/BABEL-GRANT.sql
+++ b/test/JDBC/input/BABEL-GRANT.sql
@@ -16,12 +16,30 @@ GO
 DROP TYPE IF EXISTS type_int;
 GO
 
+DROP USER IF EXISTS [babel-6067-u1];
+GO
+
+IF EXISTS (SELECT * FROM sys.server_principals WHERE name = 'babel-6067-l1')
+BEGIN
+    DROP LOGIN [babel-6067-l1];
+END
+GO
+
 ---
 ---  Prepare Objects
 ---
 
 ---- SCHEMA
 CREATE SCHEMA scm;
+GO
+
+create SCHEMA scm2;
+GO
+
+CREATE LOGIN [babel-6067-l1] WITH PASSWORD = '12345678'
+GO
+
+CREATE USER [babel-6067-u1] FOR LOGIN [babel-6067-l1]
 GO
 
 ---- TABLE
@@ -150,6 +168,13 @@ GRANT UPDATE (a) ON t1 TO guest WITH GRANT OPTION;
 GO
 
 REVOKE GRANT OPTION FOR UPDATE (a) ON t1 FROM guest;
+GO
+
+GRANT SELECT,INSERT,UPDATE,DELETE,EXECUTE ON SCHEMA::scm2 TO [babel-6067-u1];
+GO
+
+-- Validate create procedure grants proc permission to username having hypens like babel-6067-u1
+CREATE PROCEDURE scm2.babel_6067_p1 AS SELECT 'Hello';
 GO
 
 --- 
@@ -285,6 +310,9 @@ GO
 GRANT EXECUTE ON XML SCHEMA COLLECTION::scm TO public;
 GO
 
+GRANT EXECUTE ON scm2.babel_6067_p1 TO [babel-6067-u1];
+GO
+
 ---
 ---  Check for supported and unsupported REVOKE syntax
 ---
@@ -362,6 +390,9 @@ REVOKE EXECUTE ON USER::test TO public;
 GO
 
 REVOKE EXECUTE ON XML SCHEMA COLLECTION::scm TO public;
+GO
+
+REVOKE EXECUTE ON SCHEMA::scm2 TO [babel-6067-u1];
 GO
 
 ---
@@ -446,8 +477,13 @@ GO
 ---
 ---  Clean Up
 ---
+DROP PROCEDURE IF EXISTS scm2.babel_6067_p1;
+GO
 
 DROP SCHEMA scm;
+GO
+
+DROP SCHEMA scm2;
 GO
 
 DROP VIEW IF EXISTS my_view;
@@ -466,4 +502,13 @@ DROP PROCEDURE IF EXISTS my_proc;
 GO
 
 DROP TYPE IF EXISTS type_int;
+GO
+
+DROP USER IF EXISTS [babel-6067-u1];
+GO
+
+IF EXISTS (SELECT * FROM sys.server_principals WHERE name = 'babel-6067-l1')
+BEGIN
+    DROP LOGIN [babel-6067-l1];
+END
 GO

--- a/test/JDBC/input/GRANT_SCHEMA-before-15_9-16_5-vu-cleanup.mix
+++ b/test/JDBC/input/GRANT_SCHEMA-before-15_9-16_5-vu-cleanup.mix
@@ -72,6 +72,9 @@ go
 drop user babel_5172_u2;
 go
 
+drop user [babel_5172-u3];
+go
+
 use master
 go
 
@@ -99,6 +102,9 @@ drop login babel_5172_l1;
 go
 
 drop login babel_5172_l2;
+go
+
+drop login [babel_5172-l3];
 go
 
 drop database babel_5172_db

--- a/test/JDBC/input/GRANT_SCHEMA-before-15_9-16_5-vu-prepare.mix
+++ b/test/JDBC/input/GRANT_SCHEMA-before-15_9-16_5-vu-prepare.mix
@@ -18,6 +18,12 @@ go
 create user babel_5172_u2 for login babel_5172_l2;
 go
 
+create login [babel_5172-l3] with password = '123';
+go
+
+create user [babel_5172-u3] for login [babel_5172-l3];
+go
+
 -- create schema with authorization
 create schema babel_5172_s1 authorization babel_5172_u1
 go
@@ -105,4 +111,12 @@ exec babel_5172_s1.p5;
 go
 
 select babel_5172_s1.f5();
+go
+
+-- tsql
+use babel_5172_db
+go
+
+-- grant select privilege on the schema with user babel_5172-u3
+grant select, execute on schema::babel_5172_s1 to [babel_5172-u3];
 go

--- a/test/JDBC/input/GRANT_SCHEMA-before-15_9-16_5-vu-verify.mix
+++ b/test/JDBC/input/GRANT_SCHEMA-before-15_9-16_5-vu-verify.mix
@@ -68,6 +68,14 @@ go
 use master
 go
 
+-- tsql user=babel_5172-l3 password=123
+-- objects created by babel_5172_u1 should be accessible
+use babel_5172_db
+go
+
+exec babel_5172_s1.p5;
+go
+
 -- tsql user=babel_5172_l1 password=123
 -- create new objects using babel_5172_u1 user
 use babel_5172_db
@@ -129,6 +137,10 @@ go
 revoke select, execute on schema::babel_5172_s1 from babel_5172_u2;
 go
 
+-- revoke select privilege on the schema with user babel_5172_u1
+revoke select, execute on schema::babel_5172_s1 from [babel_5172-u3];
+go
+
 use master;
 go
 
@@ -186,4 +198,15 @@ select babel_5172_s1.f4();
 go
 
 use master
+go
+
+-- tsql user=babel_5172-l3 password=123
+-- no objects should be accessible, since schema privilege is revoked
+use babel_5172_db;
+go
+
+select * from babel_5172_s1.t1;
+go
+
+exec babel_5172_s1.p1;
 go


### PR DESCRIPTION

Problem: If the username contains special characters, then grant permission on object fails for the username containing special character as grantee name is not quoted in the GRANT internal query.

This commit adds the quote character for grantee name in the GRANT internal query.

Task: BABEL-6067


(cherry picked from commit 4223b732656e7199edb6d68abc06c9307a4d83c6)

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
NA

* **Major version upgrade tests -**
NA

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).