### PR TITLE
Fix use of constant initializer for static xml handle counter variable

### DIFF
--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -119,9 +119,9 @@ static bool is_supported_case_sp_describe_undeclared_parameters = true;
 #define Anum_xml_handle_temp_table_ns_data 7
 
 #define MD5_HASH_LEN 32
+#define XML_HANDLE_COUNTER_START 0
+#define XML_HANDLE_COUNTER_INVALID (INT_MAX / 2)
 
-const  int   XML_HANDLE_COUNTER_START = 0;
-const  int   XML_HANDLE_COUNTER_INVALID = INT_MAX / 2;
 static int   current_xml_handle_counter = XML_HANDLE_COUNTER_INVALID;
 Bitmapset   *active_xml_handles_counter = NULL;
 static char *xml_handle_temp_table_name = NULL;


### PR DESCRIPTION
### Description
Currently in procedure.c static variable `current_xml_handle_counter` is assigned to a const int variable which is causing build failures for gcc version `7.3.1`. Updated the constant variable declarations to MACRO.

Authored-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved

NA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).