### PR TITLE
Added tests for temp table index rollback semantics fix

### DIFF
--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -47,3 +47,252 @@ text
 on
 ~~END~~
 
+
+-- tsql
+CREATE TABLE #temp_with_indexes(fullname VARCHAR PRIMARY KEY, id INT);
+GO
+CREATE UNIQUE INDEX id_idx on #temp_with_indexes(id);
+GO
+
+BEGIN TRAN
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1);
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1); -- this violates id_idx Constraint
+COMMIT TRAN
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#temp_with_indexes_pkey")~~
+
+SELECT * FROM #temp_with_indexes;
+GO
+~~START~~
+varchar#!#int
+a#!#1
+~~END~~
+
+
+
+
+
+
+CREATE PROCEDURE test_nested_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1_proc1(a int)
+    INSERT INTO #t1_proc1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1_proc1 ADD b varchar(50)
+        TRUNCATE TABLE #t1_proc1
+        INSERT INTO #t1_proc1 VALUES (1, 'two')
+        -- Should just be (1, 'two')
+        SELECT * FROM #t1_proc1
+        SAVE TRAN s1
+            DROP TABLE #t1_proc1
+            CREATE TABLE #t1_proc1(a varchar(100))
+            INSERT INTO #t1_proc1 VALUES ('three')
+            CREATE UNIQUE CLUSTERED INDEX IX_tmpSpec ON #t1_proc1(a)
+            -- Should just be 'three'
+            SELECT * FROM #t1_proc1
+        ROLLBACK TRAN s1
+        -- Should just be (1, 'two')
+        SELECT * FROM #t1_proc1
+        CREATE TABLE #t2_proc1(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc1 VALUES ('four')
+        CREATE UNIQUE CLUSTERED INDEX IX_t2_proc1 ON #t2_proc1(b)
+        -- ('four', 1)
+        SELECT * FROM #t2_proc1
+        DROP TABLE #t2_proc1
+    ROLLBACK;
+    -- Should have just 6
+    SELECT * FROM #t1_proc1
+END
+GO
+
+
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    BEGIN TRAN
+        SAVE TRAN S1
+        CREATE TABLE #t1_proc2(a int)
+        ALTER TABLE #t1_proc2 ADD b varchar(50)
+        INSERT INTO #t1_proc2 VALUES (1, 'two')
+		CREATE UNIQUE CLUSTERED INDEX IX_t1_proc2 ON #t1_proc2(a)
+		-- (1,'two')
+        SELECT * FROM #t1_proc2
+        DROP TABLE #t1_proc2
+        CREATE TABLE #t1_proc2(a varchar(100))
+        INSERT INTO #t1_proc2 VALUES ('three')
+		-- ('three')
+        SELECT * FROM #t1_proc2
+        CREATE TABLE #t2_proc2(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc2 VALUES ('four')
+		CREATE UNIQUE CLUSTERED INDEX IX_t2_proc2 ON #t2_proc2(a)
+		-- ('four',1)
+        SELECT * FROM #t2_proc2
+        DROP TABLE #t2_proc2
+        INSERT INTO #t1_proc2 values ('one'), ('two')
+		-- ('three','one','two')
+        SELECT * FROM #t1_proc2
+    COMMIT
+END
+GO
+
+CREATE PROCEDURE execute_rollback_tests(@loop_count int) AS
+BEGIN
+    DECLARE @counter int = 1;
+    DECLARE @error_message varchar(500);
+    
+    WHILE @counter <= @loop_count
+    BEGIN
+        
+        -- Execute first procedure
+        BEGIN TRY
+            EXEC test_nested_rollback_in_proc;
+        END TRY
+        BEGIN CATCH
+            SET @error_message = ERROR_MESSAGE();
+            PRINT 'ERROR in test_nested_rollback_in_proc: ' + @error_message;
+        END CATCH
+        
+        -- Execute second procedure
+        BEGIN TRY
+            EXEC implicit_rollback_in_proc;
+        END TRY
+        BEGIN CATCH
+            SET @error_message = ERROR_MESSAGE();
+            PRINT 'ERROR in implicit_rollback_in_proc: ' + @error_message;
+        END CATCH
+        
+        SET @counter = @counter + 1;
+        
+    END
+    
+    PRINT '';
+    PRINT 'All test iterations completed.';
+END
+GO
+
+EXEC execute_rollback_tests 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~START~~
+int
+6
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#two
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+three
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#int
+four#!#1
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+three
+one
+two
+~~END~~
+
+
+CREATE TABLE #temptable(a text);
+GO
+INSERT INTO #temptable VALUES (REPLICATE('a', 900000));
+GO
+~~ROW COUNT: 1~~
+
+CREATE INDEX a_idx on #temptable(a);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index row requires 10328 bytes, maximum size is 8191)~~
+
+DROP TABLE #temptable; -- this previously would fail with a cache lookup failed error due to incorrect rollback of index
+GO
+
+CREATE TABLE #temptable(a text);
+GO
+INSERT INTO #temptable VALUES (REPLICATE('a', 900000));
+GO
+~~ROW COUNT: 1~~
+
+CREATE INDEX #a_idx on #temptable(a);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index row requires 10328 bytes, maximum size is 8191)~~
+
+DROP TABLE #temptable;
+GO
+
+CREATE TABLE #temptable(a text);
+GO
+INSERT INTO #temptable VALUES (REPLICATE('a', 900000));
+GO
+~~ROW COUNT: 1~~
+
+BEGIN TRAN
+	CREATE INDEX a_idx on #temptable(a);
+COMMIT TRAN
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: index row requires 10328 bytes, maximum size is 8191)~~
+
+SELECT COUNT(*) FROM #temptable; -- this should return the result
+GO
+~~START~~
+int
+1
+~~END~~
+
+DROP TABLE #temptable;
+GO
+
+DROP PROCEDURE execute_rollback_tests, implicit_rollback_in_proc, test_nested_rollback_in_proc;
+GO

--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -1,4 +1,4 @@
-expected/temp_table_rollback.out-- psql 
+-- psql 
 -- Session-local setting, so it will only apply to this test.
 show babelfishpg_tsql.temp_table_xact_support;
 GO

--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -1,4 +1,4 @@
--- psql 
+expected/temp_table_rollback.out-- psql 
 -- Session-local setting, so it will only apply to this test.
 show babelfishpg_tsql.temp_table_xact_support;
 GO
@@ -73,6 +73,36 @@ a#!#1
 ~~END~~
 
 
+SET XACT_ABORT ON;
+GO
+
+TRUNCATE TABLE #temp_with_indexes;
+GO
+
+BEGIN TRAN
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1);
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1); -- this violates id_idx Constraint
+COMMIT TRAN
+GO
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 2627)~~
+
+~~ERROR (Message: duplicate key value violates unique constraint "#temp_with_indexes_pkey")~~
+
+SELECT * FROM #temp_with_indexes; -- since XACT_ABORT is ON, we should not get any tuples since last transaction is marked aborted after the uniqueness error
+GO
+~~START~~
+varchar#!#int
+~~END~~
+
+
+DROP TABLE #temp_with_indexes;
+GO
+
+SET XACT_ABORT OFF;
+GO
+
 
 
 
@@ -83,6 +113,8 @@ BEGIN
     INSERT INTO #t1_proc1 values (6)
     BEGIN TRAN;
         ALTER TABLE #t1_proc1 ADD b varchar(50)
+		-- Shows all the ENRs created
+		SELECT * FROM sys.babelfish_get_enr_list();
         TRUNCATE TABLE #t1_proc1
         INSERT INTO #t1_proc1 VALUES (1, 'two')
         -- Should just be (1, 'two')
@@ -94,6 +126,15 @@ BEGIN
             CREATE UNIQUE CLUSTERED INDEX IX_tmpSpec ON #t1_proc1(a)
             -- Should just be 'three'
             SELECT * FROM #t1_proc1
+			ALTER TABLE #t1_proc1 ADD b INT
+			TRUNCATE TABLE #t1_proc1
+			SAVE TRAN s2
+				ALTER TABLE #t1_proc1 DROP a;
+				INSERT INTO #t1_proc1 VALUES (GENERATE_SERIES(1,5));
+				-- (1,2,3,4,5)
+				SELECT * FROM #t1_proc1
+				-- Shows all the ENRs created
+				SELECT * FROM sys.babelfish_get_enr_list();
         ROLLBACK TRAN s1
         -- Should just be (1, 'two')
         SELECT * FROM #t1_proc1
@@ -178,6 +219,14 @@ EXEC execute_rollback_tests 1;
 GO
 ~~ROW COUNT: 1~~
 
+~~START~~
+int#!#text
+20073#!##t1_proc1
+20076#!##pg_toast_20073
+20077#!##pg_toast_20073_index
+20057#!##temp_rollback_1
+~~END~~
+
 ~~ROW COUNT: 1~~
 
 ~~START~~
@@ -190,6 +239,25 @@ int#!#varchar
 ~~START~~
 varchar
 three
+~~END~~
+
+~~ROW COUNT: 5~~
+
+~~START~~
+int
+1
+2
+3
+4
+5
+~~END~~
+
+~~START~~
+int#!#text
+20081#!##t1_proc1
+20084#!##pg_toast_20081
+20085#!##pg_toast_20081_index
+20057#!##temp_rollback_1
 ~~END~~
 
 ~~START~~
@@ -296,3 +364,25 @@ GO
 
 DROP PROCEDURE execute_rollback_tests, implicit_rollback_in_proc, test_nested_rollback_in_proc;
 GO
+
+CREATE TABLE #t_with_ident(a INT IDENTITY(1,5) PRIMARY KEY);
+GO
+SELECT * FROM sys.babelfish_get_enr_list();
+GO
+~~START~~
+int#!#text
+20057#!##temp_rollback_1
+20138#!##t_with_ident_a_seq
+20139#!##t_with_ident
+20142#!##t_with_ident_pkey
+~~END~~
+
+DROP TABLE #t_with_ident;
+GO
+SELECT * FROM sys.babelfish_get_enr_list();
+GO
+~~START~~
+int#!#text
+20057#!##temp_rollback_1
+~~END~~
+

--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -103,6 +103,12 @@ GO
 SET XACT_ABORT OFF;
 GO
 
+CREATE VIEW enr_view AS
+    SELECT relname
+    FROM sys.babelfish_get_enr_list()
+	ORDER BY relname
+GO
+
 
 
 
@@ -114,7 +120,7 @@ BEGIN
     BEGIN TRAN;
         ALTER TABLE #t1_proc1 ADD b varchar(50)
 		-- Shows all the ENRs created
-		SELECT * FROM sys.babelfish_get_enr_list();
+		SELECT * FROM enr_view;
         TRUNCATE TABLE #t1_proc1
         INSERT INTO #t1_proc1 VALUES (1, 'two')
         -- Should just be (1, 'two')
@@ -134,7 +140,7 @@ BEGIN
 				-- (1,2,3,4,5)
 				SELECT * FROM #t1_proc1
 				-- Shows all the ENRs created
-				SELECT * FROM sys.babelfish_get_enr_list();
+				SELECT * FROM enr_view;
         ROLLBACK TRAN s1
         -- Should just be (1, 'two')
         SELECT * FROM #t1_proc1
@@ -220,11 +226,11 @@ GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
-int#!#text
-20073#!##t1_proc1
-20076#!##pg_toast_20073
-20077#!##pg_toast_20073_index
-20057#!##temp_rollback_1
+text
+#pg_toast_20073
+#pg_toast_20073_index
+#t1_proc1
+#temp_rollback_1
 ~~END~~
 
 ~~ROW COUNT: 1~~
@@ -253,11 +259,11 @@ int
 ~~END~~
 
 ~~START~~
-int#!#text
-20081#!##t1_proc1
-20084#!##pg_toast_20081
-20085#!##pg_toast_20081_index
-20057#!##temp_rollback_1
+text
+#pg_toast_20081
+#pg_toast_20081_index
+#t1_proc1
+#temp_rollback_1
 ~~END~~
 
 ~~START~~
@@ -367,22 +373,25 @@ GO
 
 CREATE TABLE #t_with_ident(a INT IDENTITY(1,5) PRIMARY KEY);
 GO
-SELECT * FROM sys.babelfish_get_enr_list();
+SELECT * FROM enr_view;
 GO
 ~~START~~
-int#!#text
-20057#!##temp_rollback_1
-20138#!##t_with_ident_a_seq
-20139#!##t_with_ident
-20142#!##t_with_ident_pkey
+text
+#temp_rollback_1
+#t_with_ident
+#t_with_ident_a_seq
+#t_with_ident_pkey
 ~~END~~
 
 DROP TABLE #t_with_ident;
 GO
-SELECT * FROM sys.babelfish_get_enr_list();
+SELECT * FROM enr_view;
 GO
 ~~START~~
-int#!#text
-20057#!##temp_rollback_1
+text
+#temp_rollback_1
 ~~END~~
 
+
+DROP VIEW enr_view;
+GO

--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -104,7 +104,12 @@ SET XACT_ABORT OFF;
 GO
 
 CREATE VIEW enr_view AS
-    SELECT relname
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
     FROM sys.babelfish_get_enr_list()
 	ORDER BY relname
 GO
@@ -227,8 +232,8 @@ GO
 
 ~~START~~
 text
-#pg_toast_20073
-#pg_toast_20073_index
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
 #t1_proc1
 #temp_rollback_1
 ~~END~~
@@ -260,8 +265,8 @@ int
 
 ~~START~~
 text
-#pg_toast_20081
-#pg_toast_20081_index
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
 #t1_proc1
 #temp_rollback_1
 ~~END~~

--- a/test/JDBC/expected/temp_table_rollback.out
+++ b/test/JDBC/expected/temp_table_rollback.out
@@ -36,6 +36,9 @@ int
 ~~END~~
 
 
+DROP TABLE #temp_rollback_1;
+GO
+
 -- psql
 set babelfishpg_tsql.temp_table_xact_support = on; 
 GO
@@ -235,7 +238,6 @@ text
 #pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
 #t1_proc1
-#temp_rollback_1
 ~~END~~
 
 ~~ROW COUNT: 1~~
@@ -268,7 +270,6 @@ text
 #pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
 #t1_proc1
-#temp_rollback_1
 ~~END~~
 
 ~~START~~
@@ -382,7 +383,6 @@ SELECT * FROM enr_view;
 GO
 ~~START~~
 text
-#temp_rollback_1
 #t_with_ident
 #t_with_ident_a_seq
 #t_with_ident_pkey
@@ -394,7 +394,6 @@ SELECT * FROM enr_view;
 GO
 ~~START~~
 text
-#temp_rollback_1
 ~~END~~
 
 

--- a/test/JDBC/input/temp_tables/temp_table_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_rollback.mix
@@ -65,6 +65,12 @@ GO
 SET XACT_ABORT OFF;
 GO
 
+CREATE VIEW enr_view AS
+    SELECT relname
+    FROM sys.babelfish_get_enr_list()
+	ORDER BY relname
+GO
+
 CREATE PROCEDURE test_nested_rollback_in_proc AS
 BEGIN
     CREATE TABLE #t1_proc1(a int)
@@ -72,7 +78,7 @@ BEGIN
     BEGIN TRAN;
         ALTER TABLE #t1_proc1 ADD b varchar(50)
 		-- Shows all the ENRs created
-		SELECT * FROM sys.babelfish_get_enr_list();
+		SELECT * FROM enr_view;
         TRUNCATE TABLE #t1_proc1
         INSERT INTO #t1_proc1 VALUES (1, 'two')
         -- Should just be (1, 'two')
@@ -93,7 +99,7 @@ BEGIN
 				-- (1,2,3,4,5)
 				SELECT * FROM #t1_proc1
 				-- Shows all the ENRs created
-				SELECT * FROM sys.babelfish_get_enr_list();
+				SELECT * FROM enr_view;
         ROLLBACK TRAN s1
 
         -- Should just be (1, 'two')
@@ -216,9 +222,12 @@ GO
 
 CREATE TABLE #t_with_ident(a INT IDENTITY(1,5) PRIMARY KEY);
 GO
-SELECT * FROM sys.babelfish_get_enr_list();
+SELECT * FROM enr_view;
 GO
 DROP TABLE #t_with_ident;
 GO
-SELECT * FROM sys.babelfish_get_enr_list();
+SELECT * FROM enr_view;
+GO
+
+DROP VIEW enr_view;
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_rollback.mix
@@ -45,12 +45,34 @@ GO
 SELECT * FROM #temp_with_indexes;
 GO
 
+SET XACT_ABORT ON;
+GO
+
+TRUNCATE TABLE #temp_with_indexes;
+GO
+
+BEGIN TRAN
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1);
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1); -- this violates id_idx Constraint
+COMMIT TRAN
+GO
+SELECT * FROM #temp_with_indexes; -- since XACT_ABORT is ON, we should not get any tuples since last transaction is marked aborted after the uniqueness error
+GO
+
+DROP TABLE #temp_with_indexes;
+GO
+
+SET XACT_ABORT OFF;
+GO
+
 CREATE PROCEDURE test_nested_rollback_in_proc AS
 BEGIN
     CREATE TABLE #t1_proc1(a int)
     INSERT INTO #t1_proc1 values (6)
     BEGIN TRAN;
         ALTER TABLE #t1_proc1 ADD b varchar(50)
+		-- Shows all the ENRs created
+		SELECT * FROM sys.babelfish_get_enr_list();
         TRUNCATE TABLE #t1_proc1
         INSERT INTO #t1_proc1 VALUES (1, 'two')
         -- Should just be (1, 'two')
@@ -63,6 +85,15 @@ BEGIN
             CREATE UNIQUE CLUSTERED INDEX IX_tmpSpec ON #t1_proc1(a)
             -- Should just be 'three'
             SELECT * FROM #t1_proc1
+			ALTER TABLE #t1_proc1 ADD b INT
+			TRUNCATE TABLE #t1_proc1
+			SAVE TRAN s2
+				ALTER TABLE #t1_proc1 DROP a;
+				INSERT INTO #t1_proc1 VALUES (GENERATE_SERIES(1,5));
+				-- (1,2,3,4,5)
+				SELECT * FROM #t1_proc1
+				-- Shows all the ENRs created
+				SELECT * FROM sys.babelfish_get_enr_list();
         ROLLBACK TRAN s1
 
         -- Should just be (1, 'two')
@@ -181,4 +212,13 @@ DROP TABLE #temptable;
 GO
 
 DROP PROCEDURE execute_rollback_tests, implicit_rollback_in_proc, test_nested_rollback_in_proc;
+GO
+
+CREATE TABLE #t_with_ident(a INT IDENTITY(1,5) PRIMARY KEY);
+GO
+SELECT * FROM sys.babelfish_get_enr_list();
+GO
+DROP TABLE #t_with_ident;
+GO
+SELECT * FROM sys.babelfish_get_enr_list();
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_rollback.mix
@@ -24,6 +24,9 @@ GO
 SELECT * FROM #temp_rollback_1
 GO
 
+DROP TABLE #temp_rollback_1;
+GO
+
 -- psql
 set babelfishpg_tsql.temp_table_xact_support = on; 
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_rollback.mix
@@ -66,7 +66,12 @@ SET XACT_ABORT OFF;
 GO
 
 CREATE VIEW enr_view AS
-    SELECT relname
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
     FROM sys.babelfish_get_enr_list()
 	ORDER BY relname
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback.mix
+++ b/test/JDBC/input/temp_tables/temp_table_rollback.mix
@@ -30,3 +30,155 @@ GO
 
 show babelfishpg_tsql.temp_table_xact_support;
 GO
+
+-- tsql
+CREATE TABLE #temp_with_indexes(fullname VARCHAR PRIMARY KEY, id INT);
+GO
+CREATE UNIQUE INDEX id_idx on #temp_with_indexes(id);
+GO
+
+BEGIN TRAN
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1);
+	INSERT INTO #temp_with_indexes(fullname, id) VALUES ('a', 1); -- this violates id_idx Constraint
+COMMIT TRAN
+GO
+SELECT * FROM #temp_with_indexes;
+GO
+
+CREATE PROCEDURE test_nested_rollback_in_proc AS
+BEGIN
+    CREATE TABLE #t1_proc1(a int)
+    INSERT INTO #t1_proc1 values (6)
+    BEGIN TRAN;
+        ALTER TABLE #t1_proc1 ADD b varchar(50)
+        TRUNCATE TABLE #t1_proc1
+        INSERT INTO #t1_proc1 VALUES (1, 'two')
+        -- Should just be (1, 'two')
+        SELECT * FROM #t1_proc1
+
+        SAVE TRAN s1
+            DROP TABLE #t1_proc1
+            CREATE TABLE #t1_proc1(a varchar(100))
+            INSERT INTO #t1_proc1 VALUES ('three')
+            CREATE UNIQUE CLUSTERED INDEX IX_tmpSpec ON #t1_proc1(a)
+            -- Should just be 'three'
+            SELECT * FROM #t1_proc1
+        ROLLBACK TRAN s1
+
+        -- Should just be (1, 'two')
+        SELECT * FROM #t1_proc1
+
+        CREATE TABLE #t2_proc1(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc1 VALUES ('four')
+        CREATE UNIQUE CLUSTERED INDEX IX_t2_proc1 ON #t2_proc1(b)
+
+        -- ('four', 1)
+        SELECT * FROM #t2_proc1
+        DROP TABLE #t2_proc1
+    ROLLBACK;
+    -- Should have just 6
+    SELECT * FROM #t1_proc1
+END
+GO
+
+CREATE PROCEDURE implicit_rollback_in_proc AS 
+BEGIN
+    BEGIN TRAN
+        SAVE TRAN S1
+        CREATE TABLE #t1_proc2(a int)
+        ALTER TABLE #t1_proc2 ADD b varchar(50)
+        INSERT INTO #t1_proc2 VALUES (1, 'two')
+		CREATE UNIQUE CLUSTERED INDEX IX_t1_proc2 ON #t1_proc2(a)
+		-- (1,'two')
+        SELECT * FROM #t1_proc2
+        DROP TABLE #t1_proc2
+        CREATE TABLE #t1_proc2(a varchar(100))
+        INSERT INTO #t1_proc2 VALUES ('three')
+		-- ('three')
+        SELECT * FROM #t1_proc2
+
+        CREATE TABLE #t2_proc2(b varchar(50), a int identity primary key)
+        INSERT INTO #t2_proc2 VALUES ('four')
+		CREATE UNIQUE CLUSTERED INDEX IX_t2_proc2 ON #t2_proc2(a)
+		-- ('four',1)
+        SELECT * FROM #t2_proc2
+        DROP TABLE #t2_proc2
+
+        INSERT INTO #t1_proc2 values ('one'), ('two')
+		-- ('three','one','two')
+        SELECT * FROM #t1_proc2
+    COMMIT
+END
+GO
+
+CREATE PROCEDURE execute_rollback_tests(@loop_count int) AS
+BEGIN
+    DECLARE @counter int = 1;
+    DECLARE @error_message varchar(500);
+    
+    WHILE @counter <= @loop_count
+    BEGIN
+        
+        -- Execute first procedure
+        BEGIN TRY
+            EXEC test_nested_rollback_in_proc;
+        END TRY
+        BEGIN CATCH
+            SET @error_message = ERROR_MESSAGE();
+            PRINT 'ERROR in test_nested_rollback_in_proc: ' + @error_message;
+        END CATCH
+        
+        -- Execute second procedure
+        BEGIN TRY
+            EXEC implicit_rollback_in_proc;
+        END TRY
+        BEGIN CATCH
+            SET @error_message = ERROR_MESSAGE();
+            PRINT 'ERROR in implicit_rollback_in_proc: ' + @error_message;
+        END CATCH
+        
+        SET @counter = @counter + 1;
+        
+    END
+    
+    PRINT '';
+    PRINT 'All test iterations completed.';
+END
+GO
+
+EXEC execute_rollback_tests 1;
+GO
+
+CREATE TABLE #temptable(a text);
+GO
+INSERT INTO #temptable VALUES (REPLICATE('a', 900000));
+GO
+CREATE INDEX a_idx on #temptable(a);
+GO
+DROP TABLE #temptable; -- this previously would fail with a cache lookup failed error due to incorrect rollback of index
+GO
+
+CREATE TABLE #temptable(a text);
+GO
+INSERT INTO #temptable VALUES (REPLICATE('a', 900000));
+GO
+CREATE INDEX #a_idx on #temptable(a);
+GO
+DROP TABLE #temptable;
+GO
+
+CREATE TABLE #temptable(a text);
+GO
+INSERT INTO #temptable VALUES (REPLICATE('a', 900000));
+GO
+BEGIN TRAN
+	CREATE INDEX a_idx on #temptable(a);
+COMMIT TRAN
+GO
+SELECT COUNT(*) FROM #temptable; -- this should return the result
+GO
+DROP TABLE #temptable;
+GO
+
+DROP PROCEDURE execute_rollback_tests, implicit_rollback_in_proc, test_nested_rollback_in_proc;
+GO


### PR DESCRIPTION
Temp table indexes starting without a '#' were not marked and hence did not follow rollback semantics leading to crashes and "cache lookup" failures

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/626

### Issues Resolved

Task: BABEL-6096, BABEL-5982

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).