### PR TITLE
Datalength() fixed for various datatypes 

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -1088,33 +1088,102 @@ pgerror(PG_FUNCTION_ARGS)
 	PG_RETURN_VARCHAR_P((*common_utility_plugin_ptr->tsql_varchar_input) ((error_sqlstate), strlen(error_sqlstate), -1));
 }
 
+/*
+ * Structure to cache metadata needed in datalength().
+ */
+typedef struct DatalengthIOData
+{
+	Oid			argtypeid;
+	int			typlen;
+} DatalengthIOData;
 
-/* returns data length of one Datum
- * this function is very similar to pg_column_size, but returns untoasted data without header sizes for bytea objects
-*/
+/* 
+ * datalength()
+ * 	Returns data length of one Datum.
+ * 	This function is very similar to pg_column_size, but returns 
+ * 	untoasted data without header sizes for bytea objects
+ */
 Datum
 datalength(PG_FUNCTION_ARGS)
 {
 	Datum		value = PG_GETARG_DATUM(0);
 	int32 result;
 	int			typlen;
+	DatalengthIOData *my_extra;
+	Oid			argtypeid;
 
-	/* On first call, get the input type's typlen, and save at *fn_extra */
-	if (fcinfo->flinfo->fn_extra == NULL)
+	my_extra = (DatalengthIOData *) fcinfo->flinfo->fn_extra;
+
+	/* On first call, get the input type's oid and typlen, and save at *fn_extra */
+	if (my_extra == NULL)
 	{
+		Oid			immediate_base_type;
 		/* Lookup the datatype of the supplied argument */
-		Oid			argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+		argtypeid = get_fn_expr_argtype(fcinfo->flinfo, 0);
+		
+		/* UDT Handling. */
+		immediate_base_type = get_immediate_base_type_of_UDT_internal(argtypeid);
+		if (OidIsValid(immediate_base_type))
+		{
+			argtypeid = immediate_base_type;
+		}
 
 		typlen = get_typlen(argtypeid);
 		if (typlen == 0)		/* should not happen */
 			elog(ERROR, "cache lookup failed for type %u", argtypeid);
 
-		fcinfo->flinfo->fn_extra = MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
-													  sizeof(int));
-		*((int *) fcinfo->flinfo->fn_extra) = typlen;
+		my_extra = (DatalengthIOData *) MemoryContextAlloc(fcinfo->flinfo->fn_mcxt,
+														  sizeof(DatalengthIOData));
+		my_extra->argtypeid = argtypeid;
+		my_extra->typlen = typlen;
 	}
 	else
-		typlen = *((int *) fcinfo->flinfo->fn_extra);
+	{
+		argtypeid = my_extra->argtypeid;
+		typlen = my_extra->typlen;
+	}
+
+	/* Handling fixed storage size datatypes. */
+	if ((*common_utility_plugin_ptr->is_tsql_tinyint_datatype)(argtypeid))
+	{
+		PG_RETURN_INT32(1);
+	}
+	else if ((*common_utility_plugin_ptr->is_tsql_smallmoney_datatype)(argtypeid) || 
+			 (*common_utility_plugin_ptr->is_tsql_smalldatetime_datatype)(argtypeid))
+	{
+		PG_RETURN_INT32(4);
+	}
+	else if (argtypeid == DATEOID)
+	{
+		PG_RETURN_INT32(3);
+	}
+	else if (argtypeid == TIMEOID)
+	{
+		PG_RETURN_INT32(5);
+	}
+	else if (is_numeric_datatype(argtypeid))
+	{
+		Numeric result_numeric_val = DatumGetNumeric(value);
+		int32 val_typmod = (*common_utility_plugin_ptr->tsql_numeric_get_typmod)(result_numeric_val);
+		int32 val_precision = ((val_typmod - VARHDRSZ) >> 16) & 0xffff;
+
+		if (1 <= val_precision && val_precision <= 9)
+		{
+			PG_RETURN_INT32(5);
+		}
+		else if (10 <= val_precision && val_precision <= 19)
+		{
+			PG_RETURN_INT32(9);
+		}
+		else if (20 <= val_precision && val_precision <= 28)
+		{
+			PG_RETURN_INT32(13);
+		}
+		else if (29 <= val_precision && val_precision <= 38)
+		{
+			PG_RETURN_INT32(17);
+		}
+	}
 
 	if (typlen == -1)
 	{

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2378,6 +2378,7 @@ extern void	exec_alter_role_cmd(char *query_str, RoleSpec *role);
 extern bool     validate_special_function(char *proc_nsname, char *proc_name, int nargs, bool num_args_match);
 extern int32    resolve_numeric_typmod_from_exp(Plan *plan, Node *expr, bool *found);
 extern Oid      get_immediate_base_type_of_UDT_internal(Oid oid);
+extern bool 	is_numeric_datatype(Oid typid);
 
 /*
  * Function in pltsql_ruleutils.c

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -1199,7 +1199,7 @@ is_numeric_cast(Oid func_oid)
 /*
  * is_numeric_datatype - returns bool if given datatype is numeric, decimal, UDT on numeric or decimal.
  */
-static bool
+bool
 is_numeric_datatype(Oid typid)
 {
 	if (OidIsValid(typid) && getBaseType(typid) == NUMERICOID)

--- a/test/JDBC/expected/BABEL-5129-vu-verify.out
+++ b/test/JDBC/expected/BABEL-5129-vu-verify.out
@@ -60,7 +60,7 @@ SELECT ISNUMERIC(@a), LEN(@a), DATALENGTH(@a)
 GO
 ~~START~~
 int#!#int#!#int
-1#!#9#!#6
+1#!#9#!#5
 ~~END~~
 
 

--- a/test/JDBC/expected/babel_function_string-before-15-5-or-14-10-vu-verify.out
+++ b/test/JDBC/expected/babel_function_string-before-15-5-or-14-10-vu-verify.out
@@ -160,7 +160,7 @@ SELECT datalength(a), datalength(b),datalength(c),datalength(d),datalength(e), d
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-4#!#8#!#1#!#2#!#2#!#4#!#4#!#8#!#4
+4#!#8#!#1#!#2#!#1#!#5#!#5#!#8#!#4
 <NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 
@@ -169,7 +169,7 @@ SELECT datalength(a), datalength(b),datalength(c),datalength(d),datalength(e), d
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-8#!#8#!#4#!#8#!#8#!#8#!#8#!#16
+4#!#8#!#3#!#8#!#8#!#4#!#5#!#16
 <NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/babel_function_string-vu-verify.out
+++ b/test/JDBC/expected/babel_function_string-vu-verify.out
@@ -160,7 +160,7 @@ SELECT datalength(a), datalength(b),datalength(c),datalength(d),datalength(e), d
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-4#!#8#!#1#!#2#!#2#!#4#!#4#!#8#!#4
+4#!#8#!#1#!#2#!#1#!#5#!#5#!#8#!#4
 <NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 
@@ -169,7 +169,7 @@ SELECT datalength(a), datalength(b),datalength(c),datalength(d),datalength(e), d
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-8#!#8#!#4#!#8#!#8#!#8#!#8#!#16
+4#!#8#!#3#!#8#!#8#!#4#!#5#!#16
 <NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/babel_function_string.out
+++ b/test/JDBC/expected/babel_function_string.out
@@ -187,7 +187,7 @@ SELECT datalength(a), datalength(b),datalength(c),datalength(d),datalength(e), d
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-4#!#8#!#1#!#2#!#2#!#4#!#4#!#8#!#4
+4#!#8#!#1#!#2#!#1#!#5#!#5#!#8#!#4
 <NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 
@@ -211,7 +211,7 @@ SELECT datalength(a), datalength(b),datalength(c),datalength(d),datalength(e), d
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
-8#!#8#!#4#!#8#!#8#!#8#!#8#!#16
+4#!#8#!#3#!#8#!#8#!#4#!#5#!#16
 <NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 ~~END~~
 

--- a/test/JDBC/expected/datalength.out
+++ b/test/JDBC/expected/datalength.out
@@ -333,7 +333,7 @@ SELECT
 GO
 ~~START~~
 int#!#int#!#int#!#int
-2#!#2#!#4#!#8
+1#!#2#!#4#!#8
 ~~END~~
 
 
@@ -345,7 +345,7 @@ SELECT
 GO
 ~~START~~
 int#!#int#!#int#!#int
-6#!#6#!#8#!#4
+5#!#5#!#8#!#4
 ~~END~~
 
 
@@ -360,7 +360,7 @@ SELECT
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int
-4#!#8#!#8#!#8#!#8#!#10
+3#!#8#!#8#!#4#!#5#!#10
 ~~END~~
 
 
@@ -509,7 +509,7 @@ SELECT
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int
-8#!#8#!#6#!#6#!#6
+8#!#4#!#5#!#5#!#5
 ~~END~~
 
 
@@ -554,7 +554,7 @@ FROM datalength_t2;
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int#!#int
-4#!#6#!#8#!#4#!#8#!#8
+4#!#5#!#8#!#4#!#5#!#8
 ~~END~~
 
 
@@ -990,6 +990,1560 @@ int#!#int#!#int#!#int
 ~~END~~
 
 
+-- Extra test cases 
+-- UDT
+create type tinyint_babel_6120 from tinyint;
+create type date_babel_6120 from date;
+create type smalldatetime_babel_6120 from smalldatetime;
+create type time_babel_6120 from time;
+create type smallmoney_babel_6120 from smallmoney;
+create type numeric_babel_6120 from numeric(21,5);
+create type decimal_babel_6120 from decimal(21,5);
+GO
+
+create type smallint_babel_6120 from smallint;
+create type int_babel_6120 from int;
+create type bigint_babel_6120 from bigint;
+create type datetime_babel_6120 from datetime;
+create type datetime2_babel_6120 from datetime2;
+create type datetimeoffset_babel_6120 from datetimeoffset;
+create type money_babel_6120 from money;
+go
+
+
+-- tinyint
+-- JIRA query
+SELECT DATALENGTH(CAST(123 AS TINYINT))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT DATALENGTH(CAST('123' AS TINYINT))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT DATALENGTH(CAST('' AS TINYINT))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.33 AS TINYINT))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123 AS tinyint_babel_6120))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- smallint : 2 (as expected)
+SELECT DATALENGTH(CAST(123 AS SMALLINT))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT DATALENGTH(CAST('123' AS SMALLINT))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT DATALENGTH(CAST('' AS SMALLINT))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.33 AS SMALLINT))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123 AS smallint_babel_6120))
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+
+-- INT : 4 (as expected)
+SELECT DATALENGTH(CAST(123 AS INT))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST('123' AS INT))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST('' AS INT))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.33 AS INT))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(123)
+go
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123 AS int_babel_6120))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+
+-- bitint : 8 (as expected)
+SELECT DATALENGTH(CAST(123 AS bigint))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST('123' AS bigint))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST('' AS bigint))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.33 AS bigint))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123 AS bigint_babel_6120))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+-- numeric, testing for different precision range for actual input
+SELECT DATALENGTH(CAST(123.45 AS NUMERIC(10,2)))
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(123.45) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.451234 AS NUMERIC(10,2))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.451234 AS NUMERIC(5,2))) 
+Go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.451234 AS NUMERIC(1,0))) -- over flow
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT DATALENGTH(CAST(1 AS NUMERIC(1,0)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(1.0 AS NUMERIC(1,0)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(1.0 AS NUMERIC(5,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(12.346 AS NUMERIC(5,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(12345.6789 AS NUMERIC(9,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(12345.6789 AS NUMERIC(10,3)))  
+Go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(12345.6789 AS NUMERIC(11,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123456789123456789.679 AS NUMERIC(21,3))) 
+go
+~~START~~
+int
+13
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123456789123456789123456789123.12345678 AS NUMERIC(38,8))) 
+go
+~~START~~
+int
+17
+~~END~~
+
+
+Select datalength(123456789123456789123456789123.12345678) 
+GO
+~~START~~
+int
+17
+~~END~~
+
+
+SELECT DATALENGTH(CAST(0.679 AS NUMERIC(21,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(0.1234567891 AS NUMERIC(21,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(0.1234567234567891 AS NUMERIC(21,3)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(0.1234567234567891 AS NUMERIC(21,11))) 
+go
+~~START~~
+int
+9
+~~END~~
+
+
+SELECT DATALENGTH(CAST(1.1234567234567891 AS NUMERIC(38,5))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123456789123.679 AS numeric_babel_6120)) 
+go
+~~START~~
+int
+9
+~~END~~
+
+
+-- extra 0 is appended and hence 21 precision, 13 result
+SELECT DATALENGTH(CAST(0.12345678912345678912 AS NUMERIC(38,21))) 
+go
+~~START~~
+int
+13
+~~END~~
+
+
+
+-- When significant digit is 0, 
+-- we have divergance between TSQL doc and actual functionality
+-- we are matching TSQL doc.
+-- Even though precision is 10, returns 5 byte according to 1-9 precision range
+SELECT DATALENGTH(CAST(0.1234567234567891 AS NUMERIC(21,10)))
+go
+~~START~~
+int
+9
+~~END~~
+
+
+-- Even though precision is 20, returns 9 byte according to 10-28 precision range
+SELECT DATALENGTH(CAST(0.12345678912345678912 AS NUMERIC(38,20))) 
+go
+~~START~~
+int
+13
+~~END~~
+
+
+-- Even though precision is 20, returns 9 byte according to 10-28 precision range
+SELECT DATALENGTH(CAST(0.123456789123456789121 AS NUMERIC(38,20))) 
+go
+~~START~~
+int
+13
+~~END~~
+
+
+-- decimal
+-- JIRA query
+SELECT DATALENGTH(CAST(123.45 AS DECIMAL(10,2)))
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(123.45)
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.451234 AS DECIMAL(10,2)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.451234 AS DECIMAL(5,2))) 
+Go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123.451234 AS DECIMAL(1,0))) -- over flow
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: numeric field overflow)~~
+
+
+SELECT DATALENGTH(CAST(1 AS DECIMAL(1,0)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(1.0 AS DECIMAL(5,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(12.346 AS DECIMAL(5,3))) 
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST(12345678.679 AS DECIMAL(21,3))) 
+go
+~~START~~
+int
+9
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123456789123456789.679 AS DECIMAL(21,3))) 
+go
+~~START~~
+int
+13
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123456789123456789123456789123.12345678 AS DECIMAL(38,8))) 
+go
+~~START~~
+int
+17
+~~END~~
+
+
+Select datalength(123456789123456789123456789123.12345678) 
+GO
+~~START~~
+int
+17
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123456789123.679 AS decimal_babel_6120)) 
+go
+~~START~~
+int
+9
+~~END~~
+
+
+-- money
+select DATALENGTH(CAST(123.45 AS MONEY))
+go
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123 AS MONEY))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST('123' AS MONEY))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST('' AS MONEY))
+GO
+~~START~~
+int
+8
+~~END~~
+
+
+SELECT DATALENGTH(CAST(NULL AS MONEY)) -- NULL
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(CAST(123.45 AS money_babel_6120))
+go
+~~START~~
+int
+8
+~~END~~
+
+
+-- smallmoney
+-- JIRA query
+select DATALENGTH(CAST(123.45 AS SMALLMONEY))
+go
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST(123 AS SMALLMONEY))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST('123' AS SMALLMONEY))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST('' AS SMALLMONEY))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST(NULL AS SMALLMONEY))
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(CAST(123.45 AS smallmoney_babel_6120))
+go
+~~START~~
+int
+4
+~~END~~
+
+
+-- date
+-- JIRA query
+SELECT DATALENGTH(CAST('2024-01-01' AS DATE))
+go
+~~START~~
+int
+3
+~~END~~
+
+
+select datalength(CAST('' AS DATE))
+go
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT DATALENGTH(CAST('2024-01-01' AS date_babel_6120))
+go
+~~START~~
+int
+3
+~~END~~
+
+
+-- smalldatetime
+-- JIRA query
+SELECT DATALENGTH(CAST('2024-01-01 12:34:56' AS SMALLDATETIME))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+select datalength(CAST('' AS SMALLDATETIME))
+go
+~~START~~
+int
+4
+~~END~~
+
+
+SELECT DATALENGTH(CAST('2024-01-01 12:34:56' AS smalldatetime_babel_6120))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+
+-- time
+-- JIRA query
+SELECT DATALENGTH(CAST('12:34:56' AS TIME))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST('12:10:30.123' AS TIME))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST('12:10:30.123' AS TIME(5)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(CAST('' AS TIME))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+SELECT DATALENGTH(CAST('12:10:30.123' AS time_babel_6120))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+-- datetime
+select datalength(cast('01/02/03' as datetime))
+go
+~~START~~
+int
+8
+~~END~~
+
+
+select datalength(CAST('' AS datetime))
+go
+~~START~~
+int
+8
+~~END~~
+
+
+select datalength(cast('01/02/03' as datetime_babel_6120))
+go
+~~START~~
+int
+8
+~~END~~
+
+
+-- datetime2
+select datalength(cast('Apr 1 2000 14:30' as datetime2))
+Go
+~~START~~
+int
+8
+~~END~~
+
+
+select datalength(CAST('' AS DATETIME2))
+go
+~~START~~
+int
+8
+~~END~~
+
+
+select datalength(cast('Apr 1 2000 14:30' as datetime2_babel_6120))
+Go
+~~START~~
+int
+8
+~~END~~
+
+
+-- datetimeoffset
+select datalength(cast('3/12/24 14:30 +8:00' as datetimeoffset))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(CAST('' AS datetimeoffset))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast('3/12/24 14:30 +8:00' as datetimeoffset_babel_6120))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+-- XML
+SELECT DATALENGTH(CAST('<root>test</root>' AS XML)) AS XML_Length;
+Go
+~~START~~
+int
+17
+~~END~~
+
+
+SELECT DATALENGTH(CAST(N'<root>test</root>' AS XML)) AS XML_Length;
+go
+~~START~~
+int
+17
+~~END~~
+
+
+SELECT DATALENGTH(CAST('<root>te界t</root>' AS XML)) AS XML_Length;
+go
+~~START~~
+int
+19
+~~END~~
+
+
+-- String datatypes : FIX with BABEL-1520/BABEL-1516
+-- char
+select datalength(char(0))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('' as char))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select datalength(cast('' as char(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast('asdfg' as char(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast('asdfg' as char))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select datalength(cast(N'asdfg' as char))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select datalength(cast(N'asdfg' as char(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast(NULL as char(10)))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select datalength(cast(NULL as char))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(cast('🌟' as char)) 
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as char)) 
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as char(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+-- varchar
+-- VARCHAR
+select datalength(cast('' as varchar))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('' as varchar(10)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('asdfg' as varchar(10)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast('asdfg' as varchar))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(N'asdfg' as varchar))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(N'asdfg' as varchar(10)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(NULL as varchar(10)))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select datalength(cast(NULL as varchar))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(cast('🌟' as varchar)) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as varchar)) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as varchar(10)))
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select datalength(cast('世界' as varchar)) 
+Go
+~~START~~
+int
+6
+~~END~~
+
+
+select datalength(cast(N'世界' as varchar)) 
+go
+~~START~~
+int
+6
+~~END~~
+
+
+select datalength(cast(N'世界' as varchar(10))) 
+go
+~~START~~
+int
+6
+~~END~~
+
+
+-- VARCHAR(MAX)
+select datalength(cast('' as varchar(max)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('asdfg' as varchar(max)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(N'asdfg' as varchar(max)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(NULL as varchar(max)))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(cast('🌟' as varchar(max))) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as varchar(max))) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select datalength(cast(N'世界' as varchar(max))) 
+go
+~~START~~
+int
+6
+~~END~~
+
+
+-- NCHAR
+select datalength(nchar(0))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('' as nchar))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select datalength(cast('' as nchar(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast('asdfg' as nchar(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast('asdfg' as nchar))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select datalength(cast(N'asdfg' as nchar))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+select datalength(cast(N'asdfg' as nchar(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(cast(NULL as nchar(10)))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select datalength(cast(NULL as nchar))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(cast('🌟' as nchar)) 
+go
+~~START~~
+int
+33
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as nchar)) 
+go
+~~START~~
+int
+33
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as nchar(10)))
+go
+~~START~~
+int
+13
+~~END~~
+
+
+select datalength(cast(N'世界' as nchar)) 
+go
+~~START~~
+int
+34
+~~END~~
+
+
+select datalength(cast(N'世界' as nchar(10))) 
+go
+~~START~~
+int
+14
+~~END~~
+
+
+-- NVARCHAR
+select datalength(cast('' as nvarchar))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('' as nvarchar(10)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('asdfg' as nvarchar(10)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast('asdfg' as nvarchar))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(N'asdfg' as nvarchar))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(N'asdfg' as nvarchar(10)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(NULL as nvarchar(10)))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select datalength(cast(NULL as nvarchar))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(cast('🌟' as nvarchar)) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as nvarchar)) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as nvarchar(10)))
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select datalength(cast(N'世界' as nvarchar)) 
+go
+~~START~~
+int
+6
+~~END~~
+
+
+select datalength(cast(N'世界' as nvarchar(10))) 
+go
+~~START~~
+int
+6
+~~END~~
+
+
+-- NVARCHAR(MAX)
+select datalength(cast('' as nvarchar(max)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(cast('asdfg' as nvarchar(max)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(N'asdfg' as nvarchar(max)))
+go
+~~START~~
+int
+5
+~~END~~
+
+
+select datalength(cast(NULL as nvarchar(max)))
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select DATALENGTH(cast('🌟' as nvarchar(max))) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select DATALENGTH(cast(N'🌟' as nvarchar(max))) 
+go
+~~START~~
+int
+4
+~~END~~
+
+
+select datalength(cast(N'世界' as nvarchar(max))) 
+go
+~~START~~
+int
+6
+~~END~~
+
+
+
+-- combination  - multibyte/accented/surroagte
+select DATALENGTH('Hello') , DATALENGTH(N'Hello')
+go
+~~START~~
+int#!#int
+5#!#5
+~~END~~
+
+
+select DATALENGTH('こんにちは'), DATALENGTH(N'こんにちは')
+GO
+~~START~~
+int#!#int
+15#!#15
+~~END~~
+
+
+select DATALENGTH('Hàáâ') , DATALENGTH(N'Hàáâ')
+go
+~~START~~
+int#!#int
+7#!#7
+~~END~~
+
+
+select DATALENGTH('こàáâは'), DATALENGTH(N'こàáâは')
+go
+~~START~~
+int#!#int
+12#!#12
+~~END~~
+
+
+select DATALENGTH('🌟🌟🌟'), DATALENGTH(N'🌟🌟🌟')
+go
+~~START~~
+int#!#int
+12#!#12
+~~END~~
+
+
+-- truncation
+declare @a varchar(2) = 'hello'
+select DATALENGTH(@a)
+go
+~~START~~
+int
+2
+~~END~~
+
+
+declare @a Nvarchar(2) = N'hello'
+select DATALENGTH(@a)
+go
+~~START~~
+int
+2
+~~END~~
+
+
+
+-- text 
+select datalength(cast('abd' as text))
+Go
+~~START~~
+int
+3
+~~END~~
+
+
+select datalength(cast(N'abd' as text))
+Go
+~~START~~
+int
+3
+~~END~~
+
+
+select DATALENGTH(cast('こんにちは' as text)), DATALENGTH(cast(N'こんにちは' as text))
+GO
+~~START~~
+int#!#int
+15#!#15
+~~END~~
+
+
+-- ntext
+select datalength(cast('abd' as ntext))
+Go
+~~START~~
+int
+3
+~~END~~
+
+
+select datalength(cast(N'abd' as ntext))
+Go
+~~START~~
+int
+3
+~~END~~
+
+
+select DATALENGTH(cast('こんにちは' as ntext)), DATALENGTH(cast(N'こんにちは' as ntext))
+GO
+~~START~~
+int#!#int
+15#!#15
+~~END~~
+
+
+-- binary
+select datalength(CAST('0x65' AS BINARY(10)))
+GO
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(CAST(0x65 AS BINARY(10)))
+go
+~~START~~
+int
+10
+~~END~~
+
+
+select datalength(CAST(0x65 AS BINARY))
+go
+~~START~~
+int
+30
+~~END~~
+
+
+-- FIX with BABEL-5610
+select datalength(CAST('' AS BINARY(10)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select datalength(CAST('' AS BINARY))
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- varbinary
+select datalength(CAST(0x65 AS varbinary))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+
+select datalength(CAST(0x65 AS varbinary(max)))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+
+select datalength(CAST(0x65 AS varbinary(10)))
+go
+~~START~~
+int
+1
+~~END~~
+
+
+
+select datalength(CAST('0x65' AS VARBINARY(10)))
+go
+~~START~~
+int
+4
+~~END~~
+
+
+
+select datalength(CAST('' AS VARBINARY(10)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+
+select datalength(CAST('' AS VARBINARY))
+go
+~~START~~
+int
+0
+~~END~~
+
 
 -- Cleanup
 DROP TABLE datalength_t2;
@@ -1032,3 +2586,20 @@ DROP TABLE datalength_ConstrainedTable;
 DROP TABLE datalength_t7;
 GO
 
+drop type tinyint_babel_6120;
+drop type date_babel_6120;
+drop type smalldatetime_babel_6120;
+drop type time_babel_6120;
+drop type smallmoney_babel_6120;
+drop type numeric_babel_6120;
+drop type decimal_babel_6120;
+GO
+
+drop type smallint_babel_6120;
+drop type int_babel_6120;
+drop type bigint_babel_6120;
+drop type datetime_babel_6120;
+drop type datetime2_babel_6120;
+drop type datetimeoffset_babel_6120;
+drop type money_babel_6120;
+go

--- a/test/JDBC/input/functions/string_functions/datalength.sql
+++ b/test/JDBC/input/functions/string_functions/datalength.sql
@@ -701,6 +701,637 @@ GO
 SELECT * FROM datalength_vw_DataLengthSummary;
 GO
 
+-- Extra test cases 
+-- UDT
+create type tinyint_babel_6120 from tinyint;
+create type date_babel_6120 from date;
+create type smalldatetime_babel_6120 from smalldatetime;
+create type time_babel_6120 from time;
+create type smallmoney_babel_6120 from smallmoney;
+create type numeric_babel_6120 from numeric(21,5);
+create type decimal_babel_6120 from decimal(21,5);
+GO
+
+create type smallint_babel_6120 from smallint;
+create type int_babel_6120 from int;
+create type bigint_babel_6120 from bigint;
+create type datetime_babel_6120 from datetime;
+create type datetime2_babel_6120 from datetime2;
+create type datetimeoffset_babel_6120 from datetimeoffset;
+create type money_babel_6120 from money;
+go
+
+
+-- tinyint
+-- JIRA query
+SELECT DATALENGTH(CAST(123 AS TINYINT))
+GO
+
+SELECT DATALENGTH(CAST('123' AS TINYINT))
+GO
+
+SELECT DATALENGTH(CAST('' AS TINYINT))
+GO
+
+SELECT DATALENGTH(CAST(123.33 AS TINYINT))
+GO
+
+SELECT DATALENGTH(CAST(123 AS tinyint_babel_6120))
+GO
+
+-- smallint : 2 (as expected)
+SELECT DATALENGTH(CAST(123 AS SMALLINT))
+GO
+
+SELECT DATALENGTH(CAST('123' AS SMALLINT))
+GO
+
+SELECT DATALENGTH(CAST('' AS SMALLINT))
+GO
+
+SELECT DATALENGTH(CAST(123.33 AS SMALLINT))
+GO
+
+SELECT DATALENGTH(CAST(123 AS smallint_babel_6120))
+GO
+
+
+-- INT : 4 (as expected)
+SELECT DATALENGTH(CAST(123 AS INT))
+GO
+
+SELECT DATALENGTH(CAST('123' AS INT))
+GO
+
+SELECT DATALENGTH(CAST('' AS INT))
+GO
+
+SELECT DATALENGTH(CAST(123.33 AS INT))
+GO
+
+SELECT DATALENGTH(123)
+go
+
+SELECT DATALENGTH(CAST(123 AS int_babel_6120))
+GO
+
+-- bitint : 8 (as expected)
+
+SELECT DATALENGTH(CAST(123 AS bigint))
+GO
+
+SELECT DATALENGTH(CAST('123' AS bigint))
+GO
+
+SELECT DATALENGTH(CAST('' AS bigint))
+GO
+
+SELECT DATALENGTH(CAST(123.33 AS bigint))
+GO
+
+SELECT DATALENGTH(CAST(123 AS bigint_babel_6120))
+GO
+
+-- numeric, testing for different precision range for actual input
+SELECT DATALENGTH(CAST(123.45 AS NUMERIC(10,2)))
+GO
+
+SELECT DATALENGTH(123.45) 
+go
+
+SELECT DATALENGTH(CAST(123.451234 AS NUMERIC(10,2))) 
+go
+
+SELECT DATALENGTH(CAST(123.451234 AS NUMERIC(5,2))) 
+Go
+
+SELECT DATALENGTH(CAST(123.451234 AS NUMERIC(1,0))) -- over flow
+go
+
+SELECT DATALENGTH(CAST(1 AS NUMERIC(1,0)))
+go
+
+SELECT DATALENGTH(CAST(1.0 AS NUMERIC(1,0)))
+go
+
+SELECT DATALENGTH(CAST(1.0 AS NUMERIC(5,3))) 
+go
+
+SELECT DATALENGTH(CAST(12.346 AS NUMERIC(5,3))) 
+go
+
+SELECT DATALENGTH(CAST(12345.6789 AS NUMERIC(9,3))) 
+go
+
+SELECT DATALENGTH(CAST(12345.6789 AS NUMERIC(10,3)))  
+Go
+
+SELECT DATALENGTH(CAST(12345.6789 AS NUMERIC(11,3))) 
+go
+
+SELECT DATALENGTH(CAST(123456789123456789.679 AS NUMERIC(21,3))) 
+go
+
+SELECT DATALENGTH(CAST(123456789123456789123456789123.12345678 AS NUMERIC(38,8))) 
+go
+
+Select datalength(123456789123456789123456789123.12345678) 
+GO
+
+SELECT DATALENGTH(CAST(0.679 AS NUMERIC(21,3))) 
+go
+
+SELECT DATALENGTH(CAST(0.1234567891 AS NUMERIC(21,3))) 
+go
+
+SELECT DATALENGTH(CAST(0.1234567234567891 AS NUMERIC(21,3)))
+go
+
+SELECT DATALENGTH(CAST(0.1234567234567891 AS NUMERIC(21,11))) 
+go
+
+SELECT DATALENGTH(CAST(1.1234567234567891 AS NUMERIC(38,5))) 
+go
+
+SELECT DATALENGTH(CAST(123456789123.679 AS numeric_babel_6120)) 
+go
+
+-- extra 0 is appended and hence 21 precision, 13 result
+SELECT DATALENGTH(CAST(0.12345678912345678912 AS NUMERIC(38,21))) 
+go
+
+-- When significant digit is 0, 
+-- we have divergance between TSQL doc and actual functionality
+-- we are matching TSQL doc.
+
+-- Even though precision is 10, returns 5 byte according to 1-9 precision range
+SELECT DATALENGTH(CAST(0.1234567234567891 AS NUMERIC(21,10)))
+go
+
+-- Even though precision is 20, returns 9 byte according to 10-28 precision range
+SELECT DATALENGTH(CAST(0.12345678912345678912 AS NUMERIC(38,20))) 
+go
+
+-- Even though precision is 20, returns 9 byte according to 10-28 precision range
+SELECT DATALENGTH(CAST(0.123456789123456789121 AS NUMERIC(38,20))) 
+go
+
+-- decimal
+-- JIRA query
+SELECT DATALENGTH(CAST(123.45 AS DECIMAL(10,2)))
+GO
+
+SELECT DATALENGTH(123.45)
+go
+
+SELECT DATALENGTH(CAST(123.451234 AS DECIMAL(10,2)))
+go
+
+SELECT DATALENGTH(CAST(123.451234 AS DECIMAL(5,2))) 
+Go
+
+SELECT DATALENGTH(CAST(123.451234 AS DECIMAL(1,0))) -- over flow
+go
+
+SELECT DATALENGTH(CAST(1 AS DECIMAL(1,0)))
+go
+
+SELECT DATALENGTH(CAST(1.0 AS DECIMAL(5,3))) 
+go
+
+SELECT DATALENGTH(CAST(12.346 AS DECIMAL(5,3))) 
+go
+
+SELECT DATALENGTH(CAST(12345678.679 AS DECIMAL(21,3))) 
+go
+
+SELECT DATALENGTH(CAST(123456789123456789.679 AS DECIMAL(21,3))) 
+go
+
+SELECT DATALENGTH(CAST(123456789123456789123456789123.12345678 AS DECIMAL(38,8))) 
+go
+
+Select datalength(123456789123456789123456789123.12345678) 
+GO
+
+SELECT DATALENGTH(CAST(123456789123.679 AS decimal_babel_6120)) 
+go
+
+-- money
+select DATALENGTH(CAST(123.45 AS MONEY))
+go
+
+SELECT DATALENGTH(CAST(123 AS MONEY))
+GO
+
+SELECT DATALENGTH(CAST('123' AS MONEY))
+GO
+
+SELECT DATALENGTH(CAST('' AS MONEY))
+GO
+
+SELECT DATALENGTH(CAST(NULL AS MONEY)) -- NULL
+go
+
+select DATALENGTH(CAST(123.45 AS money_babel_6120))
+go
+
+-- smallmoney
+-- JIRA query
+select DATALENGTH(CAST(123.45 AS SMALLMONEY))
+go
+
+SELECT DATALENGTH(CAST(123 AS SMALLMONEY))
+GO
+
+SELECT DATALENGTH(CAST('123' AS SMALLMONEY))
+GO
+
+SELECT DATALENGTH(CAST('' AS SMALLMONEY))
+GO
+
+SELECT DATALENGTH(CAST(NULL AS SMALLMONEY))
+GO
+
+select DATALENGTH(CAST(123.45 AS smallmoney_babel_6120))
+go
+
+-- date
+-- JIRA query
+SELECT DATALENGTH(CAST('2024-01-01' AS DATE))
+go
+
+select datalength(CAST('' AS DATE))
+go
+
+SELECT DATALENGTH(CAST('2024-01-01' AS date_babel_6120))
+go
+
+-- smalldatetime
+-- JIRA query
+SELECT DATALENGTH(CAST('2024-01-01 12:34:56' AS SMALLDATETIME))
+GO
+
+select datalength(CAST('' AS SMALLDATETIME))
+go
+
+SELECT DATALENGTH(CAST('2024-01-01 12:34:56' AS smalldatetime_babel_6120))
+GO
+
+
+-- time
+-- JIRA query
+SELECT DATALENGTH(CAST('12:34:56' AS TIME))
+go
+
+SELECT DATALENGTH(CAST('12:10:30.123' AS TIME))
+go
+
+SELECT DATALENGTH(CAST('12:10:30.123' AS TIME(5)))
+go
+
+select datalength(CAST('' AS TIME))
+go
+
+SELECT DATALENGTH(CAST('12:10:30.123' AS time_babel_6120))
+go
+
+-- datetime
+select datalength(cast('01/02/03' as datetime))
+go
+
+select datalength(CAST('' AS datetime))
+go
+
+select datalength(cast('01/02/03' as datetime_babel_6120))
+go
+
+-- datetime2
+select datalength(cast('Apr 1 2000 14:30' as datetime2))
+Go
+
+select datalength(CAST('' AS DATETIME2))
+go
+
+select datalength(cast('Apr 1 2000 14:30' as datetime2_babel_6120))
+Go
+
+-- datetimeoffset
+select datalength(cast('3/12/24 14:30 +8:00' as datetimeoffset))
+go
+
+select datalength(CAST('' AS datetimeoffset))
+go
+
+select datalength(cast('3/12/24 14:30 +8:00' as datetimeoffset_babel_6120))
+go
+
+-- XML
+SELECT DATALENGTH(CAST('<root>test</root>' AS XML)) AS XML_Length;
+Go
+
+SELECT DATALENGTH(CAST(N'<root>test</root>' AS XML)) AS XML_Length;
+go
+
+SELECT DATALENGTH(CAST('<root>te界t</root>' AS XML)) AS XML_Length;
+go
+
+-- String datatypes : FIX with BABEL-1520/BABEL-1516
+-- char
+select datalength(char(0))
+go
+
+select datalength(cast('' as char))
+go
+
+select datalength(cast('' as char(10)))
+go
+
+select datalength(cast('asdfg' as char(10)))
+go
+
+select datalength(cast('asdfg' as char))
+go
+
+select datalength(cast(N'asdfg' as char))
+go
+
+select datalength(cast(N'asdfg' as char(10)))
+go
+
+select datalength(cast(NULL as char(10)))
+go
+
+select datalength(cast(NULL as char))
+go
+
+select DATALENGTH(cast('🌟' as char)) 
+go
+
+select DATALENGTH(cast(N'🌟' as char)) 
+go
+
+select DATALENGTH(cast(N'🌟' as char(10)))
+go
+
+-- varchar
+-- VARCHAR
+select datalength(cast('' as varchar))
+go
+
+select datalength(cast('' as varchar(10)))
+go
+
+select datalength(cast('asdfg' as varchar(10)))
+go
+
+select datalength(cast('asdfg' as varchar))
+go
+
+select datalength(cast(N'asdfg' as varchar))
+go
+
+select datalength(cast(N'asdfg' as varchar(10)))
+go
+
+select datalength(cast(NULL as varchar(10)))
+go
+
+select datalength(cast(NULL as varchar))
+go
+
+select DATALENGTH(cast('🌟' as varchar)) 
+go
+
+select DATALENGTH(cast(N'🌟' as varchar)) 
+go
+
+select DATALENGTH(cast(N'🌟' as varchar(10)))
+go
+
+select datalength(cast('世界' as varchar)) 
+Go
+
+select datalength(cast(N'世界' as varchar)) 
+go
+
+select datalength(cast(N'世界' as varchar(10))) 
+go
+
+-- VARCHAR(MAX)
+select datalength(cast('' as varchar(max)))
+go
+
+select datalength(cast('asdfg' as varchar(max)))
+go
+
+select datalength(cast(N'asdfg' as varchar(max)))
+go
+
+select datalength(cast(NULL as varchar(max)))
+go
+
+select DATALENGTH(cast('🌟' as varchar(max))) 
+go
+
+select DATALENGTH(cast(N'🌟' as varchar(max))) 
+go
+
+select datalength(cast(N'世界' as varchar(max))) 
+go
+
+-- NCHAR
+select datalength(nchar(0))
+go
+
+select datalength(cast('' as nchar))
+go
+
+select datalength(cast('' as nchar(10)))
+go
+
+select datalength(cast('asdfg' as nchar(10)))
+go
+
+select datalength(cast('asdfg' as nchar))
+go
+
+select datalength(cast(N'asdfg' as nchar))
+go
+
+select datalength(cast(N'asdfg' as nchar(10)))
+go
+
+select datalength(cast(NULL as nchar(10)))
+go
+
+select datalength(cast(NULL as nchar))
+go
+
+select DATALENGTH(cast('🌟' as nchar)) 
+go
+
+select DATALENGTH(cast(N'🌟' as nchar)) 
+go
+
+select DATALENGTH(cast(N'🌟' as nchar(10)))
+go
+
+select datalength(cast(N'世界' as nchar)) 
+go
+
+select datalength(cast(N'世界' as nchar(10))) 
+go
+
+-- NVARCHAR
+select datalength(cast('' as nvarchar))
+go
+
+select datalength(cast('' as nvarchar(10)))
+go
+
+select datalength(cast('asdfg' as nvarchar(10)))
+go
+
+select datalength(cast('asdfg' as nvarchar))
+go
+
+select datalength(cast(N'asdfg' as nvarchar))
+go
+
+select datalength(cast(N'asdfg' as nvarchar(10)))
+go
+
+select datalength(cast(NULL as nvarchar(10)))
+go
+
+select datalength(cast(NULL as nvarchar))
+go
+
+select DATALENGTH(cast('🌟' as nvarchar)) 
+go
+
+select DATALENGTH(cast(N'🌟' as nvarchar)) 
+go
+
+select DATALENGTH(cast(N'🌟' as nvarchar(10)))
+go
+
+select datalength(cast(N'世界' as nvarchar)) 
+go
+
+select datalength(cast(N'世界' as nvarchar(10))) 
+go
+
+-- NVARCHAR(MAX)
+select datalength(cast('' as nvarchar(max)))
+go
+
+select datalength(cast('asdfg' as nvarchar(max)))
+go
+
+select datalength(cast(N'asdfg' as nvarchar(max)))
+go
+
+select datalength(cast(NULL as nvarchar(max)))
+go
+
+select DATALENGTH(cast('🌟' as nvarchar(max))) 
+go
+
+select DATALENGTH(cast(N'🌟' as nvarchar(max))) 
+go
+
+select datalength(cast(N'世界' as nvarchar(max))) 
+go
+
+-- combination  - multibyte/accented/surroagte
+
+select DATALENGTH('Hello') , DATALENGTH(N'Hello')
+go
+
+select DATALENGTH('こんにちは'), DATALENGTH(N'こんにちは')
+GO
+
+select DATALENGTH('Hàáâ') , DATALENGTH(N'Hàáâ')
+go
+
+select DATALENGTH('こàáâは'), DATALENGTH(N'こàáâは')
+go
+
+select DATALENGTH('🌟🌟🌟'), DATALENGTH(N'🌟🌟🌟')
+go
+
+-- truncation
+declare @a varchar(2) = 'hello'
+select DATALENGTH(@a)
+go
+
+declare @a Nvarchar(2) = N'hello'
+select DATALENGTH(@a)
+go
+
+
+-- text 
+select datalength(cast('abd' as text))
+Go
+
+select datalength(cast(N'abd' as text))
+Go
+
+select DATALENGTH(cast('こんにちは' as text)), DATALENGTH(cast(N'こんにちは' as text))
+GO
+
+-- ntext
+select datalength(cast('abd' as ntext))
+Go
+
+select datalength(cast(N'abd' as ntext))
+Go
+
+select DATALENGTH(cast('こんにちは' as ntext)), DATALENGTH(cast(N'こんにちは' as ntext))
+GO
+
+-- binary
+select datalength(CAST('0x65' AS BINARY(10)))
+GO
+
+select datalength(CAST(0x65 AS BINARY(10)))
+go
+
+select datalength(CAST(0x65 AS BINARY))
+go
+
+-- FIX with BABEL-5610
+select datalength(CAST('' AS BINARY(10)))
+go
+
+select datalength(CAST('' AS BINARY))
+GO
+
+-- varbinary
+select datalength(CAST(0x65 AS varbinary))
+go
+
+
+select datalength(CAST(0x65 AS varbinary(max)))
+go
+
+
+select datalength(CAST(0x65 AS varbinary(10)))
+go
+
+
+select datalength(CAST('0x65' AS VARBINARY(10)))
+go
+
+
+select datalength(CAST('' AS VARBINARY(10)))
+go
+
+
+select datalength(CAST('' AS VARBINARY))
+go
 
 -- Cleanup
 DROP TABLE datalength_t2;
@@ -739,3 +1370,20 @@ DROP TABLE datalength_ConstrainedTable;
 DROP TABLE datalength_t7;
 GO
 
+drop type tinyint_babel_6120;
+drop type date_babel_6120;
+drop type smalldatetime_babel_6120;
+drop type time_babel_6120;
+drop type smallmoney_babel_6120;
+drop type numeric_babel_6120;
+drop type decimal_babel_6120;
+GO
+
+drop type smallint_babel_6120;
+drop type int_babel_6120;
+drop type bigint_babel_6120;
+drop type datetime_babel_6120;
+drop type datetime2_babel_6120;
+drop type datetimeoffset_babel_6120;
+drop type money_babel_6120;
+go


### PR DESCRIPTION
### Description

This PR fixes the datalength() for the following datatypes along with their UDTs, to align the output with TSQL:
1. Tinyint
2. Date
3. Smalldatetime
4. Time
5. Smallmoney
6. Numeric/decimal

Cherry-picked from PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4124

Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)

### Issues Resolved

BABEL-6120

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -**  NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).