### PR TITLE
Fix precision/scale of numeric columns in SELECT INTO with GROUP BY. 

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -1432,23 +1432,22 @@ resolve_numeric_typmod_from_exp(Plan *plan, Node *expr, bool *found)
 					}
 				}
 
-				/* if varno is INNER_VAR or OUTER_VAR then we need plan, else we cannot find typmod, hence set found as false and return -1 */
-				if (plan == NULL && (var->varno == INNER_VAR || var->varno == OUTER_VAR))
-				{
-					if (found != NULL) *found = false;
-					return -1;
-				}
-
 				if (var->vartypmod == -1)
 				{
 					/* UDT handling in T_var */
-					Oid immediate_base_type = get_immediate_base_type_of_UDT_internal(var->vartype);
+					Oid	immediate_base_type = get_immediate_base_type_of_UDT_internal(var->vartype);
 					if (OidIsValid(immediate_base_type))
 					{
 						int32 typmod = -1;
 						getBaseTypeAndTypmod(var->vartype, &typmod);
 						if (typmod != -1)
 							return typmod;
+						else
+						{
+							int32	fixlen_default_typmod = get_default_typmod_for_fixedsize_dataypes(immediate_base_type);
+							if (fixlen_default_typmod != -1)
+								return fixlen_default_typmod;
+						}
 					}
 
 					/*
@@ -1459,10 +1458,9 @@ resolve_numeric_typmod_from_exp(Plan *plan, Node *expr, bool *found)
 					 * Plan check ensures typmod consistency to preventing incorrect values,
 					 * ensuring plan is not changed if typmod is calculated in execution stage.
 					 */
-					if (plan)
+					if (plan || (plan == NULL && (var->varno == INNER_VAR || var->varno == OUTER_VAR)))
 					{
-						int32 		fixlen_default_typmod;
-						fixlen_default_typmod = get_default_typmod_for_fixedsize_dataypes(var->vartype);
+						int32	fixlen_default_typmod = get_default_typmod_for_fixedsize_dataypes(var->vartype);
 						if (fixlen_default_typmod != -1)
 							return fixlen_default_typmod;
 					}

--- a/test/JDBC/expected/babel_numeric.out
+++ b/test/JDBC/expected/babel_numeric.out
@@ -1331,6 +1331,345 @@ GO
 drop TYPE numeric_7_2;
 GO
 
+create table BABEL_6081_t1(id int, value decimal(15,2))
+go
+
+insert into BABEL_6081_t1 values(1,2.5),(1,3.5),(1,4.5),(2,1.5),(2,2.5)
+go
+~~ROW COUNT: 5~~
+
+
+select
+    avg(value) as avgValue,
+    avg(value) * 1.0 as avgValueMul,
+    avg(value) / 1.0 as avgValueDiv
+into avg_t from BABEL_6081_t1 group by id
+go
+
+select COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE from information_schema.columns where table_name = 'avg_t';
+go
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+avgvalue#!#38#!#10#!#6
+avgvaluemul#!#38#!#10#!#6
+avgvaluediv#!#38#!#10#!#6
+~~END~~
+
+
+drop table BABEL_6081_t1
+go
+
+drop table avg_t
+go
+
+CREATE TABLE decimal_test (
+    id INT,
+    value1 DECIMAL(10,2),
+    value2 DECIMAL(15,4),
+    category INT
+)
+GO
+
+INSERT INTO decimal_test VALUES
+(1, 123.45, 123.4567, 1),
+(1, 234.56, 234.5678, 1),
+(2, 345.67, 345.6789, 2),
+(2, 456.78, 456.7890, 2),
+(3, 567.89, 567.8901, 1)
+GO
+~~ROW COUNT: 5~~
+
+
+SELECT
+    AVG(value1) as avg_value1,
+    AVG(value2) as avg_value2,
+    AVG(value1) * 1.000 as avg_value1_mul
+INTO avg_results
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('avg_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+avg_value1#!#38#!#10#!#6
+avg_value1_mul#!#38#!#10#!#6
+avg_value2#!#38#!#10#!#6
+~~END~~
+
+
+SELECT
+    SUM(value1) as sum_value1,
+    SUM(value2) as sum_value2,
+    SUM(value2) / 1.0000 as sum_value2_div
+INTO sum_results
+FROM decimal_test
+GROUP BY category
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('sum_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+sum_value1#!#38#!#10#!#2
+sum_value2#!#38#!#10#!#4
+sum_value2_div#!#38#!#10#!#6
+~~END~~
+
+
+SELECT
+    SUM(value1 * value2) as product_sum,
+    AVG(value1 * value2) as product_avg,
+    SUM(value1) * SUM(value2) / 1.0000 as product_sum_div
+INTO calc_results
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('calc_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+product_avg#!#38#!#10#!#6
+product_sum#!#38#!#10#!#6
+product_sum_div#!#38#!#10#!#6
+~~END~~
+
+
+CREATE TABLE numeric_test (
+    id INT,
+    num1 NUMERIC(12,4),
+    num2 NUMERIC(16,6)
+)
+GO
+
+INSERT INTO numeric_test VALUES
+(1, 1234.5678, 1234.567890),
+(1, 2345.6789, 2345.678901),
+(2, 3456.7890, 3456.789012),
+(2, 4567.8901, 4567.890123)
+GO
+~~ROW COUNT: 4~~
+
+
+SELECT 
+    SUM(num1) as sum_num1,
+    SUM(num2) as sum_num2,
+    AVG(num1) as avg_num1,
+    AVG(num2) as avg_num2,
+    SUM(num2) * AVG(num1) as sum_num2_div
+INTO numeric_results
+FROM numeric_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('numeric_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+avg_num1#!#38#!#10#!#6
+avg_num2#!#38#!#10#!#6
+sum_num1#!#38#!#10#!#4
+sum_num2#!#38#!#10#!#6
+sum_num2_div#!#38#!#10#!#6
+~~END~~
+
+
+SELECT
+    MAX(value1) - MIN(value1) as value1_range,
+    MAX(value2) - MIN(value2) as value2_range,
+    MAX(value2) * MIN(value2) as value2_product
+INTO range_results
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('range_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+value1_range#!#11#!#10#!#2
+value2_product#!#31#!#10#!#8
+value2_range#!#16#!#10#!#4
+~~END~~
+
+
+SELECT
+    SUM(value1)/COUNT(*) as manual_avg1,
+    AVG(value1) as builtin_avg1,
+    SUM(value2)/COUNT(*) as manual_avg2,
+    AVG(value2) as builtin_avg2
+INTO precision_test
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('precision_test')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+builtin_avg1#!#38#!#10#!#6
+builtin_avg2#!#38#!#10#!#6
+manual_avg1#!#38#!#10#!#6
+manual_avg2#!#38#!#10#!#6
+~~END~~
+
+
+SELECT
+    COUNT(*) as count,
+    SUM(value1) as sum1,
+    AVG(value1) as avg1,
+    MIN(value1) as min1,
+    MAX(value1) as max1,
+    COUNT(*) * AVG(value1) * 1.0000 as count_mul
+INTO multi_agg_results
+FROM decimal_test
+GROUP BY category
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('multi_agg_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+avg1#!#38#!#10#!#6
+count#!#10#!#10#!#0
+count_mul#!#38#!#10#!#6
+max1#!#10#!#10#!#2
+min1#!#10#!#10#!#2
+sum1#!#38#!#10#!#2
+~~END~~
+
+
+CREATE TABLE decimal_zero_test (
+    id INT,
+    value DECIMAL(10,2)
+)
+GO
+
+INSERT INTO decimal_zero_test VALUES
+(1, 0.00),
+(1, 10.50),
+(2, 0.00),
+(2, 0.00)
+GO
+~~ROW COUNT: 4~~
+
+
+SELECT
+    AVG(value) as avg_value,
+    SUM(value) as sum_value
+INTO zero_value_results
+FROM decimal_zero_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('zero_value_results')
+ORDER BY COLUMN_NAME;
+GO
+~~START~~
+nvarchar#!#tinyint#!#smallint#!#int
+avg_value#!#38#!#10#!#6
+sum_value#!#38#!#10#!#2
+~~END~~
+
+
+DROP TABLE decimal_test
+GO
+
+DROP TABLE numeric_test
+GO
+
+DROP TABLE decimal_zero_test
+GO
+
+DROP TABLE avg_results
+GO
+
+DROP TABLE sum_results
+GO
+
+DROP TABLE calc_results
+GO
+
+DROP TABLE numeric_results
+GO
+
+DROP TABLE range_results
+GO
+
+DROP TABLE precision_test
+GO
+
+DROP TABLE multi_agg_results
+GO
+
+DROP TABLE zero_value_results
+GO
+
 -- cx query
 drop table if exists [testtable1];
 GO
@@ -1573,4 +1912,152 @@ drop table if exists [testtable1];
 GO
 
 drop table if exists [testtable2];
+GO
+
+CREATE TYPE BABEL_6081_int FROM INT;
+GO
+
+CREATE TYPE BABEL_6081_numeric FROM NUMERIC(4, 2);
+GO
+
+CREATE TABLE BABEL_6081_t2 (id NUMERIC(4, 2));
+GO
+INSERT INTO BABEL_6081_t2 VALUES (1.0)
+GO
+~~ROW COUNT: 1~~
+
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS INT) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id * avg(c2.int_id) AS product 
+    INTO 
+        BABEL_6081_t3 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE 
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t3' order by COLUMN_NAME
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#tinyint#!#smallint#!#int
+master#!#dbo#!#babel_6081_t3#!#product#!#15#!#10#!#2
+~~END~~
+
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS BABEL_6081_int) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id * avg(c2.int_id) AS product 
+    INTO 
+        BABEL_6081_t4 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE 
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t4' order by COLUMN_NAME
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#tinyint#!#smallint#!#int
+master#!#dbo#!#babel_6081_t4#!#product#!#15#!#10#!#2
+~~END~~
+
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS BABEL_6081_numeric) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id * avg(c2.int_id) AS product 
+    INTO 
+        BABEL_6081_t5 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t5' order by COLUMN_NAME
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#tinyint#!#smallint#!#int
+master#!#dbo#!#babel_6081_t5#!#product#!#38#!#10#!#6
+~~END~~
+
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS INT) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id, 
+    c1.id * avg(c2.int_id) AS product 
+INTO 
+    BABEL_6081_t6 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE 
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t6' order by COLUMN_NAME
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#tinyint#!#smallint#!#int
+master#!#dbo#!#babel_6081_t6#!#id#!#4#!#10#!#2
+master#!#dbo#!#babel_6081_t6#!#product#!#15#!#10#!#2
+~~END~~
+
+
+DROP TABLE BABEL_6081_t2
+GO
+
+DROP TABLE BABEL_6081_t3
+GO
+
+DROP TABLE BABEL_6081_t4
+GO
+
+DROP TABLE BABEL_6081_t5
+GO
+
+DROP TABLE BABEL_6081_t6
+GO
+
+DROP TYPE BABEL_6081_int;
+GO
+
+DROP TYPE BABEL_6081_numeric;
 GO

--- a/test/JDBC/input/babel_numeric.sql
+++ b/test/JDBC/input/babel_numeric.sql
@@ -689,6 +689,269 @@ GO
 drop TYPE numeric_7_2;
 GO
 
+create table BABEL_6081_t1(id int, value decimal(15,2))
+go
+
+insert into BABEL_6081_t1 values(1,2.5),(1,3.5),(1,4.5),(2,1.5),(2,2.5)
+go
+
+select
+    avg(value) as avgValue,
+    avg(value) * 1.0 as avgValueMul,
+    avg(value) / 1.0 as avgValueDiv
+into avg_t from BABEL_6081_t1 group by id
+go
+
+select COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE from information_schema.columns where table_name = 'avg_t';
+go
+
+drop table BABEL_6081_t1
+go
+
+drop table avg_t
+go
+
+CREATE TABLE decimal_test (
+    id INT,
+    value1 DECIMAL(10,2),
+    value2 DECIMAL(15,4),
+    category INT
+)
+GO
+
+INSERT INTO decimal_test VALUES
+(1, 123.45, 123.4567, 1),
+(1, 234.56, 234.5678, 1),
+(2, 345.67, 345.6789, 2),
+(2, 456.78, 456.7890, 2),
+(3, 567.89, 567.8901, 1)
+GO
+
+SELECT
+    AVG(value1) as avg_value1,
+    AVG(value2) as avg_value2,
+    AVG(value1) * 1.000 as avg_value1_mul
+INTO avg_results
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('avg_results')
+ORDER BY COLUMN_NAME;
+GO
+
+SELECT
+    SUM(value1) as sum_value1,
+    SUM(value2) as sum_value2,
+    SUM(value2) / 1.0000 as sum_value2_div
+INTO sum_results
+FROM decimal_test
+GROUP BY category
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('sum_results')
+ORDER BY COLUMN_NAME;
+GO
+
+SELECT
+    SUM(value1 * value2) as product_sum,
+    AVG(value1 * value2) as product_avg,
+    SUM(value1) * SUM(value2) / 1.0000 as product_sum_div
+INTO calc_results
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('calc_results')
+ORDER BY COLUMN_NAME;
+GO
+
+CREATE TABLE numeric_test (
+    id INT,
+    num1 NUMERIC(12,4),
+    num2 NUMERIC(16,6)
+)
+GO
+
+INSERT INTO numeric_test VALUES
+(1, 1234.5678, 1234.567890),
+(1, 2345.6789, 2345.678901),
+(2, 3456.7890, 3456.789012),
+(2, 4567.8901, 4567.890123)
+GO
+
+SELECT 
+    SUM(num1) as sum_num1,
+    SUM(num2) as sum_num2,
+    AVG(num1) as avg_num1,
+    AVG(num2) as avg_num2,
+    SUM(num2) * AVG(num1) as sum_num2_div
+INTO numeric_results
+FROM numeric_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('numeric_results')
+ORDER BY COLUMN_NAME;
+GO
+
+SELECT
+    MAX(value1) - MIN(value1) as value1_range,
+    MAX(value2) - MIN(value2) as value2_range,
+    MAX(value2) * MIN(value2) as value2_product
+INTO range_results
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('range_results')
+ORDER BY COLUMN_NAME;
+GO
+
+SELECT
+    SUM(value1)/COUNT(*) as manual_avg1,
+    AVG(value1) as builtin_avg1,
+    SUM(value2)/COUNT(*) as manual_avg2,
+    AVG(value2) as builtin_avg2
+INTO precision_test
+FROM decimal_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('precision_test')
+ORDER BY COLUMN_NAME;
+GO
+
+SELECT
+    COUNT(*) as count,
+    SUM(value1) as sum1,
+    AVG(value1) as avg1,
+    MIN(value1) as min1,
+    MAX(value1) as max1,
+    COUNT(*) * AVG(value1) * 1.0000 as count_mul
+INTO multi_agg_results
+FROM decimal_test
+GROUP BY category
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('multi_agg_results')
+ORDER BY COLUMN_NAME;
+GO
+
+CREATE TABLE decimal_zero_test (
+    id INT,
+    value DECIMAL(10,2)
+)
+GO
+
+INSERT INTO decimal_zero_test VALUES
+(1, 0.00),
+(1, 10.50),
+(2, 0.00),
+(2, 0.00)
+GO
+
+SELECT
+    AVG(value) as avg_value,
+    SUM(value) as sum_value
+INTO zero_value_results
+FROM decimal_zero_test
+GROUP BY id
+GO
+
+select
+    COLUMN_NAME,
+    NUMERIC_PRECISION,
+    NUMERIC_PRECISION_RADIX,
+    NUMERIC_SCALE
+from information_schema.columns
+where
+table_name IN ('zero_value_results')
+ORDER BY COLUMN_NAME;
+GO
+
+DROP TABLE decimal_test
+GO
+
+DROP TABLE numeric_test
+GO
+
+DROP TABLE decimal_zero_test
+GO
+
+DROP TABLE avg_results
+GO
+
+DROP TABLE sum_results
+GO
+
+DROP TABLE calc_results
+GO
+
+DROP TABLE numeric_results
+GO
+
+DROP TABLE range_results
+GO
+
+DROP TABLE precision_test
+GO
+
+DROP TABLE multi_agg_results
+GO
+
+DROP TABLE zero_value_results
+GO
+
 -- cx query
 drop table if exists [testtable1];
 GO
@@ -854,4 +1117,129 @@ drop table if exists [testtable1];
 GO
 
 drop table if exists [testtable2];
+GO
+
+CREATE TYPE BABEL_6081_int FROM INT;
+GO
+
+CREATE TYPE BABEL_6081_numeric FROM NUMERIC(4, 2);
+GO
+
+CREATE TABLE BABEL_6081_t2 (id NUMERIC(4, 2));
+GO
+INSERT INTO BABEL_6081_t2 VALUES (1.0)
+GO
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS INT) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id * avg(c2.int_id) AS product 
+    INTO 
+        BABEL_6081_t3 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE 
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t3' order by COLUMN_NAME
+GO
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS BABEL_6081_int) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id * avg(c2.int_id) AS product 
+    INTO 
+        BABEL_6081_t4 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE 
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t4' order by COLUMN_NAME
+GO
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS BABEL_6081_numeric) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id * avg(c2.int_id) AS product 
+    INTO 
+        BABEL_6081_t5 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t5' order by COLUMN_NAME
+GO
+
+WITH 
+cte1 AS ( 
+    SELECT id, CAST(id AS INT) AS int_id 
+    FROM BABEL_6081_t2 
+), 
+cte2 AS ( 
+    SELECT DISTINCT int_id 
+    FROM cte1 
+) 
+SELECT 
+    c1.id, 
+    c1.id * avg(c2.int_id) AS product 
+INTO 
+    BABEL_6081_t6 
+FROM cte1 c1 
+JOIN cte2 c2 ON c1.int_id = c2.int_id 
+GROUP BY c1.id; 
+GO
+
+select TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE 
+from information_schema.columns 
+where TABLE_NAME = 'BABEL_6081_t6' order by COLUMN_NAME
+GO
+
+DROP TABLE BABEL_6081_t2
+GO
+
+DROP TABLE BABEL_6081_t3
+GO
+
+DROP TABLE BABEL_6081_t4
+GO
+
+DROP TABLE BABEL_6081_t5
+GO
+
+DROP TABLE BABEL_6081_t6
+GO
+
+DROP TYPE BABEL_6081_int;
+GO
+
+DROP TYPE BABEL_6081_numeric;
 GO


### PR DESCRIPTION
### 1. Issues

If a GROUP BY clause is used in a SELECT statement, the target list during initialisation of TupleDesc will contains

- all target columns mentioned in SELECT statement
- columns from the GROUP BY clause (In this case column "id")
The columns from GROUP BY clause which is not there in target columns are marked as junk column, which will be filtered out later. During initialisation of TupleDesc we are computing and storing the correct typmod information for all the columns in target list

Later after TupleDesc is initialised, if any of the column is marked as junk, Junk filtration is done which recomputes the entire TupleDesc which leads to losing the typmod information of avgValue column.

### 2. Changes made to fix the issues

Earlier we used to return typmod as `-1` if plan was NULL for `T_var` node whereas correct typmod was preserved in `var->vartypmod`. So we fixed that portion in thi PR.

### Issues Resolved

Task: BABEL-6081

cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4121

Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).