### PR TITLE
Handling empty string casting in binary

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -2687,7 +2687,41 @@ tsql_coerce_string_literal_hook(Oid targetTypeId,
 				break;
 		}
 
-		if (i == -1)
+		if ((*common_utility_plugin_ptr->is_tsql_binary_datatype) (baseTypeId) ||
+			(*common_utility_plugin_ptr->is_tsql_varbinary_datatype) (baseTypeId) ||
+			(*common_utility_plugin_ptr->is_tsql_rowversion_or_timestamp_datatype) (baseTypeId))
+		{
+			/*
+			 * binary datatype should be passed in client encoding
+			 * when explicit cast is called
+			 */
+
+			TypeName 	*varcharTypeName = makeTypeNameFromNameList(list_make2(makeString("sys"),
+																	makeString("varchar")));
+			Node 		*result;
+			Const 		*tempcon;
+
+			typenameTypeIdAndMod(NULL, (const TypeName *)varcharTypeName, &baseTypeId, &baseTypeMod);
+
+			tempcon = makeConst(baseTypeId, -1,
+								tsql_get_database_or_server_collation_oid_internal(false),
+								-1, PointerGetDatum(cstring_to_text(value)),
+								false, false);
+
+			result = coerce_to_target_type(NULL, (Node *) tempcon, baseTypeId,
+										   targetTypeId, targetTypeMod,
+										   COERCION_EXPLICIT,
+										   COERCE_EXPLICIT_CAST,
+										   location);
+			
+			if (varcharTypeName)
+				pfree(varcharTypeName);
+
+			ReleaseSysCache(baseType);
+			
+			return result;
+		}
+		else if (i == -1)
 		{
 			/*
 			 * i == 1 means the value does not contain any characters but
@@ -2803,38 +2837,6 @@ tsql_coerce_string_literal_hook(Oid targetTypeId,
 				default:
 					newcon->constvalue = stringTypeDatum(baseType, value, inputTypeMod);
 			}
-		}
-		else if ((*common_utility_plugin_ptr->is_tsql_binary_datatype) (baseTypeId) ||
-				 (*common_utility_plugin_ptr->is_tsql_varbinary_datatype) (baseTypeId) ||
-				 (*common_utility_plugin_ptr->is_tsql_rowversion_or_timestamp_datatype) (baseTypeId))
-		{
-			/*
-			 * binary datatype should be passed in client encoding
-			 * when explicit cast is called
-			 */
-
-			TypeName 	*varcharTypeName = makeTypeNameFromNameList(list_make2(makeString("sys"),
-																	makeString("varchar")));
-			Node 		*result;
-			Const 		*tempcon;
-
-			typenameTypeIdAndMod(NULL, (const TypeName *)varcharTypeName, &baseTypeId, &baseTypeMod);
-
-			tempcon = makeConst(baseTypeId, -1,
-								tsql_get_database_or_server_collation_oid_internal(false),
-								-1, PointerGetDatum(cstring_to_text(value)),
-								false, false);
-
-			result = coerce_to_target_type(NULL, (Node *) tempcon, baseTypeId,
-										   targetTypeId, targetTypeMod,
-										   COERCION_EXPLICIT,
-										   COERCE_EXPLICIT_CAST,
-										   location);
-			
-			pfree(varcharTypeName);
-			ReleaseSysCache(baseType);
-			
-			return result;
 		}
 		else
 		{

--- a/test/JDBC/expected/TestBinary.out
+++ b/test/JDBC/expected/TestBinary.out
@@ -1075,7 +1075,7 @@ FROM BinaryCastingDemo;
 GO
 ~~START~~
 int#!#varchar#!#varchar#!#varbinary#!#binary#!#varbinary#!#int#!#int#!#int
-1#!#Empty string#!#VARCHAR#!##!#00000000000000000000#!##!#0#!#0#!#0
+1#!#Empty string#!#VARCHAR#!##!#00000000000000000000#!##!#0#!#10#!#0
 2#!#NULL value#!#VARCHAR#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 3#!#Simple text#!#VARCHAR#!#48656C6C6F#!#48656C6C6F0000000000#!#48656C6C6F#!#5#!#10#!#5
 4#!#Long text#!#VARCHAR#!#546869734973414C6F6E6754657874#!#546869734973414C6F6E#!#546869734973414C6F6E#!#15#!#10#!#10
@@ -4313,5 +4313,55 @@ varchar#!#varbinary
 Leading Zeros Sort#!#0001
 Leading Zeros Sort#!#0100
 Leading Zeros Sort#!#1000
+~~END~~
+
+
+
+-- Empty string casting to binary/varbinary
+select cast(CAST('0x00' AS BINARY) as varbinary)
+GO
+~~START~~
+varbinary
+307830300000000000000000000000000000000000000000000000000000
+~~END~~
+
+
+select cast(CAST(0x00 AS BINARY) as varbinary)
+GO
+~~START~~
+varbinary
+000000000000000000000000000000000000000000000000000000000000
+~~END~~
+
+
+select CAST('' AS BINARY(10))
+go
+~~START~~
+binary
+00000000000000000000
+~~END~~
+
+
+select cast(CAST('' AS BINARY(10)) as varbinary(10))
+go
+~~START~~
+varbinary
+00000000000000000000
+~~END~~
+
+
+select cast(CAST('' AS BINARY) as varbinary)
+go
+~~START~~
+varbinary
+000000000000000000000000000000000000000000000000000000000000
+~~END~~
+
+
+select cast(CAST('' AS varbinary) as BINARY)
+go
+~~START~~
+binary
+000000000000000000000000000000000000000000000000000000000000
 ~~END~~
 

--- a/test/JDBC/expected/babel_isnumeric-vu-verify.out
+++ b/test/JDBC/expected/babel_isnumeric-vu-verify.out
@@ -815,11 +815,12 @@ int
 
 
 -- binary/varbinary
+-- Fix with BABEL-6101
 select isnumeric(cast('' as binary))
 go
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -830,12 +831,13 @@ int
 0
 ~~END~~
 
- 
+
+-- Fix with BABEL-6101 
 select isnumeric(cast('' as binary(1)))
 go
 ~~START~~
 int
-0
+1
 ~~END~~
 
 
@@ -994,6 +996,7 @@ int
 
 
 -- misc tests
+-- Fix with BABEL-6101
 select isnumeric(cast(24 as varbinary))
 Go
 ~~START~~

--- a/test/JDBC/expected/datalength.out
+++ b/test/JDBC/expected/datalength.out
@@ -377,6 +377,68 @@ int#!#int#!#int#!#int
 ~~END~~
 
 
+-- empty string 
+SELECT  
+    DATALENGTH(CAST('' AS BINARY(10))) as binary_10,  
+    DATALENGTH(CAST('' AS BINARY)) as binary_default, 
+    DATALENGTH(CAST(0x00 AS BINARY)) as binary_0_default, 
+    DATALENGTH(CAST('0x00' AS BINARY)) as binary_str0_default, 
+    DATALENGTH(CAST('  ' AS BINARY(10))) as binary_space_10,  
+    DATALENGTH(CAST('  ' AS BINARY)) as binary__space_default, 
+    DATALENGTH(CAST('' AS VARBINARY(10))) as varbinary_10,  
+    DATALENGTH(CAST('' AS VARBINARY)) as varbinary_default  
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+10#!#30#!#30#!#30#!#10#!#30#!#0#!#0
+~~END~~
+
+
+-- NULL testing
+SELECT  
+    DATALENGTH(CAST(NULL AS BINARY(10))) as binary_10,  
+    DATALENGTH(CAST(NULL AS BINARY)) as binary_default, 
+    DATALENGTH(CAST('NULL' AS BINARY)) as binary_str0_default,  
+    DATALENGTH(CAST(' NULL  ' AS BINARY)) as binary_space_default,
+    DATALENGTH(CAST(NULL AS VARBINARY(10))) as varbinary_10,  
+    DATALENGTH(CAST(NULL AS VARBINARY)) as varbinary_default,
+    DATALENGTH(CAST('NULL' AS VARBINARY)) as varbinary_str_default,
+    DATALENGTH(CAST(' NULL ' AS VARBINARY)) as varbinary_space_default   
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+<NULL>#!#<NULL>#!#30#!#30#!#<NULL>#!#<NULL>#!#4#!#6
+~~END~~
+
+
+-- binary to varbinary, empty string
+select 
+    DATALENGTH(CAST(CAST(0x00 AS BINARY) as varbinary)),
+    DATALENGTH(cast(CAST('0x00' AS BINARY) as varbinary)),
+    DATALENGTH(cast(CAST('' AS BINARY(10)) as varbinary(10))),
+    DATALENGTH(cast(CAST('' AS BINARY(10)) as varbinary(max))),
+    DATALENGTH(cast(CAST('' AS BINARY) as varbinary))
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int
+30#!#30#!#10#!#10#!#30
+~~END~~
+
+
+-- varbinary to binary, empty string
+select 
+    DATALENGTH(CAST(CAST(0x00 AS varbinary) as BINARY)),
+    DATALENGTH(cast(CAST('0x00' AS varbinary) as BINARY)),
+    DATALENGTH(cast(CAST('' AS varbinary(10)) as BINARY(10))),
+    DATALENGTH(cast(CAST('' AS varbinary(max)) as BINARY(10))),
+    DATALENGTH(cast(CAST('' AS varbinary) as BINARY))
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int
+30#!#30#!#10#!#10#!#30
+~~END~~
+
+
 -- 7. Other Data Types
 SELECT 
     DATALENGTH(CAST(1 AS BIT)) AS Bit_Length,
@@ -389,6 +451,65 @@ int#!#int#!#int#!#int
 1#!#16#!#4#!#17
 ~~END~~
 
+
+-- rowversion, no regression
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'ignore';
+GO
+
+select datalength(cast(cast('a' as rowversion) as varchar))
+GO
+~~START~~
+int
+1
+~~END~~
+
+select datalength(cast('' as rowversion))
+GO
+~~START~~
+int
+12
+~~END~~
+
+select datalength(cast(cast('' as rowversion) as varchar))
+GO
+~~START~~
+int
+0
+~~END~~
+
+select datalength(cast(NULL as rowversion))
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+select datalength(cast(cast('NULL' as rowversion) as varchar))
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- timestamp, no regression
+select 
+    datalength(cast('' as TIMESTAMP)),
+    datalength(cast(' ' as TIMESTAMP)),
+    datalength(cast(cast('' as TIMESTAMP) as varbinary)),
+    datalength(cast(NULL as TIMESTAMP)),
+    datalength(cast('NULL' as TIMESTAMP)),
+    datalength(cast('NULL ' as TIMESTAMP)),
+    datalength(cast(cast('NULL' as TIMESTAMP) as varbinary))
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int#!#int#!#int
+12#!#12#!#8#!#<NULL>#!#12#!#12#!#8
+~~END~~
+
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'strict';
+GO
 
 -- 8. NULL Values
 SELECT 
@@ -2474,12 +2595,11 @@ int
 ~~END~~
 
 
--- FIX with BABEL-5610
 select datalength(CAST('' AS BINARY(10)))
 go
 ~~START~~
 int
-0
+10
 ~~END~~
 
 
@@ -2487,7 +2607,7 @@ select datalength(CAST('' AS BINARY))
 GO
 ~~START~~
 int
-0
+30
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestBinary.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/TestBinary.out
@@ -1075,7 +1075,7 @@ FROM BinaryCastingDemo;
 GO
 ~~START~~
 int#!#varchar#!#varchar#!#varbinary#!#binary#!#varbinary#!#int#!#int#!#int
-1#!#Empty string#!#VARCHAR#!##!#00000000000000000000#!##!#0#!#0#!#0
+1#!#Empty string#!#VARCHAR#!##!#00000000000000000000#!##!#0#!#10#!#0
 2#!#NULL value#!#VARCHAR#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
 3#!#Simple text#!#VARCHAR#!#48656C6C6F#!#48656C6C6F0000000000#!#48656C6C6F#!#5#!#10#!#5
 4#!#Long text#!#VARCHAR#!#546869734973414C6F6E6754657874#!#546869734973414C6F6E#!#546869734973414C6F6E#!#15#!#10#!#10
@@ -4313,5 +4313,55 @@ varchar#!#varbinary
 Leading Zeros Sort#!#0001
 Leading Zeros Sort#!#0100
 Leading Zeros Sort#!#1000
+~~END~~
+
+
+
+-- Empty string casting to binary/varbinary
+select cast(CAST('0x00' AS BINARY) as varbinary)
+GO
+~~START~~
+varbinary
+307830300000000000000000000000000000000000000000000000000000
+~~END~~
+
+
+select cast(CAST(0x00 AS BINARY) as varbinary)
+GO
+~~START~~
+varbinary
+000000000000000000000000000000000000000000000000000000000000
+~~END~~
+
+
+select CAST('' AS BINARY(10))
+go
+~~START~~
+binary
+00000000000000000000
+~~END~~
+
+
+select cast(CAST('' AS BINARY(10)) as varbinary(10))
+go
+~~START~~
+varbinary
+00000000000000000000
+~~END~~
+
+
+select cast(CAST('' AS BINARY) as varbinary)
+go
+~~START~~
+varbinary
+000000000000000000000000000000000000000000000000000000000000
+~~END~~
+
+
+select cast(CAST('' AS varbinary) as BINARY)
+go
+~~START~~
+binary
+000000000000000000000000000000000000000000000000000000000000
 ~~END~~
 

--- a/test/JDBC/input/babel_isnumeric-vu-verify.sql
+++ b/test/JDBC/input/babel_isnumeric-vu-verify.sql
@@ -325,12 +325,14 @@ select isnumeric(N'123')
 go
 
 -- binary/varbinary
+-- Fix with BABEL-6101
 select isnumeric(cast('' as binary))
 go
 
 select isnumeric(cast('' as varbinary))
 go
- 
+
+-- Fix with BABEL-6101 
 select isnumeric(cast('' as binary(1)))
 go
 
@@ -397,6 +399,7 @@ select isnumeric(cast(1234567812345678123456781234567812345678 as text))
 go
 
 -- misc tests
+-- Fix with BABEL-6101
 select isnumeric(cast(24 as varbinary))
 Go
 

--- a/test/JDBC/input/datatypes/TestBinary.sql
+++ b/test/JDBC/input/datatypes/TestBinary.sql
@@ -3047,3 +3047,23 @@ SELECT 'Leading Zeros Sort',
     CAST(0x1000 AS VARBINARY(4))
 ORDER BY BinaryValue;
 GO
+
+
+-- Empty string casting to binary/varbinary
+select cast(CAST('0x00' AS BINARY) as varbinary)
+GO
+
+select cast(CAST(0x00 AS BINARY) as varbinary)
+GO
+
+select CAST('' AS BINARY(10))
+go
+
+select cast(CAST('' AS BINARY(10)) as varbinary(10))
+go
+
+select cast(CAST('' AS BINARY) as varbinary)
+go
+
+select cast(CAST('' AS varbinary) as BINARY)
+go

--- a/test/JDBC/input/functions/string_functions/datalength.sql
+++ b/test/JDBC/input/functions/string_functions/datalength.sql
@@ -328,12 +328,83 @@ SELECT
     DATALENGTH(CAST('Hello' AS IMAGE)) AS Image_Length;
 GO
 
+-- empty string 
+SELECT  
+    DATALENGTH(CAST('' AS BINARY(10))) as binary_10,  
+    DATALENGTH(CAST('' AS BINARY)) as binary_default, 
+    DATALENGTH(CAST(0x00 AS BINARY)) as binary_0_default, 
+    DATALENGTH(CAST('0x00' AS BINARY)) as binary_str0_default, 
+    DATALENGTH(CAST('  ' AS BINARY(10))) as binary_space_10,  
+    DATALENGTH(CAST('  ' AS BINARY)) as binary__space_default, 
+    DATALENGTH(CAST('' AS VARBINARY(10))) as varbinary_10,  
+    DATALENGTH(CAST('' AS VARBINARY)) as varbinary_default  
+GO
+
+-- NULL testing
+SELECT  
+    DATALENGTH(CAST(NULL AS BINARY(10))) as binary_10,  
+    DATALENGTH(CAST(NULL AS BINARY)) as binary_default, 
+    DATALENGTH(CAST('NULL' AS BINARY)) as binary_str0_default,  
+    DATALENGTH(CAST(' NULL  ' AS BINARY)) as binary_space_default,
+    DATALENGTH(CAST(NULL AS VARBINARY(10))) as varbinary_10,  
+    DATALENGTH(CAST(NULL AS VARBINARY)) as varbinary_default,
+    DATALENGTH(CAST('NULL' AS VARBINARY)) as varbinary_str_default,
+    DATALENGTH(CAST(' NULL ' AS VARBINARY)) as varbinary_space_default   
+GO
+
+-- binary to varbinary, empty string
+select 
+    DATALENGTH(CAST(CAST(0x00 AS BINARY) as varbinary)),
+    DATALENGTH(cast(CAST('0x00' AS BINARY) as varbinary)),
+    DATALENGTH(cast(CAST('' AS BINARY(10)) as varbinary(10))),
+    DATALENGTH(cast(CAST('' AS BINARY(10)) as varbinary(max))),
+    DATALENGTH(cast(CAST('' AS BINARY) as varbinary))
+GO
+
+-- varbinary to binary, empty string
+select 
+    DATALENGTH(CAST(CAST(0x00 AS varbinary) as BINARY)),
+    DATALENGTH(cast(CAST('0x00' AS varbinary) as BINARY)),
+    DATALENGTH(cast(CAST('' AS varbinary(10)) as BINARY(10))),
+    DATALENGTH(cast(CAST('' AS varbinary(max)) as BINARY(10))),
+    DATALENGTH(cast(CAST('' AS varbinary) as BINARY))
+GO
+
 -- 7. Other Data Types
 SELECT 
     DATALENGTH(CAST(1 AS BIT)) AS Bit_Length,
     DATALENGTH(NEWID()) AS UniqueIdentifier_Length,
     DATALENGTH(CAST('true' AS SQL_VARIANT)) AS SqlVariant_Length,
     DATALENGTH(CAST('<root>test</root>' AS XML)) AS XML_Length;
+GO
+
+-- rowversion, no regression
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'ignore';
+GO
+
+select datalength(cast(cast('a' as rowversion) as varchar))
+GO
+select datalength(cast('' as rowversion))
+GO
+select datalength(cast(cast('' as rowversion) as varchar))
+GO
+select datalength(cast(NULL as rowversion))
+GO
+select datalength(cast(cast('NULL' as rowversion) as varchar))
+GO
+
+-- timestamp, no regression
+select 
+    datalength(cast('' as TIMESTAMP)),
+    datalength(cast(' ' as TIMESTAMP)),
+    datalength(cast(cast('' as TIMESTAMP) as varbinary)),
+    datalength(cast(NULL as TIMESTAMP)),
+    datalength(cast('NULL' as TIMESTAMP)),
+    datalength(cast('NULL ' as TIMESTAMP)),
+    datalength(cast(cast('NULL' as TIMESTAMP) as varbinary))
+GO
+
+EXEC sp_babelfish_configure 'babelfishpg_tsql.escape_hatch_rowversion', 'strict';
 GO
 
 -- 8. NULL Values
@@ -1302,7 +1373,6 @@ go
 select datalength(CAST(0x65 AS BINARY))
 go
 
--- FIX with BABEL-5610
 select datalength(CAST('' AS BINARY(10)))
 go
 


### PR DESCRIPTION
### Description

Previously in Babelfish, when empty string inputs were cast as binary, we internally handled them using varbinaryin since binaryin doesn't exist. This caused the input to be treated as varbinary first and later cast to binary, resulting in the loss of binary typmod information. With this commit, we will properly handle empty string casting as binary.

Cherry-pick from PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4125
Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)

### Issues Resolved

BABEL-5610

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).