### PR TITLE
[OSS-ONLY] Updating vector extension version 

### DIFF
--- a/.github/composite-actions/build-vector-extension/action.yml
+++ b/.github/composite-actions/build-vector-extension/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Build vector Extension
       run: |
         cd ..
-        export VECTOR_VERSION="0.7.2"
+        export VECTOR_VERSION="0.8.1"
         sudo apt-get install wget
         wget https://github.com/pgvector/pgvector/archive/refs/tags/v${VECTOR_VERSION}.tar.gz
         tar -xvzf v${VECTOR_VERSION}.tar.gz

--- a/.github/composite-actions/setup-base-version/action.yml
+++ b/.github/composite-actions/setup-base-version/action.yml
@@ -71,7 +71,7 @@ runs:
     - name: Build vector Extension
       run: |
         cd ..
-        export VECTOR_VERSION="0.7.2"
+        export VECTOR_VERSION="0.8.1"
         sudo apt-get install wget
         wget https://github.com/pgvector/pgvector/archive/refs/tags/v${VECTOR_VERSION}.tar.gz 
         tar -xvzf v${VECTOR_VERSION}.tar.gz

--- a/.github/workflows/minor-version-upgrade.yml
+++ b/.github/workflows/minor-version-upgrade.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build vector Extension
         run: |
           cd ..
-          export VECTOR_VERSION="0.7.2"
+          export VECTOR_VERSION="0.8.1"
           sudo apt-get install wget
           wget https://github.com/pgvector/pgvector/archive/refs/tags/v${VECTOR_VERSION}.tar.gz
           tar -xvzf v${VECTOR_VERSION}.tar.gz


### PR DESCRIPTION
### Description

This commit will be updating vector extension version from `0.7.2` to `0.8.1`.

cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4310

Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)


### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).