### PR TITLE
fixing revoke permission from object behaviour

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -3863,12 +3863,21 @@ update_privileges_of_object(const char *schema_name,
 
 /*
  * Checks if a particular privilege exists in catalog BABELFISH_SCHEMA_PERMISSIONS.
+ * 
+ * If curr_permission is set to INVALID_PERMISSION, this function only checks for
+ * the existence of an entry in the catalog without validating specific permissions.
+ * Otherwise, it verifies if the specified permission bits (curr_permission) are
+ * set in the catalog entry's permission field.
+ *
+ * Returns true if the requested permission exists (or if an entry exists when
+ * INVALID_PERMISSION is specified), false otherwise.
  */
 bool
 privilege_exists_in_bbf_schema_permissions(const char *schema_name,
 							const char *object_name,
 							const char *grantee,
-							const char *object_type)
+							const char *object_type,
+							int	curr_permission)
 {
 	Relation	bbf_schema_rel;
 	HeapTuple	tuple_bbf_schema;
@@ -3962,8 +3971,29 @@ privilege_exists_in_bbf_schema_permissions(const char *schema_name,
 	}
 
 	tuple_bbf_schema = systable_getnext(scan);
-	if (HeapTupleIsValid(tuple_bbf_schema))
-		catalog_entry_exists = true;
+	while (HeapTupleIsValid(tuple_bbf_schema))
+    {
+		if (curr_permission == INVALID_PERMISSION)
+			catalog_entry_exists = true;
+		else
+		{
+			/* find the permission corresponding to tuple_bbf_schema */
+			Datum datum;
+			bool isnull;
+			int sch_permission = INVALID_PERMISSION;
+
+			datum = heap_getattr(tuple_bbf_schema, Anum_bbf_schema_perms_permission, RelationGetDescr(bbf_schema_rel), &isnull);
+			if (isnull)
+				catalog_entry_exists = false;
+			else
+				sch_permission = DatumGetInt32(datum);
+
+			if (!isnull && ((sch_permission & curr_permission) == curr_permission))
+				catalog_entry_exists = true;
+
+		}
+		tuple_bbf_schema = systable_getnext(scan);
+    }
 
 	systable_endscan(scan);
 	table_close(bbf_schema_rel, AccessShareLock);
@@ -4164,7 +4194,7 @@ add_or_update_object_in_bbf_schema(const char *schema_name,
 				bool is_grant,
 				const char *func_args)
 {
-	if (!privilege_exists_in_bbf_schema_permissions(schema_name, object_name, grantee, object_type))
+	if (!privilege_exists_in_bbf_schema_permissions(schema_name, object_name, grantee, object_type, INVALID_PERMISSION))
 		add_entry_to_bbf_schema_perms(schema_name, object_name, new_permission, grantee, object_type, func_args);
 	else
 		update_privileges_of_object(schema_name, object_name, new_permission, grantee, object_type, is_grant);

--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -333,6 +333,7 @@ typedef FormData_bbf_function_ext *Form_bbf_function_ext;
 #define OBJ_PROCEDURE "p"
 #define OBJ_FUNCTION "f"
 #define NUMBER_OF_PERMISSIONS 6
+#define INVALID_PERMISSION -1
 
 /* check if rolename is sysadmin */
 #define IS_ROLENAME_SYSADMIN(rolname) \
@@ -375,7 +376,7 @@ typedef struct FormData_bbf_schema_perms
 typedef FormData_bbf_schema_perms *Form_bbf_schema_perms;
 
 extern void add_entry_to_bbf_schema_perms(const char *schema_name, const char *object_name, int permission, const char *grantee, const char *object_type, const char *func_args);
-extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
+extern bool privilege_exists_in_bbf_schema_permissions(const char *schema_name, const char *object_name, const char *grantee, const char *object_type, int curr_permission);
 extern void update_privileges_of_object(const char *schema_name, const char *object_name, int new_permission, const char *grantee, const char *object_type, bool is_grant);
 extern void remove_entry_from_bbf_schema_perms(const char *schema_name, const char *object_name, const char *grantee, const char *object_type);
 extern void remove_user_entry_from_bbf_schema_perms(Oid user_oid);

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3991,7 +3991,7 @@ exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt)
 		else
 		{
 			/* For REVOKE statement, update privileges in the catalog. */
-			if (privilege_exists_in_bbf_schema_permissions(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rolname, OBJ_SCHEMA))
+			if (privilege_exists_in_bbf_schema_permissions(stmt->schema_name, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rolname, OBJ_SCHEMA, INVALID_PERMISSION))
 			{
 				/* If any object in the schema has the OBJECT level permission. Then, internally grant that permission back. */
 				for (i = 0; i < NUMBER_OF_PERMISSIONS; i++)

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4895,16 +4895,15 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								}
 								else
 								{
-									privileges = (char **) palloc0(8 * sizeof(char *));
+									privileges = (char **) palloc0(7 * sizeof(char *));
 									privileges[0] = pstrdup("insert");
 									privileges[1] = pstrdup("select");
 									privileges[2] = pstrdup("update");
 									privileges[3] = pstrdup("delete");
 									privileges[4] = pstrdup("references");
 									privileges[5] = pstrdup("truncate");
-									privileges[6] = pstrdup("maintain");
 									privileges[7] = pstrdup("trigger");
-									number_of_privs = 8;
+									number_of_privs = 7;
 								}
 
 								for (int i = 0; i < number_of_privs; i++)

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4902,7 +4902,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 									privileges[3] = pstrdup("delete");
 									privileges[4] = pstrdup("references");
 									privileges[5] = pstrdup("truncate");
-									privileges[7] = pstrdup("trigger");
+									privileges[6] = pstrdup("trigger");
 									number_of_privs = 7;
 								}
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4846,6 +4846,8 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					bool exec_pg_command = false;
 					ListCell   *lc;
 					ListCell	*lc1;
+					List  		*all_privileges = NIL;    /* Initialize an empty list */
+
 					if (rv->schemaname != NULL)
 						logical_schema = get_logical_schema_name(rv->schemaname, false);
 					else
@@ -4863,61 +4865,137 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
 								add_or_update_object_in_bbf_schema(logical_schema, obj, ALL_PERMISSIONS_ON_RELATION, rol_spec->rolename, OBJ_RELATION, true, NULL);
 							}
+							exec_pg_command = true;
 						}
 						else
 						{
+							Oid objoid = 	InvalidOid;
+							Form_pg_class	pg_class_tuple;
+							char 			**privileges;
+
+							objoid = RangeVarGetRelid(rv, NoLock, true);
+							if (OidIsValid(objoid))
+							{
+								HeapTuple		tuple;
+								int 			number_of_privs;
+								/* Get the namespace OID and rekind type of the table. */
+								tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(objoid));
+								if (!HeapTupleIsValid(tuple))
+									return;
+
+								pg_class_tuple = (Form_pg_class) GETSTRUCT(tuple);
+
+								if (pg_class_tuple->relkind == RELKIND_SEQUENCE)
+								{
+									privileges = (char **) palloc0(3 * sizeof(char *));
+									privileges[0] = pstrdup("select");
+									privileges[1] = pstrdup("update");
+									privileges[2] = pstrdup("usage");
+									number_of_privs = 3;
+								}
+								else
+								{
+									privileges = (char **) palloc0(8 * sizeof(char *));
+									privileges[0] = pstrdup("insert");
+									privileges[1] = pstrdup("select");
+									privileges[2] = pstrdup("update");
+									privileges[3] = pstrdup("delete");
+									privileges[4] = pstrdup("references");
+									privileges[5] = pstrdup("truncate");
+									privileges[6] = pstrdup("maintain");
+									privileges[7] = pstrdup("trigger");
+									number_of_privs = 8;
+								}
+
+								for (int i = 0; i < number_of_privs; i++)
+								{
+									AccessPriv *ap = makeNode(AccessPriv);
+									ap->priv_name = privileges[i];
+									ap->cols = NIL;
+									all_privileges = lappend(all_privileges, ap);
+								}
+								ReleaseSysCache(tuple);
+								pfree(privileges);
+							}
+
 							foreach(lc, grant->grantees)
 							{
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+
 								/* Special database roles should throw an error. */
 								throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
+
 								/*
 								 * 1. If permission on schema exists, don't revoke any permission from the object.
 								 * 2. If permission on object exists, update the privilege in the catalog and revoke permission.
 								 */
-								update_privileges_of_object(logical_schema, obj, ALL_PERMISSIONS_ON_RELATION, rol_spec->rolename, OBJ_RELATION, false);
-								if (privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
-									return;
-							}
-						}
-						exec_pg_command = true;
-					}
-					foreach(lc1, grant->privileges)
-					{
-						AccessPriv *ap = (AccessPriv *) lfirst(lc1);
-						AclMode privilege = string_to_privilege(ap->priv_name);
-						if (grant->is_grant)
-						{
-							exec_pg_command = true;
-							/* Don't add/update an entry, if the permission is granted on column list.*/
-							if (ap->cols == NULL)
-							{
-								foreach(lc, grant->grantees)
+								foreach(lc1, all_privileges)
 								{
-									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									/* Special database roles should throw an error. */
-									throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
-									add_or_update_object_in_bbf_schema(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, true, NULL);
+									AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+									AclMode privilege = string_to_privilege(ap->priv_name);
+								
+									if (!privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA, privilege))
+										exec_pg_command = true;
+									else
+										all_privileges = foreach_delete_current(all_privileges, lc1);
+
+								}
+								update_privileges_of_object(logical_schema, obj, ALL_PERMISSIONS_ON_RELATION, rol_spec->rolename, OBJ_RELATION, false);
+							}
+							/* 
+							 * If all_privileges length is 5 then pass grant->privilege as NIL i.e fallback to existing behaviour,
+							 * as no common privilege between object and schema.
+							 */
+							if (list_length(all_privileges) == 0)
+								return;
+							else
+								grant->privileges = all_privileges;
+						}
+					}
+					else
+					{
+						foreach(lc1, grant->privileges)
+						{
+							AccessPriv *ap = (AccessPriv *) lfirst(lc1);
+							AclMode privilege = string_to_privilege(ap->priv_name);
+							if (grant->is_grant)
+							{
+								exec_pg_command = true;
+								/* Don't add/update an entry, if the permission is granted on column list.*/
+								if (ap->cols == NULL)
+								{
+									foreach(lc, grant->grantees)
+									{
+										RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+										/* Special database roles should throw an error. */
+										throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
+										add_or_update_object_in_bbf_schema(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, true, NULL);
+									}
 								}
 							}
-						}
-						else
-						{
-							/* Don't update an entry, if the permission is granted on column list.*/
-							if (ap->cols == NULL)
+							else
 							{
-								foreach(lc, grant->grantees)
+								/* Don't update an entry, if the permission is granted on column list.*/
+								if (ap->cols == NULL)
 								{
-									RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
-									/* Special database roles should throw an error. */
-									throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
-									/*
-									 * If permission on schema exists, don't revoke any permission from the object.
-									 */
-									if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
-										exec_pg_command = true;
-
-									update_privileges_of_object(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, false);
+									foreach(lc, grant->grantees)
+									{
+										RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
+										/* Special database roles should throw an error. */
+										throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
+										/* If permission on schema exists, don't revoke any permission from the object. */
+										if (!privilege_exists_in_bbf_schema_permissions(logical_schema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA, privilege))
+										{
+											/* 
+											 * If the privilege is not common to schema and object then 
+											 * execute_pg_command true and append the privilege to filtered list 
+											 */
+											exec_pg_command = true;
+										}
+										else
+											grant->privileges = foreach_delete_current(grant->privileges, lc1);
+										update_privileges_of_object(logical_schema, obj, privilege, rol_spec->rolename, OBJ_RELATION, false);
+									}
 								}
 							}
 						}
@@ -4938,6 +5016,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 					const char *obj_type = NULL;
 					Oid func_oid = LookupFuncWithArgs(OBJECT_ROUTINE, ob, true);
 					const char *func_args = NULL;
+
 					if (OidIsValid(func_oid))
 						func_args = gen_func_arg_list(func_oid);
 					if (grant->objtype == OBJECT_FUNCTION)
@@ -4984,7 +5063,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								 * 2. If permission on object exists, update the privilege in the catalog and revoke permission.
 								 */
 								update_privileges_of_object(logicalschema, funcname, ALL_PERMISSIONS_ON_FUNCTION, rol_spec->rolename, obj_type, false);
-								if (privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
+								if (privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA, INVALID_PERMISSION))
 									return;
 							}
 						}
@@ -5019,11 +5098,18 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 								RoleSpec	   *rol_spec = (RoleSpec *) lfirst(lc);
 								/* Special database roles should throw an error. */
 								throw_error_for_fixed_db_role(rol_spec->rolename, dbname);
-								/*
-								 * If permission on schema exists, don't revoke any permission from the object.
-								 */
-								if (!exec_pg_command && !privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA))
+								/* If permission on schema exists, don't revoke any permission from the object. */
+								if (!privilege_exists_in_bbf_schema_permissions(logicalschema, PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA, rol_spec->rolename, OBJ_SCHEMA, privilege))
+								{
+									/* 
+									 * If the privilege is not common to schema and object then 
+									 * execute_pg_command true.
+									 */
 									exec_pg_command = true;
+								}
+								else
+									grant->privileges =foreach_delete_current(grant->privileges, lc1);
+
 								/* Update the privilege in the catalog. */
 								update_privileges_of_object(logicalschema, funcname, privilege, rol_spec->rolename, obj_type, false);
 							}

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -2491,6 +2491,14 @@ string_to_privilege(const char *privname)
 		return ACL_REFERENCES;
 	if (strcmp(privname, "execute") == 0)
 		return ACL_EXECUTE;
+	if (strcmp(privname, "truncate") == 0)
+		return ACL_TRUNCATE;
+	if (strcmp(privname, "maintain") == 0)
+		return ACL_MAINTAIN;
+	if (strcmp(privname, "trigger") == 0)
+		return ACL_TRIGGER;
+	if (strcmp(privname, "usage") == 0)
+		return ACL_USAGE;
 	else
 		return 0;
 }

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -2493,8 +2493,6 @@ string_to_privilege(const char *privname)
 		return ACL_EXECUTE;
 	if (strcmp(privname, "truncate") == 0)
 		return ACL_TRUNCATE;
-	if (strcmp(privname, "maintain") == 0)
-		return ACL_MAINTAIN;
 	if (strcmp(privname, "trigger") == 0)
 		return ACL_TRIGGER;
 	if (strcmp(privname, "usage") == 0)

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -6664,3 +6664,140 @@ go
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
 ~~END~~
 
+
+-- tsql
+create schema sch;
+go
+create table sch.t1(a int)
+go
+create login l with password = '123';create user u for login l;
+go
+
+--Case 1 : when perms on schema and object are overlapping(i.e not mutually exclusive)
+grant select on schema::sch to u
+go
+grant select, insert on sch.t1 to u;
+go
+-- psql 
+select * from sys.babelfish_schema_permissions;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+1#!#sch#!#ALL#!#2#!#master_u#!#s#!#<NULL>#!#<NULL>
+1#!#sch#!#t1#!#3#!#master_u#!#r#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- tsql
+revoke select, insert on sch.t1 to u;
+go
+
+-- psql 
+select * from sys.babelfish_schema_permissions;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+1#!#sch#!#ALL#!#2#!#master_u#!#s#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- tsql user=l password=123
+select * from sch.t1
+go
+~~START~~
+int
+~~END~~
+
+insert into sch.t1 values (1)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+-- terminate-tsql-conn user=l password=123
+
+-- tsql
+drop table sch.t1
+go
+drop schema sch
+go
+drop user u
+go
+drop login l
+go
+
+-- tsql
+-- Test Group 19 [REVOKE ALL with schema permissions]
+create login babel_test_l1 with password = '123';
+go
+
+create user babel_test_u1 for login babel_test_l1;
+go
+
+create schema babel_test_s1;
+go
+
+create table babel_test_s1.t1(a int);
+go
+
+-- Grant table and schema permissions
+grant select, insert on babel_test_s1.t1 to babel_test_u1;
+go
+
+grant select on schema::babel_test_s1 to babel_test_u1;
+go
+
+-- Revoke all permissions from table
+SELECT relname, relacl 
+FROM pg_class 
+WHERE relname = 't1'
+go
+~~START~~
+varchar#!#varchar
+t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=ar/master_dbo}
+~~END~~
+
+revoke all on babel_test_s1.t1 from babel_test_u1;
+go
+
+SELECT relname, relacl 
+FROM pg_class 
+WHERE relname = 't1'
+go
+~~START~~
+varchar#!#varchar
+t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=r/master_dbo}
+~~END~~
+
+
+-- tsql user=babel_test_l1 password=123
+-- Try to insert into table (should fail due to revoked permissions)
+select * from babel_test_s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+
+insert into babel_test_s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+-- terminate-tsql-conn user=babel_test_l1 password=123
+
+-- tsql
+-- Cleanup
+drop table babel_test_s1.t1;
+go
+
+drop schema babel_test_s1;
+go
+
+drop user babel_test_u1;
+go
+
+-- tsql
+drop login babel_test_l1;
+go

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -6754,7 +6754,7 @@ WHERE relname = 't1'
 go
 ~~START~~
 varchar#!#varchar
-t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=ar/master_dbo}
+t1#!#{master_dbo=arwdDxt/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=ar/master_dbo}
 ~~END~~
 
 revoke all on babel_test_s1.t1 from babel_test_u1;
@@ -6766,7 +6766,7 @@ WHERE relname = 't1'
 go
 ~~START~~
 varchar#!#varchar
-t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=r/master_dbo}
+t1#!#{master_dbo=arwdDxt/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=r/master_dbo}
 ~~END~~
 
 

--- a/test/JDBC/expected/single_db/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/single_db/GRANT_SCHEMA.out
@@ -6664,3 +6664,140 @@ go
 "sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#"sys"."varchar"
 ~~END~~
 
+
+-- tsql
+create schema sch;
+go
+create table sch.t1(a int)
+go
+create login l with password = '123';create user u for login l;
+go
+
+--Case 1 : when perms on schema and object are overlapping(i.e not mutually exclusive)
+grant select on schema::sch to u
+go
+grant select, insert on sch.t1 to u;
+go
+-- psql 
+select * from sys.babelfish_schema_permissions;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+1#!#sch#!#ALL#!#2#!#master_u#!#s#!#<NULL>#!#<NULL>
+1#!#sch#!#t1#!#3#!#master_u#!#r#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- tsql
+revoke select, insert on sch.t1 to u;
+go
+
+-- psql 
+select * from sys.babelfish_schema_permissions;
+go
+~~START~~
+int2#!#"sys"."varchar"#!#"sys"."varchar"#!#int4#!#"sys"."varchar"#!#bpchar#!#text#!#"sys"."varchar"
+1#!#sch#!#ALL#!#2#!#master_u#!#s#!#<NULL>#!#<NULL>
+~~END~~
+
+
+-- tsql user=l password=123
+select * from sch.t1
+go
+~~START~~
+int
+~~END~~
+
+insert into sch.t1 values (1)
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+-- terminate-tsql-conn user=l password=123
+
+-- tsql
+drop table sch.t1
+go
+drop schema sch
+go
+drop user u
+go
+drop login l
+go
+
+-- tsql
+-- Test Group 19 [REVOKE ALL with schema permissions]
+create login babel_test_l1 with password = '123';
+go
+
+create user babel_test_u1 for login babel_test_l1;
+go
+
+create schema babel_test_s1;
+go
+
+create table babel_test_s1.t1(a int);
+go
+
+-- Grant table and schema permissions
+grant select, insert on babel_test_s1.t1 to babel_test_u1;
+go
+
+grant select on schema::babel_test_s1 to babel_test_u1;
+go
+
+-- Revoke all permissions from table
+SELECT relname, relacl 
+FROM pg_class 
+WHERE relname = 't1'
+go
+~~START~~
+varchar#!#varchar
+t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=ar/master_dbo}
+~~END~~
+
+revoke all on babel_test_s1.t1 from babel_test_u1;
+go
+
+SELECT relname, relacl 
+FROM pg_class 
+WHERE relname = 't1'
+go
+~~START~~
+varchar#!#varchar
+t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=r/master_dbo}
+~~END~~
+
+
+-- tsql user=babel_test_l1 password=123
+-- Try to insert into table (should fail due to revoked permissions)
+select * from babel_test_s1.t1;
+go
+~~START~~
+int
+~~END~~
+
+
+insert into babel_test_s1.t1 values (1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: permission denied for table t1)~~
+
+-- terminate-tsql-conn user=babel_test_l1 password=123
+
+-- tsql
+-- Cleanup
+drop table babel_test_s1.t1;
+go
+
+drop schema babel_test_s1;
+go
+
+drop user babel_test_u1;
+go
+
+-- tsql
+drop login babel_test_l1;
+go

--- a/test/JDBC/expected/single_db/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/single_db/GRANT_SCHEMA.out
@@ -6754,7 +6754,7 @@ WHERE relname = 't1'
 go
 ~~START~~
 varchar#!#varchar
-t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=ar/master_dbo}
+t1#!#{master_dbo=arwdDxt/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=ar/master_dbo}
 ~~END~~
 
 revoke all on babel_test_s1.t1 from babel_test_u1;
@@ -6766,7 +6766,7 @@ WHERE relname = 't1'
 go
 ~~START~~
 varchar#!#varchar
-t1#!#{master_dbo=arwdDxtm/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=r/master_dbo}
+t1#!#{master_dbo=arwdDxt/master_dbo,master_db_datareader=r/master_dbo,master_db_datawriter=awd/master_dbo,master_db_ddladmin=D/master_dbo,master_babel_test_u1=r/master_dbo}
 ~~END~~
 
 

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -3673,3 +3673,103 @@ go
 select schema_name, object_name, permission, grantee, grantor from sys.babelfish_schema_permissions
 where object_name = 'GRANT_SCHEMA_t1' collate sys.database_default;
 go
+
+-- tsql
+create schema sch;
+go
+create table sch.t1(a int)
+go
+create login l with password = '123';create user u for login l;
+go
+
+--Case 1 : when perms on schema and object are overlapping(i.e not mutually exclusive)
+grant select on schema::sch to u
+go
+grant select, insert on sch.t1 to u;
+go
+-- psql 
+select * from sys.babelfish_schema_permissions;
+go
+
+-- tsql
+revoke select, insert on sch.t1 to u;
+go
+
+-- psql 
+select * from sys.babelfish_schema_permissions;
+go
+
+-- tsql user=l password=123
+select * from sch.t1
+go
+insert into sch.t1 values (1)
+go
+-- terminate-tsql-conn user=l password=123
+
+-- tsql
+drop table sch.t1
+go
+drop schema sch
+go
+drop user u
+go
+drop login l
+go
+
+-- tsql
+-- Test Group 19 [REVOKE ALL with schema permissions]
+create login babel_test_l1 with password = '123';
+go
+
+create user babel_test_u1 for login babel_test_l1;
+go
+
+create schema babel_test_s1;
+go
+
+create table babel_test_s1.t1(a int);
+go
+
+-- Grant table and schema permissions
+grant select, insert on babel_test_s1.t1 to babel_test_u1;
+go
+
+grant select on schema::babel_test_s1 to babel_test_u1;
+go
+
+-- Revoke all permissions from table
+SELECT relname, relacl 
+FROM pg_class 
+WHERE relname = 't1'
+go
+revoke all on babel_test_s1.t1 from babel_test_u1;
+go
+
+SELECT relname, relacl 
+FROM pg_class 
+WHERE relname = 't1'
+go
+
+-- tsql user=babel_test_l1 password=123
+-- Try to insert into table (should fail due to revoked permissions)
+select * from babel_test_s1.t1;
+go
+
+insert into babel_test_s1.t1 values (1);
+go
+-- terminate-tsql-conn user=babel_test_l1 password=123
+
+-- tsql
+-- Cleanup
+drop table babel_test_s1.t1;
+go
+
+drop schema babel_test_s1;
+go
+
+drop user babel_test_u1;
+go
+
+-- tsql
+drop login babel_test_l1;
+go


### PR DESCRIPTION
### Description
Cherry-pick from : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3994
In addition in v16.x PG do not have maintain privilege over table, so removed that.
Problem : When we grant some permissions on schema and object in that schema to a user, in that case regardless of permission that we are trying to revoke, in babelfish we never really execute the revoke and just update the catalog. Fixed the issue by adding a permission check in the privilege check function so that we execute revoke when the schema permission and object permission are not common. Secondly, we are revoking the permission which are already not granted to the schema, if any permission granted to schema and object both then we won't revoke it, for that we are updating the grant-privileges list in the query tree itself before execution stage.

Issues Resolved
[BABEL-5904]

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).