### PR TITLE
[OSS-ONLY][WIP] Restrict grant/revoke to/from any babelfish created role via PG port

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1208,6 +1208,10 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
 		return true;
 
+	/* Allow grant operations when called by superuser (e.g., during initialize_babelfish) */
+	if (superuser())
+		return true;
+
 	/* Restrict roles to added as a member of babelfish roles */
 	foreach(item, grant_stmt->granted_roles)
 	{

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -61,7 +61,7 @@ static bool handle_drop_role(DropRoleStmt *drop_role_stmt);
 static bool handle_rename(RenameStmt *rename_stmt);
 static bool handle_alter_role(AlterRoleStmt* alter_role_stmt);
 static bool handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt);
-static bool handle_grant_role(GrantRoleStmt *grant_stmt);
+// static bool handle_grant_role(GrantRoleStmt *grant_stmt);
 
 /* Drop database handler */
 static bool handle_dropdb(DropdbStmt *dropdb_stmt);
@@ -716,9 +716,9 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 		case T_AlterRoleSetStmt:
 			handle_result = handle_alter_role_set((AlterRoleSetStmt*)parsetree);
 			break;
-		case T_GrantRoleStmt:
-			handle_result = handle_grant_role((GrantRoleStmt *) parsetree);
-			break;
+		// case T_GrantRoleStmt:
+		// 	handle_result = handle_grant_role((GrantRoleStmt *) parsetree);
+		// 	break;
 		default:
 			break;
 	}
@@ -1200,46 +1200,46 @@ handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt)
  * Returns: true - We're not attempting to modify something we shouldn't have access to. Normal security checks.
  *          false - We've reported an error and should not continue executing this call.
  */
-static bool
-handle_grant_role(GrantRoleStmt *grant_stmt)
-{
-	ListCell *item;
+// static bool
+// handle_grant_role(GrantRoleStmt *grant_stmt)
+// {
+// 	ListCell *item;
 
-	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
-		return true;
+// 	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
+// 		return true;
 
-	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
-	if (superuser_arg(GetSessionUserId()))
-		return true;
+// 	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
+// 	if (superuser_arg(GetSessionUserId()))
+// 		return true;
 
-	/* Restrict roles to added as a member of babelfish roles */
-	foreach(item, grant_stmt->granted_roles)
-	{
-		AccessPriv *priv = (AccessPriv *) lfirst(item);
-		char	   *rolename = priv->priv_name;
-		Oid			roleid;
+// 	/* Restrict roles to added as a member of babelfish roles */
+// 	foreach(item, grant_stmt->granted_roles)
+// 	{
+// 		AccessPriv *priv = (AccessPriv *) lfirst(item);
+// 		char	   *rolename = priv->priv_name;
+// 		Oid			roleid;
 
-		if (rolename == NULL)
-			continue;
+// 		if (rolename == NULL)
+// 			continue;
 
-		roleid = get_role_oid(rolename, false);
-		if (OidIsValid(roleid) && is_babelfish_role(rolename))
-			check_babelfish_alterrole_restictions(false);
-	}
+// 		roleid = get_role_oid(rolename, false);
+// 		if (OidIsValid(roleid) && is_babelfish_role(rolename))
+// 			check_babelfish_alterrole_restictions(false);
+// 	}
 
-	/* Restrict grant to/from babelfish role */
-	foreach(item, grant_stmt->grantee_roles)
-	{
-		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
-		Oid			roleid;
+// 	/* Restrict grant to/from babelfish role */
+// 	foreach(item, grant_stmt->grantee_roles)
+// 	{
+// 		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
+// 		Oid			roleid;
 
-		roleid = get_rolespec_oid(rolespec, false);
-		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
-			check_babelfish_alterrole_restictions(false);
-	}
+// 		roleid = get_rolespec_oid(rolespec, false);
+// 		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
+// 			check_babelfish_alterrole_restictions(false);
+// 	}
 
-	return true;
-}
+// 	return true;
+// }
 
 /*
  * Check if current user has create db privileges

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -964,9 +964,7 @@ is_babelfish_role(const char *role)
 		const char *parent_role_name = GetUserNameFromId(parent_role_oid, false);
 
 		/* Check if the parent role is a Babelfish role */
-		if (is_member_of_role(sysadmin_oid, parent_role_oid) ||
-			is_member_of_role(securityadmin, parent_role_oid) ||
-			is_member_of_role(dbcreator, parent_role_oid))
+		if (is_member_of_role(sysadmin_oid, parent_role_oid))
 		{
 			is_babelfish_login = true;
 			break;

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -61,7 +61,7 @@ static bool handle_drop_role(DropRoleStmt *drop_role_stmt);
 static bool handle_rename(RenameStmt *rename_stmt);
 static bool handle_alter_role(AlterRoleStmt* alter_role_stmt);
 static bool handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt);
-// static bool handle_grant_role(GrantRoleStmt *grant_stmt);
+static bool handle_grant_role(GrantRoleStmt *grant_stmt);
 
 /* Drop database handler */
 static bool handle_dropdb(DropdbStmt *dropdb_stmt);
@@ -716,9 +716,9 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 		case T_AlterRoleSetStmt:
 			handle_result = handle_alter_role_set((AlterRoleSetStmt*)parsetree);
 			break;
-		// case T_GrantRoleStmt:
-		// 	handle_result = handle_grant_role((GrantRoleStmt *) parsetree);
-		// 	break;
+		case T_GrantRoleStmt:
+			handle_result = handle_grant_role((GrantRoleStmt *) parsetree);
+			break;
 		default:
 			break;
 	}
@@ -1201,46 +1201,46 @@ handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt)
  * Returns: true - We're not attempting to modify something we shouldn't have access to. Normal security checks.
  *          false - We've reported an error and should not continue executing this call.
  */
-// static bool
-// handle_grant_role(GrantRoleStmt *grant_stmt)
-// {
-// 	ListCell *item;
+static bool
+handle_grant_role(GrantRoleStmt *grant_stmt)
+{
+	ListCell *item;
 
-// 	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
-// 		return true;
+	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
+		return true;
 
-// 	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
-// 	if (superuser_arg(GetSessionUserId()))
-// 		return true;
+	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
+	if (superuser_arg(GetSessionUserId()))
+		return true;
 
-// 	/* Restrict roles to added as a member of babelfish roles */
-// 	foreach(item, grant_stmt->granted_roles)
-// 	{
-// 		AccessPriv *priv = (AccessPriv *) lfirst(item);
-// 		char	   *rolename = priv->priv_name;
-// 		Oid			roleid;
+	/* Restrict roles to added as a member of babelfish roles */
+	foreach(item, grant_stmt->granted_roles)
+	{
+		AccessPriv *priv = (AccessPriv *) lfirst(item);
+		char	   *rolename = priv->priv_name;
+		Oid			roleid;
 
-// 		if (rolename == NULL)
-// 			continue;
+		if (rolename == NULL)
+			continue;
 
-// 		roleid = get_role_oid(rolename, false);
-// 		if (OidIsValid(roleid) && is_babelfish_role(rolename))
-// 			check_babelfish_alterrole_restictions(false);
-// 	}
+		roleid = get_role_oid(rolename, false);
+		if (OidIsValid(roleid) && is_babelfish_role(rolename))
+			check_babelfish_alterrole_restictions(false);
+	}
 
-// 	/* Restrict grant to/from babelfish role */
-// 	foreach(item, grant_stmt->grantee_roles)
-// 	{
-// 		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
-// 		Oid			roleid;
+	/* Restrict grant to/from babelfish role */
+	foreach(item, grant_stmt->grantee_roles)
+	{
+		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
+		Oid			roleid;
 
-// 		roleid = get_rolespec_oid(rolespec, false);
-// 		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
-// 			check_babelfish_alterrole_restictions(false);
-// 	}
+		roleid = get_rolespec_oid(rolespec, false);
+		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
+			check_babelfish_alterrole_restictions(false);
+	}
 
-// 	return true;
-// }
+	return true;
+}
 
 /*
  * Check if current user has create db privileges

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1250,8 +1250,8 @@ have_createdb_privilege(void)
 	bool		result = false;
 	HeapTuple	utup;
 
-	/* Superusers can always do everything */
-	if (superuser())
+	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
+	if (superuser_arg(GetSessionUserId()))
 		return true;
 
 	utup = SearchSysCache1(AUTHOID, ObjectIdGetDatum(GetUserId()));

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -19,6 +19,7 @@
 #include "access/genam.h"
 #include "access/htup_details.h"
 #include "access/table.h"
+#include "catalog/pg_auth_members.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_db_role_setting.h"
 #include "commands/dbcommands.h"
@@ -34,6 +35,7 @@
 #include "utils/syscache.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
+#include "utils/catcache.h"
 
 static int	FindMatchingParam(List *params, const char *name);
 static Node *TransformParamRef(ParseState *pstate, ParamRef *pref);
@@ -916,8 +918,11 @@ check_babelfish_droprole_restrictions(char *role)
  * 	This function check the underlying assumption on the membership chain instead
  * 	sysadmin <-- dbo* <--- db_owner* <--- users/roles
  *
+ * A Babelfish login is a member of babelfish created user/role i.e., dbo, guest or user created user.
+ *
  * actual dbo and db_owner name varies across different babelfish logical databases
  */
+
 static bool
 is_babelfish_role(const char *role)
 {
@@ -926,28 +931,49 @@ is_babelfish_role(const char *role)
 	Oid			bbf_master_guest_oid;
 	Oid			bbf_tempdb_guest_oid;
 	Oid			bbf_msdb_guest_oid;
+	CatCList	*memlist;
+	int			i;
+	bool		is_babelfish_login = false;
 
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
 
-	if (sysadmin_oid == InvalidOid || role_oid == InvalidOid)
+	if (!OidIsValid(sysadmin_oid) || !OidIsValid(role_oid))
 		return false;
 
 	if (is_member_of_role(sysadmin_oid, role_oid))
 		return true;
 
+	/* Most of the Babelfish logins would be a member of one of these guest roles.*/
 	bbf_master_guest_oid = get_role_oid("master_guest", true);
 	bbf_tempdb_guest_oid = get_role_oid("tempdb_guest", true);
 	bbf_msdb_guest_oid = get_role_oid("msdb_guest", true);
-	if (OidIsValid(bbf_master_guest_oid)
-		&& OidIsValid(bbf_tempdb_guest_oid)
-		&& OidIsValid(bbf_msdb_guest_oid)
-		&& (is_member_of_role(role_oid, bbf_master_guest_oid)
-		|| is_member_of_role(role_oid, bbf_tempdb_guest_oid)
-		|| is_member_of_role(role_oid, bbf_msdb_guest_oid)))
+	if ((OidIsValid(bbf_master_guest_oid) && is_member_of_role(role_oid, bbf_master_guest_oid))
+		|| (OidIsValid(bbf_tempdb_guest_oid) && is_member_of_role(role_oid, bbf_tempdb_guest_oid))
+		|| (OidIsValid(bbf_msdb_guest_oid) && is_member_of_role(role_oid, bbf_msdb_guest_oid)))
 		return true;
 
-	return false;
+	/* Check if it's a Babelfish login, if it's not a member of any guest role.*/
+	memlist = SearchSysCacheList1(AUTHMEMMEMROLE,
+								ObjectIdGetDatum(role_oid));
+	for (i = 0; i < memlist->n_members; i++)
+	{
+		HeapTuple   tup = &memlist->members[i]->tuple;
+		Form_pg_auth_members form = (Form_pg_auth_members) GETSTRUCT(tup);
+		Oid         parent_role_oid = form->roleid;
+		const char *parent_role_name = GetUserNameFromId(parent_role_oid, false);
+
+		/* Check if the parent role is a Babelfish role */
+		if (is_member_of_role(sysadmin_oid, parent_role_oid) ||
+			is_member_of_role(securityadmin, parent_role_oid) ||
+			is_member_of_role(dbcreator, parent_role_oid))
+		{
+			is_babelfish_login = true;
+			break;
+		}
+	}
+	ReleaseSysCacheList(memlist);
+	return is_babelfish_login;
 }
 
 /*
@@ -1184,7 +1210,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
 		return true;
 
-	/* Restrict roles to added as a member of bbf_role_admin */
+	/* Restrict roles to added as a member of babelfish roles */
 	foreach(item, grant_stmt->granted_roles)
 	{
 		AccessPriv *priv = (AccessPriv *) lfirst(item);
@@ -1199,7 +1225,7 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 			check_babelfish_alterrole_restictions(false);
 	}
 
-	/* Restrict grant to/from bbf_role_admin role */
+	/* Restrict grant to/from babelfish role */
 	foreach(item, grant_stmt->grantee_roles)
 	{
 		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -931,9 +931,9 @@ is_babelfish_role(const char *role)
 	Oid			bbf_master_guest_oid;
 	Oid			bbf_tempdb_guest_oid;
 	Oid			bbf_msdb_guest_oid;
-	CatCList	*memlist;
-	int			i;
-	bool		is_babelfish_login = false;
+	// CatCList	*memlist;
+	// int			i;
+	// bool		is_babelfish_login = false;
 
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
@@ -953,25 +953,26 @@ is_babelfish_role(const char *role)
 		|| (OidIsValid(bbf_msdb_guest_oid) && is_member_of_role(role_oid, bbf_msdb_guest_oid)))
 		return true;
 
-	/* Check if it's a Babelfish login, if it's not a member of any guest role.*/
-	memlist = SearchSysCacheList1(AUTHMEMMEMROLE,
-								ObjectIdGetDatum(role_oid));
-	for (i = 0; i < memlist->n_members; i++)
-	{
-		HeapTuple   tup = &memlist->members[i]->tuple;
-		Form_pg_auth_members form = (Form_pg_auth_members) GETSTRUCT(tup);
-		Oid         parent_role_oid = form->roleid;
-		const char *parent_role_name = GetUserNameFromId(parent_role_oid, false);
+	// /* Check if it's a Babelfish login, if it's not a member of any guest role.*/
+	// memlist = SearchSysCacheList1(AUTHMEMMEMROLE,
+	// 							ObjectIdGetDatum(role_oid));
+	// for (i = 0; i < memlist->n_members; i++)
+	// {
+	// 	HeapTuple   tup = &memlist->members[i]->tuple;
+	// 	Form_pg_auth_members form = (Form_pg_auth_members) GETSTRUCT(tup);
+	// 	Oid         parent_role_oid = form->roleid;
+	// 	const char *parent_role_name = GetUserNameFromId(parent_role_oid, false);
 
-		/* Check if the parent role is a Babelfish role */
-		if (is_member_of_role(sysadmin_oid, parent_role_oid))
-		{
-			is_babelfish_login = true;
-			break;
-		}
-	}
-	ReleaseSysCacheList(memlist);
-	return is_babelfish_login;
+	// 	/* Check if the parent role is a Babelfish role */
+	// 	if (is_member_of_role(sysadmin_oid, parent_role_oid))
+	// 	{
+	// 		is_babelfish_login = true;
+	// 		break;
+	// 	}
+	// }
+	// ReleaseSysCacheList(memlist);
+	// return is_babelfish_login;
+	return false;
 }
 
 /*

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -59,6 +59,7 @@ static bool handle_drop_role(DropRoleStmt *drop_role_stmt);
 static bool handle_rename(RenameStmt *rename_stmt);
 static bool handle_alter_role(AlterRoleStmt* alter_role_stmt);
 static bool handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt);
+static bool handle_grant_role(GrantRoleStmt *grant_stmt);
 
 /* Drop database handler */
 static bool handle_dropdb(DropdbStmt *dropdb_stmt);
@@ -713,6 +714,9 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 		case T_AlterRoleSetStmt:
 			handle_result = handle_alter_role_set((AlterRoleSetStmt*)parsetree);
 			break;
+		case T_GrantRoleStmt:
+			handle_result = handle_grant_role((GrantRoleStmt *) parsetree);
+			break;
 		default:
 			break;
 	}
@@ -1162,6 +1166,51 @@ handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt)
      */
     pfree(name);
     return true;
+}
+
+/*
+ * handle_grant_role
+ *
+ * Handles GRANT/REVOKE ROLE TO/FROM ROLE.
+ *
+ * Returns: true - We're not attempting to modify something we shouldn't have access to. Normal security checks.
+ *          false - We've reported an error and should not continue executing this call.
+ */
+static bool
+handle_grant_role(GrantRoleStmt *grant_stmt)
+{
+	ListCell *item;
+
+	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
+		return true;
+
+	/* Restrict roles to added as a member of bbf_role_admin */
+	foreach(item, grant_stmt->granted_roles)
+	{
+		AccessPriv *priv = (AccessPriv *) lfirst(item);
+		char	   *rolename = priv->priv_name;
+		Oid			roleid;
+
+		if (rolename == NULL)
+			continue;
+
+		roleid = get_role_oid(rolename, false);
+		if (OidIsValid(roleid) && is_babelfish_role(rolename))
+			check_babelfish_alterrole_restictions(false);
+	}
+
+	/* Restrict grant to/from bbf_role_admin role */
+	foreach(item, grant_stmt->grantee_roles)
+	{
+		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
+		Oid			roleid;
+
+		roleid = get_rolespec_oid(rolespec, false);
+		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
+			check_babelfish_alterrole_restictions(false);
+	}
+
+	return true;
 }
 
 /*

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -19,7 +19,6 @@
 #include "access/genam.h"
 #include "access/htup_details.h"
 #include "access/table.h"
-#include "catalog/pg_auth_members.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_db_role_setting.h"
 #include "commands/dbcommands.h"
@@ -35,7 +34,6 @@
 #include "utils/syscache.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
-#include "utils/catcache.h"
 
 static int	FindMatchingParam(List *params, const char *name);
 static Node *TransformParamRef(ParseState *pstate, ParamRef *pref);
@@ -918,8 +916,6 @@ check_babelfish_droprole_restrictions(char *role)
  * 	This function check the underlying assumption on the membership chain instead
  * 	sysadmin <-- dbo* <--- db_owner* <--- users/roles
  *
- * A Babelfish login is a member of babelfish created user/role i.e., dbo, guest or user created user.
- *
  * actual dbo and db_owner name varies across different babelfish logical databases
  */
 
@@ -931,9 +927,6 @@ is_babelfish_role(const char *role)
 	Oid			bbf_master_guest_oid;
 	Oid			bbf_tempdb_guest_oid;
 	Oid			bbf_msdb_guest_oid;
-	// CatCList	*memlist;
-	// int			i;
-	// bool		is_babelfish_login = false;
 
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
@@ -953,25 +946,6 @@ is_babelfish_role(const char *role)
 		|| (OidIsValid(bbf_msdb_guest_oid) && is_member_of_role(role_oid, bbf_msdb_guest_oid)))
 		return true;
 
-	// /* Check if it's a Babelfish login, if it's not a member of any guest role.*/
-	// memlist = SearchSysCacheList1(AUTHMEMMEMROLE,
-	// 							ObjectIdGetDatum(role_oid));
-	// for (i = 0; i < memlist->n_members; i++)
-	// {
-	// 	HeapTuple   tup = &memlist->members[i]->tuple;
-	// 	Form_pg_auth_members form = (Form_pg_auth_members) GETSTRUCT(tup);
-	// 	Oid         parent_role_oid = form->roleid;
-	// 	const char *parent_role_name = GetUserNameFromId(parent_role_oid, false);
-
-	// 	/* Check if the parent role is a Babelfish role */
-	// 	if (is_member_of_role(sysadmin_oid, parent_role_oid))
-	// 	{
-	// 		is_babelfish_login = true;
-	// 		break;
-	// 	}
-	// }
-	// ReleaseSysCacheList(memlist);
-	// return is_babelfish_login;
 	return false;
 }
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -942,9 +942,9 @@ is_babelfish_role(const char *role)
 	if (OidIsValid(bbf_master_guest_oid)
 		&& OidIsValid(bbf_tempdb_guest_oid)
 		&& OidIsValid(bbf_msdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_master_guest_oid)
-		&& is_member_of_role(role_oid, bbf_tempdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_msdb_guest_oid))
+		&& (is_member_of_role(role_oid, bbf_master_guest_oid)
+		|| is_member_of_role(role_oid, bbf_tempdb_guest_oid)
+		|| is_member_of_role(role_oid, bbf_msdb_guest_oid)))
 		return true;
 
 	return false;

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1208,8 +1208,8 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
 		return true;
 
-	/* Allow grant operations when called by superuser (e.g., during initialize_babelfish) */
-	if (superuser())
+	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
+	if (superuser_arg(GetSessionUserId()))
 		return true;
 
 	/* Restrict roles to added as a member of babelfish roles */
@@ -1250,9 +1250,9 @@ have_createdb_privilege(void)
 	bool		result = false;
 	HeapTuple	utup;
 
-	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
-	if (superuser_arg(GetSessionUserId()))
-		return true;
+	/* Superusers can always do everything */
+	if (superuser())
+		true;
 
 	utup = SearchSysCache1(AUTHOID, ObjectIdGetDatum(GetUserId()));
 	if (HeapTupleIsValid(utup))

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -1252,7 +1252,7 @@ have_createdb_privilege(void)
 
 	/* Superusers can always do everything */
 	if (superuser())
-		true;
+		return true;
 
 	utup = SearchSysCache1(AUTHOID, ObjectIdGetDatum(GetUserId()));
 	if (HeapTupleIsValid(utup))

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -2,6 +2,12 @@
 create login permission_restrictions_tsql_login with password = '123';
 go
 
+create login permission_restrictions_tsql_login1 with password = '123';
+go
+
+create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -40,6 +46,56 @@ go
 ~~ERROR (Code: 0)~~
 
 ~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_db_datareader;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -111,6 +167,56 @@ go
 alter user permission_restrictions_psql_user1 with password '1234'
 go
 
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant master_db_datareader to master_db_datareader;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go
@@ -162,6 +268,28 @@ void
 ~~END~~
 
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
 -- tsql
+drop user permission_restrictions_tsql_user1;
+go
+
+drop login permission_restrictions_tsql_login1;
+go
+
 drop login permission_restrictions_tsql_login
 go

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -92,14 +92,6 @@ go
     Server SQLState: 42501)~~
 
 
-grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
 go
@@ -109,13 +101,9 @@ go
     Server SQLState: 42501)~~
 
 
-drop user permission_restrictions_tsql_login2;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
 
 drop user permission_restrictions_tsql_login3;
 go
@@ -203,14 +191,6 @@ go
 
 -- Grant on BBF role should not be allowed
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
 go
 ~~ERROR (Code: 0)~~
 

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -8,6 +8,32 @@ go
 create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
 go
 
+-- create user for a login in master, tempdb and msdb
+create login permission_restrictions_tsql_login2 with password = '123';
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use tempdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use msdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use master
+go
+
+-- create a login with no mapped user
+create login permission_restrictions_tsql_login3 with password = '123';
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -74,6 +100,14 @@ go
     Server SQLState: 42501)~~
 
 
+grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
 grant master_db_datareader to master_db_datareader;
 go
 ~~ERROR (Code: 0)~~
@@ -84,6 +118,22 @@ go
 
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user permission_restrictions_tsql_login2;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user permission_restrictions_tsql_login3;
 go
 ~~ERROR (Code: 0)~~
 
@@ -192,6 +242,14 @@ go
     Server SQLState: 42501)~~
 
 
+grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
 grant master_db_datareader to master_db_datareader;
 go
 ~~ERROR (Code: 0)~~
@@ -202,6 +260,22 @@ go
 
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user permission_restrictions_tsql_login2;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user permission_restrictions_tsql_login3;
 go
 ~~ERROR (Code: 0)~~
 
@@ -276,6 +350,14 @@ bool
 ~~END~~
 
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
 select pg_sleep(1);
 GO
 ~~START~~
@@ -288,8 +370,29 @@ void
 drop user permission_restrictions_tsql_user1;
 go
 
+drop user permission_restrictions_tsql_login2;
+go
+
+use tempdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+use msdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
 drop login permission_restrictions_tsql_login1;
 go
 
+drop login permission_restrictions_tsql_login2;
+go
+
 drop login permission_restrictions_tsql_login
+go
+
+drop login permission_restrictions_tsql_login3;
 go

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -76,15 +76,7 @@ go
 
 
 -- Grant on BBF role should not be allowed
-grant master_db_datareader to permission_restrictions_psql_user;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-grant master_db_datareader to master_permission_restrictions_tsql_user1;
+grant permission_restrictions_psql_user to master_permission_restrictions_tsql_user1;
 go
 ~~ERROR (Code: 0)~~
 
@@ -101,14 +93,6 @@ go
 
 
 grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-grant master_db_datareader to master_db_datareader;
 go
 ~~ERROR (Code: 0)~~
 
@@ -218,22 +202,6 @@ alter user permission_restrictions_psql_user1 with password '1234'
 go
 
 -- Grant on BBF role should not be allowed
-grant master_db_datareader to permission_restrictions_psql_user;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
-grant master_db_datareader to master_permission_restrictions_tsql_user1;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
 go
 ~~ERROR (Code: 0)~~
@@ -250,14 +218,6 @@ go
     Server SQLState: 42501)~~
 
 
-grant master_db_datareader to master_db_datareader;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
-
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
 go
@@ -267,13 +227,9 @@ go
     Server SQLState: 42501)~~
 
 
-drop user permission_restrictions_tsql_login2;
-go
-~~ERROR (Code: 0)~~
-
-~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
-    Server SQLState: 42501)~~
-
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
 
 drop user permission_restrictions_tsql_login3;
 go

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -44,7 +44,7 @@ grant sysadmin to permission_restrictions_tsql_login;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -62,7 +62,7 @@ grant sysadmin to permission_restrictions_psql_user;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -101,10 +101,10 @@ go
     Server SQLState: 42501)~~
 
 
+
 -- TODO: BABEL-5565
 -- drop user permission_restrictions_tsql_login2;
 -- go
-
 drop user permission_restrictions_tsql_login3;
 go
 ~~ERROR (Code: 0)~~
@@ -136,7 +136,7 @@ grant sysadmin to permission_restrictions_tsql_login;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -154,7 +154,7 @@ grant sysadmin to permission_restrictions_psql_user;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -207,10 +207,10 @@ go
     Server SQLState: 42501)~~
 
 
+
 -- TODO: BABEL-5565
 -- drop user permission_restrictions_tsql_login2;
 -- go
-
 drop user permission_restrictions_tsql_login3;
 go
 ~~ERROR (Code: 0)~~

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -8,6 +8,32 @@ go
 create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
 go
 
+-- create user for a login in master, tempdb and msdb
+create login permission_restrictions_tsql_login2 with password = '123';
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use tempdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use msdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use master
+go
+
+-- create a login with no mapped user
+create login permission_restrictions_tsql_login3 with password = '123';
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -39,11 +65,20 @@ go
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
 go
 
+grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
+go
+
 grant master_db_datareader to master_db_datareader;
 go
 
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+drop user permission_restrictions_tsql_login3;
 go
 
 drop user master_permission_restrictions_tsql_user1;
@@ -97,11 +132,20 @@ go
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
 go
 
+grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
+go
+
 grant master_db_datareader to master_db_datareader;
 go
 
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+drop user permission_restrictions_tsql_login3;
 go
 
 drop user master_permission_restrictions_tsql_user1;
@@ -147,6 +191,10 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
 WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
 GO
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
 select pg_sleep(1);
 GO
 
@@ -154,8 +202,29 @@ GO
 drop user permission_restrictions_tsql_user1;
 go
 
+drop user permission_restrictions_tsql_login2;
+go
+
+use tempdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+use msdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
 drop login permission_restrictions_tsql_login1;
 go
 
+drop login permission_restrictions_tsql_login2;
+go
+
 drop login permission_restrictions_tsql_login
+go
+
+drop login permission_restrictions_tsql_login3;
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -2,6 +2,12 @@
 create login permission_restrictions_tsql_login with password = '123';
 go
 
+create login permission_restrictions_tsql_login1 with password = '123';
+go
+
+create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -21,6 +27,26 @@ go
 
 -- Altering a role by an underprivileged login should be restricted
 alter user permission_restrictions_psql_user with password '123'
+go
+
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_db_datareader;
+go
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+
+drop user master_permission_restrictions_tsql_user1;
 go
 
 -- Dropping a role by an underprivileged login should be restricted
@@ -61,6 +87,26 @@ go
 alter user permission_restrictions_psql_user1 with password '1234'
 go
 
+-- Grant on BBF role should not be allowed
+grant master_db_datareader to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_permission_restrictions_tsql_user1;
+go
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+
+grant master_db_datareader to master_db_datareader;
+go
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+
+drop user master_permission_restrictions_tsql_user1;
+go
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go
@@ -97,6 +143,19 @@ GO
 select pg_sleep(1);
 GO
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+select pg_sleep(1);
+GO
+
 -- tsql
+drop user permission_restrictions_tsql_user1;
+go
+
+drop login permission_restrictions_tsql_login1;
+go
+
 drop login permission_restrictions_tsql_login
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -62,9 +62,6 @@ go
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
 go
 
-grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
-go
-
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
 go
@@ -121,15 +118,13 @@ go
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
 go
 
-grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
-go
-
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
 go
 
-drop user permission_restrictions_tsql_login2;
-go
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
 
 drop user permission_restrictions_tsql_login3;
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -56,10 +56,7 @@ alter user permission_restrictions_psql_user with password '123'
 go
 
 -- Grant on BBF role should not be allowed
-grant master_db_datareader to permission_restrictions_psql_user;
-go
-
-grant master_db_datareader to master_permission_restrictions_tsql_user1;
+grant permission_restrictions_psql_user to master_permission_restrictions_tsql_user1;
 go
 
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
@@ -68,15 +65,13 @@ go
 grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
 go
 
-grant master_db_datareader to master_db_datareader;
-go
-
 -- dropping of BBF users/logins should not be allowed
 drop user permission_restrictions_tsql_login1;
 go
 
-drop user permission_restrictions_tsql_login2;
-go
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
 
 drop user permission_restrictions_tsql_login3;
 go
@@ -123,19 +118,10 @@ alter user permission_restrictions_psql_user1 with password '1234'
 go
 
 -- Grant on BBF role should not be allowed
-grant master_db_datareader to permission_restrictions_psql_user;
-go
-
-grant master_db_datareader to master_permission_restrictions_tsql_user1;
-go
-
 grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
 go
 
 grant permission_restrictions_tsql_login2 to permission_restrictions_psql_user;
-go
-
-grant master_db_datareader to master_db_datareader;
 go
 
 -- dropping of BBF users/logins should not be allowed


### PR DESCRIPTION
### Description


This commit restricts grant/revoke .. to/from ..  any Babelfish created role/login/user via PG endpoint.


### Issue
Task: BABEL-5505

Signed-off-by: Shalini Lohia <lshalini@amazon.com>