### PR TITLE
Fix: deadlock during temp oid initialization in pltsql_GetNewTempObjectId()

### DIFF
--- a/contrib/babelfishpg_tsql/sql/ownership.sql
+++ b/contrib/babelfishpg_tsql/sql/ownership.sql
@@ -180,6 +180,11 @@ BEGIN
 
   -- let sysadmin only to update babelfish_domain_mapping
   GRANT ALL ON TABLE sys.babelfish_domain_mapping TO sysadmin;
+
+  -- initialize the temp_oid_buffer_start during bbf initialization
+  -- this is idempotent; if there's already a persisted value
+  -- for temp_oid_buffer_start, it will not do anything
+  CALL sys.persist_temp_oid_buffer_start();
 END
 $$;
 

--- a/contrib/babelfishpg_tsql/sql/sys_procedures.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_procedures.sql
@@ -351,3 +351,6 @@ AS 'babelfishpg_tsql', 'sp_xml_removedocument'
 LANGUAGE C;
 
 GRANT EXECUTE ON PROCEDURE sys.sp_xml_removedocument( IN INTEGER ) TO PUBLIC;
+
+CREATE OR REPLACE PROCEDURE sys.persist_temp_oid_buffer_start()
+AS 'babelfishpg_tsql', 'persist_temp_oid_buffer_start_internal' LANGUAGE C;

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--5.3.0--5.4.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--5.3.0--5.4.0.sql
@@ -633,3 +633,79 @@ FROM pg_catalog.pg_timezone_names
 WHERE sys.pltsql_timezone_mapping_pg_to_windows(name) IS NOT NULL
 ORDER BY name;
 GRANT SELECT ON sys.time_zone_info TO PUBLIC;
+
+
+CREATE OR REPLACE PROCEDURE sys.persist_temp_oid_buffer_start()
+AS 'babelfishpg_tsql', 'persist_temp_oid_buffer_start_internal' LANGUAGE C;
+
+-- initialize the temp_oid_buffer_start during upgrade
+-- this is idempotent; if there's already a persisted value
+-- for temp_oid_buffer_start, it will not do anything
+CALL sys.persist_temp_oid_buffer_start();
+
+-- The items in initialize_babel_extras procedure need to be initialized or created 
+-- during babelfish initialization. They depend on the core babelfish to be initialized first.
+CREATE OR REPLACE PROCEDURE initialize_babel_extras()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  CREATE OR REPLACE PROCEDURE sys.create_xp_qv_in_master_dbo()
+  LANGUAGE C
+  AS 'babelfishpg_tsql', 'create_xp_qv_in_master_dbo_internal';
+
+  CREATE OR REPLACE PROCEDURE sys.create_xp_instance_regread_in_master_dbo()
+  LANGUAGE C
+  AS 'babelfishpg_tsql', 'create_xp_instance_regread_in_master_dbo_internal';
+
+  CALL sys.create_xp_qv_in_master_dbo();
+  ALTER PROCEDURE master_dbo.xp_qv OWNER TO sysadmin;
+  DROP PROCEDURE sys.create_xp_qv_in_master_dbo;
+
+  CALL sys.create_xp_instance_regread_in_master_dbo();
+  ALTER PROCEDURE master_dbo.xp_instance_regread(sys.nvarchar(512), sys.sysname, sys.nvarchar(512), int) OWNER TO sysadmin;
+  ALTER PROCEDURE master_dbo.xp_instance_regread(sys.nvarchar(512), sys.sysname, sys.nvarchar(512), sys.nvarchar(512)) OWNER TO sysadmin;
+  DROP PROCEDURE sys.create_xp_instance_regread_in_master_dbo;
+
+  CREATE OR REPLACE VIEW msdb_dbo.syspolicy_system_health_state
+  AS
+    SELECT 
+      CAST(0 as BIGINT) AS health_state_id,
+      CAST(0 as INT) AS policy_id,
+      CAST(NULL AS sys.DATETIME) AS last_run_date,
+      CAST('' AS sys.NVARCHAR(400)) AS target_query_expression_with_id,
+      CAST('' AS sys.NVARCHAR) AS target_query_expression,
+      CAST(1 as sys.BIT) AS result
+    WHERE FALSE;
+  GRANT SELECT ON msdb_dbo.syspolicy_system_health_state TO PUBLIC;
+  ALTER VIEW msdb_dbo.syspolicy_system_health_state OWNER TO sysadmin;
+
+  CREATE OR REPLACE FUNCTION msdb_dbo.fn_syspolicy_is_automation_enabled()
+  RETURNS INTEGER
+  AS 
+  $fn_body$    
+    SELECT 0;
+  $fn_body$
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  ALTER FUNCTION msdb_dbo.fn_syspolicy_is_automation_enabled() OWNER TO sysadmin;
+
+  CREATE OR REPLACE VIEW msdb_dbo.syspolicy_configuration
+  AS
+    SELECT CAST(t.name AS sys.sysname), CAST(t.current_value AS sys.sql_variant) FROM
+    (
+      VALUES
+      ('Enabled', CAST(0 AS int)),
+      ('HistoryRetentionInDays', CAST(0 AS int)),
+      ('LogOnSuccess', CAST(0 AS int))
+    )t (name, current_value);
+  GRANT SELECT ON msdb_dbo.syspolicy_configuration TO PUBLIC;
+  ALTER VIEW msdb_dbo.syspolicy_configuration OWNER TO sysadmin;
+
+  -- let sysadmin only to update babelfish_domain_mapping
+  GRANT ALL ON TABLE sys.babelfish_domain_mapping TO sysadmin;
+
+  -- initialize the temp_oid_buffer_start during bbf initialization
+  -- this is idempotent; if there's already a persisted value
+  -- for temp_oid_buffer_start, it will not do anything
+  CALL sys.persist_temp_oid_buffer_start();
+END
+$$;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -290,6 +290,8 @@ static Oid 	pltsql_GetNewTempOidWithIndex(Relation relation, Oid indexId, AttrNu
 static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
 static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
 static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
+static bool verify_stmt_alterdatabaseset(Node* n, const char* dbname, const char* config);
+PG_FUNCTION_INFO_V1(persist_temp_oid_buffer_start_internal);
 
 /*********************************************************
  * 			Weak Binding Views Related Declarations
@@ -971,6 +973,65 @@ pltsql_GetNewTempObjectId()
 	nextTempOid++;
 
 	return result;
+}
+
+Datum
+persist_temp_oid_buffer_start_internal(PG_FUNCTION_ARGS)
+{
+	/*
+	 * If we are not rdsadmin, we will not proceed.
+	 * persistence of temp_oid_buffer_start now happens during bbf 
+	 * initialization and upgrades by rdsadmin
+	 */
+	if (!superuser())
+		ereport(ERROR,
+                (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+                 (errmsg("must be superuser to use this function"))));
+
+	/* safety check, we should never get here during persisting in a Hot standby */
+	if (RecoveryInProgress())
+		elog(ERROR, "temp oid initialization cannot happen during recovery");	
+
+	/*
+	 * temp_oid_buffer_size = 0 would indicate that the feature is 
+	 * disabled, so persisting oid start is triggered from an upgrade.
+	 * 
+	 * This is unlikely because if temp_oid_buffer_size = 0, this should
+	 * mean that the operator did this for the cluster in case of temp table
+	 * related issue, which should also mean that the oid_start is persisted
+	 * in that cluster.
+	 */
+	if (temp_oid_buffer_size <= 0)
+		ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 (errmsg("temp oid initialization cannot be triggered when buffer size is 0."))));
+
+	/*
+	 * This means tempOidStart was changed but the GUC temp_oid_buffer_start was not
+	 * changed/persisted. We should avoid moving forward and error out to avoid persisting 
+	 * incorrect start.
+	 */
+	if (OidIsValid(TransamVariables->tempOidStart) && !OidIsValid(BUFFER_START_TO_OID))
+		ereport(ERROR,
+                (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+                 (errmsg("tempOidStart is already set in shmem. temp oid initialization cannot be done."))));
+
+	/*
+	 * In order to persist the setting, we can simply call pltsql_GetNewTempObjectId.
+	 * If during upgrade, we find that the temp_oid_buffer_start is already persisted,
+	 * then pltsql_GetNewTempObjectId will not try to persist it again.
+	 *
+	 * If the persistence fails, then temp_oid_buffer_start is initialized to INT_MIN
+	 */
+	pltsql_GetNewTempObjectId();
+
+	/*
+	 * This means that the persistence of temp_oid_buffer_start failed
+	 */
+	if (!OidIsValid(BUFFER_START_TO_OID))
+		elog(ERROR, "unable to persist temp_oid_buffer_start in pg_db_role_setting");
+
+	PG_RETURN_BOOL(true);
 }
 
 Oid
@@ -5165,81 +5226,74 @@ pltsql_validate_var_datatype_scale(const TypeName *typeName, Type typ)
  * To properly persist a new value of temp_oid_buffer_start, we must set it
  * in pg_settings, as it would in an ALTER DATABASE ... SET ... command.
  *
+ * This persistence can only be done as rdsadmin, because temp_oid_buffer_start is SUSET GUC.
+ * And any error in this function means failure during babelfish initialization or upgrade.
+ *
  * Returns true on success.
  */
-static bool set_and_persist_temp_oid_buffer_start(Oid new_oid)
+static bool
+set_and_persist_temp_oid_buffer_start(Oid new_oid)
 {
-	HeapTuple	tuple, newtuple;
-	Relation	rel;
-	ScanKeyData scankey[2];
-	SysScanDesc scan;
-	const char *babelfish_db_name = NULL;
-	char 	   *new_oid_str = NULL;
-	Oid			babelfish_db_id = InvalidOid;
-	int 		translated_oid = OID_TO_BUFFER_START(new_oid);
-	Datum		repl_val[Natts_pg_db_role_setting];
-	bool		repl_null[Natts_pg_db_role_setting];
-	bool		repl_repl[Natts_pg_db_role_setting];
-	Datum		datum;
-	ArrayType  *a;
+	const char  *babelfish_db_name = NULL;
+	char        *config_name = "babelfishpg_tsql.temp_oid_buffer_start";
+	char        *altdbstmt;
+	int         translated_oid = OID_TO_BUFFER_START(new_oid);
+	List        *parsetree_list;
+	Node        *stmt;
+	PlannedStmt *wrapper;
 
 	babelfish_db_name = GetConfigOption("babelfishpg_tsql.database_name", true, false);
 	if (!babelfish_db_name)
 		return false;
 
-	babelfish_db_id = get_database_oid(babelfish_db_name, true);
-
-	if (!OidIsValid(babelfish_db_id))
+	altdbstmt = psprintf("ALTER DATABASE %s SET %s = %d", babelfish_db_name, config_name, translated_oid);
+	parsetree_list = raw_parser(altdbstmt, RAW_PARSE_DEFAULT);
+	if (list_length(parsetree_list) != 1)
+	{
+		elog(WARNING, "Implicit VariableSet stmt during temp OID buffer initialization is incorrect or corrupt");
 		return false;
-
-	new_oid_str = psprintf("%d", translated_oid);
-
-	rel = table_open(DbRoleSettingRelationId, RowExclusiveLock);
-	ScanKeyInit(&scankey[0],
-				Anum_pg_db_role_setting_setdatabase,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(babelfish_db_id));
-	ScanKeyInit(&scankey[1],
-				Anum_pg_db_role_setting_setrole,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(InvalidOid));
-	scan = systable_beginscan(rel, DbRoleSettingDatidRolidIndexId, true,
-							  NULL, 2, scankey);
-	tuple = systable_getnext(scan);
-
-	/* temp_oid_buffer_start has a default setting, so it should be there already. */
-	if (!HeapTupleIsValid(tuple))
+	}
+	stmt = parsetree_nth_stmt(parsetree_list, 0);
+	if (!verify_stmt_alterdatabaseset(stmt,babelfish_db_name,config_name))
+	{
+		elog(WARNING, "Implicit VariableSet stmt during temp OID buffer initialization is incorrect or corrupt");
 		return false;
+	}
 
-	memset(repl_repl, false, sizeof(repl_repl));
-	repl_repl[Anum_pg_db_role_setting_setconfig - 1] = true;
-	repl_null[Anum_pg_db_role_setting_setconfig - 1] = false;
+	/* Run the built query */
+	/* need to make a wrapper PlannedStmt */
+	wrapper = makeNode(PlannedStmt);
+	wrapper->commandType = CMD_UTILITY;
+	wrapper->canSetTag = false;
+	wrapper->utilityStmt = stmt;
+	wrapper->stmt_location = 0;
+	wrapper->stmt_len = strlen(altdbstmt);
 
-	Assert(strlen(new_oid_str) > 0);
-	datum = CStringGetTextDatum(psprintf("%s=%s", "babelfishpg_tsql.temp_oid_buffer_start", new_oid_str));
-	a = construct_array(&datum, 1,
-							TEXTOID,
-							-1, false, TYPALIGN_INT);
-
-	repl_val[Anum_pg_db_role_setting_setconfig - 1] =
-		PointerGetDatum(a);
-
-	newtuple = heap_modify_tuple(tuple, RelationGetDescr(rel),
-									repl_val, repl_null, repl_repl);
-	
-	/*
-	 * During unit tests, this will crash if it's executed multiple times in the same transaction since
-	 * concurrent tuple updates are not allowed.
-	 */
-	if (!TEST_persist_temp_oid_buffer_start_disable_catalog_update)
-		CatalogTupleUpdate(rel, &tuple->t_self, newtuple);
-
-	systable_endscan(scan);
-
-	table_close(rel, RowExclusiveLock);
+	ProcessUtility(wrapper,
+				altdbstmt,
+				false,
+				PROCESS_UTILITY_SUBCOMMAND,
+				NULL,
+				NULL,
+				None_Receiver,
+				NULL);
+	CommandCounterIncrement();
 
 	temp_oid_buffer_start = translated_oid;
 
+	return true;
+}
+
+static bool
+verify_stmt_alterdatabaseset(Node* n, const char* dbname, const char* config)
+{
+	AlterDatabaseSetStmt*	stmt = (AlterDatabaseSetStmt*) n;
+	VariableSetStmt* 		vsstmt = stmt->setstmt;
+	if (!stmt->dbname || strcmp(stmt->dbname, dbname) != 0)
+		return false;
+	if (!vsstmt || vsstmt->kind != VAR_SET_VALUE 
+		|| !vsstmt->name || strcmp(vsstmt->name, config) != 0)
+		return false;
 	return true;
 }
 

--- a/test/JDBC/expected/0_temp_oid_buffer_start-vu-cleanup.out
+++ b/test/JDBC/expected/0_temp_oid_buffer_start-vu-cleanup.out
@@ -1,0 +1,3 @@
+-- tsql
+DROP VIEW db_role_settings_view 
+GO

--- a/test/JDBC/expected/0_temp_oid_buffer_start-vu-prepare.out
+++ b/test/JDBC/expected/0_temp_oid_buffer_start-vu-prepare.out
@@ -1,0 +1,6 @@
+-- tsql
+CREATE VIEW db_role_settings_view 
+AS
+SELECT unnest(setconfig) AS setting
+FROM pg_db_role_setting;
+GO

--- a/test/JDBC/expected/0_temp_oid_buffer_start-vu-verify.out
+++ b/test/JDBC/expected/0_temp_oid_buffer_start-vu-verify.out
@@ -1,0 +1,15 @@
+-- tsql
+SELECT
+substring(setting, 1, charindex('=',setting)-1) as setting, 
+CASE
+	WHEN substring(setting, charindex('=',setting)+1) <> '-2147483648' THEN 'ok'
+	ELSE 'not ok'
+END as isOK
+FROM db_role_settings_view
+WHERE setting like '%babelfishpg_tsql.temp_oid_buffer_start%'
+GO
+~~START~~
+varchar#!#varchar
+babelfishpg_tsql.temp_oid_buffer_start#!#ok
+~~END~~
+

--- a/test/JDBC/input/temp_tables/0_temp_oid_buffer_start-vu-cleanup.mix
+++ b/test/JDBC/input/temp_tables/0_temp_oid_buffer_start-vu-cleanup.mix
@@ -1,0 +1,3 @@
+-- tsql
+DROP VIEW db_role_settings_view 
+GO

--- a/test/JDBC/input/temp_tables/0_temp_oid_buffer_start-vu-prepare.mix
+++ b/test/JDBC/input/temp_tables/0_temp_oid_buffer_start-vu-prepare.mix
@@ -1,0 +1,6 @@
+-- tsql
+CREATE VIEW db_role_settings_view 
+AS
+SELECT unnest(setconfig) AS setting
+FROM pg_db_role_setting;
+GO

--- a/test/JDBC/input/temp_tables/0_temp_oid_buffer_start-vu-verify.mix
+++ b/test/JDBC/input/temp_tables/0_temp_oid_buffer_start-vu-verify.mix
@@ -1,0 +1,10 @@
+-- tsql
+SELECT
+substring(setting, 1, charindex('=',setting)-1) as setting, 
+CASE
+	WHEN substring(setting, charindex('=',setting)+1) <> '-2147483648' THEN 'ok'
+	ELSE 'not ok'
+END as isOK
+FROM db_role_settings_view
+WHERE setting like '%babelfishpg_tsql.temp_oid_buffer_start%'
+GO

--- a/test/JDBC/upgrade/17_7/schedule
+++ b/test/JDBC/upgrade/17_7/schedule
@@ -657,3 +657,4 @@ Select_top_N_percent
 ascii_function
 test_convert_to_binary
 cast_datetime_to_binary
+0_temp_oid_buffer_start


### PR DESCRIPTION
The deadlock is because two transactions race to set the temp_oid_buffer_start in pg_db_role_setting and one of them waits on the other to complete while still holding a LW lock which in turn is needed by the other transaction to even proceed.
The solution is to make the persistence of temp_oid_buffer_start independent of user transactions. For this, we are now persisting this at babelfish initialization for new clusters and also during upgrades

Task: BABEL-6183

Signed-off-by: Ayush Shah <ayushdsh@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).