### PR TITLE
Community merge 15.14 fix -  Add snapshot before doing multi inserts in TOAST tables

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -37,6 +37,7 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/rls.h"
+#include "utils/snapmgr.h"
 #include "pltsql.h"
 
 /*
@@ -357,12 +358,16 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 	 * context before calling it.
 	 */
 	oldcontext = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
+	PushActiveSnapshot(GetTransactionSnapshot());
+
 	table_multi_insert(resultRelInfo->ri_RelationDesc,
 					   slots,
 					   nused,
 					   mycid,
 					   ti_options,
 					   buffer->bistate);
+
+	PopActiveSnapshot();
 
 	for (i = 0; i < nused; i++)
 	{

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -344,6 +344,7 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 	int			nused = buffer->nused;
 	ResultRelInfo *resultRelInfo = buffer->resultRelInfo;
 	TupleTableSlot **slots = buffer->slots;
+	bool		need_snapshot = !ActiveSnapshotSet();
 
 	/*
 	 * Print error context information correctly, if one of the operations
@@ -358,7 +359,13 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 	 * context before calling it.
 	 */
 	oldcontext = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
-	PushActiveSnapshot(GetTransactionSnapshot());
+
+	/*
+	 * table_multi_insert might involve TOAST table access,
+	 * so we need to ensure that there is a valid snapshot.
+	 */
+	if (need_snapshot)
+		PushActiveSnapshot(GetTransactionSnapshot());
 
 	table_multi_insert(resultRelInfo->ri_RelationDesc,
 					   slots,
@@ -367,7 +374,8 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 					   ti_options,
 					   buffer->bistate);
 
-	PopActiveSnapshot();
+	if (need_snapshot)
+	 		PopActiveSnapshot();
 
 	for (i = 0; i < nused; i++)
 	{


### PR DESCRIPTION
### Description

table_multi_insert might involve TOAST table access, so this commit ensures that there is a valid snapshot.

Task: BABEL-5957
Signed-off-by: Sharu Goel <goelshar@amazon.com>


### Issues Resolved

BABEL-5957

### Test Scenarios Covered ###
* **Use case based -** N/A


* **Boundary conditions -** N/A


* **Arbitrary inputs -** N/A


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).