### PR TITLE
Fix crash when pg_cron background jobs throw errors in Babelfish

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6165,7 +6165,14 @@ terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 		if ((rc = SPI_finish()) != SPI_OK_FINISH)
 			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
-	if (send_error)
+	/*
+	 * For background workers, MessageContext is not set up. 
+	 * For Background worker errors are handled via PG_RE_THROW() since
+	 * IS_TDS_CLIENT() will be false, bypassing TSQL transaction handling. Without the
+	 * !AmBackgroundWorkerProcess check, attempting to use MessageContext in a background
+	 * worker would cause a crash.
+	 */
+	if (send_error && !AmBackgroundWorkerProcess())
 	{
 		ErrorData  *edata;
 		MemoryContext oldCtx = CurrentMemoryContext;


### PR DESCRIPTION
### Description
Problem: When pg_cron is enabled with babelfish and we run a background job which is obvious to throw some error, then we are landing into a crash

RCA: The problem is when we run a pg_cron and execute a query via background worker then in terminate_batch function memory context MessageContext is not initialised( or is NULL), which leads to crash.
Fix: Check if we are connected via background worker then do not switch to MessageContext instead, throw error afterwards.

```
babelfish_db=# SELECT * FROM cron.job_run_details;
 jobid | runid | job_pid |   database   | username |             command              | status |                         
 return_message                          |          start_time           |           end_time            
-------+-------+---------+--------------+----------+----------------------------------+--------+-------------------------
-----------------------------------------+-------------------------------+-------------------------------
     1 |     1 |   42037 | babelfish_db | pranavjc |  SELECT * FROM master_dbo.f1();  | failed | ERROR: invalid input syn
tax for type integer: "a"               +| 2025-10-06 18:07:00.006197+00 | 2025-10-06 18:07:00.209119+00
       |       |         |              |          |                                  |        | CONTEXT: PL/tsql functio
n master_dbo.f1() line 1 at RETURN QUERY |                               | 
     1 |     2 |   42628 | babelfish_db | pranavjc |  SELECT * FROM master_dbo.f1();  | failed | ERROR: invalid input syn
tax for type integer: "a"               +| 2025-10-06 18:08:00.003336+00 | 2025-10-06 18:08:00.205403+00
       |       |         |              |          |                                  |        | CONTEXT: PL/tsql functio
n master_dbo.f1() line 1 at RETURN QUERY |                               | 
     1 |     3 |   43712 | babelfish_db | pranavjc |  SELECT * FROM master_dbo.f1();  | failed | ERROR: invalid input syn
tax for type integer: "a"               +| 2025-10-06 18:09:00.003417+00 | 2025-10-06 18:09:00.198498+00
       |       |         |              |          |                                  |        | CONTEXT: PL/tsql functio
n master_dbo.f1() line 1 at RETURN QUERY |                               | 
(3 rows)



logs: 

babelfish_db=# 2025-10-06 18:07:00.005 UTC [40494] LOG:  cron job 1 starting:  SELECT * FROM master_dbo.f1(); 
2025-10-06 18:07:00.204 UTC [42037] ERROR:  invalid input syntax for type integer: "a"
2025-10-06 18:07:00.204 UTC [42037] CONTEXT:  PL/tsql function master_dbo.f1() line 1 at RETURN QUERY
2025-10-06 18:07:00.204 UTC [42037] STATEMENT:   SELECT * FROM master_dbo.f1(); 
2025-10-06 18:07:00.209 UTC [40487] LOG:  background worker "pg_cron" (PID 42037) exited with exit code 1
2025-10-06 18:08:00.002 UTC [40494] LOG:  cron job 1 starting:  SELECT * FROM master_dbo.f1(); 
2025-10-06 18:08:00.200 UTC [42628] ERROR:  invalid input syntax for type integer: "a"
2025-10-06 18:08:00.200 UTC [42628] CONTEXT:  PL/tsql function master_dbo.f1() line 1 at RETURN QUERY
2025-10-06 18:08:00.200 UTC [42628] STATEMENT:   SELECT * FROM master_dbo.f1(); 
2025-10-06 18:08:00.205 UTC [40487] LOG:  background worker "pg_cron" (PID 42628) exited with exit code 1
babelfish_db=# 2025-10-06 18:09:00.002 UTC [40494] LOG:  cron job 1 starting:  SELECT * FROM master_dbo.f1(); 
2025-10-06 18:09:00.193 UTC [43712] ERROR:  invalid input syntax for type integer: "a"
2025-10-06 18:09:00.193 UTC [43712] CONTEXT:  PL/tsql function master_dbo.f1() line 1 at RETURN QUERY
2025-10-06 18:09:00.193 UTC [43712] STATEMENT:   SELECT * FROM master_dbo.f1(); 
2025-10-06 18:09:00.198 UTC [40487] LOG:  background worker "pg_cron" (PID 43712) exited with exit code 1

```

### Issues Resolved

[BABEL-5995]
Signed-off-by: Pranav Jain [pranavjc@amazon.com](mailto:pranavjc@amazon.com)
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).