### PR TITLE
fix to ownership chaining permission check during planner phase (#4193)

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -5012,7 +5012,11 @@ update_rte_perms_info_walker(Node *node, void *context)
 
 					if (physical_schemaname && !is_shared_schema(physical_schemaname))
 					{
-						if (OidIsValid(perminfo->checkAsUser))
+ 						Oid relOwner = get_rel_owner(rte->relid);
+  		  
+  		 				if (pltsql_enable_ownership_chaining && is_valid_func_ownership_chain(perminfo, relOwner))
+  		 					perminfo->checkAsUser = relOwner;
+  		 				else if (OidIsValid(perminfo->checkAsUser))
 						{
 							Oid loginId = get_login_for_user(perminfo->checkAsUser, physical_schemaname);
 							if (OidIsValid(loginId))


### PR DESCRIPTION
cherry-picked from 3b1782f34118630fb9ecba532c9ade16bc2d970a
Due to the community change commit: e2d4ef8de86, we are checking the views permission before planner(much before executor stage where existing ownership chaining validation hook is implemented). To handle this added check for is_valid_func_ownership_chaining in an already implemented a walker : update_rte_perms_info_walker, if valid ownership chaining scenario then we will update the checkAsUser field accordingly.

Issues Resolved
[BABEL-6156]
Signed-off-by: Pranav Jain pranavjc@amazon.com

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).