### PR TITLE
Create active snapshot for ResetTempTableNamespace as it might involve TOAST table access.

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -89,6 +89,7 @@ static
 void
 TdsDiscardAll()
 {
+	bool		need_snapshot = !ActiveSnapshotSet();
 	/*
 	 * Disallow DISCARD ALL in a transaction block. This is arguably
 	 * inconsistent (we don't make a similar check in the command sequence
@@ -105,7 +106,19 @@ TdsDiscardAll()
 	Async_UnlistenAll();
 	LockReleaseAll(USER_LOCKMETHOD, true);
 	ResetPlanCache();
+
+	/*
+	 * ResetTempTableNamespace might involve TOAST table access,
+	 * so we need to ensure that there is a valid snapshot.
+	 */
+	if (need_snapshot)
+		PushActiveSnapshot(GetTransactionSnapshot());
+
 	ResetTempTableNamespace();
+
+	if (need_snapshot)
+	 		PopActiveSnapshot();
+
 	ResetSequenceCaches();
 }
 


### PR DESCRIPTION
### Description

ResetTempTableNamespace might involve TOAST table access, so this commit ensures that there is a valid snapshot.

### Issues Resolved

Task: BABEL-6152

cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4162

Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).