### PR TITLE
Obtain correct first character in pattern for ESCAPE in LIKE

### DIFF
--- a/test/JDBC/expected/BABEL-4271-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-4271-vu-cleanup.out
@@ -1,3 +1,10 @@
 -- Test to check like escape null and like escape ''
 drop table babel_4271_vu_prepare_t1;
 go
+
+-- BABEL-6180
+DROP TABLE like_escape_test;
+GO
+
+DROP TABLE like_escape_test_2;
+GO

--- a/test/JDBC/expected/BABEL-4271-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-4271-vu-prepare.out
@@ -24,3 +24,69 @@ go
 
 ~~ROW COUNT: 1~~
 
+
+-- BABEL-6180
+-- Create test table with diverse data
+CREATE TABLE like_escape_test (
+    id INT,
+    test_data VARCHAR(200),
+    description VARCHAR(100)
+);
+GO
+
+
+
+
+
+
+
+-- Insert comprehensive test data
+INSERT INTO like_escape_test VALUES 
+-- Bracket test data
+(1, '[300]', 'literal brackets'),
+(2, '[200]', 'literal brackets'),
+(3, 'prefix[300]suffix', 'brackets in middle'),
+(4, '[abc]def', 'brackets with letters'),
+(5, '[100-200]', 'brackets with dash'),
+-- Underscore test data
+(10, '_test_', 'literal underscores'),
+(11, 'prefix_test_suffix', 'underscores in middle'),
+(12, '__double__', 'double underscores'),
+-- Percent test data
+(20, '100%', 'literal percent'),
+(21, 'prefix%suffix', 'percent in middle'),
+(22, '%%double%%', 'double percents'),
+-- Mixed wildcard test data
+(30, '[test_%]', 'mixed brackets and wildcards'),
+(31, '_[abc]_', 'mixed underscores and brackets'),
+(32, '%[100]%', 'mixed percents and brackets'),
+-- Special characters
+(40, 'test!data', 'exclamation mark'),
+(41, 'test#data', 'hash mark'),
+(42, 'test@data', 'at symbol'),
+(43, 'test\\data', 'backslash'),
+-- Edge cases
+(50, '', 'empty string'),
+(51, '[', 'single bracket'),
+(52, ']', 'single bracket'),
+(53, '_', 'single underscore'),
+(54, '%', 'single percent'),
+(55, '!', 'single exclamation'),
+-- Complex patterns
+(60, '[a-z]test[0-9]', 'complex bracket pattern'),
+(61, 'multi_level_test', 'multiple underscores'),
+(62, 'percent%in%middle', 'multiple percents');
+GO
+~~ROW COUNT: 27~~
+
+
+CREATE TABLE like_escape_test_2 (
+Id INT,
+BranchNumber INT
+);
+GO
+
+INSERT INTO like_escape_test_2 (Id, BranchNumber) VALUES (1, 100), (2, 200), (3, 300);
+GO
+~~ROW COUNT: 3~~
+

--- a/test/JDBC/expected/BABEL-4271-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4271-vu-verify.out
@@ -181,3 +181,460 @@ abc#!#def
 #!#
 ~~END~~
 
+
+
+
+-- BABEL-6180
+-- =============================================================================
+-- TEST SECTION 1: Escaped Brackets with Different Escape Characters
+-- =============================================================================
+--- '=== TEST 1: Escaped Brackets with Backslash ==='
+-- Test 1.1: Exact bracket patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\[300\]' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+~~END~~
+
+
+-- Test 1.2: Infix bracket patterns (the main fix)
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[300\]%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+3#!#prefix[300]suffix
+~~END~~
+
+
+-- Test 1.3: Prefix bracket patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\[300\]%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+~~END~~
+
+
+-- Test 1.4: Suffix bracket patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[300\]' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+~~END~~
+
+
+
+--- '=== TEST 2: Escaped Brackets with Exclamation Mark ===' as test_section;
+-- Test 2.1: Exact bracket patterns with !
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '![300!]' ESCAPE '!' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+~~END~~
+
+
+-- Test 2.2: Infix bracket patterns with !
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%![300!]%' ESCAPE '!' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+3#!#prefix[300]suffix
+~~END~~
+
+
+-- Test 2.3: Mixed bracket patterns with !
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '![abc!]%' ESCAPE '!' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+4#!#[abc]def
+~~END~~
+
+
+
+--- '=== TEST 3: Escaped Brackets with Hash Mark ===' as test_section;
+-- Test 3.1: Various bracket patterns with #
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%#[300#]%' ESCAPE '#' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+3#!#prefix[300]suffix
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 2: Escaped Underscores with Different Escape Characters
+-- =============================================================================
+---  '=== TEST 4: Escaped Underscores ==='
+-- Test 4.1: Exact underscore patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\_test\_' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+10#!#_test_
+~~END~~
+
+
+-- Test 4.2: Infix underscore patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\_test\_%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+10#!#_test_
+11#!#prefix_test_suffix
+~~END~~
+
+
+-- Test 4.3: Mixed underscore and wildcard patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE 'prefix\_test\_%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+11#!#prefix_test_suffix
+~~END~~
+
+
+-- Test 4.4: Underscore with different escape character
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%!_test!_%' ESCAPE '!' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+10#!#_test_
+11#!#prefix_test_suffix
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 3: Escaped Percent Signs
+-- =============================================================================
+--- '=== TEST 5: Escaped Percent Signs ==='
+-- Test 5.1: Exact percent patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '100\%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+20#!#100%
+~~END~~
+
+
+-- Test 5.2: Infix percent patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\%%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+20#!#100%
+21#!#prefix%suffix
+22#!#%%double%%
+30#!#[test_%]
+32#!#%[100]%
+54#!#%
+62#!#percent%in%middle
+~~END~~
+
+
+-- Test 5.3: Percent with different escape character
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%!%%' ESCAPE '!' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+20#!#100%
+21#!#prefix%suffix
+22#!#%%double%%
+30#!#[test_%]
+32#!#%[100]%
+54#!#%
+62#!#percent%in%middle
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 4: Mixed Escaped and Unescaped Wildcards
+-- =============================================================================
+--- '=== TEST 6: Mixed Escaped and Unescaped Wildcards ==='
+-- Test 6.1: Escaped brackets with unescaped wildcards
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[%\]%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+2#!#[200]
+3#!#prefix[300]suffix
+4#!#[abc]def
+5#!#[100-200]
+30#!#[test_%]
+31#!#_[abc]_
+32#!#%[100]%
+60#!#[a-z]test[0-9]
+~~END~~
+
+
+-- Test 6.2: Escaped underscores with unescaped percent
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\_level\_%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+61#!#multi_level_test
+~~END~~
+
+
+-- Test 6.3: Complex mixed pattern
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '_\[%\]_' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+31#!#_[abc]_
+32#!#%[100]%
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 5: Different Escape Characters
+-- =============================================================================
+--- '=== TEST 7: Various Escape Characters ==='
+-- Test 7.1: At symbol as escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%@[300@]%' ESCAPE '@' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+3#!#prefix[300]suffix
+~~END~~
+
+
+-- Test 7.2: Hash as escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%#[300#]%' ESCAPE '#' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+3#!#prefix[300]suffix
+~~END~~
+
+
+-- Test 7.3: Pipe as escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%|[300|]%' ESCAPE '|' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+3#!#prefix[300]suffix
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 6: Edge Cases and Error Conditions
+-- =============================================================================
+--- '=== TEST 8: Edge Cases ==='
+-- Test 8.1: Empty pattern
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+50#!#
+~~END~~
+
+
+-- Test 8.2: Single character patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\[' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+51#!#[
+~~END~~
+
+
+-- Test 8.3: Multiple consecutive escapes
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[\]%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 7: Bracket Wildcard Behavior (Unescaped)
+-- =============================================================================
+--- '=== TEST 9: Bracket Wildcards (Unescaped) ==='
+-- Test 9.1: Character class matching
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[0-9]%' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+2#!#[200]
+3#!#prefix[300]suffix
+5#!#[100-200]
+20#!#100%
+32#!#%[100]%
+60#!#[a-z]test[0-9]
+~~END~~
+
+
+-- Test 9.2: Character class matching [a-z]
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[a-z]%' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+3#!#prefix[300]suffix
+4#!#[abc]def
+10#!#_test_
+11#!#prefix_test_suffix
+12#!#__double__
+21#!#prefix%suffix
+22#!#%%double%%
+30#!#[test_%]
+31#!#_[abc]_
+40#!#test!data
+41#!#test#data
+42#!#test@data
+43#!#test\\data
+60#!#[a-z]test[0-9]
+61#!#multi_level_test
+62#!#percent%in%middle
+~~END~~
+
+
+-- Test 9.3: Specific character set
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[abc]%' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+4#!#[abc]def
+12#!#__double__
+22#!#%%double%%
+31#!#_[abc]_
+40#!#test!data
+41#!#test#data
+42#!#test@data
+43#!#test\\data
+60#!#[a-z]test[0-9]
+62#!#percent%in%middle
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 8: Performance and Regression Tests
+-- =============================================================================
+--- '=== TEST 10: Regression Tests ===' as test_section;
+-- Test 10.1: Ensure normal wildcards still work
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%test%' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+10#!#_test_
+11#!#prefix_test_suffix
+30#!#[test_%]
+40#!#test!data
+41#!#test#data
+42#!#test@data
+43#!#test\\data
+60#!#[a-z]test[0-9]
+61#!#multi_level_test
+~~END~~
+
+
+-- Test 10.2: Ensure normal underscore wildcard still works
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '_test_' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+10#!#_test_
+~~END~~
+
+
+-- Test 10.3: Complex pattern without escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[0-9]%' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+2#!#[200]
+3#!#prefix[300]suffix
+5#!#[100-200]
+20#!#100%
+32#!#%[100]%
+60#!#[a-z]test[0-9]
+~~END~~
+
+
+
+
+-- =============================================================================
+-- TEST SECTION 9: TSQL Compatibility Tests
+-- =============================================================================
+--- '=== TEST 11: TSQL Compatibility ===' as test_section;
+-- Test 11.1: Typical TSQL escape patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[%\]%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#[300]
+2#!#[200]
+3#!#prefix[300]suffix
+4#!#[abc]def
+5#!#[100-200]
+30#!#[test_%]
+31#!#_[abc]_
+32#!#%[100]%
+60#!#[a-z]test[0-9]
+~~END~~
+
+
+-- Test 11.2: TSQL underscore escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\_test\_%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+10#!#_test_
+11#!#prefix_test_suffix
+~~END~~
+
+
+-- Test 11.3: TSQL percent escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\%%' ESCAPE '\' ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+20#!#100%
+21#!#prefix%suffix
+22#!#%%double%%
+30#!#[test_%]
+32#!#%[100]%
+54#!#%
+62#!#percent%in%middle
+~~END~~
+
+
+SELECT * FROM
+(
+SELECT string_agg('[' + CAST(BranchNumber as varchar(50)) + ']', ',') as BranchesOfAccounts
+FROM like_escape_test_2
+GROUP BY Id
+) a
+WHERE BranchesOfAccounts LIKE '%\[300\]%' ESCAPE '\';
+GO
+~~START~~
+varchar
+[300]
+~~END~~
+

--- a/test/JDBC/input/BABEL-4271-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-4271-vu-cleanup.sql
@@ -1,3 +1,10 @@
 -- Test to check like escape null and like escape ''
 drop table babel_4271_vu_prepare_t1;
 go
+
+-- BABEL-6180
+DROP TABLE like_escape_test;
+GO
+
+DROP TABLE like_escape_test_2;
+GO

--- a/test/JDBC/input/BABEL-4271-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-4271-vu-prepare.sql
@@ -10,3 +10,65 @@ insert into babel_4271_vu_prepare_t1 values (' abc','abc')
 insert into babel_4271_vu_prepare_t1 values ('abc','def')
 insert into babel_4271_vu_prepare_t1 values ('','')
 go
+
+-- BABEL-6180
+-- Create test table with diverse data
+CREATE TABLE like_escape_test (
+    id INT,
+    test_data VARCHAR(200),
+    description VARCHAR(100)
+);
+GO
+
+-- Insert comprehensive test data
+INSERT INTO like_escape_test VALUES 
+-- Bracket test data
+(1, '[300]', 'literal brackets'),
+(2, '[200]', 'literal brackets'),
+(3, 'prefix[300]suffix', 'brackets in middle'),
+(4, '[abc]def', 'brackets with letters'),
+(5, '[100-200]', 'brackets with dash'),
+
+-- Underscore test data
+(10, '_test_', 'literal underscores'),
+(11, 'prefix_test_suffix', 'underscores in middle'),
+(12, '__double__', 'double underscores'),
+
+-- Percent test data
+(20, '100%', 'literal percent'),
+(21, 'prefix%suffix', 'percent in middle'),
+(22, '%%double%%', 'double percents'),
+
+-- Mixed wildcard test data
+(30, '[test_%]', 'mixed brackets and wildcards'),
+(31, '_[abc]_', 'mixed underscores and brackets'),
+(32, '%[100]%', 'mixed percents and brackets'),
+
+-- Special characters
+(40, 'test!data', 'exclamation mark'),
+(41, 'test#data', 'hash mark'),
+(42, 'test@data', 'at symbol'),
+(43, 'test\\data', 'backslash'),
+
+-- Edge cases
+(50, '', 'empty string'),
+(51, '[', 'single bracket'),
+(52, ']', 'single bracket'),
+(53, '_', 'single underscore'),
+(54, '%', 'single percent'),
+(55, '!', 'single exclamation'),
+
+-- Complex patterns
+(60, '[a-z]test[0-9]', 'complex bracket pattern'),
+(61, 'multi_level_test', 'multiple underscores'),
+(62, 'percent%in%middle', 'multiple percents');
+GO
+
+CREATE TABLE like_escape_test_2 (
+Id INT,
+BranchNumber INT
+);
+GO
+
+INSERT INTO like_escape_test_2 (Id, BranchNumber) VALUES (1, 100), (2, 200), (3, 300);
+GO

--- a/test/JDBC/input/BABEL-4271-vu-verify.sql
+++ b/test/JDBC/input/BABEL-4271-vu-verify.sql
@@ -50,3 +50,203 @@ SELECT '', '' from babel_4271_vu_prepare_t1 where '' LIKE babel_4271_vu_prepare_
 go
 SELECT a, b from babel_4271_vu_prepare_t1 where '' LIKE '' ESCAPE null;
 go
+
+-- BABEL-6180
+-- =============================================================================
+-- TEST SECTION 1: Escaped Brackets with Different Escape Characters
+-- =============================================================================
+
+--- '=== TEST 1: Escaped Brackets with Backslash ==='
+
+-- Test 1.1: Exact bracket patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\[300\]' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 1.2: Infix bracket patterns (the main fix)
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[300\]%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 1.3: Prefix bracket patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\[300\]%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 1.4: Suffix bracket patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[300\]' ESCAPE '\' ORDER BY id;
+GO
+
+--- '=== TEST 2: Escaped Brackets with Exclamation Mark ===' as test_section;
+
+-- Test 2.1: Exact bracket patterns with !
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '![300!]' ESCAPE '!' ORDER BY id;
+GO
+
+-- Test 2.2: Infix bracket patterns with !
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%![300!]%' ESCAPE '!' ORDER BY id;
+GO
+
+-- Test 2.3: Mixed bracket patterns with !
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '![abc!]%' ESCAPE '!' ORDER BY id;
+GO
+
+--- '=== TEST 3: Escaped Brackets with Hash Mark ===' as test_section;
+
+-- Test 3.1: Various bracket patterns with #
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%#[300#]%' ESCAPE '#' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 2: Escaped Underscores with Different Escape Characters
+-- =============================================================================
+
+---  '=== TEST 4: Escaped Underscores ==='
+
+-- Test 4.1: Exact underscore patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\_test\_' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 4.2: Infix underscore patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\_test\_%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 4.3: Mixed underscore and wildcard patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE 'prefix\_test\_%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 4.4: Underscore with different escape character
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%!_test!_%' ESCAPE '!' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 3: Escaped Percent Signs
+-- =============================================================================
+
+--- '=== TEST 5: Escaped Percent Signs ==='
+
+-- Test 5.1: Exact percent patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '100\%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 5.2: Infix percent patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\%%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 5.3: Percent with different escape character
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%!%%' ESCAPE '!' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 4: Mixed Escaped and Unescaped Wildcards
+-- =============================================================================
+
+--- '=== TEST 6: Mixed Escaped and Unescaped Wildcards ==='
+
+-- Test 6.1: Escaped brackets with unescaped wildcards
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[%\]%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 6.2: Escaped underscores with unescaped percent
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\_level\_%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 6.3: Complex mixed pattern
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '_\[%\]_' ESCAPE '\' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 5: Different Escape Characters
+-- =============================================================================
+
+--- '=== TEST 7: Various Escape Characters ==='
+
+-- Test 7.1: At symbol as escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%@[300@]%' ESCAPE '@' ORDER BY id;
+GO
+
+-- Test 7.2: Hash as escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%#[300#]%' ESCAPE '#' ORDER BY id;
+GO
+
+-- Test 7.3: Pipe as escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%|[300|]%' ESCAPE '|' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 6: Edge Cases and Error Conditions
+-- =============================================================================
+
+--- '=== TEST 8: Edge Cases ==='
+
+-- Test 8.1: Empty pattern
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '' ORDER BY id;
+GO
+
+-- Test 8.2: Single character patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '\[' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 8.3: Multiple consecutive escapes
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[\]%' ESCAPE '\' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 7: Bracket Wildcard Behavior (Unescaped)
+-- =============================================================================
+
+--- '=== TEST 9: Bracket Wildcards (Unescaped) ==='
+
+-- Test 9.1: Character class matching
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[0-9]%' ORDER BY id;
+GO
+
+-- Test 9.2: Character class matching [a-z]
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[a-z]%' ORDER BY id;
+GO
+
+-- Test 9.3: Specific character set
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[abc]%' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 8: Performance and Regression Tests
+-- =============================================================================
+
+--- '=== TEST 10: Regression Tests ===' as test_section;
+
+-- Test 10.1: Ensure normal wildcards still work
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%test%' ORDER BY id;
+GO
+
+-- Test 10.2: Ensure normal underscore wildcard still works
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '_test_' ORDER BY id;
+GO
+
+-- Test 10.3: Complex pattern without escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%[0-9]%' ORDER BY id;
+GO
+
+-- =============================================================================
+-- TEST SECTION 9: TSQL Compatibility Tests
+-- =============================================================================
+
+--- '=== TEST 11: TSQL Compatibility ===' as test_section;
+
+-- Test 11.1: Typical TSQL escape patterns
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\[%\]%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 11.2: TSQL underscore escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\_test\_%' ESCAPE '\' ORDER BY id;
+GO
+
+-- Test 11.3: TSQL percent escape
+SELECT id, test_data FROM like_escape_test WHERE test_data LIKE '%\%%' ESCAPE '\' ORDER BY id;
+GO
+
+SELECT * FROM
+(
+SELECT string_agg('[' + CAST(BranchNumber as varchar(50)) + ']', ',') as BranchesOfAccounts
+FROM like_escape_test_2
+GROUP BY Id
+) a
+WHERE BranchesOfAccounts LIKE '%\[300\]%' ESCAPE '\';
+GO

--- a/test/JDBC/upgrade/14_19/schedule
+++ b/test/JDBC/upgrade/14_19/schedule
@@ -496,3 +496,4 @@ cast_string_to_binary-before-16_8
 cast_binary_to_string-before-16_8
 test_conv_text_to_binary-before-15_5
 test_conv_text_to_string-before-14_21
+BABEL-4271

--- a/test/JDBC/upgrade/14_20/schedule
+++ b/test/JDBC/upgrade/14_20/schedule
@@ -496,3 +496,4 @@ cast_string_to_binary-before-16_8
 cast_binary_to_string-before-16_8
 test_conv_text_to_binary-before-15_5
 test_conv_text_to_string-before-14_21
+BABEL-4271

--- a/test/JDBC/upgrade/14_21/schedule
+++ b/test/JDBC/upgrade/14_21/schedule
@@ -496,3 +496,4 @@ cast_string_to_binary-before-16_8
 cast_binary_to_string-before-16_8
 test_conv_text_to_binary-before-15_5
 test_conv_text_to_string-before-14_21
+BABEL-4271

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -605,3 +605,4 @@ test_conv_text_to_string
 babel_timezoneinfo_before_17_7
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+BABEL-4271

--- a/test/JDBC/upgrade/15_15/schedule
+++ b/test/JDBC/upgrade/15_15/schedule
@@ -601,3 +601,4 @@ test_conv_text_to_string
 babel_timezoneinfo_before_17_7
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+BABEL-4271

--- a/test/JDBC/upgrade/15_16/schedule
+++ b/test/JDBC/upgrade/15_16/schedule
@@ -600,5 +600,4 @@ test_conv_text_to_binary-before-16_8
 test_conv_text_to_string
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
-#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370
 BABEL-4271

--- a/test/JDBC/upgrade/15_16/schedule
+++ b/test/JDBC/upgrade/15_16/schedule
@@ -600,3 +600,5 @@ test_conv_text_to_binary-before-16_8
 test_conv_text_to_string
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+#babel_timezoneinfo_before_17_7#Commenting the test as a temporary fix to ticket BABEL 5370
+BABEL-4271

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -642,3 +642,4 @@ test_conv_text_to_string
 babel_timezoneinfo_before_17_7
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+BABEL-4271

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -639,3 +639,4 @@ test_conv_text_to_binary-before-17_7
 test_conv_text_to_string
 test_convert_to_binary
 cast_datetime_to_binary
+BABEL-4271

--- a/test/JDBC/upgrade/16_12/schedule
+++ b/test/JDBC/upgrade/16_12/schedule
@@ -639,3 +639,4 @@ test_conv_text_to_binary-before-17_7
 test_conv_text_to_string
 test_convert_to_binary
 cast_datetime_to_binary
+BABEL-4271

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -643,3 +643,4 @@ test_conv_text_to_string
 babel_timezoneinfo_before_17_7
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+BABEL-4271

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -650,3 +650,4 @@ test_conv_text_to_string
 babel_timezoneinfo_before_17_7
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+BABEL-4271

--- a/test/JDBC/upgrade/17_6/schedule
+++ b/test/JDBC/upgrade/17_6/schedule
@@ -658,3 +658,4 @@ test_conv_text_to_string
 babel_timezoneinfo_before_17_7
 test_convert_to_binary-before-17_7-16_11
 cast_datetime_to_binary-before-17_7-16_11
+BABEL-4271

--- a/test/JDBC/upgrade/17_7/schedule
+++ b/test/JDBC/upgrade/17_7/schedule
@@ -661,3 +661,4 @@ test_conv_text_to_binary-before-17_7
 test_conv_text_to_string
 test_convert_to_binary
 cast_datetime_to_binary
+BABEL-4271

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -664,3 +664,4 @@ test_convert_to_binary
 cast_datetime_to_binary
 test_output_clause
 update_with_var
+BABEL-4271


### PR DESCRIPTION
### Description
Whenever there is ESCAPE in LIKE operator and the pattern is either infix or postfix, babelfish is unable to handle the wildcard properly. 

The engine commit fixes that by ignoring the ESCAPE character in the pattern and finding the correct pattern: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/658

This commit adds the test for such scenarios.

 
### Issues Resolved

Task: BABEL-6180
Authored-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)
Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
