### PR TITLE
INSERT INTO table DEFAULT VALUES does not work properly for domain types

### DIFF
--- a/test/JDBC/expected/create_table_with_default_insert.out
+++ b/test/JDBC/expected/create_table_with_default_insert.out
@@ -1,0 +1,110 @@
+IF OBJECT_ID('test_unicode_defaults') IS NOT NULL DROP TABLE test_unicode_defaults;
+GO
+ 
+CREATE TABLE test_unicode_defaults
+(
+    id              INT IDENTITY PRIMARY KEY,
+    col_char        CHAR(10) DEFAULT 'a😄ğğş',
+    col_nchar       NCHAR(10) DEFAULT N'a😄ğğş',
+    col_varchar     VARCHAR(10) DEFAULT 'a😄ğğş',
+    col_nvarchar    NVARCHAR(10) DEFAULT N'a😄ğğş'
+);
+GO
+
+INSERT INTO test_unicode_defaults DEFAULT VALUES;
+GO
+~~ROW COUNT: 1~~
+
+
+
+SELECT * FROM test_unicode_defaults;
+INSERT INTO test_unicode_defaults VALUES ('a😄ğğş',N'a😄ğğş','a😄ğğş',N'a😄ğğş');
+GO
+~~START~~
+int#!#char#!#nchar#!#varchar#!#nvarchar
+1#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+~~END~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM test_unicode_defaults;
+GO
+~~START~~
+int#!#char#!#nchar#!#varchar#!#nvarchar
+1#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+2#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+~~END~~
+
+
+INSERT INTO test_unicode_defaults VALUES ('000',N'000','000',N'000');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM test_unicode_defaults;
+GO
+~~START~~
+int#!#char#!#nchar#!#varchar#!#nvarchar
+1#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+2#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+3#!#000       #!#000       #!#000#!#000
+~~END~~
+
+
+UPDATE test_unicode_defaults
+SET col_nchar = CAST(N'a😄ğğş' AS NVARCHAR(10))
+WHERE id = 3;
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE test_unicode_defaults
+SET col_nvarchar = CAST(N'a😄ğğş' AS NVARCHAR(10))
+WHERE id = 3;
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE test_unicode_defaults
+SET col_char = CAST(N'a😄ğğş' AS VARCHAR(10))
+WHERE id = 3;
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE test_unicode_defaults
+SET col_varchar = CAST(N'a😄ğğş' AS VARCHAR(10))
+WHERE id = 3;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM test_unicode_defaults;
+GO
+~~START~~
+int#!#char#!#nchar#!#varchar#!#nvarchar
+1#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+2#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+3#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+~~END~~
+
+
+INSERT INTO test_unicode_defaults DEFAULT VALUES;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM test_unicode_defaults;
+GO
+~~START~~
+int#!#char#!#nchar#!#varchar#!#nvarchar
+1#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+2#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+3#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+4#!#a????     #!#a😄ğğş    #!#a????#!#a😄ğğş
+~~END~~
+
+
+IF OBJECT_ID('test_unicode_defaults') IS NOT NULL DROP TABLE test_unicode_defaults;
+GO

--- a/test/JDBC/input/create_table_with_default_insert.sql
+++ b/test/JDBC/input/create_table_with_default_insert.sql
@@ -1,0 +1,61 @@
+IF OBJECT_ID('test_unicode_defaults') IS NOT NULL DROP TABLE test_unicode_defaults;
+GO
+ 
+CREATE TABLE test_unicode_defaults
+(
+    id              INT IDENTITY PRIMARY KEY,
+    col_char        CHAR(10) DEFAULT 'a😄ğğş',
+    col_nchar       NCHAR(10) DEFAULT N'a😄ğğş',
+    col_varchar     VARCHAR(10) DEFAULT 'a😄ğğş',
+    col_nvarchar    NVARCHAR(10) DEFAULT N'a😄ğğş'
+);
+GO
+
+INSERT INTO test_unicode_defaults DEFAULT VALUES;
+GO
+
+SELECT * FROM test_unicode_defaults;
+
+INSERT INTO test_unicode_defaults VALUES ('a😄ğğş',N'a😄ğğş','a😄ğğş',N'a😄ğğş');
+GO
+
+SELECT * FROM test_unicode_defaults;
+GO
+
+INSERT INTO test_unicode_defaults VALUES ('000',N'000','000',N'000');
+GO
+
+SELECT * FROM test_unicode_defaults;
+GO
+
+UPDATE test_unicode_defaults
+SET col_nchar = CAST(N'a😄ğğş' AS NVARCHAR(10))
+WHERE id = 3;
+GO
+
+UPDATE test_unicode_defaults
+SET col_nvarchar = CAST(N'a😄ğğş' AS NVARCHAR(10))
+WHERE id = 3;
+GO
+
+UPDATE test_unicode_defaults
+SET col_char = CAST(N'a😄ğğş' AS VARCHAR(10))
+WHERE id = 3;
+GO
+
+UPDATE test_unicode_defaults
+SET col_varchar = CAST(N'a😄ğğş' AS VARCHAR(10))
+WHERE id = 3;
+GO
+
+SELECT * FROM test_unicode_defaults;
+GO
+
+INSERT INTO test_unicode_defaults DEFAULT VALUES;
+GO
+
+SELECT * FROM test_unicode_defaults;
+GO
+
+IF OBJECT_ID('test_unicode_defaults') IS NOT NULL DROP TABLE test_unicode_defaults;
+GO


### PR DESCRIPTION
### Description
Test is created for https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/625
Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/648

Cherry-pick from PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4130

### Issues Resolved
https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/4069, BABEL-6085


### Test Scenarios Covered
Create table with default values and insert the default values

### Check List
Commits are signed per the DCO using --signoff
By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).