### PR TITLE
Temporarily Ignored babel_timezoneinfo tests

### DIFF
--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -12,6 +12,7 @@ all
 
 # TODO
 ignore#!#charindex_and_replace_CIAI_collations
+ignore#!#babel_timezoneinfo
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -12,13 +12,17 @@ all
 
 # TODO
 ignore#!#charindex_and_replace_CIAI_collations
-ignore#!#babel_timezoneinfo
 
 # BABEL-SP_FKEYS test is very slow and causing github action timeout.
 
 # JDBC bulk insert API seems to call SET FMTONLY ON without calling SET FMTONLY OFF, causing some spurious test failures.
 ignore#!#insertbulk
 ignore#!#BABEL-SQLvariant
+
+#This test case needs to be ignored temporarily for BABEL 5370 flaky test cases
+ignore#!#babel_timezoneinfo-vu-prepare
+ignore#!#babel_timezoneinfo-vu-verify
+ignore#!#babel_timezoneinfo-vu-cleanup
 
 # Ignore upgrade tests in normal JDBC run. These are tests that cannot be run in non-upgrade contexts due
 # to changing the behavior between pre- and post-commit.

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -471,4 +471,4 @@ view_sec_setting_before_17_6-or-16_10
 alter-function-with-weak-view
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -593,4 +593,4 @@ view_sec_setting_before_17_6-or-16_10
 alter-function-with-weak-view
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -591,4 +591,4 @@ view_sec_setting_before_17_6-or-16_10
 alter-function-with-weak-view
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -597,4 +597,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -598,4 +598,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_15/schedule
+++ b/test/JDBC/upgrade/15_15/schedule
@@ -594,4 +594,4 @@ babel_assign_nchar
 alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -507,4 +507,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -527,4 +527,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -540,4 +540,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -576,4 +576,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -591,4 +591,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -600,4 +600,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -592,4 +592,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -584,4 +584,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -635,4 +635,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -633,4 +633,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -600,4 +600,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -606,4 +606,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -621,4 +621,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -627,4 +627,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -632,4 +632,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -636,4 +636,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -629,4 +629,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -643,4 +643,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/17_6/schedule
+++ b/test/JDBC/upgrade/17_6/schedule
@@ -651,4 +651,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
-babel_timezoneinfo_before_17_7
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -655,4 +655,4 @@ alter-table-null-notnull
 openxml_without_with_clause
 Select_top_N_percent
 ascii_function
-babel_timezoneinfo
+#babel_timezoneinfo#Commenting the test as a temporary fix to ticket BABEL 5370

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -148,6 +148,7 @@ Could not find upgrade tests for function sys.openxml_simple
 Could not find upgrade tests for function sys.options
 Could not find upgrade tests for function sys.patindex_ai_collations
 Could not find upgrade tests for function sys.pltsql_assign_var
+Could not find upgrade tests for function sys.pltsql_timezone_mapping_pg_to_windows
 Could not find upgrade tests for function sys.remove_accents_internal_using_cache
 Could not find upgrade tests for function sys.role_id
 Could not find upgrade tests for function sys.sp_column_privileges_internal
@@ -216,3 +217,4 @@ Could not find upgrade tests for view sys.sp_special_columns_view
 Could not find upgrade tests for view sys.sp_statistics_view
 Could not find upgrade tests for view sys.sp_stored_procedures_view
 Could not find upgrade tests for view sys.sp_table_privileges_view
+Could not find upgrade tests for view sys.time_zone_info

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -989,4 +989,5 @@ View sys.spt_tablecollations_view
 View sys.synonyms
 View sys.syscharsets
 View sys.syslanguages
+View sys.time_zone_info
 View sys.xml_schema_collections


### PR DESCRIPTION
### Description

Commit: https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/eb5b5491b4e43aab828a30eac7ab028b30b44fef, introduces test babel_timezoneinfo, this test are dependent on day light saving and can be flaky with change in day light saving in different regions. As an interim solution, this PR disables the timezone-related tests in the schedule and upgrade files to unblocks test failures.

### Issues Resolved

NA

### Test Scenarios Covered ###
NA



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).