### PR TITLE
STRING_SPLIT nvarchar overload

### DIFF
--- a/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
+++ b/contrib/babelfishpg_tsql/sql/datatype_string_operators.sql
@@ -22,11 +22,11 @@ $BODY$
 LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 GRANT EXECUTE ON FUNCTION sys.unicode(IN VARCHAR) TO PUBLIC;
 
-CREATE OR REPLACE FUNCTION sys.string_split(IN string VARCHAR, IN separator VARCHAR, OUT value VARCHAR) RETURNS SETOF VARCHAR AS
+CREATE OR REPLACE FUNCTION sys.string_split(IN string sys.NVARCHAR, IN separator sys.NVARCHAR, OUT value sys.NVARCHAR) RETURNS SETOF sys.NVARCHAR AS
 $body$
 DECLARE
-    v_string VARCHAR COLLATE "C";
-    v_separator VARCHAR COLLATE "C";
+    v_string sys.NVARCHAR COLLATE "C";
+    v_separator sys.NVARCHAR COLLATE "C";
 BEGIN
 	if length(separator) != 1 then
 		RAISE EXCEPTION 'Invalid separator: %', separator USING HINT =
@@ -34,12 +34,12 @@ BEGIN
         else
 	        v_string := string; -- use COLLATE "C"
 		v_separator := separator; -- use COLLATE "C"
-		RETURN QUERY(SELECT cast(unnest(string_to_array(v_string, v_separator)) as varchar));
+		RETURN QUERY(SELECT cast(unnest(string_to_array(v_string, v_separator)) as sys.NVARCHAR));
         end if;
 END
 $body$
 LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
-GRANT EXECUTE ON FUNCTION sys.string_split(IN VARCHAR, IN VARCHAR, OUT VARCHAR) TO PUBLIC;
+GRANT EXECUTE ON FUNCTION sys.string_split(IN sys.NVARCHAR, IN sys.NVARCHAR, OUT sys.NVARCHAR) TO PUBLIC;
 
 CREATE OR REPLACE FUNCTION sys.string_escape(IN str sys.NVARCHAR, IN type TEXT) RETURNS sys.NVARCHAR
 AS 'babelfishpg_tsql', 'string_escape' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/test/JDBC/expected/babel_collation.out
+++ b/test/JDBC/expected/babel_collation.out
@@ -343,7 +343,7 @@ int
 SELECT value FROM STRING_SPLIT('Lorem ipsum dolor sit amet.', ' ');
 go
 ~~START~~
-varchar
+nvarchar
 Lorem
 ipsum
 dolor
@@ -355,7 +355,7 @@ amet.
 SELECT value FROM STRING_SPLIT('a,b,c,d', ' ');
 go
 ~~START~~
-varchar
+nvarchar
 a,b,c,d
 ~~END~~
 
@@ -363,7 +363,7 @@ a,b,c,d
 SELECT value FROM STRING_SPLIT('123abc456', 'abc'); -- expect 'invalid separator'
 go
 ~~START~~
-varchar
+nvarchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Invalid separator: abc)~~
@@ -387,7 +387,7 @@ SELECT REPLACE('nothing to do', 'none', 'should not see this');
 drop table testing_collation;
 go
 ~~START~~
-varchar
+nvarchar
 clothing
 road
 touring

--- a/test/JDBC/expected/babel_function_string-vu-verify.out
+++ b/test/JDBC/expected/babel_function_string-vu-verify.out
@@ -649,7 +649,7 @@ int
 SELECT STRING_SPLIT('Lorem ipsum dolor sit amet.', ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 Lorem
 ipsum
 dolor
@@ -661,7 +661,7 @@ amet.
 SELECT STRING_SPLIT('clothing,road,,touring,bike', ',')
 GO
 ~~START~~
-varchar
+nvarchar
 clothing
 road
 
@@ -673,7 +673,7 @@ bike
 SELECT STRING_SPLIT('||||||||', '|')
 GO
 ~~START~~
-varchar
+nvarchar
 
 
 
@@ -689,7 +689,7 @@ varchar
 SELECT STRING_SPLIT(NULL, ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 ~~END~~
 
 
@@ -697,7 +697,7 @@ varchar
 SELECT STRING_SPLIT('asdf', '')
 GO
 ~~START~~
-varchar
+nvarchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Invalid separator: )~~
@@ -706,21 +706,21 @@ varchar
 SELECT STRING_SPLIT('asdf', NULL)
 GO
 ~~START~~
-varchar
+nvarchar
 ~~END~~
 
 
 SELECT STRING_SPLIT(NULL, NULL)
 GO
 ~~START~~
-varchar
+nvarchar
 ~~END~~
 
 
 SELECT STRING_SPLIT(CAST('nvarchar nvarchar nvarchar' as nvarchar), CAST(' ' as nvarchar))
 GO
 ~~START~~
-varchar
+nvarchar
 nvarchar
 nvarchar
 nvarchar
@@ -730,7 +730,7 @@ nvarchar
 SELECT STRING_SPLIT(CAST('varchar varchar varchar' as varchar), CAST(' ' as varchar))
 GO
 ~~START~~
-varchar
+nvarchar
 varchar
 varchar
 varchar
@@ -740,7 +740,7 @@ varchar
 SELECT STRING_SPLIT('char char char', ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 char
 char
 char
@@ -750,7 +750,7 @@ char
 SELECT STRING_SPLIT('a,b,c,d', ',')
 GO
 ~~START~~
-varchar
+nvarchar
 a
 b
 c
@@ -761,7 +761,7 @@ d
 SELECT STRING_SPLIT('mississippi island lives in igloo', 'i')
 GO
 ~~START~~
-varchar
+nvarchar
 m
 ss
 ss
@@ -777,7 +777,7 @@ gloo
 SELECT STRING_SPLIT(CAST('asdf' as nchar(4)), ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 asdf
 ~~END~~
 
@@ -785,7 +785,7 @@ asdf
 SELECT STRING_SPLIT(CAST('asdf' as char(4)), ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 asdf
 ~~END~~
 
@@ -794,7 +794,7 @@ asdf
 SELECT STRING_SPLIT('Lorem ipsum', 'too many chars')
 GO
 ~~START~~
-varchar
+nvarchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Invalid separator: too many chars)~~
@@ -803,7 +803,7 @@ varchar
 SELECT value FROM STRING_SPLIT('Lorem ipsum dolor sit amet.', ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 Lorem
 ipsum
 dolor

--- a/test/JDBC/expected/babel_function_string.out
+++ b/test/JDBC/expected/babel_function_string.out
@@ -488,7 +488,7 @@ int
 SELECT STRING_SPLIT('Lorem ipsum dolor sit amet.', ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 Lorem
 ipsum
 dolor
@@ -500,7 +500,7 @@ amet.
 SELECT STRING_SPLIT('clothing,road,,touring,bike', ',')
 GO
 ~~START~~
-varchar
+nvarchar
 clothing
 road
 
@@ -512,7 +512,7 @@ bike
 SELECT STRING_SPLIT('||||||||', '|')
 GO
 ~~START~~
-varchar
+nvarchar
 
 
 
@@ -528,7 +528,7 @@ varchar
 SELECT STRING_SPLIT(NULL, ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 ~~END~~
 
 
@@ -536,7 +536,7 @@ varchar
 SELECT STRING_SPLIT('asdf', '')
 GO
 ~~START~~
-varchar
+nvarchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Invalid separator: )~~
@@ -545,21 +545,21 @@ varchar
 SELECT STRING_SPLIT('asdf', NULL)
 GO
 ~~START~~
-varchar
+nvarchar
 ~~END~~
 
 
 SELECT STRING_SPLIT(NULL, NULL)
 GO
 ~~START~~
-varchar
+nvarchar
 ~~END~~
 
 
 SELECT STRING_SPLIT(CAST('nvarchar nvarchar nvarchar' as nvarchar), CAST(' ' as nvarchar))
 GO
 ~~START~~
-varchar
+nvarchar
 nvarchar
 nvarchar
 nvarchar
@@ -569,7 +569,7 @@ nvarchar
 SELECT STRING_SPLIT(CAST('varchar varchar varchar' as varchar), CAST(' ' as varchar))
 GO
 ~~START~~
-varchar
+nvarchar
 varchar
 varchar
 varchar
@@ -579,7 +579,7 @@ varchar
 SELECT STRING_SPLIT('char char char', ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 char
 char
 char
@@ -589,7 +589,7 @@ char
 SELECT STRING_SPLIT('a,b,c,d', ',')
 GO
 ~~START~~
-varchar
+nvarchar
 a
 b
 c
@@ -600,7 +600,7 @@ d
 SELECT STRING_SPLIT('mississippi island lives in igloo', 'i')
 GO
 ~~START~~
-varchar
+nvarchar
 m
 ss
 ss
@@ -616,7 +616,7 @@ gloo
 SELECT STRING_SPLIT(CAST('asdf' as nchar(4)), ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 asdf
 ~~END~~
 
@@ -624,7 +624,7 @@ asdf
 SELECT STRING_SPLIT(CAST('asdf' as char(4)), ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 asdf
 ~~END~~
 
@@ -633,7 +633,7 @@ asdf
 SELECT STRING_SPLIT('Lorem ipsum', 'too many chars')
 GO
 ~~START~~
-varchar
+nvarchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Invalid separator: too many chars)~~
@@ -642,7 +642,7 @@ varchar
 SELECT value FROM STRING_SPLIT('Lorem ipsum dolor sit amet.', ' ')
 GO
 ~~START~~
-varchar
+nvarchar
 Lorem
 ipsum
 dolor

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collation.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collation.out
@@ -343,7 +343,7 @@ int
 SELECT value FROM STRING_SPLIT('Lorem ipsum dolor sit amet.', ' ');
 go
 ~~START~~
-varchar
+nvarchar
 Lorem
 ipsum
 dolor
@@ -355,7 +355,7 @@ amet.
 SELECT value FROM STRING_SPLIT('a,b,c,d', ' ');
 go
 ~~START~~
-varchar
+nvarchar
 a,b,c,d
 ~~END~~
 
@@ -363,7 +363,7 @@ a,b,c,d
 SELECT value FROM STRING_SPLIT('123abc456', 'abc'); -- expect 'invalid separator'
 go
 ~~START~~
-varchar
+nvarchar
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: Invalid separator: abc)~~
@@ -387,7 +387,7 @@ SELECT REPLACE('nothing to do', 'none', 'should not see this');
 drop table testing_collation;
 go
 ~~START~~
-varchar
+nvarchar
 clothing
 road
 touring


### PR DESCRIPTION
### Description

Add nvarchar overload to string_split procedure.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).