### PR TITLE
Fix Typo

### DIFF
--- a/contrib/babelfishpg_common/src/varbinary.c
+++ b/contrib/babelfishpg_common/src/varbinary.c
@@ -867,7 +867,7 @@ bpcharvarbinary(PG_FUNCTION_ARGS)
 	if (!isExplicit)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("Implicit conversion from data type bpchar to "
+				 errmsg("Implicit conversion from data type char to "
 						"varbinary is not allowed. Use the CONVERT function "
 						"to run this query.")));
 
@@ -888,7 +888,7 @@ bpcharvarbinary(PG_FUNCTION_ARGS)
 
 		ereport(ERROR,
 			   (errcode(ERRCODE_INTERNAL_ERROR),
-				errmsg("Failed to convert from data type bpchar to varbinary, %s",
+				errmsg("Failed to convert from data type char to varbinary, %s",
 					   errorData->message)));
 	}
 	PG_END_TRY();
@@ -1541,7 +1541,7 @@ bpcharrowversion(PG_FUNCTION_ARGS)
 	if (!isExplicit)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("Implicit conversion from data type bpchar to "
+				 errmsg("Implicit conversion from data type char to "
 						"rowversion is not allowed. Use the CONVERT function "
 						"to run this query.")));
 

--- a/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_function_helpers.sql
@@ -10314,7 +10314,7 @@ AS
 $BODY$
 DECLARE result sys.varbinary;
 BEGIN
-    IF pg_typeof(arg) IN ('text'::regtype, 'sys.ntext'::regtype, 'sys.nvarchar'::regtype, 'sys.bpchar'::regtype, 'sys.nchar'::regtype, 'sys.varchar') THEN
+    IF pg_typeof(arg) IN ('text'::regtype, 'sys.ntext'::regtype, 'sys.nvarchar'::regtype, 'sys.bpchar'::regtype, 'sys.nchar'::regtype, 'sys.varchar'::regtype) THEN
         RETURN sys.babelfish_conv_string_to_varbinary(arg, p_style);
     ELSE
         IF typmod = -1 THEN

--- a/test/JDBC/expected/BABEL-1499.out
+++ b/test/JDBC/expected/BABEL-1499.out
@@ -17,7 +17,7 @@ DECLARE @a varbinary(10); SET @a = CAST('21' AS char(10)); SELECT @a
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Implicit conversion from data type bpchar to varbinary is not allowed. Use the CONVERT function to run this query.)~~
+~~ERROR (Message: Implicit conversion from data type char to varbinary is not allowed. Use the CONVERT function to run this query.)~~
 
 
 DECLARE @a varbinary(10); SET @a = CAST('21' AS varchar(10)); SELECT @a

--- a/test/JDBC/expected/BABEL-453.out
+++ b/test/JDBC/expected/BABEL-453.out
@@ -132,7 +132,7 @@ INSERT INTO t453_varbin VALUES (@var);
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Implicit conversion from data type bpchar to varbinary is not allowed. Use the CONVERT function to run this query.)~~
+~~ERROR (Message: Implicit conversion from data type char to varbinary is not allowed. Use the CONVERT function to run this query.)~~
 
 
 DECLARE @var VARCHAR(10) = 'ab';


### PR DESCRIPTION
### Description

The typo in sys_function_helpers is fixed and "char" keyword is used instead of "bpchar" in error messages since it is what user will see.



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).