### PR TITLE
Fix crash when pg_cron background jobs throw errors in Babelfish

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5826,7 +5826,7 @@ terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 		if ((rc = SPI_finish()) != SPI_OK_FINISH)
 			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
-	if (send_error)
+	if (send_error && !IsBackgroundWorker)
 	{
 		ErrorData  *edata;
 		MemoryContext oldCtx = CurrentMemoryContext;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5826,6 +5826,13 @@ terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 		if ((rc = SPI_finish()) != SPI_OK_FINISH)
 			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
+	/*
+	 * For background workers, MessageContext is not set up. 
+	 * For Background worker errors are handled via PG_RE_THROW() since
+	 * IS_TDS_CLIENT() will be false, bypassing TSQL transaction handling. Without the
+	 * !IsBackgroundWorker check, attempting to use MessageContext in a background
+	 * worker would cause a crash.
+	 */
 	if (send_error && !IsBackgroundWorker)
 	{
 		ErrorData  *edata;


### PR DESCRIPTION
### Description
Problem: When pg_cron is enabled with babelfish and we run a background job which is obvious to throw some error, then we are landing into a crash

RCA: The problem is when we run a pg_cron and execute a query via background worker then in terminate_batch function memory context MessageContext is not initialised( or is NULL), which leads to crash.
Fix: Check if we are connected via background worker then do not switch to MessageContext instead, throw error afterwards.

After fix results:

```
babelfish_db=# SELECT * FROM cron.job_run_details;
 jobid | runid | job_pid |   database   | username |             command              | status |                          return_mess
age                          |          start_time           |           end_time            
-------+-------+---------+--------------+----------+----------------------------------+--------+-------------------------------------
-----------------------------+-------------------------------+-------------------------------
     1 |     1 |    3673 | babelfish_db | pranavjc |  SELECT * FROM master_dbo.f1();  | failed | ERROR: invalid input syntax for type
 integer: "a"               +| 2025-09-28 19:26:00.005961+00 | 2025-09-28 19:26:00.200067+00
       |       |         |              |          |                                  |        | CONTEXT: PL/tsql function master_dbo
.f1() line 1 at RETURN QUERY |                               | 
     1 |     2 |    4560 | babelfish_db | pranavjc |  SELECT * FROM master_dbo.f1();  | failed | ERROR: invalid input syntax for type
 integer: "a"               +| 2025-09-28 19:27:00.003202+00 | 2025-09-28 19:27:00.198453+00
       |       |         |              |          |                                  |        | CONTEXT: PL/tsql function master_dbo
.f1() line 1 at RETURN QUERY |                               | 
     1 |     3 |    6194 | babelfish_db | pranavjc |  SELECT * FROM master_dbo.f1();  | failed | ERROR: invalid input syntax for type
 integer: "a"               +| 2025-09-28 19:28:00.003781+00 | 2025-09-28 19:28:00.199305+00
       |       |         |              |          |                                  |        | CONTEXT: PL/tsql function master_dbo
.f1() line 1 at RETURN QUERY |                               | 
(3 rows)
```
Tested with parallel query as well, working as expected.



### Issues Resolved

[BABEL-5995]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).