### PR TITLE
Alter authorization on database to roles should be blocked (#4304)

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.h
+++ b/contrib/babelfishpg_tsql/src/catalog.h
@@ -325,6 +325,7 @@ typedef FormData_bbf_function_ext *Form_bbf_function_ext;
 #define BABELFISH_SECURITYADMIN "securityadmin"
 #define BABELFISH_SYSADMIN "sysadmin"
 #define BABELFISH_DBCREATOR "dbcreator"
+#define BABELFISH_ROLEADMIN "bbf_role_admin"
 #define PERMISSIONS_FOR_ALL_OBJECTS_IN_SCHEMA "ALL"
 #define ALL_PERMISSIONS_ON_RELATION 47 /* last 6 bits as 101111 represents ALL privileges on a relation. */
 #define ALL_PERMISSIONS_ON_FUNCTION 128 /* last 8 bits as 10000000 represents ALL privileges on a procedure/function. */
@@ -344,6 +345,11 @@ typedef FormData_bbf_function_ext *Form_bbf_function_ext;
 #define IS_ROLENAME_SECURITYADMIN(rolname) \
 	(strlen(rolname) == 13 && \
 	strncmp(rolname, BABELFISH_SECURITYADMIN, 13) == 0)
+
+/* check if rolename is bbf_role_admin */
+#define IS_ROLENAME_BABELFISHROLEADMIN(rolname) \
+	(strlen(rolname) == 14 && \
+	strncmp(rolname, BABELFISH_ROLEADMIN, 14) == 0)
 
 /* check if rolename is dbcreator */
 #define IS_ROLENAME_DBCREATOR(rolname) \

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -4029,8 +4029,15 @@ exec_stmt_change_dbowner(PLtsql_execstate *estate, PLtsql_stmt_change_dbowner *s
 						errmsg("Cannot find the database '%s', because it does not exist or you do not have permission.", stmt->db_name)));
 	}
 
+	/* Throw error if it's a Babelfish fixed server role or "bbf_role_admin". */
+	if (IS_BBF_FIXED_SERVER_ROLE(stmt->new_owner_name) || IS_ROLENAME_BABELFISHROLEADMIN(stmt->new_owner_name))
+	{
+		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+						errmsg("An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.")));
+	}
+
 	/* Verify new owner exists as a login. */
-	if (get_role_oid(stmt->new_owner_name, true) == InvalidOid)
+	if (!is_login_name(stmt->new_owner_name))
 	{
 		ereport(ERROR, (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 						errmsg("Cannot find the principal '%s', because it does not exist or you do not have permission.", stmt->new_owner_name)));

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -150,7 +150,7 @@ create_bbf_authid_login_ext(CreateRoleStmt *stmt)
 
 	if (IS_BBF_FIXED_SERVER_ROLE(stmt->role))
 		new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("R");
-	else if (strcmp(stmt->role, "bbf_role_admin") == 0)
+	else if (IS_ROLENAME_BABELFISHROLEADMIN(stmt->role))
 		new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("Z");
 	else if (from_windows)
 		new_record_login_ext[LOGIN_EXT_TYPE] = CStringGetTextDatum("U");
@@ -711,7 +711,7 @@ Oid
 get_bbf_role_admin_oid(void)
 {
 	if (!OidIsValid(bbf_admin_oid))
-		bbf_admin_oid = get_role_oid("bbf_role_admin", false);
+		bbf_admin_oid = get_role_oid(BABELFISH_ROLEADMIN, false);
 	return bbf_admin_oid;
 }
 
@@ -1113,7 +1113,7 @@ drop_all_logins(PG_FUNCTION_ARGS)
 		 * Remove SA from authid_login_ext now but do not add it to the list
 		 * because we don't want to remove the corresponding PG role.
 		 */
-		if (role_is_sa(get_role_oid(rolname, false)) || (strcmp(rolname, "bbf_role_admin") == 0)
+		if (role_is_sa(get_role_oid(rolname, false)) || IS_ROLENAME_BABELFISHROLEADMIN(rolname)
 									|| IS_BBF_FIXED_SERVER_ROLE(rolname))
 			CatalogTupleDelete(bbf_authid_login_ext_rel, &tuple->t_self);
 		else
@@ -1390,7 +1390,7 @@ create_bbf_authid_user_ext(CreateRoleStmt *stmt, bool has_schema, bool has_login
 			SetUserIdAndSecContext(save_userid, save_sec_context);
 		}
 		PG_END_TRY();
-		grant_revoke_role_to_login(login_name_str, get_guest_role_name(db_name), "bbf_role_admin", false); /* revoke even membership granted by bbf_role_admin */
+		grant_revoke_role_to_login(login_name_str, get_guest_role_name(db_name), BABELFISH_ROLEADMIN, false); /* revoke even membership granted by bbf_role_admin */
 		pfree(db_name);
 	}
 
@@ -1586,7 +1586,7 @@ revoke_guest_from_mapped_logins(PG_FUNCTION_ARGS)
 
 				char *db_name = TextDatumGetCString(name);
 				grant_revoke_role_to_login(login, get_guest_role_name(db_name), NULL, false);
-				grant_revoke_role_to_login(login, get_guest_role_name(db_name), "bbf_role_admin", false); /* revoke even membership granted by bbf_role_admin */
+				grant_revoke_role_to_login(login, get_guest_role_name(db_name), BABELFISH_ROLEADMIN, false); /* revoke even membership granted by bbf_role_admin */
 				pfree(db_name);
 			}
 		}
@@ -1753,7 +1753,7 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 		{
 			/* First revoke this user from old login as the user is being mapped to a new login. */
 			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, NULL, false);
-			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, "bbf_role_admin", false);
+			grant_revoke_role_to_login(old_login_name, stmt->role->rolename, BABELFISH_ROLEADMIN, false);
 			/* Now grant guest user to old login as it's mapped user is being removed. */
 			grant_revoke_role_to_login(old_login_name, get_guest_role_name(get_cur_db_name()), NULL, true);
 		}
@@ -1776,7 +1776,7 @@ alter_bbf_authid_user_ext(AlterRoleStmt *stmt)
 			SetUserIdAndSecContext(save_userid, save_sec_context);
 		}
 		PG_END_TRY();
-		grant_revoke_role_to_login(login_name_str, get_guest_role_name(get_cur_db_name()), "bbf_role_admin", false); /* revoke even membership granted by bbf_role_admin */
+		grant_revoke_role_to_login(login_name_str, get_guest_role_name(get_cur_db_name()), BABELFISH_ROLEADMIN, false); /* revoke even membership granted by bbf_role_admin */
 	}
 
 	if (new_user_name)

--- a/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
+++ b/test/JDBC/expected/alter_authorization_change_db_owner-vu-verify.out
@@ -1181,9 +1181,90 @@ go
 -- go
 -- use master
 -- go
+-- When new owner is an internal role, user-defined role, database principal or server principal - Error out.
 use master
 go
 drop database DB64long_0123456789012345678901234567890123456789012345678901234
+go
+create role alter_auth_r1
+go
+create database alter_auth_db
+go
+alter authorization on database::alter_auth_db TO bbf_role_admin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+alter authorization on database::alter_auth_db TO securityadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+alter authorization on database::alter_auth_db TO sysadmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+alter authorization on database::alter_auth_db TO dbcreator
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+alter authorization on database::alter_auth_db TO db_datareader
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'db_datareader', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO db_datawriter
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'db_datawriter', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO db_ddladmin
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'db_ddladmin', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO dbo
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'dbo', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO db_owner
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'db_owner', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO master_db_datareader
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'master_db_datareader', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO alter_auth_r1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'alter_auth_r1', because it does not exist or you do not have permission.)~~
+
+alter authorization on database::alter_auth_db TO master_alter_auth_r1
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot find the principal 'master_alter_auth_r1', because it does not exist or you do not have permission.)~~
+
+drop role alter_auth_r1
+go
+drop database alter_auth_db
 go
 
 

--- a/test/JDBC/expected/sp_changedbowner-vu-verify.out
+++ b/test/JDBC/expected/sp_changedbowner-vu-verify.out
@@ -726,6 +726,95 @@ drop database DB64long_0123456789012345678901234567890123456789012345678901234
 go
 
 -- tsql
+-- When new owner is an internal role, user-defined role, database principal or server principal - Error out.
+use master
+go
+create database sp_changedbowner_db
+go
+use sp_changedbowner_db
+go
+create role sp_changedbowner_r1
+go
+exec sp_changedbowner 'bbf_role_admin'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+exec sp_changedbowner 'securityadmin'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+exec sp_changedbowner 'sysadmin'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+exec sp_changedbowner 'dbcreator'
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: An entity of type database cannot be owned by a role, a group, an approle, or by principals mapped to certificates or asymmetric keys.)~~
+
+exec sp_changedbowner 'db_datareader'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'db_datareader', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'db_datawriter'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'db_datawriter', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'db_ddladmin'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'db_ddladmin', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'dbo'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'dbo', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'db_owner'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'db_owner', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'master_db_datareader'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'master_db_datareader', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'sp_changedbowner_r1'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'sp_changedbowner_r1', because it does not exist or you do not have permission.)~~
+
+exec sp_changedbowner 'sp_changedbowner_db_sp_changedbowner_r1'
+go
+~~ERROR (Code: 50000)~~
+
+~~ERROR (Message: Cannot find the principal 'sp_changedbowner_db_sp_changedbowner_r1', because it does not exist or you do not have permission.)~~
+
+drop role sp_changedbowner_r1
+go
+use master
+go
+drop database sp_changedbowner_db
+go
+
+-- tsql
 use master
 go
 set nocount on

--- a/test/JDBC/input/alter_authorization_change_db_owner-vu-verify.mix
+++ b/test/JDBC/input/alter_authorization_change_db_owner-vu-verify.mix
@@ -681,9 +681,42 @@ go
 -- go
 
 -- tsql
+-- When new owner is an internal role, user-defined role, database principal or server principal - Error out.
 use master
 go
 drop database DB64long_0123456789012345678901234567890123456789012345678901234
+go
+create role alter_auth_r1
+go
+create database alter_auth_db
+go
+alter authorization on database::alter_auth_db TO bbf_role_admin
+go
+alter authorization on database::alter_auth_db TO securityadmin
+go
+alter authorization on database::alter_auth_db TO sysadmin
+go
+alter authorization on database::alter_auth_db TO dbcreator
+go
+alter authorization on database::alter_auth_db TO db_datareader
+go
+alter authorization on database::alter_auth_db TO db_datawriter
+go
+alter authorization on database::alter_auth_db TO db_ddladmin
+go
+alter authorization on database::alter_auth_db TO dbo
+go
+alter authorization on database::alter_auth_db TO db_owner
+go
+alter authorization on database::alter_auth_db TO master_db_datareader
+go
+alter authorization on database::alter_auth_db TO alter_auth_r1
+go
+alter authorization on database::alter_auth_db TO master_alter_auth_r1
+go
+drop role alter_auth_r1
+go
+drop database alter_auth_db
 go
 
 

--- a/test/JDBC/input/sp_changedbowner-vu-verify.mix
+++ b/test/JDBC/input/sp_changedbowner-vu-verify.mix
@@ -413,6 +413,47 @@ go
 drop database DB64long_0123456789012345678901234567890123456789012345678901234
 go
 
+-- When new owner is an internal role, user-defined role, database principal or server principal - Error out.
+-- tsql
+use master
+go
+create database sp_changedbowner_db
+go
+use sp_changedbowner_db
+go
+create role sp_changedbowner_r1
+go
+exec sp_changedbowner 'bbf_role_admin'
+go
+exec sp_changedbowner 'securityadmin'
+go
+exec sp_changedbowner 'sysadmin'
+go
+exec sp_changedbowner 'dbcreator'
+go
+exec sp_changedbowner 'db_datareader'
+go
+exec sp_changedbowner 'db_datawriter'
+go
+exec sp_changedbowner 'db_ddladmin'
+go
+exec sp_changedbowner 'dbo'
+go
+exec sp_changedbowner 'db_owner'
+go
+exec sp_changedbowner 'master_db_datareader'
+go
+exec sp_changedbowner 'sp_changedbowner_r1'
+go
+exec sp_changedbowner 'sp_changedbowner_db_sp_changedbowner_r1'
+go
+drop role sp_changedbowner_r1
+go
+use master
+go
+drop database sp_changedbowner_db
+go
+
 -- tsql
 use master
 go


### PR DESCRIPTION
Alter authorization on database to any database role/fixed server role/sysadmin should be blocked. Earlier, it was checking if the role exists in the pg_authid for login. This was returning true for database role/fixed server role/sysadmin which is not the expected T-SQL behaviour.

Tasks: BABEL-6122

Signed-off-by: Shalini Lohia lshalini@amazon.com

