### PR TITLE
[OSS-ONLY] Installing gcc-9

### DIFF
--- a/.github/composite-actions/build-modified-postgres/action.yml
+++ b/.github/composite-actions/build-modified-postgres/action.yml
@@ -95,6 +95,11 @@ runs:
           ( version_le "$engine_version" "14.17" || 
             ( [[ "${engine_version%%.*}" == "15" ]] && version_le "$engine_version" "15.12" ) || 
             ( [[ "${engine_version%%.*}" == "16" ]] && version_le "$engine_version" "16.8" ) ); then
+
+          # Install gcc-9 as it is removed from ubuntu22.04
+          sudo apt-get update
+          sudo apt-get install g++-9 -y
+
           export CC='ccache gcc-9'
         else
           export CC='ccache gcc'


### PR DESCRIPTION
### Description

This commit installs GCC 9 for postgres versions prior to 14.18, 15.13 and 16.9 in GitHub Actions. GCC 9 is removed from ubuntu22.04 as mentioned in this [issue](https://github.com/actions/runner-images/issues/12898).

cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4257

Authored-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)
Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).