### PR TITLE
Community merge 15.14 fix -  Add snapshot before doing multi inserts in TOAST tables (#4179)

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -89,6 +89,7 @@ static
 void
 TdsDiscardAll()
 {
+	bool		need_snapshot = !ActiveSnapshotSet();
 	/*
 	 * Disallow DISCARD ALL in a transaction block. This is arguably
 	 * inconsistent (we don't make a similar check in the command sequence
@@ -105,7 +106,19 @@ TdsDiscardAll()
 	Async_UnlistenAll();
 	LockReleaseAll(USER_LOCKMETHOD, true);
 	ResetPlanCache();
+
+	/*
+	 * ResetTempTableNamespace might involve TOAST table access,
+	 * so we need to ensure that there is a valid snapshot.
+	 */
+	if (need_snapshot)
+		PushActiveSnapshot(GetTransactionSnapshot());
+
 	ResetTempTableNamespace();
+
+	if (need_snapshot)
+	 		PopActiveSnapshot();
+
 	ResetSequenceCaches();
 }
 

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -37,6 +37,7 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/rls.h"
+#include "utils/snapmgr.h"
 #include "pltsql.h"
 
 /*
@@ -343,6 +344,7 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 	int			nused = buffer->nused;
 	ResultRelInfo *resultRelInfo = buffer->resultRelInfo;
 	TupleTableSlot **slots = buffer->slots;
+	bool		need_snapshot = !ActiveSnapshotSet();
 
 	/*
 	 * Print error context information correctly, if one of the operations
@@ -357,12 +359,23 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 	 * context before calling it.
 	 */
 	oldcontext = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
+
+	/*
+	 * table_multi_insert might involve TOAST table access,
+	 * so we need to ensure that there is a valid snapshot.
+	 */
+	if (need_snapshot)
+		PushActiveSnapshot(GetTransactionSnapshot());
+
 	table_multi_insert(resultRelInfo->ri_RelationDesc,
 					   slots,
 					   nused,
 					   mycid,
 					   ti_options,
 					   buffer->bistate);
+
+	if (need_snapshot)
+	 		PopActiveSnapshot();
 
 	for (i = 0; i < nused; i++)
 	{


### PR DESCRIPTION
### Description

table_multi_insert might involve TOAST table access, so this commit ensures that there is a valid snapshot.

Task: BABEL-5957
Signed-off-by: Sharu Goel <goelshar@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).