### PR TITLE
Removing test from 16_11 schedule file since the sys.time_zone_info already exists in 4_X 

### DIFF
--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -633,6 +633,5 @@ alter-function-with-weak-view
 view_sec_setting_before_17_6-or-16_10
 alter-table-null-notnull
 ascii_function
-babel_timezoneinfo_before_17_7
 test_convert_to_binary
 cast_datetime_to_binary


### PR DESCRIPTION
### Description

Removed my test file from 16_11 schedule file, as the feature already exist in 4_X relates to https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4164

### Issues Resolved

BABEL 6157, which relates to BABEL-5370

### Test Scenarios Covered ###
* **Use case based -**

* **Boundary conditions -**

* **Arbitrary inputs -**

* **Negative test cases -**

* **Minor version upgrade tests -**

* **Major version upgrade tests -**

* **Performance tests -**

* **Tooling impact -**

* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).