### PR TITLE
Fixing flaky test in sys-columns-dep-vu-verify and babel_numeric

### DIFF
--- a/test/JDBC/expected/babel_numeric.out
+++ b/test/JDBC/expected/babel_numeric.out
@@ -1346,13 +1346,13 @@ select
 into avg_t from BABEL_6081_t1 group by id
 go
 
-select COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE from information_schema.columns where table_name = 'avg_t';
+select COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE from information_schema.columns where table_name = 'avg_t' ORDER BY COLUMN_NAME;
 go
 ~~START~~
 nvarchar#!#tinyint#!#smallint#!#int
 avgvalue#!#38#!#10#!#6
-avgvaluemul#!#38#!#10#!#6
 avgvaluediv#!#38#!#10#!#6
+avgvaluemul#!#38#!#10#!#6
 ~~END~~
 
 

--- a/test/JDBC/input/babel_numeric.sql
+++ b/test/JDBC/input/babel_numeric.sql
@@ -702,7 +702,7 @@ select
 into avg_t from BABEL_6081_t1 group by id
 go
 
-select COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE from information_schema.columns where table_name = 'avg_t';
+select COLUMN_NAME, NUMERIC_PRECISION, NUMERIC_PRECISION_RADIX, NUMERIC_SCALE from information_schema.columns where table_name = 'avg_t' ORDER BY COLUMN_NAME;
 go
 
 drop table BABEL_6081_t1

--- a/test/JDBC/upgrade/latest/verification_cleanup/13_9/sys-columns-dep-vu-verify.sql
+++ b/test/JDBC/upgrade/latest/verification_cleanup/13_9/sys-columns-dep-vu-verify.sql
@@ -1,4 +1,4 @@
--- sla 20000
+-- sla 40000
 exec sys_columns_dep_vu_prepare_p1
 go
 


### PR DESCRIPTION
### Description

This commit fixes flaky test failures in sys-columns-dep-vu-verify and babel_numeric files. 

This flaky test in sys-columns-dep-vu-verify is caused by the large number of objects created while preparing all test files. In the 13_9-14_6-target_latest test suite, we first run only a limited number of verify-cleanup files before executing the entire test set. By the time a query is called that internally invokes sys.columns, there are many objects in the system, resulting in increased execution time.
Additionally, added a group by clause in babel_numeric, for consistent results.

Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)

### Issues Resolved

BABEL-6169


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).