### PR TITLE
[OSS-ONLY]Fix dotnet with pgaudit failure in github actions

### DIFF
--- a/.github/scripts/pgaudit_executor_hook_null_check.patch
+++ b/.github/scripts/pgaudit_executor_hook_null_check.patch
@@ -1,0 +1,11 @@
+--- a/pgaudit.c
++++ b/pgaudit.c
+@@ -1529,7 +1529,7 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls,
+                 auditEventStack->auditEvent.permInfos = permInfos;
+             }
+         }
+-        else
++        else if (auditEventStack != NULL)
+         {
+             STACK_NOT_EMPTY();
+             log_select_dml(auditOid, rangeTabls, permInfos);

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -2,7 +2,6 @@ name: JDBC Tests With PG AUDIT Enable
 # on:
 #   schedule:
 #     - cron: '0 0 * * *'  # runs every midnight
-
 on: [push, pull_request]
 
 jobs:
@@ -88,13 +87,13 @@ jobs:
             git clone --depth 1 --branch REL_17_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # adding the patch to fix BABEL-4600 to test in Github
-            sed -i '1517 s/^        else$/        else if (auditEventStack != NULL)/' pgaudit.c
+            sed -i '1532 s/^        else$/        else if (auditEventStack != NULL)/' pgaudit.c
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           elif [[ "${{ matrix.extension_branch }}" == 'BABEL_4_X_DEV' ]]; then
             git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # adding the patch to fix BABEL-4600 to test in Github
-            sed -i '1452 s/^        else$/        else if (auditEventStack != NULL)/' pgaudit.c
+            sed -i '1467 s/^        else$/        else if (auditEventStack != NULL)/' pgaudit.c
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           else
             echo "Unsupported branch: ${{ matrix.extension_branch }}"

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,14 +1,13 @@
 name: JDBC Tests With PG AUDIT Enable
-# on:
-#   schedule:
-#     - cron: '0 0 * * *'  # runs every midnight
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs every midnight
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
     strategy:
       matrix:
-        extension_branch: [latest]
+        extension_branch: [BABEL_4_X_DEV,BABEL_5_X_DEV]
 
     env:
       INSTALL_DIR: psql
@@ -83,18 +82,16 @@ jobs:
           cd ~
           rm -rf pgaudit
           # Determine PgAudit version based on Babelfish branch
-          if [[ "${{ matrix.extension_branch }}" == 'latest' ]]; then
+          if [[ "${{ matrix.extension_branch }}" == 'BABEL_5_X_DEV' ]]; then
             git clone --depth 1 --branch REL_17_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600
-            ls -la ${{ github.workspace }}/.github/scripts/
             patch -p1 < ${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           elif [[ "${{ matrix.extension_branch }}" == 'BABEL_4_X_DEV' ]]; then
             git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600
-            ls -la ${{ github.workspace }}/.github/scripts/
             patch -p1 < ${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           else

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,7 +1,8 @@
 name: JDBC Tests With PG AUDIT Enable
-on:
-  schedule:
-    - cron: '0 0 * * *'  # runs every midnight
+# on:
+#   schedule:
+#     - cron: '0 0 * * *'  # runs every midnight
+on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
@@ -85,14 +86,14 @@ jobs:
           if [[ "${{ matrix.extension_branch }}" == 'BABEL_5_X_DEV' ]]; then
             git clone --depth 1 --branch REL_17_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
-            # adding the patch to fix BABEL-4600 to test in Github
-            sed -i '1532 s/^        else$/        else if (auditEventStack != NULL)/' pgaudit.c
+            # Apply patch to fix BABEL-4600
+            patch -p1 < ../${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           elif [[ "${{ matrix.extension_branch }}" == 'BABEL_4_X_DEV' ]]; then
             git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
-            # adding the patch to fix BABEL-4600 to test in Github
-            sed -i '1467 s/^        else$/        else if (auditEventStack != NULL)/' pgaudit.c
+            # Apply patch to fix BABEL-4600
+            patch -p1 < ../${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           else
             echo "Unsupported branch: ${{ matrix.extension_branch }}"

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -8,7 +8,7 @@ jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
     strategy:
       matrix:
-        extension_branch: [BABEL_4_X_DEV,BABEL_5_X_DEV]
+        extension_branch: [BABEL_4_X_DEV,${{ github.head_ref }}]
 
     env:
       INSTALL_DIR: psql

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -8,7 +8,7 @@ jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
     strategy:
       matrix:
-        extension_branch: [BABEL_4_X_DEV,${{ github.head_ref }}]
+        extension_branch: [BABEL_4_X_DEV,$GITHUB_HEAD_REF]
 
     env:
       INSTALL_DIR: psql

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -124,11 +124,11 @@ jobs:
           sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-verify' JDBC/jdbc_schedule
           sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-cleanup' JDBC/jdbc_schedule
 
-      # - name: Run JDBC Tests
-      #   id: jdbc
-      #   if: always() && steps.install-extensions.outcome == 'success'
-      #   timeout-minutes: 60
-      #   uses: ./.github/composite-actions/run-jdbc-tests
+      - name: Run JDBC Tests
+        id: jdbc
+        if: always() && steps.install-extensions.outcome == 'success'
+        timeout-minutes: 60
+        uses: ./.github/composite-actions/run-jdbc-tests
 
       - name: Drop and re-create Babelfish database with pgaudit installed
         id: re-install-extensions

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -2,7 +2,6 @@ name: JDBC Tests With PG AUDIT Enable
 on:
   schedule:
     - cron: '0 0 * * *'  # runs every midnight
-on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -8,7 +8,7 @@ jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
     strategy:
       matrix:
-        extension_branch: [BABEL_4_X_DEV,$GITHUB_HEAD_REF]
+        extension_branch: [BABEL_4_X_DEV, "${{ github.head_ref }}"]
 
     env:
       INSTALL_DIR: psql

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -8,7 +8,7 @@ jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
     strategy:
       matrix:
-        extension_branch: [BABEL_4_X_DEV, "${{ github.head_ref }}"]
+        extension_branch: [latest]
 
     env:
       INSTALL_DIR: psql
@@ -83,7 +83,7 @@ jobs:
           cd ~
           rm -rf pgaudit
           # Determine PgAudit version based on Babelfish branch
-          if [[ "${{ matrix.extension_branch }}" == 'BABEL_5_X_DEV' ]]; then
+          if [[ "${{ matrix.extension_branch }}" == 'latest' ]]; then
             git clone --depth 1 --branch REL_17_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -87,13 +87,13 @@ jobs:
             git clone --depth 1 --branch REL_17_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600
-            patch -p1 < ../${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
+            patch -p1 < ${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           elif [[ "${{ matrix.extension_branch }}" == 'BABEL_4_X_DEV' ]]; then
             git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600
-            patch -p1 < ../${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
+            patch -p1 < ${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           else
             echo "Unsupported branch: ${{ matrix.extension_branch }}"

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -87,12 +87,14 @@ jobs:
             git clone --depth 1 --branch REL_17_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600
+            ls -la ${{ github.workspace }}/.github/scripts/
             patch -p1 < ${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           elif [[ "${{ matrix.extension_branch }}" == 'BABEL_4_X_DEV' ]]; then
             git clone --depth 1 --branch REL_16_STABLE https://github.com/pgaudit/pgaudit.git
             cd pgaudit
             # Apply patch to fix BABEL-4600
+            ls -la ${{ github.workspace }}/.github/scripts/
             patch -p1 < ${{ github.workspace }}/.github/scripts/pgaudit_executor_hook_null_check.patch
             make install USE_PGXS=1 PG_CONFIG=~/psql/bin/pg_config 
           else

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,7 +1,9 @@
 name: JDBC Tests With PG AUDIT Enable
-on:
-  schedule:
-    - cron: '0 0 * * *'  # runs every midnight
+# on:
+#   schedule:
+#     - cron: '0 0 * * *'  # runs every midnight
+
+on: [push, pull_request]
 
 jobs:
   run-babelfish-jdbc-tests-with-pg-audit:
@@ -123,11 +125,11 @@ jobs:
           sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-verify' JDBC/jdbc_schedule
           sudo sed -i '$a\ignore#!#babel_datatype_sqlvariant-vu-cleanup' JDBC/jdbc_schedule
 
-      - name: Run JDBC Tests
-        id: jdbc
-        if: always() && steps.install-extensions.outcome == 'success'
-        timeout-minutes: 60
-        uses: ./.github/composite-actions/run-jdbc-tests
+      # - name: Run JDBC Tests
+      #   id: jdbc
+      #   if: always() && steps.install-extensions.outcome == 'success'
+      #   timeout-minutes: 60
+      #   uses: ./.github/composite-actions/run-jdbc-tests
 
       - name: Drop and re-create Babelfish database with pgaudit installed
         id: re-install-extensions

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -1,7 +1,7 @@
 name: JDBC Tests With PG AUDIT Enable
-# on:
-#   schedule:
-#     - cron: '0 0 * * *'  # runs every midnight
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs every midnight
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION

### Description

Due the community changes([commit](https://github.com/pgaudit/pgaudit/pull/277)) in pgaudit.c file, the path to fix BABEL-4600 become out-dated. Updated the patch which fixes the dotnet test failure when pgaudit extension is installed.

### Issues Resolved

[BABEL-6201]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).