### PR TITLE
Fixed geometry/geography bugs_4_8_STABLE

### DIFF
--- a/contrib/babelfishpg_common/sql/geography.sql
+++ b/contrib/babelfishpg_common/sql/geography.sql
@@ -249,7 +249,7 @@ CREATE OR REPLACE FUNCTION sys.Geography__Point(float8, float8, srid integer)
 	AS 'babelfishpg_common', 'geography_point'
 	LANGUAGE 'c' IMMUTABLE PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION sys.Geography__STPointFromText(sys.NVARCHAR, integer)
+CREATE OR REPLACE FUNCTION sys.Geography__STPointFromText(sys.NVARCHAR,srid integer)
 	RETURNS sys.GEOGRAPHY
 	AS $$
 	DECLARE
@@ -267,7 +267,7 @@ CREATE OR REPLACE FUNCTION sys.Geography__STPointFromText(sys.NVARCHAR, integer)
 		IF Geomtype = 'ST_Point' THEN
 			RETURN geom;
 		ELSE
-			RAISE EXCEPTION '% is not supported', Geomtype;
+			RAISE EXCEPTION 'Expected "POINT" at Position 1. The input has %', $1;
 		END IF;
 	END;
 	$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/contrib/babelfishpg_common/sql/geometry.sql
+++ b/contrib/babelfishpg_common/sql/geometry.sql
@@ -244,7 +244,7 @@ CREATE OR REPLACE FUNCTION sys.STAsBinary(sys.GEOMETRY)
 	AS 'babelfishpg_common', 'st_as_binary_geometry'
 	LANGUAGE 'c' IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION sys.Geometry__STPointFromText(sys.NVARCHAR, integer)
+CREATE OR REPLACE FUNCTION sys.Geometry__STPointFromText(sys.NVARCHAR,srid integer)
 	RETURNS sys.GEOMETRY
 	AS $$
 	DECLARE
@@ -262,7 +262,7 @@ CREATE OR REPLACE FUNCTION sys.Geometry__STPointFromText(sys.NVARCHAR, integer)
 		IF Geomtype = 'ST_Point' THEN
 				RETURN geom;
 		ELSE
-			RAISE EXCEPTION '% is not supported', Geomtype;
+			RAISE EXCEPTION 'Expected "POINT" at Position 1. The input has %', $1;
 		END IF;
 	END;
 	$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/contrib/babelfishpg_common/sql/upgrades/spatial_types--4.7.0--4.8.0.sql
+++ b/contrib/babelfishpg_common/sql/upgrades/spatial_types--4.7.0--4.8.0.sql
@@ -308,7 +308,7 @@ $$;
 
 CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'geography__stpointfromtext_deprecated_4_8_0');
 
-CREATE OR REPLACE FUNCTION sys.Geography__STPointFromText(sys.NVARCHAR, integer)
+CREATE OR REPLACE FUNCTION sys.Geography__STPointFromText(sys.NVARCHAR,srid integer)
 	RETURNS sys.GEOGRAPHY
 	AS $$
 	DECLARE
@@ -326,7 +326,7 @@ CREATE OR REPLACE FUNCTION sys.Geography__STPointFromText(sys.NVARCHAR, integer)
 		IF Geomtype = 'ST_Point' THEN
 			RETURN geom;
 		ELSE
-			RAISE EXCEPTION '% is not supported', Geomtype;
+			RAISE EXCEPTION 'Expected "POINT" at Position 1. The input has %', $1;
 		END IF;
 	END;
 	$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;
@@ -566,7 +566,7 @@ $$;
 
 CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'geometry__stpointfromtext_deprecated_4_8_0');
 
-CREATE OR REPLACE FUNCTION sys.Geometry__STPointFromText(sys.NVARCHAR, integer)
+CREATE OR REPLACE FUNCTION sys.Geometry__STPointFromText(sys.NVARCHAR,srid integer)
 	RETURNS sys.GEOMETRY
 	AS $$
 	DECLARE
@@ -584,7 +584,7 @@ CREATE OR REPLACE FUNCTION sys.Geometry__STPointFromText(sys.NVARCHAR, integer)
 		IF Geomtype = 'ST_Point' THEN
 				RETURN geom;
 		ELSE
-			RAISE EXCEPTION '% is not supported', Geomtype;
+			RAISE EXCEPTION 'Expected "POINT" at Position 1. The input has %', $1;
 		END IF;
 	END;
 	$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE;

--- a/contrib/babelfishpg_common/src/geo.c
+++ b/contrib/babelfishpg_common/src/geo.c
@@ -29,6 +29,22 @@ geo_wkt_rewrite(text* input_text)
 
     /* Convert PostgreSQL TEXT to C string */
     input_str = text_to_cstring(input_text);
+
+     /* Validate input string for printable ASCII characters */
+    if (input_str && strlen(input_str) > 0) 
+    {
+        /* Check all characters for non-printable ASCII (outside range 0-127) */
+        for (int i = 0; input_str[i] != '\0'; i++)
+        {
+            if ((unsigned char)input_str[i] > 127)
+            {
+                pfree(input_str);
+                ereport(ERROR,
+                        (errcode(ERRCODE_SYNTAX_ERROR),
+                         errmsg("The input well-known text (WKT) is not valid")));
+            }
+        }
+    }
    
     PG_TRY();
     {

--- a/contrib/babelfishpg_common/src/geo_scan.l
+++ b/contrib/babelfishpg_common/src/geo_scan.l
@@ -35,7 +35,9 @@ POLYHEDRALSURFACE     { yyerror(NULL, "Invalid Geometry");  return POLYHEDRALSUR
 TRIANGLE              { yyerror(NULL, "Invalid Geometry");  return TRIANGLE_TOK; }
 TIN                   { yyerror(NULL, "Invalid Geometry");  return TIN_TOK; }
 
-[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)([eE][-+]?[0-9]+)? {
+[+-]?[0-9]*\.[0-9]*\.[0-9]* { yyerror(NULL, "Invalid number format"); }
+
+[+-]?([0-9]+\.[0-9]+|[0-9]+|\.[0-9]+)([eE][-+]?[0-9]+)? {
     double val = atof(yytext);
     yylval.val = val;
     return DOUBLE_TOK;
@@ -58,7 +60,7 @@ ZM         { return ZM_TOK; }
 
 [ \t\n\r]+    { /* Ignore whitespace */ }
 
-.           { return yytext[0]; }
+.           { yyerror(NULL, "Invalid geometry"); }
 
 %%
 

--- a/test/JDBC/expected/Test-pointZM-vu-verify.out
+++ b/test/JDBC/expected/Test-pointZM-vu-verify.out
@@ -970,6 +970,70 @@ GO
 ~~ERROR (Message: 'geography::Point' failed because parameter 2 is not allowed to be null.)~~
 
 
+SELECT CAST('POINT(1.2.3 4)' AS geometry);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid number format)~~
+
+
+SELECT CAST(CAST('POINT(1.2.3 4)' AS CHAR(100)) AS geometry);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid number format)~~
+
+
+SELECT geometry::STGeomFromText('POINT(1.2.3 4)', 4326);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid number format)~~
+
+
+SELECT geometry::STGeomFromText('POINT(1..3 4)', 4326);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid number format)~~
+
+
+SELECT geometry::STGeomFromText('POINT(1.3.4.3 4)', 4326);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid number format)~~
+
+
+SELECT geometry::STGeomFromText('POINT(1.3.. 4)', 4326);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Invalid number format)~~
+
+
+SELECT geometry::STGeomFromText(0x504F494E542831203129, 4326);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The input well-known text (WKT) is not valid)~~
+
+
+SELECT geometry::STGeomFromText(0x50004F0049004E0054002800300020003, 0);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The input well-known text (WKT) is not valid)~~
+
+
+SELECT geometry::STGeomFromText(0x50004F0049004E00540028003000200030002900, 0);
+GO
+~~START~~
+geometry
+00000000010C00000000000000000000000000000000
+~~END~~
+
+
 -- Test with zero values
 SELECT geometry::STGeomFromText('POINT(0 0)', 4326);
 GO

--- a/test/JDBC/input/datatypes/Test-pointZM-vu-verify.sql
+++ b/test/JDBC/input/datatypes/Test-pointZM-vu-verify.sql
@@ -209,6 +209,33 @@ GO
 SELECT geography::Point(90, NULL, 4326);
 GO
 
+SELECT CAST('POINT(1.2.3 4)' AS geometry);
+GO
+
+SELECT CAST(CAST('POINT(1.2.3 4)' AS CHAR(100)) AS geometry);
+GO
+
+SELECT geometry::STGeomFromText('POINT(1.2.3 4)', 4326);
+GO
+
+SELECT geometry::STGeomFromText('POINT(1..3 4)', 4326);
+GO
+
+SELECT geometry::STGeomFromText('POINT(1.3.4.3 4)', 4326);
+GO
+
+SELECT geometry::STGeomFromText('POINT(1.3.. 4)', 4326);
+GO
+
+SELECT geometry::STGeomFromText(0x504F494E542831203129, 4326);
+GO
+
+SELECT geometry::STGeomFromText(0x50004F0049004E0054002800300020003, 0);
+GO
+
+SELECT geometry::STGeomFromText(0x50004F0049004E00540028003000200030002900, 0);
+GO
+
 -- Test with zero values
 SELECT geometry::STGeomFromText('POINT(0 0)', 4326);
 GO


### PR DESCRIPTION
#### **Fixed geometry/geography bugs** 

#### **Key Changes**:

1. Added a check to disallow non-printable ASCII charaters in the input of geospatial parser.
2. Removed incorrect support of Multiple Decimal Points for Geometry/Geography Data Type 


### Issues Resolved

BABEL-6126
BABEL-6149

Signed-off by: Mohit Raj [mrxmohit@amazon.com](mailto:mrxmohit@amazon.com)

Authored by: Mohit Raj [mrxmohit@amazon.com](mailto:mrxmohit@amazon.com)

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).