### PR TITLE
Update dump restore yml to increase max_locks_per_transaction

### DIFF
--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -325,6 +325,15 @@ runs:
         echo 'Database restore complete.'
         rm -rf ~/upgrade/dump
 
+        # Increase max_locks_per_transaction to 128 (double the default value of 64)
+        echo 'Setting max_locks_per_transaction to 128...'
+        sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "ALTER SYSTEM SET max_locks_per_transaction = 128;"
+        
+        # Restart PostgreSQL server to apply the change (max_locks_per_transaction requires restart)
+        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data stop
+        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile start
+        echo 'max_locks_per_transaction set to 128 and server restarted.'
+
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash
 

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -156,6 +156,15 @@ runs:
         # Create and initialise Babelfish extensions in the new server to perform restore.
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -v tsql_port="1433" -f .github/scripts/create_extension.sql
 
+        # Increase max_locks_per_transaction to 128 BEFORE restore to prevent out of shared memory errors
+        echo 'Setting max_locks_per_transaction to 128 before restore...'
+        sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "ALTER SYSTEM SET max_locks_per_transaction = 128;"
+        
+        # Restart PostgreSQL server to apply the change (max_locks_per_transaction requires restart)
+        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data stop
+        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile start
+        echo 'max_locks_per_transaction set to 128 and server restarted. Ready for restore.'
+
         if [[ ${{ inputs.database_level }} == false ]];then
           echo "Starting to restore whole Babelfish physical database"
           if [[ '${{ inputs.type }}' == 'full' ]];then
@@ -324,15 +333,6 @@ runs:
         fi
         echo 'Database restore complete.'
         rm -rf ~/upgrade/dump
-
-        # Increase max_locks_per_transaction to 128 (double the default value of 64)
-        echo 'Setting max_locks_per_transaction to 128...'
-        sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "ALTER SYSTEM SET max_locks_per_transaction = 128;"
-        
-        # Restart PostgreSQL server to apply the change (max_locks_per_transaction requires restart)
-        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data stop
-        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile start
-        echo 'max_locks_per_transaction set to 128 and server restarted.'
 
         sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       shell: bash

--- a/.github/composite-actions/dump-restore-util/action.yml
+++ b/.github/composite-actions/dump-restore-util/action.yml
@@ -156,14 +156,8 @@ runs:
         # Create and initialise Babelfish extensions in the new server to perform restore.
         sudo ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="jdbc_testdb" -v migration_mode=${{inputs.migration_mode}} -v tsql_port="1433" -f .github/scripts/create_extension.sql
 
-        # Increase max_locks_per_transaction to 128 BEFORE restore to prevent out of shared memory errors
-        echo 'Setting max_locks_per_transaction to 128 before restore...'
-        sudo PGPASSWORD=12345678 ~/${{ inputs.pg_new_dir }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "ALTER SYSTEM SET max_locks_per_transaction = 128;"
-        
-        # Restart PostgreSQL server to apply the change (max_locks_per_transaction requires restart)
-        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data stop
-        ~/${{ inputs.pg_new_dir }}/bin/pg_ctl -c -D ~/${{ inputs.pg_new_dir }}/data -l ~/${{ inputs.pg_new_dir }}/data/logfile start
-        echo 'max_locks_per_transaction set to 128 and server restarted. Ready for restore.'
+        # Update existing max_locks_per_transaction to 128
+        sed -i "s/^#\?max_locks_per_transaction\s*=.*/max_locks_per_transaction = 128/" ~/${{ inputs.pg_new_dir }}/data/postgresql.conf
 
         if [[ ${{ inputs.database_level }} == false ]];then
           echo "Starting to restore whole Babelfish physical database"


### PR DESCRIPTION
increasing the value of max_locks_per_transaction from 64 to 128 before restore.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).