### PR TITLE
Added tests for fix of sql_dialect check in ENRGetSystableScan() function for T-SQL temp tables (#4174)

### DIFF
--- a/test/JDBC/expected/temp_table_dialect_check-before-15_12-or-16_8-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_dialect_check-before-15_12-or-16_8-vu-cleanup.out
@@ -1,0 +1,6 @@
+-- tsql
+DROP TABLE IF EXISTS fakeGoodsInfo;
+GO
+
+DROP VIEW enr_view;
+GO

--- a/test/JDBC/expected/temp_table_dialect_check-before-15_12-or-16_8-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_dialect_check-before-15_12-or-16_8-vu-prepare.out
@@ -1,0 +1,80 @@
+-- tsql
+CREATE TABLE fakeGoodsInfo(Description ntext)
+GO
+
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+	ORDER BY relname
+GO
+
+-- insert a untoasted value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE('A', 999));
+GO
+~~ROW COUNT: 1~~
+
+-- verify that it is untoasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+~~START~~
+text#!#text
+<NULL>#!#<NULL>
+~~END~~
+
+
+-- insert a toastable value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE(newid(), 5000000));
+GO
+~~ROW COUNT: 1~~
+
+-- verify that it is toasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+~~START~~
+text#!#text
+<NULL>#!#<NULL>
+pglz#!#pglz
+~~END~~
+
+-- terminate-tsql-conn
+
+
+-- psql
+-- with temp_oid_buffer_size disabled
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#tmpgoodsinfo
+~~END~~
+
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: could not open relation with OID 86045)~~
+
+-- terminate-tsql-conn

--- a/test/JDBC/expected/temp_table_dialect_check-before-15_12-or-16_8-vu-verify.out
+++ b/test/JDBC/expected/temp_table_dialect_check-before-15_12-or-16_8-vu-verify.out
@@ -1,0 +1,67 @@
+-- psql
+-- with temp_oid_buffer_size disabled
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#tmpgoodsinfo
+~~END~~
+
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+~~START~~
+int
+2
+~~END~~
+
+-- terminate-tsql-conn
+
+-- psql
+-- with temp_oid_buffer_size enabled
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#tmpgoodsinfo
+~~END~~
+
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+~~START~~
+int
+2
+~~END~~
+
+-- terminate-tsql-conn

--- a/test/JDBC/expected/temp_table_dialect_check-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_dialect_check-vu-cleanup.out
@@ -1,0 +1,6 @@
+-- tsql
+DROP TABLE IF EXISTS fakeGoodsInfo;
+GO
+
+DROP VIEW enr_view;
+GO

--- a/test/JDBC/expected/temp_table_dialect_check-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_dialect_check-vu-prepare.out
@@ -1,0 +1,44 @@
+-- tsql
+CREATE TABLE fakeGoodsInfo(Description ntext)
+GO
+
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+	ORDER BY relname
+GO
+
+-- insert a untoasted value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE('A', 999));
+GO
+~~ROW COUNT: 1~~
+
+-- verify that it is untoasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+~~START~~
+text#!#text
+<NULL>#!#<NULL>
+~~END~~
+
+
+-- insert a toastable value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE(newid(), 5000000));
+GO
+~~ROW COUNT: 1~~
+
+-- verify that it is toasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+~~START~~
+text#!#text
+<NULL>#!#<NULL>
+pglz#!#pglz
+~~END~~
+
+-- terminate-tsql-conn

--- a/test/JDBC/expected/temp_table_dialect_check-vu-verify.out
+++ b/test/JDBC/expected/temp_table_dialect_check-vu-verify.out
@@ -1,0 +1,67 @@
+-- psql
+-- with temp_oid_buffer_size disabled
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#tmpgoodsinfo
+~~END~~
+
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+~~START~~
+int
+2
+~~END~~
+
+-- terminate-tsql-conn
+
+-- psql
+-- with temp_oid_buffer_size enabled
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#tmpgoodsinfo
+~~END~~
+
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+~~START~~
+int
+2
+~~END~~
+
+-- terminate-tsql-conn

--- a/test/JDBC/input/temp_tables/temp_table_dialect_check-before-15_12-or-16_8-vu-cleanup.mix
+++ b/test/JDBC/input/temp_tables/temp_table_dialect_check-before-15_12-or-16_8-vu-cleanup.mix
@@ -1,0 +1,6 @@
+-- tsql
+DROP TABLE IF EXISTS fakeGoodsInfo;
+GO
+
+DROP VIEW enr_view;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_dialect_check-before-15_12-or-16_8-vu-prepare.mix
+++ b/test/JDBC/input/temp_tables/temp_table_dialect_check-before-15_12-or-16_8-vu-prepare.mix
@@ -1,0 +1,53 @@
+-- sla 200000
+-- tsql
+CREATE TABLE fakeGoodsInfo(Description ntext)
+GO
+
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+	ORDER BY relname
+GO
+
+-- insert a untoasted value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE('A', 999));
+GO
+-- verify that it is untoasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+
+-- insert a toastable value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE(newid(), 5000000));
+GO
+-- verify that it is toasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+-- terminate-tsql-conn
+
+
+-- with temp_oid_buffer_size disabled
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+-- terminate-tsql-conn

--- a/test/JDBC/input/temp_tables/temp_table_dialect_check-before-15_12-or-16_8-vu-verify.mix
+++ b/test/JDBC/input/temp_tables/temp_table_dialect_check-before-15_12-or-16_8-vu-verify.mix
@@ -1,0 +1,43 @@
+-- with temp_oid_buffer_size disabled
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+-- terminate-tsql-conn
+
+-- with temp_oid_buffer_size enabled
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+-- terminate-tsql-conn

--- a/test/JDBC/input/temp_tables/temp_table_dialect_check-vu-cleanup.mix
+++ b/test/JDBC/input/temp_tables/temp_table_dialect_check-vu-cleanup.mix
@@ -1,0 +1,6 @@
+-- tsql
+DROP TABLE IF EXISTS fakeGoodsInfo;
+GO
+
+DROP VIEW enr_view;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_dialect_check-vu-prepare.mix
+++ b/test/JDBC/input/temp_tables/temp_table_dialect_check-vu-prepare.mix
@@ -1,0 +1,30 @@
+-- sla 200000
+-- tsql
+CREATE TABLE fakeGoodsInfo(Description ntext)
+GO
+
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+	ORDER BY relname
+GO
+
+-- insert a untoasted value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE('A', 999));
+GO
+-- verify that it is untoasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+
+-- insert a toastable value
+INSERT INTO fakeGoodsInfo(Description) VALUES (REPLICATE(newid(), 5000000));
+GO
+-- verify that it is toasted
+SELECT pg_column_compression(Description), pg_column_compression(Description) FROM fakeGoodsInfo;
+GO
+-- terminate-tsql-conn

--- a/test/JDBC/input/temp_tables/temp_table_dialect_check-vu-verify.mix
+++ b/test/JDBC/input/temp_tables/temp_table_dialect_check-vu-verify.mix
@@ -1,0 +1,43 @@
+-- with temp_oid_buffer_size disabled
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+-- terminate-tsql-conn
+
+-- with temp_oid_buffer_size enabled
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536;
+GO
+
+-- tsql
+SET NOCOUNT ON
+GO
+
+DROP TABLE IF EXISTS #tmpGoodsInfo;
+GO
+
+SELECT Description INTO #tmpGoodsInfo FROM dbo.fakeGoodsInfo;
+GO
+
+SELECT * FROM enr_view;
+GO
+
+SELECT COUNT(REPLACE(Description, '55', '44')) FROM #tmpGoodsInfo;
+GO
+-- terminate-tsql-conn

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -566,6 +566,9 @@ ignore#!#babel_index_nulls_order-before-16_8-or-17_4-vu-cleanup
 ignore#!#object_ownership-before-16_8-or-17_4-vu-prepare
 ignore#!#object_ownership-before-16_8-or-17_4-vu-verify
 ignore#!#object_ownership-before-16_8-or-17_4-vu-cleanup
+ignore#!#temp_table_dialect_check-before-15_12-or-16_8-vu-prepare
+ignore#!#temp_table_dialect_check-before-15_12-or-16_8-vu-verify
+ignore#!#temp_table_dialect_check-before-15_12-or-16_8-vu-cleanup
 
 # getting timed out (TODO: BABEL-5353)
 ignore#!#BABEL-SP_TABLE_PRIVILEGES

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -458,7 +458,7 @@ public class TestQueryFile {
             diffProcessBuilder = new ProcessBuilder("diff", "-a", "-u", "-I", "~~ERROR", "-I", "Babelfish T-SQL Batch Parsing Time", "-I", "<Babelfish-T-SQL-Batch-Parsing-Time", expectedFilePath, outputFilePath);
         } else {
             // Do not compare T-SQL Batch parsing time
-            diffProcessBuilder = new ProcessBuilder("diff", "-a", "-u", "-I", "Babelfish T-SQL Batch Parsing Time", "-I", "<Babelfish-T-SQL-Batch-Parsing-Time", expectedFilePath, outputFilePath);
+            diffProcessBuilder = new ProcessBuilder("diff", "-a", "-u", "-I", ".*could not open relation with OID", "-I", "Babelfish T-SQL Batch Parsing Time", "-I", "<Babelfish-T-SQL-Batch-Parsing-Time", expectedFilePath, outputFilePath);
         }
 
         try {

--- a/test/JDBC/upgrade/14_17/schedule
+++ b/test/JDBC/upgrade/14_17/schedule
@@ -491,3 +491,4 @@ mathematical_func_tests-before-17_7-or-16_11
 babel_assign_nchar
 view_sec_setting_before_17_6-or-16_10
 ascii_function_before-17_7-or-16_11
+temp_table_dialect_check-before-15_12-or-16_8

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -593,3 +593,4 @@ view_sec_setting_before_17_6-or-16_10
 alter-function-with-weak-view
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
+temp_table_dialect_check-before-15_12-or-16_8

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -591,3 +591,4 @@ view_sec_setting_before_17_6-or-16_10
 alter-function-with-weak-view
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
+temp_table_dialect_check-before-15_12-or-16_8

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -627,3 +627,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
+temp_table_dialect_check-before-15_12-or-16_8

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -632,3 +632,4 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function_before-17_7-or-16_11
+temp_table_dialect_check-before-15_12-or-16_8


### PR DESCRIPTION
### Description
#### Cherry-pick
Ext PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4174
Ext commit - https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/e1dc95a979dacf3faf3671d885e88c6a2ffec709

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).