### PR TITLE
[OSS-ONLY] Restrict grant/revoke to/from any babelfish created role via PG port

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -59,6 +59,7 @@ static bool handle_drop_role(DropRoleStmt *drop_role_stmt);
 static bool handle_rename(RenameStmt *rename_stmt);
 static bool handle_alter_role(AlterRoleStmt* alter_role_stmt);
 static bool handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt);
+static bool handle_grant_role(GrantRoleStmt *grant_stmt);
 
 /* Drop database handler */
 static bool handle_dropdb(DropdbStmt *dropdb_stmt);
@@ -713,6 +714,9 @@ tdsutils_ProcessUtility(PlannedStmt *pstmt,
 		case T_AlterRoleSetStmt:
 			handle_result = handle_alter_role_set((AlterRoleSetStmt*)parsetree);
 			break;
+		case T_GrantRoleStmt:
+			handle_result = handle_grant_role((GrantRoleStmt *) parsetree);
+			break;
 		default:
 			break;
 	}
@@ -914,6 +918,7 @@ check_babelfish_droprole_restrictions(char *role)
  *
  * actual dbo and db_owner name varies across different babelfish logical databases
  */
+
 static bool
 is_babelfish_role(const char *role)
 {
@@ -926,21 +931,19 @@ is_babelfish_role(const char *role)
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
 
-	if (sysadmin_oid == InvalidOid || role_oid == InvalidOid)
+	if (!OidIsValid(sysadmin_oid) || !OidIsValid(role_oid))
 		return false;
 
 	if (is_member_of_role(sysadmin_oid, role_oid))
 		return true;
 
+	/* Most of the Babelfish logins would be a member of one of these guest roles.*/
 	bbf_master_guest_oid = get_role_oid("master_guest", true);
 	bbf_tempdb_guest_oid = get_role_oid("tempdb_guest", true);
 	bbf_msdb_guest_oid = get_role_oid("msdb_guest", true);
-	if (OidIsValid(bbf_master_guest_oid)
-		&& OidIsValid(bbf_tempdb_guest_oid)
-		&& OidIsValid(bbf_msdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_master_guest_oid)
-		&& is_member_of_role(role_oid, bbf_tempdb_guest_oid)
-		&& is_member_of_role(role_oid, bbf_msdb_guest_oid))
+	if ((OidIsValid(bbf_master_guest_oid) && is_member_of_role(role_oid, bbf_master_guest_oid))
+		|| (OidIsValid(bbf_tempdb_guest_oid) && is_member_of_role(role_oid, bbf_tempdb_guest_oid))
+		|| (OidIsValid(bbf_msdb_guest_oid) && is_member_of_role(role_oid, bbf_msdb_guest_oid)))
 		return true;
 
 	return false;
@@ -1162,6 +1165,55 @@ handle_alter_role_set (AlterRoleSetStmt* alter_role_set_stmt)
      */
     pfree(name);
     return true;
+}
+
+/*
+ * handle_grant_role
+ *
+ * Handles GRANT/REVOKE ROLE TO/FROM ROLE.
+ *
+ * Returns: true - We're not attempting to modify something we shouldn't have access to. Normal security checks.
+ *          false - We've reported an error and should not continue executing this call.
+ */
+static bool
+handle_grant_role(GrantRoleStmt *grant_stmt)
+{
+	ListCell *item;
+
+	if (MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
+		return true;
+
+	/* Allow grant operations when session user is superuser (e.g., during initialize_babelfish) */
+	if (superuser_arg(GetSessionUserId()))
+		return true;
+
+	/* Restrict roles to added as a member of babelfish roles */
+	foreach(item, grant_stmt->granted_roles)
+	{
+		AccessPriv *priv = (AccessPriv *) lfirst(item);
+		char	   *rolename = priv->priv_name;
+		Oid			roleid;
+
+		if (rolename == NULL)
+			continue;
+
+		roleid = get_role_oid(rolename, false);
+		if (OidIsValid(roleid) && is_babelfish_role(rolename))
+			check_babelfish_alterrole_restictions(false);
+	}
+
+	/* Restrict grant to/from babelfish role */
+	foreach(item, grant_stmt->grantee_roles)
+	{
+		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
+		Oid			roleid;
+
+		roleid = get_rolespec_oid(rolespec, false);
+		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
+			check_babelfish_alterrole_restictions(false);
+	}
+
+	return true;
 }
 
 /*

--- a/test/JDBC/expected/permission_restrictions_from_pg.out
+++ b/test/JDBC/expected/permission_restrictions_from_pg.out
@@ -2,6 +2,38 @@
 create login permission_restrictions_tsql_login with password = '123';
 go
 
+create login permission_restrictions_tsql_login1 with password = '123';
+go
+
+create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
+go
+
+-- create user for a login in master, tempdb and msdb
+create login permission_restrictions_tsql_login2 with password = '123';
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use tempdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use msdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use master
+go
+
+-- create a login with no mapped user
+create login permission_restrictions_tsql_login3 with password = '123';
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -12,7 +44,7 @@ grant sysadmin to permission_restrictions_tsql_login;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -30,7 +62,7 @@ grant sysadmin to permission_restrictions_psql_user;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -40,6 +72,52 @@ go
 ~~ERROR (Code: 0)~~
 
 ~~ERROR (Message: ERROR: permission denied
+    Server SQLState: 42501)~~
+
+
+-- Grant on BBF role should not be allowed
+grant permission_restrictions_psql_user to master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
+drop user permission_restrictions_tsql_login3;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -58,7 +136,7 @@ grant sysadmin to permission_restrictions_tsql_login;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -76,7 +154,7 @@ grant sysadmin to permission_restrictions_psql_user;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must have admin option on role "sysadmin"
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
     Server SQLState: 42501)~~
 
 
@@ -110,6 +188,44 @@ go
 -- user has sysadmin membership, alter user is allowed
 alter user permission_restrictions_psql_user1 with password '1234'
 go
+
+-- Grant on BBF role should not be allowed
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
+drop user permission_restrictions_tsql_login3;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+drop user master_permission_restrictions_tsql_user1;
+go
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be dropped or altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
 
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
@@ -162,6 +278,57 @@ void
 ~~END~~
 
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+~~START~~
+bool
+~~END~~
+
+
+select pg_sleep(1);
+GO
+~~START~~
+void
+
+~~END~~
+
+
 -- tsql
+drop user permission_restrictions_tsql_user1;
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+use tempdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+use msdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+drop login permission_restrictions_tsql_login1;
+go
+
+drop login permission_restrictions_tsql_login2;
+go
+
 drop login permission_restrictions_tsql_login
+go
+
+drop login permission_restrictions_tsql_login3;
 go

--- a/test/JDBC/input/permission_restrictions_from_pg.mix
+++ b/test/JDBC/input/permission_restrictions_from_pg.mix
@@ -2,6 +2,38 @@
 create login permission_restrictions_tsql_login with password = '123';
 go
 
+create login permission_restrictions_tsql_login1 with password = '123';
+go
+
+create user permission_restrictions_tsql_user1 for login permission_restrictions_tsql_login1;
+go
+
+-- create user for a login in master, tempdb and msdb
+create login permission_restrictions_tsql_login2 with password = '123';
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use tempdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use msdb;
+go
+
+create user permission_restrictions_tsql_login2;
+go
+
+use master
+go
+
+-- create a login with no mapped user
+create login permission_restrictions_tsql_login3 with password = '123';
+go
+
 -- psql
 create user permission_restrictions_psql_user with password '123';
 go
@@ -21,6 +53,27 @@ go
 
 -- Altering a role by an underprivileged login should be restricted
 alter user permission_restrictions_psql_user with password '123'
+go
+
+-- Grant on BBF role should not be allowed
+grant permission_restrictions_psql_user to master_permission_restrictions_tsql_user1;
+go
+
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
+
+drop user permission_restrictions_tsql_login3;
+go
+
+drop user master_permission_restrictions_tsql_user1;
 go
 
 -- Dropping a role by an underprivileged login should be restricted
@@ -61,6 +114,24 @@ go
 alter user permission_restrictions_psql_user1 with password '1234'
 go
 
+-- Grant on BBF role should not be allowed
+grant permission_restrictions_tsql_login1 to permission_restrictions_psql_user;
+go
+
+-- dropping of BBF users/logins should not be allowed
+drop user permission_restrictions_tsql_login1;
+go
+
+-- TODO: BABEL-5565
+-- drop user permission_restrictions_tsql_login2;
+-- go
+
+drop user permission_restrictions_tsql_login3;
+go
+
+drop user master_permission_restrictions_tsql_user1;
+go
+
 -- user has sysadmin membership, drop user is allowed
 drop user permission_restrictions_psql_user1;
 go
@@ -97,6 +168,44 @@ GO
 select pg_sleep(1);
 GO
 
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login1' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_get_activity(NULL)
+WHERE sys.suser_name(usesysid) = 'permission_restrictions_tsql_login2' AND backend_type = 'client backend' AND usesysid IS NOT NULL;
+GO
+
+select pg_sleep(1);
+GO
+
 -- tsql
+drop user permission_restrictions_tsql_user1;
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+use tempdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+use msdb
+go
+
+drop user permission_restrictions_tsql_login2;
+go
+
+drop login permission_restrictions_tsql_login1;
+go
+
+drop login permission_restrictions_tsql_login2;
+go
+
 drop login permission_restrictions_tsql_login
+go
+
+drop login permission_restrictions_tsql_login3;
 go


### PR DESCRIPTION
### Description


This commit restricts grant/revoke .. to/from ..  any Babelfish created role/login/user via PG endpoint.


### Issue
Task: BABEL-5505, BABEL-4728

Signed-off-by: Shalini Lohia <lshalini@amazon.com>