### PR TITLE
[OSS-ONLY] Revert Output clause changes in Executor to match with PG Returning

### DIFF
--- a/test/JDBC/expected/babel_output_clause_concurrency_test.out
+++ b/test/JDBC/expected/babel_output_clause_concurrency_test.out
@@ -1,0 +1,27 @@
+Test data created successfully
+=== Test Case 1: UPDATE with OUTPUT EPQ ===
+Description: Tests EPQ handling when UPDATE with OUTPUT clause is blocked by concurrent transaction
+UPDATE OUTPUT Results:
+old_param1: InitialValue, new_param1: ModifiedBySession1, old_lock: 100, new_lock: 7
+Test Case 1 completed: UPDATE with OUTPUT EPQ
+=== Test Case 2: DELETE with OUTPUT EPQ ===
+Description: Tests EPQ handling when DELETE with OUTPUT clause processes updated row values
+DELETE OUTPUT Results:
+Param1: UpdatedBeforeDelete, LockProcessID: 100
+Param1: UpdatedBeforeDelete, LockProcessID: 200
+Test Case 2 completed: DELETE with OUTPUT EPQ
+=== Test Case 3: INSERT with OUTPUT during concurrent operations ===
+Description: Tests INSERT with OUTPUT clause execution during concurrent lock contention
+INSERT OUTPUT Results:
+TestID: 4, Param1: ConcurrentInsert, LockProcessID: 400
+Test Case 3 completed: INSERT with OUTPUT during concurrent operations
+=== Test Case 4: Mixed DML with OUTPUT clauses ===
+Description: Tests sequence of INSERT, UPDATE, DELETE with OUTPUT clauses under EPQ conditions
+Mixed DML - INSERT OUTPUT Results:
+TestID: 5, Param1: NewRecord, LockProcessID: 500
+Mixed DML - UPDATE OUTPUT Results:
+deleted - TestID: 1, old_param: ModifiedBySession1, old_lock: 999
+inserted - TestID: 1, new_param: EPQ_Updated, new_lock: 1099
+Mixed DML - DELETE OUTPUT Results:
+Test Case 4 completed: Mixed DML - INSERT, UPDATE, DELETE in sequence
+Test passed

--- a/test/JDBC/expected/test_output_clause-vu-cleanup.out
+++ b/test/JDBC/expected/test_output_clause-vu-cleanup.out
@@ -1,0 +1,180 @@
+-- Drop all INSTEAD OF triggers first
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Update_Update;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Delete_OnUpdate;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Delete_OnDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Update_OnDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Delete_OnInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Update_OnInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_InsteadOf_Mixed;
+GO
+ 
+-- Drop all AFTER triggers
+DROP TRIGGER IF EXISTS tr_OutputTest_Insert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_OutputTest_Update;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_OutputTest_Delete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_After_Update;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Delete_OnUpdate;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Delete_OnDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Update_Update_AfterDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Delete_AfterInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Update_AfterInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_Update_Delete_Deadlock;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_Delete_Update_Deadlock;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_After_Mixed;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_InsteadOf_MixedDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_After_MixedDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_InsteadOf_MixedInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_After_MixedInsert;
+GO
+ 
+-- Drop all views
+DROP VIEW IF EXISTS OutputTestView;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Update_Update;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Update_Delete;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Delete_Delete;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Delete_Update;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Insert_Delete;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Insert_Update;
+GO
+ 
+DROP VIEW IF EXISTS MixedTriggerViewDelete;
+GO
+ 
+DROP VIEW IF EXISTS MixedTriggerViewInsert;
+GO
+ 
+-- Drop all tables
+DROP TABLE IF EXISTS OutputTest;
+GO
+ 
+DROP TABLE IF EXISTS OutputLog;
+GO
+ 
+DROP TABLE IF EXISTS TriggerLog;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Update_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Update_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Delete_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Delete_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Insert_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Insert_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQOutputLog;
+GO
+ 
+DROP TABLE IF EXISTS EPQOutputLog_Str;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Update_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Update_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Delete_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Delete_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Insert_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Insert_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Delete_Update_deadlock;
+GO
+ 
+DROP TABLE IF EXISTS MixedTriggerTest;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixed;
+GO
+ 
+DROP TABLE IF EXISTS MixedTriggerTestDelete;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixedDelete;
+GO
+ 
+DROP TABLE IF EXISTS MixedTriggerTestInsert;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixedInsert;
+GO
+ 
+DROP TABLE IF EXISTS OutputCapture;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixed;
+GO
+
+DROP TABLE IF EXISTS outputresults;
+GO

--- a/test/JDBC/expected/test_output_clause-vu-prepare.out
+++ b/test/JDBC/expected/test_output_clause-vu-prepare.out
@@ -1,0 +1,583 @@
+
+/*
+ * ===================================================================================================================
+ *                                              1. Basic Output clause test
+ * ===================================================================================================================
+ */
+-- Test setup for OUTPUT clause functionality
+CREATE TABLE OutputTest (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO OutputTest (ID, Name, Value) VALUES 
+(1, 'Test1', 100),
+(2, 'Test2', 200),
+(3, 'Test3', 300);
+GO
+~~ROW COUNT: 3~~
+
+
+-- Table for OUTPUT INTO testing
+CREATE TABLE OutputLog (
+    LogID INT,
+    Operation NVARCHAR(10),
+    ID INT,
+    Name NVARCHAR(50),
+    Value INT
+);
+GO
+
+-- Dependent objects setup
+CREATE VIEW OutputTestView AS
+SELECT ID, Name, Value, Status FROM OutputTest WHERE Status = 'Active';
+GO
+
+CREATE TABLE TriggerLog (
+    LogID INT,
+    TriggerType NVARCHAR(20),
+    TableName NVARCHAR(50),
+    RecordID INT
+);
+GO
+
+-- Triggers for testing OUTPUT with trigger interaction
+CREATE TRIGGER tr_OutputTest_Insert
+ON OutputTest
+AFTER INSERT
+AS
+BEGIN
+    INSERT INTO TriggerLog (LogID, TriggerType, TableName, RecordID)
+    SELECT inserted.ID + 1000, 'AFTER_INSERT', 'OutputTest', inserted.ID FROM inserted;
+END;
+GO
+
+CREATE TRIGGER tr_OutputTest_Update
+ON OutputTest
+AFTER UPDATE
+AS
+BEGIN
+    INSERT INTO TriggerLog (LogID, TriggerType, TableName, RecordID)
+    SELECT inserted.ID + 2000, 'AFTER_UPDATE', 'OutputTest', inserted.ID FROM inserted;
+END;
+GO
+
+CREATE TRIGGER tr_OutputTest_Delete
+ON OutputTest
+AFTER DELETE
+AS
+BEGIN
+    INSERT INTO TriggerLog (LogID, TriggerType, TableName, RecordID)
+    SELECT deleted.ID + 3000, 'AFTER_DELETE', 'OutputTest', deleted.ID FROM deleted;
+END;
+GO
+
+
+
+
+
+
+
+/*
+ * ===================================================================================================================
+ *                                              2. Triggers + DML with OUTPUT clause test
+ * ===================================================================================================================
+ */
+/*
+ * ----------------------------   2.1 All below tests are AFTER TRIGGERS test with output clause. --------------------------------------
+ */
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.1 Scenerio -
+ *  Update command with output clause
+ *  AFTER trigger on update  
+ *  Another update inside AFTER trigger updating same row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Update_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_Update_Update (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+
+-- AFTER trigger that updates the same row
+CREATE TRIGGER tr_EPQTest_After_Update
+ON EPQTest_Update_Update
+AFTER UPDATE
+AS
+BEGIN
+    -- UPDATE EPQTest_Update_Update 
+    -- SET Counter = Counter + 100
+    -- WHERE ID IN (SELECT ID FROM inserted);
+    UPDATE EPQTest_Update_Update 
+    SET Status = 'PostTrigger'
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.2 Scenerio -
+ *  Update command with output clause
+ *  AFTER trigger on update  
+ *  Delete inside AFTER trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Update_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- Insert test data
+INSERT INTO EPQTest_Update_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+
+-- Test Case 18: AFTER trigger that deletes the row being updated
+CREATE TRIGGER tr_EPQTest_Delete_OnUpdate
+ON EPQTest_Update_Delete
+AFTER UPDATE
+AS
+BEGIN
+    DELETE FROM EPQTest_Update_Delete
+    WHERE ID IN (SELECT ID FROM inserted) ;
+END;
+GO
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.3 Scenerio -
+ *  Delete command with output clause
+ *  AFTER trigger on Delete
+ *  Delete inside AFTER trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Delete_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- Insert test data
+INSERT INTO EPQTest_Delete_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+-- Test Case 19: AFTER trigger that deletes additional rows during DELETE
+CREATE TRIGGER tr_EPQTest_Delete_OnDelete
+ON EPQTest_Delete_Delete
+AFTER DELETE
+AS
+BEGIN
+    DELETE FROM EPQTest_Delete_Delete 
+    WHERE Value < (SELECT MIN(Value) FROM deleted) + 50;
+END;
+GO
+
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.4 Scenerio -
+ *  Delete command with output clause
+ *  AFTER trigger on Delete
+ *  Update inside AFTER trigger trying to update deleted row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Delete_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- Insert test data
+INSERT INTO EPQTest_Delete_Update (ID, Name, Value, Counter) VALUES
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+-- Test Case 20: AFTER DELETE trigger that tries to update deleted rows
+CREATE TRIGGER tr_EPQTest_Update_Update_AfterDelete
+ON EPQTest_Delete_Update
+AFTER DELETE
+AS
+BEGIN
+    UPDATE EPQTest_Delete_Update
+    SET Status = 'Updated_After_Delete'
+    WHERE ID IN (SELECT ID FROM deleted);
+END;
+GO
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.5 Scenerio -
+ *  Insert command with output clause
+ *  AFTER trigger on Insert
+ *  Delete inside trigger deleting new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Insert_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Test Case 21: AFTER INSERT trigger that deletes the inserted row
+CREATE TRIGGER tr_EPQTest_Delete_AfterInsert
+ON EPQTest_Insert_Delete
+AFTER INSERT
+AS
+BEGIN
+    DELETE FROM EPQTest_Insert_Delete 
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.6 Scenerio -
+ *  Insert command with output clause
+ *  AFTER trigger on Insert
+ *  Update inside trigger Updating new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Insert_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- AFTER INSERT trigger that Updates the inserted row
+CREATE TRIGGER tr_EPQTest_Update_AfterInsert
+ON EPQTest_Insert_Update
+AFTER INSERT
+AS
+BEGIN
+    UPDATE EPQTest_Insert_Update 
+    SET Status = 'PostTrigger'
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+
+
+-- Temporary table to store OUTPUT result
+CREATE TABLE EPQOutputLog (
+    LogID INT,
+    SourceID INT,
+    OldValue INT,
+    NewValue INT,
+    LogStatus NVARCHAR(20)
+);
+GO
+
+-- Temporary table to store OUTPUT result
+CREATE TABLE EPQOutputLog_Str (
+    LogID INT,
+    SourceID INT,
+    OldValue NVARCHAR(30),
+    NewValue NVARCHAR(30),
+    LogStatus NVARCHAR(20)
+);
+GO
+
+
+
+/*
+ *  ----------------------------   2.2 All below tests are INSTEAD OF TRIGGERS test with output clause. --------------------------------------------
+ */
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.1 Scenerio -
+ *  Update command with output clause
+ *  INSTEAD OF trigger on update 
+ *  Another update inside trigger updating same row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table for INSTEAD OF triggers
+CREATE TABLE EPQTest_InsteadOf_Update_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Update_Update (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+-- INSTEAD OF trigger that updates the same row
+CREATE TRIGGER tr_EPQTest_InsteadOf_Update_Update
+ON EPQTest_InsteadOf_Update_Update
+INSTEAD OF UPDATE
+AS
+BEGIN
+    UPDATE EPQTest_InsteadOf_Update_Update 
+    SET Value = i.Value + 10,
+        Counter = e.Counter + 1,
+        Status = 'Modified'
+    FROM EPQTest_InsteadOf_Update_Update e
+    INNER JOIN inserted i ON e.ID = i.ID;
+END;
+GO
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.2 Scenerio -
+ *  Update command with output clause on view
+ *  INSTEAD OF trigger on update 
+ *  Delete inside trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Update_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Update_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+-- INSTEAD OF trigger that deletes the row being updated
+CREATE TRIGGER tr_EPQTest_InsteadOf_Delete_OnUpdate
+ON EPQTest_InsteadOf_Update_Delete
+INSTEAD OF UPDATE
+AS
+BEGIN
+    DELETE FROM EPQTest_InsteadOf_Update_Delete
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.3 Scenerio -
+ *  Delete command with output clause on view
+ *  INSTEAD OF trigger on Delete 
+ *  Delete inside trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Delete_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Delete_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+
+-- INSTEAD OF trigger that deletes additional rows during DELETE
+CREATE TRIGGER tr_EPQTest_InsteadOf_Delete_OnDelete
+ON EPQTest_InsteadOf_Delete_Delete
+INSTEAD OF DELETE
+AS
+BEGIN
+    DELETE FROM EPQTest_InsteadOf_Delete_Delete 
+    WHERE Value < (SELECT MIN(Value) FROM deleted) + 50;
+    DELETE FROM EPQTest_InsteadOf_Delete_Delete
+    WHERE ID IN (SELECT ID FROM deleted);
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.4 Scenerio -
+ *  Delete command with output clause on view
+ *  INSTEAD OF trigger on Delete 
+ *  Update inside trigger updating deleted row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Delete_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Delete_Update (ID, Name, Value, Counter) VALUES
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+-- INSTEAD OF DELETE trigger that updates instead of deleting
+CREATE TRIGGER tr_EPQTest_InsteadOf_Update_OnDelete
+ON EPQTest_InsteadOf_Delete_Update
+INSTEAD OF DELETE
+AS
+BEGIN
+    UPDATE EPQTest_InsteadOf_Delete_Update
+    SET Status = 'Marked_For_Delete', Counter = Counter + 1000
+    WHERE ID IN (SELECT ID FROM deleted);
+END;
+GO
+
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.5 Scenerio -
+ *  Insert command with output clause on view
+ *  INSTEAD OF trigger on Insert 
+ *  Delete inside trigger deleting new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Insert_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- INSTEAD OF INSERT trigger that deletes existing rows
+CREATE TRIGGER tr_EPQTest_InsteadOf_Delete_OnInsert
+ON EPQTest_InsteadOf_Insert_Delete
+INSTEAD OF INSERT
+AS
+BEGIN
+    DELETE FROM EPQTest_InsteadOf_Insert_Delete 
+    WHERE Value < (SELECT MIN(Value) FROM inserted);
+    INSERT INTO EPQTest_InsteadOf_Insert_Delete (ID, Name, Value, Counter, Status)
+    SELECT ID, Name, Value, Counter, Status FROM inserted;
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.6 Scenerio -
+ *  Insert command with output clause on view
+ *  INSTEAD OF trigger on Insert 
+ *  Update inside trigger Updating new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Insert_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- INSTEAD OF INSERT trigger that updates existing rows and inserts new ones
+CREATE TRIGGER tr_EPQTest_InsteadOf_Update_OnInsert
+ON EPQTest_InsteadOf_Insert_Update
+INSTEAD OF INSERT
+AS
+BEGIN
+    UPDATE EPQTest_InsteadOf_Insert_Update 
+    SET Status = 'Updated_By_Insert', Counter = Counter + 500
+    WHERE Value < (SELECT MAX(Value) FROM inserted);
+    INSERT INTO EPQTest_InsteadOf_Insert_Update (ID, Name, Value, Counter, Status)
+    SELECT ID, Name, Value, Counter, 'Inserted_Via_Trigger' FROM inserted;
+END;
+GO

--- a/test/JDBC/expected/test_output_clause-vu-verify.out
+++ b/test/JDBC/expected/test_output_clause-vu-verify.out
@@ -1,0 +1,829 @@
+
+
+/*
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | INSERT with OUTPUT                               | Basic DML           | Tests basic INSERT OUTPUT clause             |
+ * |  2  | UPDATE with OUTPUT                               | Basic DML           | Tests basic UPDATE OUTPUT clause             |
+ * |  3  | DELETE with OUTPUT                               | Basic DML           | Tests basic DELETE OUTPUT clause             |
+ * |  4  | INSERT with OUTPUT INTO                          | OUTPUT INTO         | Tests INSERT OUTPUT INTO target table        |
+ * |  5  | UPDATE with OUTPUT INTO                          | OUTPUT INTO         | Tests UPDATE OUTPUT INTO target table        |
+ * |  6  | DELETE with OUTPUT INTO                          | OUTPUT INTO         | Tests DELETE OUTPUT INTO target table        |
+ * |  7  | Multiple row UPDATE with OUTPUT                  | Multi-row           | Tests OUTPUT with multiple affected rows     |
+ * |  8  | OUTPUT with computed columns                     | Computed Values     | Tests OUTPUT with calculated expressions     |
+ * |  9  | OUTPUT with dependent objects (view)             | View Integration    | Tests OUTPUT with view dependencies          |
+ * | 10  | UPDATE base table with OUTPUT (view test)        | View Operations     | Tests OUTPUT on base table through view      |
+ * | 11  | INSERT with OUTPUT and trigger interaction       | Trigger Basic       | Tests OUTPUT with trigger execution          |
+ * | 12  | UPDATE with OUTPUT and trigger interaction       | Trigger Basic       | Tests OUTPUT with trigger modifications      |
+ * | 13  | DELETE with OUTPUT and trigger interaction       | Trigger Basic       | Tests OUTPUT with trigger deletions          |
+ * | 14  | Multiple operations with triggers and OUTPUT INTO| Trigger Batch       | Tests batch operations with triggers         |
+ * | 15  | OUTPUT with trigger execution order validation   | Trigger Order       | Tests OUTPUT timing with trigger execution   |
+ * | 16  | Same Row UPDATE with OUTPUT (EPQ scenario)       | EPQ Complex         | Tests EPQ when trigger updates same row      |
+ * | 17  | UPDATE with AFTER UPDATE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with UPDATE inside UPDATE trigger  |
+ * | 18  | UPDATE with AFTER DELETE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with DELETE inside UPDATE trigger  |
+ * | 19  | DELETE with AFTER DELETE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with DELETE inside DELETE trigger  |
+ * | 20  | DELETE with AFTER UPDATE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with UPDATE inside DELETE trigger  |
+ * | 21  | INSERT with AFTER DELETE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with DELETE inside INSERT trigger  |
+ * | 22  | INSERT with AFTER UPDATE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with UPDATE inside INSERT trigger  |
+ * | 23  | INSTEAD OF UPDATE with UPDATE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF UPDATE OUTPUT with EPQ      |
+ * | 24  | INSTEAD OF UPDATE with DELETE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF UPDATE OUTPUT with DELETE   |
+ * | 25  | INSTEAD OF DELETE with DELETE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF DELETE OUTPUT cascading    |
+ * | 26  | INSTEAD OF DELETE with UPDATE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF DELETE OUTPUT with UPDATE   |
+ * | 27  | INSTEAD OF INSERT with DELETE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF INSERT OUTPUT with DELETE   |
+ * | 28  | INSTEAD OF INSERT with UPDATE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF INSERT OUTPUT with UPDATE   |
+ */
+/*
+ * ===================================================================================================================
+ *                                              1. Basic Output clause test
+ * ===================================================================================================================
+ */
+-- Test Case 1: INSERT with OUTPUT
+INSERT INTO OutputTest (ID, Name, Value) 
+OUTPUT inserted.ID, inserted.Name, inserted.Value
+VALUES (4, 'NewTest', 400);
+GO
+~~START~~
+int#!#nvarchar#!#int
+4#!#NewTest#!#400
+~~END~~
+
+
+-- Test Case 2: UPDATE with OUTPUT
+UPDATE OutputTest 
+SET Value = OutputTest.Value + 50
+OUTPUT deleted.Name, deleted.Value as OldValue, inserted.Value as NewValue
+WHERE ID = 1;
+GO
+~~START~~
+nvarchar#!#int#!#int
+Test1#!#100#!#150
+~~END~~
+
+
+-- Test Case 3: DELETE with OUTPUT
+DELETE FROM OutputTest
+OUTPUT deleted.ID, deleted.Name, deleted.Value
+WHERE ID = 2;
+GO
+~~START~~
+int#!#nvarchar#!#int
+2#!#Test2#!#200
+~~END~~
+
+
+-- Test Case 4: INSERT with OUTPUT INTO
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT 1, 'INSERT', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+VALUES (5, 'LoggedTest', 500);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Test Case 5: UPDATE with OUTPUT INTO
+UPDATE OutputTest
+SET Status = 'Updated'
+OUTPUT 2, 'UPDATE', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+WHERE ID = 3;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Test Case 6: DELETE with OUTPUT INTO
+DELETE FROM OutputTest
+OUTPUT 3, 'DELETE', deleted.ID, deleted.Name, deleted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+WHERE Name = 'LoggedTest';
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Test Case 7: Multiple row UPDATE with OUTPUT
+UPDATE OutputTest
+SET Value = OutputTest.Value * 2
+OUTPUT deleted.ID, deleted.Value as Before, inserted.Value as After
+WHERE OutputTest.Value > 100;
+GO
+~~START~~
+int#!#int#!#int
+4#!#400#!#800
+1#!#150#!#300
+3#!#300#!#600
+~~END~~
+
+
+-- Test Case 8: OUTPUT with computed columns
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT inserted.ID, inserted.Name, inserted.Value, inserted.Value * 2 as DoubleValue
+VALUES (6, 'Computed', 250);
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int
+6#!#Computed#!#250#!#500
+~~END~~
+
+
+-- Test Case 9: OUTPUT with dependent object (view)
+INSERT INTO OutputTest (ID, Name, Value, Status)
+OUTPUT inserted.ID, inserted.Name, inserted.Status
+VALUES (7, 'ViewTest', 600, 'Active');
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar
+7#!#ViewTest#!#Active
+~~END~~
+
+
+-- Test Case 10: UPDATE base table with OUTPUT (view test)
+UPDATE OutputTest
+SET Value = 999
+OUTPUT deleted.Name, deleted.Value as OldValue, inserted.Value as NewValue
+WHERE Name = 'ViewTest' AND Status = 'Active';
+GO
+~~START~~
+nvarchar#!#int#!#int
+ViewTest#!#600#!#999
+~~END~~
+
+
+-- Test Case 11: INSERT with OUTPUT and trigger interaction
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT inserted.ID, inserted.Name, 'TRIGGER_TEST' as TestType
+VALUES (8, 'TriggerTest1', 700);
+GO
+~~START~~
+int#!#nvarchar#!#varchar
+8#!#TriggerTest1#!#TRIGGER_TEST
+~~END~~
+
+
+-- Test Case 12: UPDATE with OUTPUT and trigger interaction
+UPDATE OutputTest
+SET Value = OutputTest.Value + 100, Status = 'Modified'
+OUTPUT deleted.Status as OldStatus, inserted.Status as NewStatus, inserted.ID
+WHERE Name = 'TriggerTest1';
+GO
+~~START~~
+nvarchar#!#nvarchar#!#int
+Active#!#Modified#!#8
+~~END~~
+
+
+-- Test Case 13: DELETE with OUTPUT and trigger interaction
+DELETE FROM OutputTest
+OUTPUT deleted.ID, deleted.Name, 'DELETED_BY_TRIGGER_TEST' as Note
+WHERE Name = 'TriggerTest1';
+GO
+~~START~~
+int#!#nvarchar#!#varchar
+8#!#TriggerTest1#!#DELETED_BY_TRIGGER_TEST
+~~END~~
+
+
+-- Test Case 14: Multiple operations with triggers and OUTPUT INTO
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT 4, 'MULTI_OP', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+VALUES (9, 'MultiOp1', 800), (10, 'MultiOp2', 900);
+GO
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+
+UPDATE OutputTest
+SET Status = 'Batch_Updated'
+OUTPUT 5, 'BATCH_UPD', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+WHERE Name LIKE 'MultiOp%';
+GO
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 2~~
+
+
+-- Test Case 15: OUTPUT with trigger execution order validation
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT inserted.ID, inserted.Name, 'OrderTest_Time' as OutputTime
+VALUES (11, 'OrderTest', 1000);
+GO
+~~START~~
+int#!#nvarchar#!#varchar
+11#!#OrderTest#!#OrderTest_Time
+~~END~~
+
+
+-- Test Case 16: Same Row UPDATE - Trigger updates the SAME ROW with OUTPUT clause
+-- This tests the most complex EPQ scenario: both original and trigger UPDATE the same row
+INSERT INTO OutputTest (ID, Name, Value, Status) VALUES (12, 'SameRowTest', 1100, 'Active');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- This UPDATE will trigger the UPDATE trigger which updates THE SAME ROW with OUTPUT
+-- Original UPDATE: Changes Value from 1100 to 1200
+-- Trigger UPDATE: Changes Value from 1200 to 2200 (1200 + 1000) and Status to 'Trigger_Modified'
+UPDATE OutputTest
+SET Value = 1200
+OUTPUT deleted.Value as OriginalOldValue, inserted.Value as OriginalNewValue, 
+       deleted.Status as OriginalOldStatus, inserted.Status as OriginalNewStatus
+WHERE Name = 'SameRowTest';
+GO
+~~START~~
+int#!#int#!#nvarchar#!#nvarchar
+1100#!#1200#!#Active#!#Active
+~~END~~
+
+
+-- Verify the final state shows both updates occurred
+SELECT ID, Name, Value, Status FROM OutputTest WHERE Name = 'SameRowTest';
+GO
+~~START~~
+int#!#nvarchar#!#int#!#nvarchar
+12#!#SameRowTest#!#1200#!#Active
+~~END~~
+
+
+-- Verify OUTPUT INTO results
+SELECT * FROM OutputLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#nvarchar#!#int
+1#!#INSERT#!#5#!#LoggedTest#!#500
+2#!#UPDATE#!#3#!#Test3#!#300
+3#!#DELETE#!#5#!#LoggedTest#!#500
+4#!#MULTI_OP#!#9#!#MultiOp1#!#800
+4#!#MULTI_OP#!#10#!#MultiOp2#!#900
+5#!#BATCH_UPD#!#9#!#MultiOp1#!#800
+5#!#BATCH_UPD#!#10#!#MultiOp2#!#900
+~~END~~
+
+
+-- Verify trigger execution
+SELECT * FROM TriggerLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#nvarchar#!#int
+1004#!#AFTER_INSERT#!#OutputTest#!#4
+1005#!#AFTER_INSERT#!#OutputTest#!#5
+1006#!#AFTER_INSERT#!#OutputTest#!#6
+1007#!#AFTER_INSERT#!#OutputTest#!#7
+1008#!#AFTER_INSERT#!#OutputTest#!#8
+1009#!#AFTER_INSERT#!#OutputTest#!#9
+1010#!#AFTER_INSERT#!#OutputTest#!#10
+1011#!#AFTER_INSERT#!#OutputTest#!#11
+1012#!#AFTER_INSERT#!#OutputTest#!#12
+2001#!#AFTER_UPDATE#!#OutputTest#!#1
+2001#!#AFTER_UPDATE#!#OutputTest#!#1
+2003#!#AFTER_UPDATE#!#OutputTest#!#3
+2003#!#AFTER_UPDATE#!#OutputTest#!#3
+2004#!#AFTER_UPDATE#!#OutputTest#!#4
+2007#!#AFTER_UPDATE#!#OutputTest#!#7
+2008#!#AFTER_UPDATE#!#OutputTest#!#8
+2009#!#AFTER_UPDATE#!#OutputTest#!#9
+2010#!#AFTER_UPDATE#!#OutputTest#!#10
+2012#!#AFTER_UPDATE#!#OutputTest#!#12
+3002#!#AFTER_DELETE#!#OutputTest#!#2
+3005#!#AFTER_DELETE#!#OutputTest#!#5
+3008#!#AFTER_DELETE#!#OutputTest#!#8
+~~END~~
+
+
+-- Verify view functionality
+SELECT * FROM OutputTestView ORDER BY ID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#nvarchar
+1#!#Test1#!#300#!#Active
+4#!#NewTest#!#800#!#Active
+6#!#Computed#!#250#!#Active
+7#!#ViewTest#!#999#!#Active
+11#!#OrderTest#!#1000#!#Active
+12#!#SameRowTest#!#1200#!#Active
+~~END~~
+
+
+-- Verify final table state
+SELECT * FROM OutputTest ORDER BY ID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#nvarchar
+1#!#Test1#!#300#!#Active
+3#!#Test3#!#600#!#Updated
+4#!#NewTest#!#800#!#Active
+6#!#Computed#!#250#!#Active
+7#!#ViewTest#!#999#!#Active
+9#!#MultiOp1#!#800#!#Batch_Updated
+10#!#MultiOp2#!#900#!#Batch_Updated
+11#!#OrderTest#!#1000#!#Active
+12#!#SameRowTest#!#1200#!#Active
+~~END~~
+
+
+
+
+
+
+
+
+/*
+ * ===================================================================================================================
+ *                                              2. Triggers with DML test.
+ * ===================================================================================================================
+ */
+/*
+ * 2.1 All below tests are AFTER TRIGGERS test with output clause
+ */
+------------------------------------------------------- UPDATE -----------------------------------------
+-- 2.1.1 update inside update trigger
+UPDATE EPQTest_Update_Update
+SET Value = 500
+OUTPUT 
+    deleted.ID,
+    deleted.Name,
+    deleted.Value as OldValue,
+    deleted.Counter as OldCounter,
+    inserted.Value as NewValue,
+    inserted.Counter as NewCounter
+WHERE ID = 1;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#int#!#int
+1#!#Row1#!#100#!#1#!#500#!#1
+~~END~~
+
+
+UPDATE EPQTest_Update_Update
+SET Value = 999
+OUTPUT 
+    1,
+    inserted.ID,
+    deleted.Value,
+    inserted.Value,
+    'Logged'
+INTO EPQOutputLog (LogID, SourceID, OldValue, NewValue, LogStatus)
+WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Final state check
+SELECT * FROM EPQTest_Update_Update ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+1#!#Row1#!#999#!#1#!#PostTrigger
+2#!#Row2#!#200#!#2#!#Active
+3#!#Row3#!#300#!#3#!#Active
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#nvarchar
+1#!#1#!#500#!#999#!#Logged
+~~END~~
+
+delete from EPQOutputLog;
+GO
+~~ROW COUNT: 1~~
+
+
+
+--2.1.2 delete inside update trigger
+UPDATE EPQTest_Update_Delete 
+SET Value = 999
+OUTPUT 
+    1,
+    inserted.ID,
+    deleted.Value,
+    inserted.Value,
+    'Logged'
+INTO EPQOutputLog (LogID, SourceID, OldValue, NewValue, LogStatus)
+WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Final state check
+SELECT * FROM EPQTest_Update_Delete ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+2#!#Row2#!#200#!#2#!#Active
+3#!#Row3#!#300#!#3#!#Active
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#nvarchar
+1#!#1#!#100#!#999#!#Logged
+~~END~~
+
+delete from EPQOutputLog;
+GO
+~~ROW COUNT: 1~~
+
+
+
+------------------------------------------------------- DELETE ------------------------------------------------
+-- 2.1.3 delete inside delete trigger
+DELETE FROM EPQTest_Delete_Delete
+OUTPUT deleted.ID, deleted.Name, deleted.Value
+WHERE ID = 2;
+GO
+~~START~~
+int#!#nvarchar#!#int
+2#!#Row2#!#200
+~~END~~
+
+
+-- Final state check
+SELECT * FROM EPQTest_Delete_Delete ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+3#!#Row3#!#300#!#3#!#Active
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#nvarchar
+~~END~~
+
+delete from EPQOutputLog;
+GO
+
+-- 2.1.4 Update inside delete trigger
+DELETE FROM EPQTest_Delete_Update
+OUTPUT deleted.ID, deleted.Name, deleted.Value
+WHERE ID = 2;
+GO
+~~START~~
+int#!#nvarchar#!#int
+2#!#Row2#!#200
+~~END~~
+
+
+-- Final state check
+SELECT * FROM EPQTest_Delete_Update ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+1#!#Row1#!#100#!#1#!#Active
+3#!#Row3#!#300#!#3#!#Active
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#nvarchar
+~~END~~
+
+delete from EPQOutputLog;
+GO
+
+
+------------------------------------------------------- INSERT -------------------------------------------------
+-- 2.1.5 delete inside insert trigger
+INSERT INTO EPQTest_Insert_Delete (ID, Name, Value, Counter)
+OUTPUT 
+    1,
+    1,
+    deleted.ID,
+    inserted.ID,
+    'Logged'
+INTO EPQOutputLog (LogID, SourceID, OldValue, NewValue, LogStatus)
+VALUES (1, 'Row1', 100, 1);
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: missing FROM-clause entry for table "deleted")~~
+
+
+-- Final state check
+SELECT * FROM EPQTest_Insert_Delete ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+~~END~~
+
+~~START~~
+int#!#int#!#int#!#int#!#nvarchar
+~~END~~
+
+delete from EPQOutputLog;
+GO
+
+
+-- 2.1.6 Update inside insert trigger
+INSERT INTO EPQTest_Insert_Update (ID, Name, Value, Counter)
+OUTPUT 
+    1,
+    1,
+    'NA',
+    inserted.Status,
+    'Logged'
+INTO EPQOutputLog_Str (LogID, SourceID, OldValue, NewValue, LogStatus)
+VALUES (1, 'Row1', 100, 1);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Final state check
+SELECT * FROM EPQTest_Insert_Update ORDER BY ID;
+SELECT * FROM EPQOutputLog_Str ORDER BY LogID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+1#!#Row1#!#100#!#1#!#PostTrigger
+~~END~~
+
+~~START~~
+int#!#int#!#nvarchar#!#nvarchar#!#nvarchar
+1#!#1#!#NA#!#Active#!#Logged
+~~END~~
+
+delete from EPQOutputLog_Str;
+GO
+~~ROW COUNT: 1~~
+
+
+
+
+
+
+
+------------------------------------------------------ INSTEAD OF TRIGGERS TEST ---------------------------------------------
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Update  + update inside update trigger
+* ------------------------------------------------------------------------------------
+*/
+-- Create table to capture OUTPUT results
+CREATE TABLE OutputCapture (
+    TestCase NVARCHAR(50),
+    ID INT,
+    Name NVARCHAR(50),
+    OldValue INT
+);
+GO
+
+-- 2.2.1 INSTEAD OF UPDATE trigger with OUTPUT - EPQ condition
+UPDATE EPQTest_InsteadOf_Update_Update
+SET Value = 1500
+OUTPUT 'InsteadOf_Update_Update', deleted.ID, deleted.Name, deleted.Value
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Update+Update OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#nvarchar#!#int
+~~END~~
+
+
+-- Verify INSTEAD OF trigger updated the row
+SELECT 'INSTEAD OF Update+Update' as TestPhase, * FROM EPQTest_InsteadOf_Update_Update WHERE ID = 1;
+GO
+~~START~~
+varchar#!#int#!#nvarchar#!#int#!#int#!#nvarchar
+INSTEAD OF Update+Update#!#1#!#Row1#!#1510#!#2#!#Modified
+~~END~~
+
+
+
+
+-- Clear OUTPUT capture
+delete from OutputCapture;
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Update  + delete inside update trigger
+* ------------------------------------------------------------------------------------
+*/
+-- 2.2.2 INSTEAD OF UPDATE trigger that deletes with OUTPUT
+UPDATE EPQTest_InsteadOf_Update_Delete
+SET Value = 2000
+OUTPUT 'InsteadOf_Update_Delete', deleted.ID, deleted.Name, deleted.Value
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Update+Delete OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#nvarchar#!#int
+~~END~~
+
+
+-- Clear OUTPUT capture
+DELETE FROM OutputCapture;
+GO
+
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Delete  + delete inside delete trigger
+* ------------------------------------------------------------------------------------
+*/
+-- 2.2.3 INSTEAD OF DELETE trigger with cascading deletes
+DELETE FROM EPQTest_InsteadOf_Delete_Delete
+OUTPUT 'InsteadOf_Delete_Delete', deleted.ID, deleted.Name, deleted.Value
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 2;
+GO
+~~ROW COUNT: 2~~
+
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Delete+Delete OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#nvarchar#!#int
+~~END~~
+
+
+-- Verify cascading deletes occurred
+SELECT 'INSTEAD OF Delete+Delete' as TestPhase, COUNT(*) as RemainingRows FROM EPQTest_InsteadOf_Delete_Delete;
+GO
+~~START~~
+varchar#!#int
+INSTEAD OF Delete+Delete#!#1
+~~END~~
+
+
+-- Clear OUTPUT capture
+DELETE FROM OutputCapture;
+GO
+
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Delete  + update inside delete trigger
+* ------------------------------------------------------------------------------------
+*/
+-- 2.2.4 INSTEAD OF DELETE trigger that updates instead of deleting
+DELETE FROM EPQTest_InsteadOf_Delete_Update
+OUTPUT 'InsteadOf_Delete_Update', deleted.ID, deleted.Name, deleted.Counter
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Delete+Update OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#nvarchar#!#int
+~~END~~
+
+
+-- Verify row was updated instead of deleted
+SELECT 'INSTEAD OF Delete+Update' as TestPhase, * FROM EPQTest_InsteadOf_Delete_Update WHERE ID = 1;
+GO
+~~START~~
+varchar#!#int#!#nvarchar#!#int#!#int#!#nvarchar
+INSTEAD OF Delete+Update#!#1#!#Row1#!#100#!#1001#!#Marked_For_Delete
+~~END~~
+
+
+-- Clear OUTPUT capture
+DELETE FROM OutputCapture;
+GO
+
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Insert  + delete inside insert trigger
+* ------------------------------------------------------------------------------------
+*/
+-- 2.2.5 Create table to capture OUTPUT results
+CREATE TABLE OutputCapture_insert (
+    TestCase NVARCHAR(50),
+    ID INT,
+    Name NVARCHAR(50),
+    OldValue INT,
+    NewValue INT,
+    Status NVARCHAR(50)
+);
+GO
+
+-- Insert some data first for delete scenario
+INSERT INTO EPQTest_InsteadOf_Insert_Delete (ID, Name, Value, Counter) VALUES (1, 'Existing1', 50, 1);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Test Case 34: INSTEAD OF INSERT trigger that deletes existing rows
+INSERT INTO EPQTest_InsteadOf_Insert_Delete (ID, Name, Value, Counter, Status)
+OUTPUT 'InsteadOf_Insert_Delete', inserted.ID, inserted.Name, 0, inserted.Value, inserted.Status
+INTO OutputCapture_insert (TestCase, ID, Name, OldValue, NewValue, Status)
+VALUES (2, 'NewRow', 100, 2, 'Active');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Insert+Delete OUTPUT' as TestPhase, * FROM OutputCapture_insert;
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#nvarchar#!#int#!#int#!#nvarchar
+~~END~~
+
+
+-- Verify existing row was deleted and new row inserted
+SELECT 'INSTEAD OF Insert+Delete' as TestPhase, COUNT(*) as TotalRows FROM EPQTest_InsteadOf_Insert_Delete;
+GO
+~~START~~
+varchar#!#int
+INSTEAD OF Insert+Delete#!#1
+~~END~~
+
+
+SELECT * FROM EPQTest_InsteadOf_Insert_Delete ORDER BY ID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+2#!#NewRow#!#100#!#2#!#Active
+~~END~~
+
+
+delete from OutputCapture_insert;
+GO
+
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Insert  + update inside insert trigger
+* ------------------------------------------------------------------------------------
+*/
+-- Insert some data first for update scenario
+INSERT INTO EPQTest_InsteadOf_Insert_Update (ID, Name, Value, Counter) VALUES (1, 'Existing1', 50, 1);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- 2.2.6 INSTEAD OF INSERT trigger that updates existing rows
+INSERT INTO EPQTest_InsteadOf_Insert_Update (ID, Name, Value, Counter, Status)
+OUTPUT 'InsteadOf_Insert_Update', inserted.ID, inserted.Name, 0, inserted.Value, inserted.Status
+INTO OutputCapture_insert (TestCase, ID, Name, OldValue, NewValue, Status)
+VALUES (2, 'NewRow', 200, 2, 'Active');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Insert+Update OUTPUT' as TestPhase, * FROM OutputCapture_insert;
+GO
+~~START~~
+varchar#!#nvarchar#!#int#!#nvarchar#!#int#!#int#!#nvarchar
+~~END~~
+
+
+-- Verify existing row was updated and new row inserted
+SELECT 'INSTEAD OF Insert+Update' as TestPhase, COUNT(*) as TotalRows FROM EPQTest_InsteadOf_Insert_Update;
+GO
+~~START~~
+varchar#!#int
+INSTEAD OF Insert+Update#!#2
+~~END~~
+
+
+SELECT * FROM EPQTest_InsteadOf_Insert_Update ORDER BY ID;
+GO
+~~START~~
+int#!#nvarchar#!#int#!#int#!#nvarchar
+1#!#Existing1#!#50#!#501#!#Updated_By_Insert
+2#!#NewRow#!#200#!#2#!#Inserted_Via_Trigger
+~~END~~
+
+
+-- Final cleanup of OUTPUT capture table
+DROP TABLE OutputCapture_insert;
+DROP TABLE OutputCapture;
+GO

--- a/test/JDBC/expected/update_with_var-vu-cleanup.out
+++ b/test/JDBC/expected/update_with_var-vu-cleanup.out
@@ -1,0 +1,95 @@
+-- Drop function first
+DROP FUNCTION IF EXISTS jira_babel_update_with_var_assign.custom_function;
+GO
+
+-- Drop all tables
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_int;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_str;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_multi;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_where;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_null;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_empty;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_single;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_numeric;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_math;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_col_assign;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_main;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_lookup;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_large;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_str_complex;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_case;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_counter;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_init;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_self;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_datetime;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_tran;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_top;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_convert;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_nested;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_other;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_dynamic;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_mixed_types;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_coalesce;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_output;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_running_max;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_cross_db;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_target;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_source;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_udf;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_concurrent;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_overflow;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_unicode;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_computed;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_recursive;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_division;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_truncation;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_identity;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_large_string;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_complex_expr;
+GO
+
+-- Drop schema
+DROP SCHEMA IF EXISTS jira_babel_update_with_var_assign;
+GO

--- a/test/JDBC/expected/update_with_var-vu-prepare.out
+++ b/test/JDBC/expected/update_with_var-vu-prepare.out
@@ -1,0 +1,292 @@
+-- Create schema for update_with_var tests
+CREATE SCHEMA jira_babel_update_with_var_assign;
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_int (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_int VALUES (1, 10), (2, 20), (3, 30);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_str (id INT, name VARCHAR(50));
+INSERT INTO jira_babel_update_with_var_assign.test_str VALUES (1, 'A'), (2, 'B'), (3, 'C');
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_multi (id INT, val INT, name VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_multi VALUES (1, 100, 'First'), (2, 200, 'Second'), (3, 300, 'Third');
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_where (id INT, val INT, status VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_where VALUES (1, 10, 'active'), (2, 20, 'inactive'), (3, 30, 'active'), (4, 40, 'inactive');
+GO
+~~ROW COUNT: 4~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_null (id INT, val INT, name VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_null VALUES (1, 10, 'A'), (2, NULL, 'B'), (3, 30, NULL), (4, 40, 'D');
+GO
+~~ROW COUNT: 4~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_empty (id INT, val INT);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_single (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_single VALUES (1, 50);
+GO
+~~ROW COUNT: 1~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_numeric (
+    id INT, 
+    int_val INT, 
+    decimal_val DECIMAL(10,2), 
+    float_val FLOAT,
+    bigint_val BIGINT
+);
+INSERT INTO jira_babel_update_with_var_assign.test_numeric VALUES 
+    (1, 10, 10.5, 10.25, 1000000000),
+    (2, 20, 20.5, 20.25, 2000000000);
+GO
+~~ROW COUNT: 2~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_math (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_math VALUES (1, 2), (2, 3), (3, 4);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_col_assign (id INT, val INT, running_total INT);
+INSERT INTO jira_babel_update_with_var_assign.test_col_assign VALUES (1, 10, 0), (2, 20, 0), (3, 30, 0);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_main (id INT, val INT);
+CREATE TABLE jira_babel_update_with_var_assign.test_lookup (id INT, multiplier INT);
+INSERT INTO jira_babel_update_with_var_assign.test_main VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO jira_babel_update_with_var_assign.test_lookup VALUES (1, 2), (2, 3), (3, 4);
+GO
+~~ROW COUNT: 3~~
+
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_large (id INT, val INT);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_str_complex (id INT, prefix VARCHAR(10), suffix VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_str_complex VALUES (1, 'A', 'X'), (2, 'B', 'Y'), (3, 'C', 'Z');
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_case (id INT, val INT, category VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_case VALUES (1, 10, 'A'), (2, 20, 'B'), (3, 30, 'A'), (4, 40, 'B');
+GO
+~~ROW COUNT: 4~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_counter (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_counter VALUES (1, 100), (2, 200), (3, 300);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_init (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_init VALUES (1, 5), (2, 10), (3, 15);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_self (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_self VALUES (1, 10), (2, 20), (3, 30);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_datetime (id INT, days_to_add INT);
+INSERT INTO jira_babel_update_with_var_assign.test_datetime VALUES (1, 1), (2, 2), (3, 3);
+GO
+~~ROW COUNT: 3~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_tran (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_tran VALUES (1, 10), (2, 20);
+GO
+~~ROW COUNT: 2~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_top (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_top VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+GO
+~~ROW COUNT: 4~~
+
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_convert (id INT, int_val INT, str_val VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_convert VALUES (1, 100, '50'), (2, 200, '75');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_nested (id INT, val INT);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_other (id INT);
+GO
+
+INSERT INTO jira_babel_update_with_var_assign.test_nested VALUES (1, 10), (2, 20);
+GO
+~~ROW COUNT: 2~~
+
+
+INSERT INTO jira_babel_update_with_var_assign.test_other VALUES (1), (1), (2);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_dynamic (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_dynamic VALUES (5), (15), (25);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_mixed_types (val INT, int_col INT, nvarchar_col NVARCHAR(10), float_col FLOAT);
+INSERT INTO jira_babel_update_with_var_assign.test_mixed_types VALUES (1, 10, N'A', 1.5), (2, 20, N'B', 2.5);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_coalesce (val INT, nullable_col VARCHAR(50));
+INSERT INTO jira_babel_update_with_var_assign.test_coalesce VALUES (1, NULL), (2, 'First'), (3, 'Second');
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_output (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_output VALUES (10), (20);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_running_max (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_running_max VALUES (5), (15), (10), (25), (20);
+GO
+~~ROW COUNT: 5~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_cross_db (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_cross_db VALUES (10), (20);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_target (id INT, val INT);
+GO
+CREATE TABLE jira_babel_update_with_var_assign.test_source (id INT, val INT);
+GO
+INSERT INTO jira_babel_update_with_var_assign.test_target VALUES (1, 100);
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO jira_babel_update_with_var_assign.test_source VALUES (1, 200), (2, 300);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE FUNCTION jira_babel_update_with_var_assign.custom_function(@val INT) RETURNS INT
+AS BEGIN
+    RETURN @val * 2;
+END;
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_udf (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_udf VALUES (5), (10);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_concurrent (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_concurrent VALUES (1), (2), (3), (4), (5);
+GO
+~~ROW COUNT: 5~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_overflow (val TINYINT);
+INSERT INTO jira_babel_update_with_var_assign.test_overflow VALUES (1), (2), (3);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_unicode (name VARCHAR(10), unicode_col NVARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_unicode VALUES ('A', N'α'), ('B', N'β');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_computed (base_val INT, computed_col AS (base_val * 2));
+INSERT INTO jira_babel_update_with_var_assign.test_computed (base_val) VALUES (10), (20);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_recursive (id INT, val INT, parent_id INT, processed BIT DEFAULT 0);
+INSERT INTO jira_babel_update_with_var_assign.test_recursive VALUES (1, 10, NULL, 0), (2, 20, 1, 0), (3, 30, 1, 0);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_division (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_division VALUES (0), (2), (4);
+GO
+~~ROW COUNT: 3~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_truncation (name VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_truncation VALUES ('VeryLongName1'), ('VeryLongName2');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_identity (id INT IDENTITY(1,1), name VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_identity (name) VALUES ('A'), ('B');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_large_string (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_large_string VALUES (1), (2);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_complex_expr (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_complex_expr VALUES (2), (3), (4);
+GO
+~~ROW COUNT: 3~~
+

--- a/test/JDBC/expected/update_with_var-vu-verify.out
+++ b/test/JDBC/expected/update_with_var-vu-verify.out
@@ -1,0 +1,2817 @@
+
+/*
+ *  ------------------------------------------------  Test case Description ------------------------------------------------
+ *
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | Basic variable assignment with UPDATE            | Basic               | Tests @sum accumulation with UPDATE          |
+ * |  2  | Multiple variables in single UPDATE              | Multi-Variable      | Tests @sum, @concat, @count simultaneously   |
+ * |  3  | Variable assignment with WHERE clause            | Filtering           | Tests conditional variable updates            |
+ * |  4  | NULL value handling in variables                 | NULL Handling       | Tests ISNULL with numeric and string vars    |
+ * |  5  | Empty table variable assignment                  | Edge Case           | Tests variables remain unchanged on empty set |
+ * |  6  | Numeric data types (DECIMAL, FLOAT, BIGINT)      | Data Types          | Tests various numeric type accumulations      |
+ * |  7  | Mathematical operations in variables             | Math Operations     | Tests *, -, + operations in variable assign  |
+ * |  8  | Variable used to update column values            | Column Update       | Tests running totals with column assignment   |
+ * |  9  | Variable assignment with JOINs                   | JOIN Operations     | Tests variables with multi-table operations   |
+ * | 10  | Large dataset variable processing                | Performance         | Tests 1000 row variable accumulation         |
+ * | 11  | Complex string operations                        | String Processing   | Tests string concatenation with formatting    |
+ * | 12  | CASE expressions in variable assignment          | Conditional Logic   | Tests conditional variable updates with CASE  |
+ * | 13  | Row counting with variables                      | Counting            | Tests row counter incrementation              |
+ * | 14  | Variables with initial values                    | Initialization      | Tests non-zero starting values               |
+ * | 15  | Self-referencing variable updates                | Complex Logic       | Tests variables affecting same UPDATE         |
+ * | 16  | DateTime operations with variables               | DateTime            | Tests date calculations in variables          |
+ * | 17  | Transaction rollback with variables              | Transaction         | Tests variable persistence across rollback    |
+ * | 18  | TOP clause with variable assignment              | Limited Processing  | Tests variables with row limiting             |
+ * | 19  | Type conversion in variable assignment           | Type Conversion     | Tests CAST operations in variable updates     |
+ * | 20  | Subqueries in variable assignment                | Subquery            | Tests nested queries with variables           |
+ * | 21  | Dynamic WHERE with variables                     | Dynamic Logic       | Tests variables in WHERE of same UPDATE      |
+ * | 22  | Mixed data types in single UPDATE                | Multi-Type          | Tests INT, NVARCHAR, FLOAT vars together     |
+ * | 23  | COALESCE/ISNULL with variables                   | NULL Functions      | Tests NULL handling functions with variables  |
+ * | 24  | Running maximum with variables                   | Aggregate Logic     | Tests MAX calculation with variables          |
+ */
+-- Test UPDATE
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_int SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 60
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+60
+~~END~~
+
+
+-- Test SELECT
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_int;
+SELECT @sum2 AS result; -- Expected: 60
+GO
+~~START~~
+int
+60
+~~END~~
+
+
+-- Test UPDATE
+DECLARE @concat VARCHAR(200) = '';
+UPDATE jira_babel_update_with_var_assign.test_str SET name = name, @concat = @concat + name;
+SELECT @concat AS result; -- Expected: 'ABC'
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- Test with delimiter
+DECLARE @concat2 VARCHAR(200) = '';
+UPDATE jira_babel_1290.test_str SET name = name, @concat2 = @concat2 + CASE WHEN @concat2 = '' THEN '' ELSE ',' END + name;
+SELECT @concat2 AS result; -- Expected: ',A,B,C' or similar
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: schema "jira_babel_1290" does not exist)~~
+
+
+-- Test UPDATE with multiple variables
+DECLARE @sum INT = 0, @concat VARCHAR(200) = '', @count INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_multi 
+SET val = val, 
+    @sum = @sum + val, 
+    @concat = @concat + name + '|',
+    @count = @count + 1;
+SELECT @sum AS sum_result, @concat AS concat_result, @count AS count_result;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#varchar#!#int
+600#!#First|Second|Third|#!#3
+~~END~~
+
+
+
+
+-- Expected: sum=600, concat='First|Second|Third|', count=3
+-- Test UPDATE with WHERE
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_where SET val = val, @sum = @sum + val WHERE status = 'active';
+SELECT @sum AS result; -- Expected: 40 (10+30)
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+40
+~~END~~
+
+
+-- Test SELECT with WHERE
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_where WHERE status = 'inactive';
+SELECT @sum2 AS result; -- Expected: 60 (20+40)
+GO
+~~START~~
+int
+60
+~~END~~
+
+
+-- Test with NULL values in numeric column
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_null SET val = val, @sum = @sum + ISNULL(val, 0);
+SELECT @sum AS result; -- Expected: 80
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int
+80
+~~END~~
+
+
+-- Test with NULL values in string column
+DECLARE @concat VARCHAR(200) = '';
+UPDATE jira_babel_update_with_var_assign.test_null SET name = name, @concat = @concat + ISNULL(name, '');
+SELECT @concat AS result; -- Expected: 'ABD'
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+varchar
+ABD
+~~END~~
+
+
+-- Test UPDATE on empty table
+DECLARE @sum INT = 100;
+UPDATE jira_babel_update_with_var_assign.test_empty SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 100 (unchanged)
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+-- Test SELECT on empty table
+DECLARE @sum2 INT = 100;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_empty;
+SELECT @sum2 AS result; -- Expected: 100 (unchanged)
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+-- Test UPDATE
+DECLARE @sum INT = 10;
+UPDATE jira_babel_update_with_var_assign.test_single SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 60
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+60
+~~END~~
+
+
+
+-- Test with DECIMAL
+DECLARE @dec_sum DECIMAL(10,2) = 0;
+UPDATE jira_babel_update_with_var_assign.test_numeric SET int_val = int_val, @dec_sum = @dec_sum + decimal_val;
+SELECT @dec_sum AS result; -- Expected: 31.00
+-- Test with FLOAT
+DECLARE @float_sum FLOAT = 0;
+UPDATE jira_babel_update_with_var_assign.test_numeric SET int_val = int_val, @float_sum = @float_sum + float_val;
+SELECT @float_sum AS result; -- Expected: 30.5
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+numeric
+31.00
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+float
+30.5
+~~END~~
+
+
+-- Test with BIGINT
+DECLARE @bigint_sum BIGINT = 0;
+UPDATE jira_babel_update_with_var_assign.test_numeric SET int_val = int_val, @bigint_sum = @bigint_sum + bigint_val;
+SELECT @bigint_sum AS result; -- Expected: 3000000000
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+bigint
+3000000000
+~~END~~
+
+
+
+
+-- Test multiplication
+DECLARE @product INT = 1;
+UPDATE jira_babel_update_with_var_assign.test_math SET val = val, @product = @product * val;
+SELECT @product AS result; -- Expected: 24 (1*2*3*4)
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+24
+~~END~~
+
+
+-- Test subtraction
+DECLARE @diff INT = 100;
+UPDATE jira_babel_update_with_var_assign.test_math SET val = val, @diff = @diff - val;
+SELECT @diff AS result; -- Expected: 91 (100-2-3-4)
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+91
+~~END~~
+
+
+-- Test mixed operations
+DECLARE @mixed INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_math SET val = val, @mixed = @mixed + val * 2;
+SELECT @mixed AS result; -- Expected: 18 (2*2 + 3*2 + 4*2)
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+18
+~~END~~
+
+
+-- Test UPDATE where variable is used to update column
+DECLARE @running INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_col_assign 
+SET @running = @running + val, 
+    running_total = @running;
+SELECT * FROM jira_babel_update_with_var_assign.test_col_assign ORDER BY id;
+-- Expected: rows with running_total showing cumulative sum
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#int#!#int
+1#!#10#!#0
+2#!#20#!#10
+3#!#30#!#30
+~~END~~
+
+
+-- Test UPDATE with JOIN
+DECLARE @sum INT = 0;
+UPDATE m 
+SET m.val = m.val, 
+    @sum = @sum + m.val * l.multiplier
+FROM jira_babel_update_with_var_assign.test_main m
+INNER JOIN jira_babel_update_with_var_assign.test_lookup l ON m.id = l.id;
+SELECT @sum AS result; -- Expected: 200 (10*2 + 20*3 + 30*4)
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+200
+~~END~~
+
+
+-- Test SELECT with JOIN
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + m.val * l.multiplier
+FROM jira_babel_update_with_var_assign.test_main m
+INNER JOIN jira_babel_update_with_var_assign.test_lookup l ON m.id = l.id;
+SELECT @sum2 AS result; -- Expected: 200
+GO
+~~START~~
+int
+200
+~~END~~
+
+
+-- Insert 1000 rows
+DECLARE @i INT = 1;
+WHILE @i <= 1000
+BEGIN
+    INSERT INTO jira_babel_update_with_var_assign.test_large VALUES (@i, @i);
+    SET @i = @i + 1;
+END
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Test UPDATE
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_large SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 500500 (sum of 1 to 1000)
+GO
+~~ROW COUNT: 1000~~
+
+~~START~~
+int
+500500
+~~END~~
+
+
+-- Test SELECT
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_large;
+SELECT @sum2 AS result; -- Expected: 500500
+GO
+~~START~~
+int
+500500
+~~END~~
+
+
+-- Test complex string concatenation
+DECLARE @result VARCHAR(200) = '';
+UPDATE jira_babel_update_with_var_assign.test_str_complex 
+SET prefix = prefix, 
+    @result = @result + '[' + prefix + '-' + suffix + ']';
+SELECT @result AS result; -- Expected: '[A-X][B-Y][C-Z]'
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar
+[A-X][B-Y][C-Z]
+~~END~~
+
+
+-- Test UPDATE with CASE
+DECLARE @sum_a INT = 0, @sum_b INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_case 
+SET val = val,
+    @sum_a = CASE WHEN category = 'A' THEN @sum_a + val ELSE @sum_a END,
+    @sum_b = CASE WHEN category = 'B' THEN @sum_b + val ELSE @sum_b END;
+SELECT @sum_a AS sum_a, @sum_b AS sum_b; -- Expected: sum_a=40, sum_b=60
+GO
+~~ROW COUNT: 4~~
+
+~~START~~
+int#!#int
+40#!#60
+~~END~~
+
+
+-- Test row counter
+DECLARE @counter INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_counter SET val = val, @counter = @counter + 1;
+SELECT @counter AS result; -- Expected: 3
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+-- Test with initial non-zero value
+DECLARE @sum INT = 100;
+UPDATE jira_babel_update_with_var_assign.test_init SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 130 (100+5+10+15)
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+130
+~~END~~
+
+
+-- Test with initial string
+DECLARE @str VARCHAR(100) = 'START:';
+UPDATE jira_babel_update_with_var_assign.test_init SET val = val, @str = @str + CAST(val AS VARCHAR(10)) + ',';
+SELECT @str AS result; -- Expected: 'START:5,10,15,'
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar
+START:5,10,15,
+~~END~~
+
+
+-- Test where variable affects the update
+DECLARE @prev INT = 0, @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_self 
+SET @sum = @sum + val,
+    val = val + @prev,
+    @prev = val;
+SELECT @sum AS sum_result, @prev AS prev_result;
+SELECT * FROM jira_babel_update_with_var_assign.test_self ORDER BY id;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#int
+100#!#60
+~~END~~
+
+~~START~~
+int#!#int
+1#!#10
+2#!#30
+3#!#60
+~~END~~
+
+
+-- Test with datetime
+DECLARE @date DATETIME = '2024-01-01', @total_days INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_datetime 
+SET days_to_add = days_to_add, 
+    @total_days = @total_days + days_to_add;
+SELECT @total_days AS result; -- Expected: 6
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+6
+~~END~~
+
+
+BEGIN TRANSACTION;
+    DECLARE @sum INT = 0;
+    UPDATE jira_babel_update_with_var_assign.test_tran SET val = val, @sum = @sum + val;
+    SELECT @sum AS result; -- Expected: 30
+ROLLBACK TRANSACTION;
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+30
+~~END~~
+
+
+-- Verify rollback doesn't affect variable
+DECLARE @sum2 INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_tran SET val = val, @sum2 = @sum2 + val;
+SELECT @sum2 AS result; -- Expected: 30 (data unchanged by rollback)
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+30
+~~END~~
+
+
+-- Test UPDATE with TOP
+DECLARE @sum INT = 0;
+UPDATE TOP(2) jira_babel_update_with_var_assign.test_top SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: Sum of first 2 rows processed
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+30
+~~END~~
+
+
+-- Test conversion during accumulation
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_convert 
+SET int_val = int_val, 
+    @sum = @sum + int_val + CAST(str_val AS INT);
+SELECT @sum AS result; -- Expected: 425 (100+50+200+75)
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+425
+~~END~~
+
+
+-- Nested subqueries with variables
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_nested 
+SET val = val, 
+    @sum = @sum + (SELECT COUNT(*) FROM jira_babel_update_with_var_assign.test_other WHERE jira_babel_update_with_var_assign.test_other.id = jira_babel_update_with_var_assign.test_nested.id);
+SELECT @sum AS result;
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+-- Variable used in WHERE clause of same UPDATE
+DECLARE @threshold INT = 10;
+UPDATE jira_babel_update_with_var_assign.test_dynamic 
+SET val = val, 
+    @threshold = @threshold + 5
+WHERE val > @threshold;
+SELECT @threshold AS result;
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+20
+~~END~~
+
+
+-- Multiple variables with different data types in single UPDATE
+DECLARE @int_sum INT = 0, @str_concat NVARCHAR(100) = N'', @float_avg FLOAT = 0, @count INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_mixed_types 
+SET val = val,
+    @int_sum = @int_sum + int_col,
+    @str_concat = @str_concat + nvarchar_col + N'|',
+    @float_avg = (@float_avg * @count + float_col) / (@count + 1),
+    @count = @count + 1;
+SELECT @int_sum, @str_concat, @float_avg, @count;
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#nvarchar#!#float#!#int
+30#!#A|B|#!#2.0#!#2
+~~END~~
+
+
+-- Variable assignment with COALESCE/ISNULL
+DECLARE @first_non_null VARCHAR(50) = NULL;
+UPDATE jira_babel_update_with_var_assign.test_coalesce 
+SET val = val,
+    @first_non_null = COALESCE(@first_non_null, nullable_col);
+SELECT @first_non_null AS result;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+varchar
+First
+~~END~~
+
+
+-- Variable assignment with aggregate functions
+DECLARE @max_so_far INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_running_max 
+SET val = val,
+    @max_so_far = CASE WHEN val > @max_so_far THEN val ELSE @max_so_far END;
+SELECT @max_so_far AS result;
+GO
+~~ROW COUNT: 5~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+-- Cross-database UPDATE with variables (if applicable)
+CREATE DATABASE test;
+USE test;
+DECLARE @sum INT = 0;
+UPDATE master.dbo.jira_babel_update_with_var_assign.test_cross_db 
+SET val = val, 
+    @sum = @sum + val;
+SELECT @sum AS result;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: UPDATE on a 4-part object name is not yet supported in Babelfish)~~
+
+
+use master
+GO
+
+
+
+
+-- UPDATE with MERGE-like behavior using variables
+DECLARE @inserted_count INT = 0, @updated_count INT = 0;
+UPDATE target 
+SET target.val = source.val,
+    @updated_count = @updated_count + 1
+FROM jira_babel_update_with_var_assign.test_target target
+INNER JOIN jira_babel_update_with_var_assign.test_source source ON target.id = source.id;
+INSERT INTO jira_babel_update_with_var_assign.test_target (id, val)
+SELECT id, val FROM jira_babel_update_with_var_assign.test_source 
+WHERE id NOT IN (SELECT id FROM jira_babel_update_with_var_assign.test_target);
+SET @inserted_count = @@ROWCOUNT;
+SELECT @updated_count, @inserted_count;
+-- Variable with user-defined functions
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_udf 
+SET val = val,
+    @sum = @sum + jira_babel_update_with_var_assign.custom_function(val);
+SELECT @sum AS result;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+30
+~~END~~
+
+
+-- Concurrent variable updates
+DECLARE @counter1 INT = 0, @counter2 INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_concurrent 
+SET val = val,
+    @counter1 = @counter1 + CASE WHEN val % 2 = 0 THEN 1 ELSE 0 END,
+    @counter2 = @counter2 + CASE WHEN val % 2 = 1 THEN 1 ELSE 0 END;
+SELECT @counter1 AS even_count, @counter2 AS odd_count;
+GO
+~~ROW COUNT: 5~~
+
+~~START~~
+int#!#int
+2#!#3
+~~END~~
+
+
+-- Variable overflow scenarios
+DECLARE @tiny TINYINT = 250;
+UPDATE jira_babel_update_with_var_assign.test_overflow 
+SET val = val,
+    @tiny = @tiny + val;
+SELECT @tiny AS result;
+GO
+~~ERROR (Code: 220)~~
+
+~~ERROR (Message: value for domain tinyint violates check constraint "tinyint_check")~~
+
+~~START~~
+tinyint
+253
+~~END~~
+
+
+-- Unicode string concatenation
+DECLARE @unicode NVARCHAR(100) = N'';
+UPDATE jira_babel_update_with_var_assign.test_unicode 
+SET name = name,
+    @unicode = @unicode + unicode_col + N'→';
+SELECT @unicode AS result;
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+nvarchar
+α→β→
+~~END~~
+
+
+-- Variable assignment with computed columns
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_computed 
+SET base_val = base_val,
+    @sum = @sum + computed_col;
+SELECT @sum AS result;
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+60
+~~END~~
+
+
+
+
+
+
+-- Recursive CTE with UPDATE and variables
+DECLARE @total_levels INT = 0;
+WITH recursive_cte AS (
+    SELECT id, val, 1 as level 
+    FROM jira_babel_update_with_var_assign.test_recursive 
+    WHERE parent_id IS NULL
+    UNION ALL
+    SELECT t.id, t.val, r.level + 1 
+    FROM jira_babel_update_with_var_assign.test_recursive t
+    INNER JOIN recursive_cte r ON t.parent_id = r.id
+)
+UPDATE t
+SET processed = 1,
+    @total_levels = @total_levels + ISNULL(r.level, 0)
+FROM jira_babel_update_with_var_assign.test_recursive t
+LEFT JOIN recursive_cte r ON t.id = r.id;
+SELECT @total_levels AS total_accumulated_levels;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+5
+~~END~~
+
+SELECT * FROM jira_babel_update_with_var_assign.test_recursive ORDER BY id;
+GO
+~~START~~
+int#!#int#!#int#!#bit
+1#!#10#!#<NULL>#!#1
+2#!#20#!#1#!#1
+3#!#30#!#1#!#1
+~~END~~
+
+
+----------------------------------------------------------------------------------------------------------------------
+-- These tests are error cases that differ compared to sql server output
+----------------------------------------------------------------------------------------------------------------------
+-- trigger scenarios
+CREATE TABLE jira_babel_update_with_var_assign.simple_test (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.simple_test VALUES (1, 10), (2, 20);
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TRIGGER trg_simple_test ON jira_babel_update_with_var_assign.simple_test
+AFTER UPDATE AS
+BEGIN
+    INSERT INTO jira_babel_update_with_var_assign.simple_test VALUES (99, 99);
+END;
+GO
+
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.simple_test SET val = val, @sum = @sum + val;
+SELECT @sum AS result;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: portal snapshots (1) did not account for all active snapshots (2))~~
+
+
+DROP TRIGGER IF EXISTS trg_simple_test;
+DROP TABLE jira_babel_update_with_var_assign.simple_test;
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.minimal_test (val INT);
+INSERT INTO jira_babel_update_with_var_assign.minimal_test VALUES (5);
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TRIGGER trg_minimal ON jira_babel_update_with_var_assign.minimal_test
+AFTER UPDATE AS BEGIN
+    SELECT 1;
+END;
+GO
+
+DECLARE @result INT = 0;
+UPDATE jira_babel_update_with_var_assign.minimal_test SET val = val, @result = @result + val;
+SELECT @result;
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ERROR (Code: 3609)~~
+
+~~ERROR (Message: The transaction ended in the trigger. The batch has been aborted.)~~
+
+
+DROP TRIGGER IF EXISTS trg_minimal;
+DROP TABLE jira_babel_update_with_var_assign.minimal_test;
+GO
+
+-- UPDATE with OUTPUT clause and variables
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_output 
+SET val = val * 2,
+    @sum = @sum + val
+OUTPUT inserted.val, deleted.val;
+SELECT @sum AS accumulated_original_values;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "RETURNING")~~
+

--- a/test/JDBC/input/Output_clause_Concurrency/babel_output_clause_concurrency_test.txt
+++ b/test/JDBC/input/Output_clause_Concurrency/babel_output_clause_concurrency_test.txt
@@ -1,0 +1,6 @@
+//Added this to test concurrency in output clause
+
+// Test Case 1: UPDATE with OUTPUT blocked by concurrent transaction, tests EPQ re-evaluation of modified row values
+// Test Case 2: DELETE with OUTPUT processes EPQ-updated row values from concurrent session modifications
+// Test Case 3: INSERT with OUTPUT executes during concurrent lock contention without blocking
+// Test Case 4: Mixed INSERT/UPDATE/DELETE with OUTPUT clauses under concurrent EPQ conditions in single transaction

--- a/test/JDBC/input/test_output_clause-vu-cleanup.sql
+++ b/test/JDBC/input/test_output_clause-vu-cleanup.sql
@@ -1,0 +1,180 @@
+-- Drop all INSTEAD OF triggers first
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Update_Update;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Delete_OnUpdate;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Delete_OnDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Update_OnDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Delete_OnInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_InsteadOf_Update_OnInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_InsteadOf_Mixed;
+GO
+ 
+-- Drop all AFTER triggers
+DROP TRIGGER IF EXISTS tr_OutputTest_Insert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_OutputTest_Update;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_OutputTest_Delete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_After_Update;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Delete_OnUpdate;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Delete_OnDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Update_Update_AfterDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Delete_AfterInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_EPQTest_Update_AfterInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_Update_Delete_Deadlock;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_Delete_Update_Deadlock;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_After_Mixed;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_InsteadOf_MixedDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_After_MixedDelete;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_InsteadOf_MixedInsert;
+GO
+ 
+DROP TRIGGER IF EXISTS tr_After_MixedInsert;
+GO
+ 
+-- Drop all views
+DROP VIEW IF EXISTS OutputTestView;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Update_Update;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Update_Delete;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Delete_Delete;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Delete_Update;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Insert_Delete;
+GO
+ 
+DROP VIEW IF EXISTS EPQView_Insert_Update;
+GO
+ 
+DROP VIEW IF EXISTS MixedTriggerViewDelete;
+GO
+ 
+DROP VIEW IF EXISTS MixedTriggerViewInsert;
+GO
+ 
+-- Drop all tables
+DROP TABLE IF EXISTS OutputTest;
+GO
+ 
+DROP TABLE IF EXISTS OutputLog;
+GO
+ 
+DROP TABLE IF EXISTS TriggerLog;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Update_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Update_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Delete_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Delete_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Insert_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Insert_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQOutputLog;
+GO
+ 
+DROP TABLE IF EXISTS EPQOutputLog_Str;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Update_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Update_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Delete_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Delete_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Insert_Delete;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_InsteadOf_Insert_Update;
+GO
+ 
+DROP TABLE IF EXISTS EPQTest_Delete_Update_deadlock;
+GO
+ 
+DROP TABLE IF EXISTS MixedTriggerTest;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixed;
+GO
+ 
+DROP TABLE IF EXISTS MixedTriggerTestDelete;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixedDelete;
+GO
+ 
+DROP TABLE IF EXISTS MixedTriggerTestInsert;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixedInsert;
+GO
+ 
+DROP TABLE IF EXISTS OutputCapture;
+GO
+ 
+DROP TABLE IF EXISTS TriggerOutputLogMixed;
+GO
+
+DROP TABLE IF EXISTS outputresults;
+GO

--- a/test/JDBC/input/test_output_clause-vu-prepare.sql
+++ b/test/JDBC/input/test_output_clause-vu-prepare.sql
@@ -1,0 +1,565 @@
+/*
+ * ===================================================================================================================
+ *                                              1. Basic Output clause test
+ * ===================================================================================================================
+ */
+
+-- Test setup for OUTPUT clause functionality
+CREATE TABLE OutputTest (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO OutputTest (ID, Name, Value) VALUES 
+(1, 'Test1', 100),
+(2, 'Test2', 200),
+(3, 'Test3', 300);
+GO
+
+-- Table for OUTPUT INTO testing
+CREATE TABLE OutputLog (
+    LogID INT,
+    Operation NVARCHAR(10),
+    ID INT,
+    Name NVARCHAR(50),
+    Value INT
+);
+GO
+
+-- Dependent objects setup
+CREATE VIEW OutputTestView AS
+SELECT ID, Name, Value, Status FROM OutputTest WHERE Status = 'Active';
+GO
+
+CREATE TABLE TriggerLog (
+    LogID INT,
+    TriggerType NVARCHAR(20),
+    TableName NVARCHAR(50),
+    RecordID INT
+);
+GO
+
+-- Triggers for testing OUTPUT with trigger interaction
+CREATE TRIGGER tr_OutputTest_Insert
+ON OutputTest
+AFTER INSERT
+AS
+BEGIN
+    INSERT INTO TriggerLog (LogID, TriggerType, TableName, RecordID)
+    SELECT inserted.ID + 1000, 'AFTER_INSERT', 'OutputTest', inserted.ID FROM inserted;
+END;
+GO
+
+CREATE TRIGGER tr_OutputTest_Update
+ON OutputTest
+AFTER UPDATE
+AS
+BEGIN
+    INSERT INTO TriggerLog (LogID, TriggerType, TableName, RecordID)
+    SELECT inserted.ID + 2000, 'AFTER_UPDATE', 'OutputTest', inserted.ID FROM inserted;
+END;
+GO
+
+CREATE TRIGGER tr_OutputTest_Delete
+ON OutputTest
+AFTER DELETE
+AS
+BEGIN
+    INSERT INTO TriggerLog (LogID, TriggerType, TableName, RecordID)
+    SELECT deleted.ID + 3000, 'AFTER_DELETE', 'OutputTest', deleted.ID FROM deleted;
+END;
+GO
+
+
+/*
+ * ===================================================================================================================
+ *                                              2. Triggers + DML with OUTPUT clause test
+ * ===================================================================================================================
+ */
+
+
+/*
+ * ----------------------------   2.1 All below tests are AFTER TRIGGERS test with output clause. --------------------------------------
+ */
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.1 Scenerio -
+ *  Update command with output clause
+ *  AFTER trigger on update  
+ *  Another update inside AFTER trigger updating same row
+ * ------------------------------------------------------------------------------------
+ */
+
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Update_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_Update_Update (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- AFTER trigger that updates the same row
+CREATE TRIGGER tr_EPQTest_After_Update
+ON EPQTest_Update_Update
+AFTER UPDATE
+AS
+BEGIN
+    -- UPDATE EPQTest_Update_Update 
+    -- SET Counter = Counter + 100
+    -- WHERE ID IN (SELECT ID FROM inserted);
+
+    UPDATE EPQTest_Update_Update 
+    SET Status = 'PostTrigger'
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.2 Scenerio -
+ *  Update command with output clause
+ *  AFTER trigger on update  
+ *  Delete inside AFTER trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Update_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- Insert test data
+INSERT INTO EPQTest_Update_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+
+-- Test Case 18: AFTER trigger that deletes the row being updated
+CREATE TRIGGER tr_EPQTest_Delete_OnUpdate
+ON EPQTest_Update_Delete
+AFTER UPDATE
+AS
+BEGIN
+    DELETE FROM EPQTest_Update_Delete
+    WHERE ID IN (SELECT ID FROM inserted) ;
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.3 Scenerio -
+ *  Delete command with output clause
+ *  AFTER trigger on Delete
+ *  Delete inside AFTER trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Delete_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- Insert test data
+INSERT INTO EPQTest_Delete_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- Test Case 19: AFTER trigger that deletes additional rows during DELETE
+CREATE TRIGGER tr_EPQTest_Delete_OnDelete
+ON EPQTest_Delete_Delete
+AFTER DELETE
+AS
+BEGIN
+    DELETE FROM EPQTest_Delete_Delete 
+    WHERE Value < (SELECT MIN(Value) FROM deleted) + 50;
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.4 Scenerio -
+ *  Delete command with output clause
+ *  AFTER trigger on Delete
+ *  Update inside AFTER trigger trying to update deleted row
+ * ------------------------------------------------------------------------------------
+ */
+
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Delete_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+
+-- Insert test data
+INSERT INTO EPQTest_Delete_Update (ID, Name, Value, Counter) VALUES
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- Test Case 20: AFTER DELETE trigger that tries to update deleted rows
+CREATE TRIGGER tr_EPQTest_Update_Update_AfterDelete
+ON EPQTest_Delete_Update
+AFTER DELETE
+AS
+BEGIN
+    UPDATE EPQTest_Delete_Update
+    SET Status = 'Updated_After_Delete'
+    WHERE ID IN (SELECT ID FROM deleted);
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.5 Scenerio -
+ *  Insert command with output clause
+ *  AFTER trigger on Insert
+ *  Delete inside trigger deleting new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Insert_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Test Case 21: AFTER INSERT trigger that deletes the inserted row
+CREATE TRIGGER tr_EPQTest_Delete_AfterInsert
+ON EPQTest_Insert_Delete
+AFTER INSERT
+AS
+BEGIN
+    DELETE FROM EPQTest_Insert_Delete 
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.1.6 Scenerio -
+ *  Insert command with output clause
+ *  AFTER trigger on Insert
+ *  Update inside trigger Updating new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_Insert_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- AFTER INSERT trigger that Updates the inserted row
+CREATE TRIGGER tr_EPQTest_Update_AfterInsert
+ON EPQTest_Insert_Update
+AFTER INSERT
+AS
+BEGIN
+    UPDATE EPQTest_Insert_Update 
+    SET Status = 'PostTrigger'
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+
+
+
+-- Temporary table to store OUTPUT result
+CREATE TABLE EPQOutputLog (
+    LogID INT,
+    SourceID INT,
+    OldValue INT,
+    NewValue INT,
+    LogStatus NVARCHAR(20)
+);
+GO
+
+-- Temporary table to store OUTPUT result
+CREATE TABLE EPQOutputLog_Str (
+    LogID INT,
+    SourceID INT,
+    OldValue NVARCHAR(30),
+    NewValue NVARCHAR(30),
+    LogStatus NVARCHAR(20)
+);
+GO
+
+/*
+ *  ----------------------------   2.2 All below tests are INSTEAD OF TRIGGERS test with output clause. --------------------------------------------
+ */
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.1 Scenerio -
+ *  Update command with output clause
+ *  INSTEAD OF trigger on update 
+ *  Another update inside trigger updating same row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table for INSTEAD OF triggers
+CREATE TABLE EPQTest_InsteadOf_Update_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Update_Update (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- INSTEAD OF trigger that updates the same row
+CREATE TRIGGER tr_EPQTest_InsteadOf_Update_Update
+ON EPQTest_InsteadOf_Update_Update
+INSTEAD OF UPDATE
+AS
+BEGIN
+    UPDATE EPQTest_InsteadOf_Update_Update 
+    SET Value = i.Value + 10,
+        Counter = e.Counter + 1,
+        Status = 'Modified'
+    FROM EPQTest_InsteadOf_Update_Update e
+    INNER JOIN inserted i ON e.ID = i.ID;
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.2 Scenerio -
+ *  Update command with output clause on view
+ *  INSTEAD OF trigger on update 
+ *  Delete inside trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Update_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Update_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- INSTEAD OF trigger that deletes the row being updated
+CREATE TRIGGER tr_EPQTest_InsteadOf_Delete_OnUpdate
+ON EPQTest_InsteadOf_Update_Delete
+INSTEAD OF UPDATE
+AS
+BEGIN
+    DELETE FROM EPQTest_InsteadOf_Update_Delete
+    WHERE ID IN (SELECT ID FROM inserted);
+END;
+GO
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.3 Scenerio -
+ *  Delete command with output clause on view
+ *  INSTEAD OF trigger on Delete 
+ *  Delete inside trigger deleting same row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Delete_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Delete_Delete (ID, Name, Value, Counter) VALUES 
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- INSTEAD OF trigger that deletes additional rows during DELETE
+CREATE TRIGGER tr_EPQTest_InsteadOf_Delete_OnDelete
+ON EPQTest_InsteadOf_Delete_Delete
+INSTEAD OF DELETE
+AS
+BEGIN
+    DELETE FROM EPQTest_InsteadOf_Delete_Delete 
+    WHERE Value < (SELECT MIN(Value) FROM deleted) + 50;
+
+    DELETE FROM EPQTest_InsteadOf_Delete_Delete
+    WHERE ID IN (SELECT ID FROM deleted);
+END;
+GO
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.4 Scenerio -
+ *  Delete command with output clause on view
+ *  INSTEAD OF trigger on Delete 
+ *  Update inside trigger updating deleted row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Delete_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- Insert test data
+INSERT INTO EPQTest_InsteadOf_Delete_Update (ID, Name, Value, Counter) VALUES
+(1, 'Row1', 100, 1),
+(2, 'Row2', 200, 2),
+(3, 'Row3', 300, 3);
+GO
+
+-- INSTEAD OF DELETE trigger that updates instead of deleting
+CREATE TRIGGER tr_EPQTest_InsteadOf_Update_OnDelete
+ON EPQTest_InsteadOf_Delete_Update
+INSTEAD OF DELETE
+AS
+BEGIN
+    UPDATE EPQTest_InsteadOf_Delete_Update
+    SET Status = 'Marked_For_Delete', Counter = Counter + 1000
+    WHERE ID IN (SELECT ID FROM deleted);
+END;
+GO
+
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.5 Scenerio -
+ *  Insert command with output clause on view
+ *  INSTEAD OF trigger on Insert 
+ *  Delete inside trigger deleting new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Insert_Delete (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- INSTEAD OF INSERT trigger that deletes existing rows
+CREATE TRIGGER tr_EPQTest_InsteadOf_Delete_OnInsert
+ON EPQTest_InsteadOf_Insert_Delete
+INSTEAD OF INSERT
+AS
+BEGIN
+    DELETE FROM EPQTest_InsteadOf_Insert_Delete 
+    WHERE Value < (SELECT MIN(Value) FROM inserted);
+
+    INSERT INTO EPQTest_InsteadOf_Insert_Delete (ID, Name, Value, Counter, Status)
+    SELECT ID, Name, Value, Counter, Status FROM inserted;
+END;
+GO
+
+/*
+ * ------------------------------------------------------------------------------------
+ *  2.2.6 Scenerio -
+ *  Insert command with output clause on view
+ *  INSTEAD OF trigger on Insert 
+ *  Update inside trigger Updating new inserted row
+ * ------------------------------------------------------------------------------------
+ */
+
+-- Setup EPQ test table
+CREATE TABLE EPQTest_InsteadOf_Insert_Update (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT,
+    Counter INT DEFAULT 0,
+    Status NVARCHAR(20) DEFAULT 'Active'
+);
+GO
+
+-- INSTEAD OF INSERT trigger that updates existing rows and inserts new ones
+CREATE TRIGGER tr_EPQTest_InsteadOf_Update_OnInsert
+ON EPQTest_InsteadOf_Insert_Update
+INSTEAD OF INSERT
+AS
+BEGIN
+    UPDATE EPQTest_InsteadOf_Insert_Update 
+    SET Status = 'Updated_By_Insert', Counter = Counter + 500
+    WHERE Value < (SELECT MAX(Value) FROM inserted);
+
+    INSERT INTO EPQTest_InsteadOf_Insert_Update (ID, Name, Value, Counter, Status)
+    SELECT ID, Name, Value, Counter, 'Inserted_Via_Trigger' FROM inserted;
+END;
+GO

--- a/test/JDBC/input/test_output_clause-vu-verify.sql
+++ b/test/JDBC/input/test_output_clause-vu-verify.sql
@@ -1,0 +1,497 @@
+/*
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | INSERT with OUTPUT                               | Basic DML           | Tests basic INSERT OUTPUT clause             |
+ * |  2  | UPDATE with OUTPUT                               | Basic DML           | Tests basic UPDATE OUTPUT clause             |
+ * |  3  | DELETE with OUTPUT                               | Basic DML           | Tests basic DELETE OUTPUT clause             |
+ * |  4  | INSERT with OUTPUT INTO                          | OUTPUT INTO         | Tests INSERT OUTPUT INTO target table        |
+ * |  5  | UPDATE with OUTPUT INTO                          | OUTPUT INTO         | Tests UPDATE OUTPUT INTO target table        |
+ * |  6  | DELETE with OUTPUT INTO                          | OUTPUT INTO         | Tests DELETE OUTPUT INTO target table        |
+ * |  7  | Multiple row UPDATE with OUTPUT                  | Multi-row           | Tests OUTPUT with multiple affected rows     |
+ * |  8  | OUTPUT with computed columns                     | Computed Values     | Tests OUTPUT with calculated expressions     |
+ * |  9  | OUTPUT with dependent objects (view)             | View Integration    | Tests OUTPUT with view dependencies          |
+ * | 10  | UPDATE base table with OUTPUT (view test)        | View Operations     | Tests OUTPUT on base table through view      |
+ * | 11  | INSERT with OUTPUT and trigger interaction       | Trigger Basic       | Tests OUTPUT with trigger execution          |
+ * | 12  | UPDATE with OUTPUT and trigger interaction       | Trigger Basic       | Tests OUTPUT with trigger modifications      |
+ * | 13  | DELETE with OUTPUT and trigger interaction       | Trigger Basic       | Tests OUTPUT with trigger deletions          |
+ * | 14  | Multiple operations with triggers and OUTPUT INTO| Trigger Batch       | Tests batch operations with triggers         |
+ * | 15  | OUTPUT with trigger execution order validation   | Trigger Order       | Tests OUTPUT timing with trigger execution   |
+ * | 16  | Same Row UPDATE with OUTPUT (EPQ scenario)       | EPQ Complex         | Tests EPQ when trigger updates same row      |
+ * | 17  | UPDATE with AFTER UPDATE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with UPDATE inside UPDATE trigger  |
+ * | 18  | UPDATE with AFTER DELETE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with DELETE inside UPDATE trigger  |
+ * | 19  | DELETE with AFTER DELETE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with DELETE inside DELETE trigger  |
+ * | 20  | DELETE with AFTER UPDATE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with UPDATE inside DELETE trigger  |
+ * | 21  | INSERT with AFTER DELETE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with DELETE inside INSERT trigger  |
+ * | 22  | INSERT with AFTER UPDATE trigger (EPQ)           | AFTER Trigger EPQ   | Tests EPQ with UPDATE inside INSERT trigger  |
+ * | 23  | INSTEAD OF UPDATE with UPDATE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF UPDATE OUTPUT with EPQ      |
+ * | 24  | INSTEAD OF UPDATE with DELETE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF UPDATE OUTPUT with DELETE   |
+ * | 25  | INSTEAD OF DELETE with DELETE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF DELETE OUTPUT cascading    |
+ * | 26  | INSTEAD OF DELETE with UPDATE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF DELETE OUTPUT with UPDATE   |
+ * | 27  | INSTEAD OF INSERT with DELETE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF INSERT OUTPUT with DELETE   |
+ * | 28  | INSTEAD OF INSERT with UPDATE trigger            | INSTEAD OF EPQ      | Tests INSTEAD OF INSERT OUTPUT with UPDATE   |
+ */
+
+/*
+ * ===================================================================================================================
+ *                                              1. Basic Output clause test
+ * ===================================================================================================================
+ */
+
+-- Test Case 1: INSERT with OUTPUT
+INSERT INTO OutputTest (ID, Name, Value) 
+OUTPUT inserted.ID, inserted.Name, inserted.Value
+VALUES (4, 'NewTest', 400);
+GO
+
+-- Test Case 2: UPDATE with OUTPUT
+UPDATE OutputTest 
+SET Value = OutputTest.Value + 50
+OUTPUT deleted.Name, deleted.Value as OldValue, inserted.Value as NewValue
+WHERE ID = 1;
+GO
+
+-- Test Case 3: DELETE with OUTPUT
+DELETE FROM OutputTest
+OUTPUT deleted.ID, deleted.Name, deleted.Value
+WHERE ID = 2;
+GO
+
+-- Test Case 4: INSERT with OUTPUT INTO
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT 1, 'INSERT', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+VALUES (5, 'LoggedTest', 500);
+GO
+
+-- Test Case 5: UPDATE with OUTPUT INTO
+UPDATE OutputTest
+SET Status = 'Updated'
+OUTPUT 2, 'UPDATE', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+WHERE ID = 3;
+GO
+
+-- Test Case 6: DELETE with OUTPUT INTO
+DELETE FROM OutputTest
+OUTPUT 3, 'DELETE', deleted.ID, deleted.Name, deleted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+WHERE Name = 'LoggedTest';
+GO
+
+-- Test Case 7: Multiple row UPDATE with OUTPUT
+UPDATE OutputTest
+SET Value = OutputTest.Value * 2
+OUTPUT deleted.ID, deleted.Value as Before, inserted.Value as After
+WHERE OutputTest.Value > 100;
+GO
+
+-- Test Case 8: OUTPUT with computed columns
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT inserted.ID, inserted.Name, inserted.Value, inserted.Value * 2 as DoubleValue
+VALUES (6, 'Computed', 250);
+GO
+
+-- Test Case 9: OUTPUT with dependent object (view)
+INSERT INTO OutputTest (ID, Name, Value, Status)
+OUTPUT inserted.ID, inserted.Name, inserted.Status
+VALUES (7, 'ViewTest', 600, 'Active');
+GO
+
+-- Test Case 10: UPDATE base table with OUTPUT (view test)
+UPDATE OutputTest
+SET Value = 999
+OUTPUT deleted.Name, deleted.Value as OldValue, inserted.Value as NewValue
+WHERE Name = 'ViewTest' AND Status = 'Active';
+GO
+
+-- Test Case 11: INSERT with OUTPUT and trigger interaction
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT inserted.ID, inserted.Name, 'TRIGGER_TEST' as TestType
+VALUES (8, 'TriggerTest1', 700);
+GO
+
+-- Test Case 12: UPDATE with OUTPUT and trigger interaction
+UPDATE OutputTest
+SET Value = OutputTest.Value + 100, Status = 'Modified'
+OUTPUT deleted.Status as OldStatus, inserted.Status as NewStatus, inserted.ID
+WHERE Name = 'TriggerTest1';
+GO
+
+-- Test Case 13: DELETE with OUTPUT and trigger interaction
+DELETE FROM OutputTest
+OUTPUT deleted.ID, deleted.Name, 'DELETED_BY_TRIGGER_TEST' as Note
+WHERE Name = 'TriggerTest1';
+GO
+
+-- Test Case 14: Multiple operations with triggers and OUTPUT INTO
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT 4, 'MULTI_OP', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+VALUES (9, 'MultiOp1', 800), (10, 'MultiOp2', 900);
+GO
+
+UPDATE OutputTest
+SET Status = 'Batch_Updated'
+OUTPUT 5, 'BATCH_UPD', inserted.ID, inserted.Name, inserted.Value INTO OutputLog (LogID, Operation, ID, Name, Value)
+WHERE Name LIKE 'MultiOp%';
+GO
+
+-- Test Case 15: OUTPUT with trigger execution order validation
+INSERT INTO OutputTest (ID, Name, Value)
+OUTPUT inserted.ID, inserted.Name, 'OrderTest_Time' as OutputTime
+VALUES (11, 'OrderTest', 1000);
+GO
+
+-- Test Case 16: Same Row UPDATE - Trigger updates the SAME ROW with OUTPUT clause
+-- This tests the most complex EPQ scenario: both original and trigger UPDATE the same row
+INSERT INTO OutputTest (ID, Name, Value, Status) VALUES (12, 'SameRowTest', 1100, 'Active');
+GO
+
+-- This UPDATE will trigger the UPDATE trigger which updates THE SAME ROW with OUTPUT
+-- Original UPDATE: Changes Value from 1100 to 1200
+-- Trigger UPDATE: Changes Value from 1200 to 2200 (1200 + 1000) and Status to 'Trigger_Modified'
+UPDATE OutputTest
+SET Value = 1200
+OUTPUT deleted.Value as OriginalOldValue, inserted.Value as OriginalNewValue, 
+       deleted.Status as OriginalOldStatus, inserted.Status as OriginalNewStatus
+WHERE Name = 'SameRowTest';
+GO
+
+-- Verify the final state shows both updates occurred
+SELECT ID, Name, Value, Status FROM OutputTest WHERE Name = 'SameRowTest';
+GO
+
+-- Verify OUTPUT INTO results
+SELECT * FROM OutputLog ORDER BY LogID;
+GO
+
+-- Verify trigger execution
+SELECT * FROM TriggerLog ORDER BY LogID;
+GO
+
+-- Verify view functionality
+SELECT * FROM OutputTestView ORDER BY ID;
+GO
+
+-- Verify final table state
+SELECT * FROM OutputTest ORDER BY ID;
+GO
+
+
+/*
+ * ===================================================================================================================
+ *                                              2. Triggers with DML test.
+ * ===================================================================================================================
+ */
+
+
+/*
+ * 2.1 All below tests are AFTER TRIGGERS test with output clause
+ */
+
+
+------------------------------------------------------- UPDATE -----------------------------------------
+
+-- 2.1.1 update inside update trigger
+UPDATE EPQTest_Update_Update
+SET Value = 500
+OUTPUT 
+    deleted.ID,
+    deleted.Name,
+    deleted.Value as OldValue,
+    deleted.Counter as OldCounter,
+    inserted.Value as NewValue,
+    inserted.Counter as NewCounter
+WHERE ID = 1;
+GO
+
+UPDATE EPQTest_Update_Update
+SET Value = 999
+OUTPUT 
+    1,
+    inserted.ID,
+    deleted.Value,
+    inserted.Value,
+    'Logged'
+INTO EPQOutputLog (LogID, SourceID, OldValue, NewValue, LogStatus)
+WHERE ID = 1;
+GO
+
+-- Final state check
+SELECT * FROM EPQTest_Update_Update ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+delete from EPQOutputLog;
+GO
+
+
+--2.1.2 delete inside update trigger
+UPDATE EPQTest_Update_Delete 
+SET Value = 999
+OUTPUT 
+    1,
+    inserted.ID,
+    deleted.Value,
+    inserted.Value,
+    'Logged'
+INTO EPQOutputLog (LogID, SourceID, OldValue, NewValue, LogStatus)
+WHERE ID = 1;
+GO
+
+-- Final state check
+SELECT * FROM EPQTest_Update_Delete ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+delete from EPQOutputLog;
+GO
+
+
+------------------------------------------------------- DELETE ------------------------------------------------
+-- 2.1.3 delete inside delete trigger
+DELETE FROM EPQTest_Delete_Delete
+OUTPUT deleted.ID, deleted.Name, deleted.Value
+WHERE ID = 2;
+GO
+
+-- Final state check
+SELECT * FROM EPQTest_Delete_Delete ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+delete from EPQOutputLog;
+GO
+
+-- 2.1.4 Update inside delete trigger
+DELETE FROM EPQTest_Delete_Update
+OUTPUT deleted.ID, deleted.Name, deleted.Value
+WHERE ID = 2;
+GO
+
+-- Final state check
+SELECT * FROM EPQTest_Delete_Update ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+delete from EPQOutputLog;
+GO
+
+------------------------------------------------------- INSERT -------------------------------------------------
+
+-- 2.1.5 delete inside insert trigger
+INSERT INTO EPQTest_Insert_Delete (ID, Name, Value, Counter)
+OUTPUT 
+    1,
+    1,
+    deleted.ID,
+    inserted.ID,
+    'Logged'
+INTO EPQOutputLog (LogID, SourceID, OldValue, NewValue, LogStatus)
+VALUES (1, 'Row1', 100, 1);
+GO
+
+-- Final state check
+SELECT * FROM EPQTest_Insert_Delete ORDER BY ID;
+SELECT * FROM EPQOutputLog ORDER BY LogID;
+GO
+delete from EPQOutputLog;
+GO
+
+
+-- 2.1.6 Update inside insert trigger
+INSERT INTO EPQTest_Insert_Update (ID, Name, Value, Counter)
+OUTPUT 
+    1,
+    1,
+    'NA',
+    inserted.Status,
+    'Logged'
+INTO EPQOutputLog_Str (LogID, SourceID, OldValue, NewValue, LogStatus)
+VALUES (1, 'Row1', 100, 1);
+GO
+
+-- Final state check
+SELECT * FROM EPQTest_Insert_Update ORDER BY ID;
+SELECT * FROM EPQOutputLog_Str ORDER BY LogID;
+GO
+delete from EPQOutputLog_Str;
+GO
+
+
+
+
+------------------------------------------------------ INSTEAD OF TRIGGERS TEST ---------------------------------------------
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Update  + update inside update trigger
+* ------------------------------------------------------------------------------------
+*/
+
+-- Create table to capture OUTPUT results
+CREATE TABLE OutputCapture (
+    TestCase NVARCHAR(50),
+    ID INT,
+    Name NVARCHAR(50),
+    OldValue INT
+);
+GO
+
+-- 2.2.1 INSTEAD OF UPDATE trigger with OUTPUT - EPQ condition
+UPDATE EPQTest_InsteadOf_Update_Update
+SET Value = 1500
+OUTPUT 'InsteadOf_Update_Update', deleted.ID, deleted.Name, deleted.Value
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 1;
+GO
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Update+Update OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+
+-- Verify INSTEAD OF trigger updated the row
+SELECT 'INSTEAD OF Update+Update' as TestPhase, * FROM EPQTest_InsteadOf_Update_Update WHERE ID = 1;
+GO
+
+-- Clear OUTPUT capture
+delete from OutputCapture;
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Update  + delete inside update trigger
+* ------------------------------------------------------------------------------------
+*/
+
+-- 2.2.2 INSTEAD OF UPDATE trigger that deletes with OUTPUT
+UPDATE EPQTest_InsteadOf_Update_Delete
+SET Value = 2000
+OUTPUT 'InsteadOf_Update_Delete', deleted.ID, deleted.Name, deleted.Value
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 1;
+GO
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Update+Delete OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+
+-- Clear OUTPUT capture
+DELETE FROM OutputCapture;
+GO
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Delete  + delete inside delete trigger
+* ------------------------------------------------------------------------------------
+*/
+
+-- 2.2.3 INSTEAD OF DELETE trigger with cascading deletes
+DELETE FROM EPQTest_InsteadOf_Delete_Delete
+OUTPUT 'InsteadOf_Delete_Delete', deleted.ID, deleted.Name, deleted.Value
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 2;
+GO
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Delete+Delete OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+
+-- Verify cascading deletes occurred
+SELECT 'INSTEAD OF Delete+Delete' as TestPhase, COUNT(*) as RemainingRows FROM EPQTest_InsteadOf_Delete_Delete;
+GO
+
+-- Clear OUTPUT capture
+DELETE FROM OutputCapture;
+GO
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Delete  + update inside delete trigger
+* ------------------------------------------------------------------------------------
+*/
+
+-- 2.2.4 INSTEAD OF DELETE trigger that updates instead of deleting
+DELETE FROM EPQTest_InsteadOf_Delete_Update
+OUTPUT 'InsteadOf_Delete_Update', deleted.ID, deleted.Name, deleted.Counter
+INTO OutputCapture (TestCase, ID, Name, OldValue)
+WHERE ID = 1;
+GO
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Delete+Update OUTPUT' as TestPhase, * FROM OutputCapture;
+GO
+
+-- Verify row was updated instead of deleted
+SELECT 'INSTEAD OF Delete+Update' as TestPhase, * FROM EPQTest_InsteadOf_Delete_Update WHERE ID = 1;
+GO
+
+-- Clear OUTPUT capture
+DELETE FROM OutputCapture;
+GO
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Insert  + delete inside insert trigger
+* ------------------------------------------------------------------------------------
+*/
+
+-- 2.2.5 Create table to capture OUTPUT results
+CREATE TABLE OutputCapture_insert (
+    TestCase NVARCHAR(50),
+    ID INT,
+    Name NVARCHAR(50),
+    OldValue INT,
+    NewValue INT,
+    Status NVARCHAR(50)
+);
+GO
+
+-- Insert some data first for delete scenario
+INSERT INTO EPQTest_InsteadOf_Insert_Delete (ID, Name, Value, Counter) VALUES (1, 'Existing1', 50, 1);
+GO
+
+-- Test Case 34: INSTEAD OF INSERT trigger that deletes existing rows
+INSERT INTO EPQTest_InsteadOf_Insert_Delete (ID, Name, Value, Counter, Status)
+OUTPUT 'InsteadOf_Insert_Delete', inserted.ID, inserted.Name, 0, inserted.Value, inserted.Status
+INTO OutputCapture_insert (TestCase, ID, Name, OldValue, NewValue, Status)
+VALUES (2, 'NewRow', 100, 2, 'Active');
+GO
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Insert+Delete OUTPUT' as TestPhase, * FROM OutputCapture_insert;
+GO
+
+-- Verify existing row was deleted and new row inserted
+SELECT 'INSTEAD OF Insert+Delete' as TestPhase, COUNT(*) as TotalRows FROM EPQTest_InsteadOf_Insert_Delete;
+GO
+
+SELECT * FROM EPQTest_InsteadOf_Insert_Delete ORDER BY ID;
+GO
+
+delete from OutputCapture_insert;
+GO
+
+/*
+* ------------------------------------------------------------------------------------
+*  INSTEAD OF Insert  + update inside insert trigger
+* ------------------------------------------------------------------------------------
+*/
+
+-- Insert some data first for update scenario
+INSERT INTO EPQTest_InsteadOf_Insert_Update (ID, Name, Value, Counter) VALUES (1, 'Existing1', 50, 1);
+GO
+
+-- 2.2.6 INSTEAD OF INSERT trigger that updates existing rows
+INSERT INTO EPQTest_InsteadOf_Insert_Update (ID, Name, Value, Counter, Status)
+OUTPUT 'InsteadOf_Insert_Update', inserted.ID, inserted.Name, 0, inserted.Value, inserted.Status
+INTO OutputCapture_insert (TestCase, ID, Name, OldValue, NewValue, Status)
+VALUES (2, 'NewRow', 200, 2, 'Active');
+GO
+
+-- Print OUTPUT results
+SELECT 'INSTEAD OF Insert+Update OUTPUT' as TestPhase, * FROM OutputCapture_insert;
+GO
+
+-- Verify existing row was updated and new row inserted
+SELECT 'INSTEAD OF Insert+Update' as TestPhase, COUNT(*) as TotalRows FROM EPQTest_InsteadOf_Insert_Update;
+GO
+
+SELECT * FROM EPQTest_InsteadOf_Insert_Update ORDER BY ID;
+GO
+
+-- Final cleanup of OUTPUT capture table
+DROP TABLE OutputCapture_insert;
+DROP TABLE OutputCapture;
+GO

--- a/test/JDBC/input/update_with_var-vu-cleanup.sql
+++ b/test/JDBC/input/update_with_var-vu-cleanup.sql
@@ -1,0 +1,95 @@
+-- Drop function first
+DROP FUNCTION IF EXISTS jira_babel_update_with_var_assign.custom_function;
+GO
+
+-- Drop all tables
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_int;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_str;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_multi;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_where;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_null;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_empty;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_single;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_numeric;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_math;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_col_assign;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_main;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_lookup;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_large;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_str_complex;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_case;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_counter;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_init;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_self;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_datetime;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_tran;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_top;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_convert;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_nested;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_other;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_dynamic;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_mixed_types;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_coalesce;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_output;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_running_max;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_cross_db;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_target;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_source;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_udf;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_concurrent;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_overflow;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_unicode;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_computed;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_recursive;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_division;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_truncation;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_identity;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_large_string;
+GO
+DROP TABLE IF EXISTS jira_babel_update_with_var_assign.test_complex_expr;
+GO
+
+-- Drop schema
+DROP SCHEMA IF EXISTS jira_babel_update_with_var_assign;
+GO

--- a/test/JDBC/input/update_with_var-vu-prepare.sql
+++ b/test/JDBC/input/update_with_var-vu-prepare.sql
@@ -1,0 +1,210 @@
+-- Create schema for update_with_var tests
+CREATE SCHEMA jira_babel_update_with_var_assign;
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_int (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_int VALUES (1, 10), (2, 20), (3, 30);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_str (id INT, name VARCHAR(50));
+INSERT INTO jira_babel_update_with_var_assign.test_str VALUES (1, 'A'), (2, 'B'), (3, 'C');
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_multi (id INT, val INT, name VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_multi VALUES (1, 100, 'First'), (2, 200, 'Second'), (3, 300, 'Third');
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_where (id INT, val INT, status VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_where VALUES (1, 10, 'active'), (2, 20, 'inactive'), (3, 30, 'active'), (4, 40, 'inactive');
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_null (id INT, val INT, name VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_null VALUES (1, 10, 'A'), (2, NULL, 'B'), (3, 30, NULL), (4, 40, 'D');
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_empty (id INT, val INT);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_single (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_single VALUES (1, 50);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_numeric (
+    id INT, 
+    int_val INT, 
+    decimal_val DECIMAL(10,2), 
+    float_val FLOAT,
+    bigint_val BIGINT
+);
+INSERT INTO jira_babel_update_with_var_assign.test_numeric VALUES 
+    (1, 10, 10.5, 10.25, 1000000000),
+    (2, 20, 20.5, 20.25, 2000000000);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_math (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_math VALUES (1, 2), (2, 3), (3, 4);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_col_assign (id INT, val INT, running_total INT);
+INSERT INTO jira_babel_update_with_var_assign.test_col_assign VALUES (1, 10, 0), (2, 20, 0), (3, 30, 0);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_main (id INT, val INT);
+CREATE TABLE jira_babel_update_with_var_assign.test_lookup (id INT, multiplier INT);
+INSERT INTO jira_babel_update_with_var_assign.test_main VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO jira_babel_update_with_var_assign.test_lookup VALUES (1, 2), (2, 3), (3, 4);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_large (id INT, val INT);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_str_complex (id INT, prefix VARCHAR(10), suffix VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_str_complex VALUES (1, 'A', 'X'), (2, 'B', 'Y'), (3, 'C', 'Z');
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_case (id INT, val INT, category VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_case VALUES (1, 10, 'A'), (2, 20, 'B'), (3, 30, 'A'), (4, 40, 'B');
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_counter (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_counter VALUES (1, 100), (2, 200), (3, 300);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_init (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_init VALUES (1, 5), (2, 10), (3, 15);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_self (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_self VALUES (1, 10), (2, 20), (3, 30);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_datetime (id INT, days_to_add INT);
+INSERT INTO jira_babel_update_with_var_assign.test_datetime VALUES (1, 1), (2, 2), (3, 3);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_tran (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_tran VALUES (1, 10), (2, 20);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_top (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_top VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.test_convert (id INT, int_val INT, str_val VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_convert VALUES (1, 100, '50'), (2, 200, '75');
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_nested (id INT, val INT);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_other (id INT);
+GO
+
+INSERT INTO jira_babel_update_with_var_assign.test_nested VALUES (1, 10), (2, 20);
+GO
+
+INSERT INTO jira_babel_update_with_var_assign.test_other VALUES (1), (1), (2);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_dynamic (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_dynamic VALUES (5), (15), (25);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_mixed_types (val INT, int_col INT, nvarchar_col NVARCHAR(10), float_col FLOAT);
+INSERT INTO jira_babel_update_with_var_assign.test_mixed_types VALUES (1, 10, N'A', 1.5), (2, 20, N'B', 2.5);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_coalesce (val INT, nullable_col VARCHAR(50));
+INSERT INTO jira_babel_update_with_var_assign.test_coalesce VALUES (1, NULL), (2, 'First'), (3, 'Second');
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_output (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_output VALUES (10), (20);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_running_max (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_running_max VALUES (5), (15), (10), (25), (20);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_cross_db (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_cross_db VALUES (10), (20);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_target (id INT, val INT);
+GO
+CREATE TABLE jira_babel_update_with_var_assign.test_source (id INT, val INT);
+GO
+INSERT INTO jira_babel_update_with_var_assign.test_target VALUES (1, 100);
+GO
+INSERT INTO jira_babel_update_with_var_assign.test_source VALUES (1, 200), (2, 300);
+GO
+
+CREATE FUNCTION jira_babel_update_with_var_assign.custom_function(@val INT) RETURNS INT
+AS BEGIN
+    RETURN @val * 2;
+END;
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_udf (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_udf VALUES (5), (10);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_concurrent (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_concurrent VALUES (1), (2), (3), (4), (5);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_overflow (val TINYINT);
+INSERT INTO jira_babel_update_with_var_assign.test_overflow VALUES (1), (2), (3);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_unicode (name VARCHAR(10), unicode_col NVARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_unicode VALUES ('A', N'α'), ('B', N'β');
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_computed (base_val INT, computed_col AS (base_val * 2));
+INSERT INTO jira_babel_update_with_var_assign.test_computed (base_val) VALUES (10), (20);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_recursive (id INT, val INT, parent_id INT, processed BIT DEFAULT 0);
+INSERT INTO jira_babel_update_with_var_assign.test_recursive VALUES (1, 10, NULL, 0), (2, 20, 1, 0), (3, 30, 1, 0);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_division (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_division VALUES (0), (2), (4);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_truncation (name VARCHAR(20));
+INSERT INTO jira_babel_update_with_var_assign.test_truncation VALUES ('VeryLongName1'), ('VeryLongName2');
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_identity (id INT IDENTITY(1,1), name VARCHAR(10));
+INSERT INTO jira_babel_update_with_var_assign.test_identity (name) VALUES ('A'), ('B');
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_large_string (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_large_string VALUES (1), (2);
+GO
+
+CREATE TABLE jira_babel_update_with_var_assign.test_complex_expr (val INT);
+INSERT INTO jira_babel_update_with_var_assign.test_complex_expr VALUES (2), (3), (4);
+GO

--- a/test/JDBC/input/update_with_var-vu-verify.sql
+++ b/test/JDBC/input/update_with_var-vu-verify.sql
@@ -1,0 +1,465 @@
+/*
+ *  ------------------------------------------------  Test case Description ------------------------------------------------
+ *
+ * |  #  |                    Test Case                     |        Type         |                    Remark                     |
+ * |-----|--------------------------------------------------|---------------------|-----------------------------------------------|
+ * |  1  | Basic variable assignment with UPDATE            | Basic               | Tests @sum accumulation with UPDATE          |
+ * |  2  | Multiple variables in single UPDATE              | Multi-Variable      | Tests @sum, @concat, @count simultaneously   |
+ * |  3  | Variable assignment with WHERE clause            | Filtering           | Tests conditional variable updates            |
+ * |  4  | NULL value handling in variables                 | NULL Handling       | Tests ISNULL with numeric and string vars    |
+ * |  5  | Empty table variable assignment                  | Edge Case           | Tests variables remain unchanged on empty set |
+ * |  6  | Numeric data types (DECIMAL, FLOAT, BIGINT)      | Data Types          | Tests various numeric type accumulations      |
+ * |  7  | Mathematical operations in variables             | Math Operations     | Tests *, -, + operations in variable assign  |
+ * |  8  | Variable used to update column values            | Column Update       | Tests running totals with column assignment   |
+ * |  9  | Variable assignment with JOINs                   | JOIN Operations     | Tests variables with multi-table operations   |
+ * | 10  | Large dataset variable processing                | Performance         | Tests 1000 row variable accumulation         |
+ * | 11  | Complex string operations                        | String Processing   | Tests string concatenation with formatting    |
+ * | 12  | CASE expressions in variable assignment          | Conditional Logic   | Tests conditional variable updates with CASE  |
+ * | 13  | Row counting with variables                      | Counting            | Tests row counter incrementation              |
+ * | 14  | Variables with initial values                    | Initialization      | Tests non-zero starting values               |
+ * | 15  | Self-referencing variable updates                | Complex Logic       | Tests variables affecting same UPDATE         |
+ * | 16  | DateTime operations with variables               | DateTime            | Tests date calculations in variables          |
+ * | 17  | Transaction rollback with variables              | Transaction         | Tests variable persistence across rollback    |
+ * | 18  | TOP clause with variable assignment              | Limited Processing  | Tests variables with row limiting             |
+ * | 19  | Type conversion in variable assignment           | Type Conversion     | Tests CAST operations in variable updates     |
+ * | 20  | Subqueries in variable assignment                | Subquery            | Tests nested queries with variables           |
+ * | 21  | Dynamic WHERE with variables                     | Dynamic Logic       | Tests variables in WHERE of same UPDATE      |
+ * | 22  | Mixed data types in single UPDATE                | Multi-Type          | Tests INT, NVARCHAR, FLOAT vars together     |
+ * | 23  | COALESCE/ISNULL with variables                   | NULL Functions      | Tests NULL handling functions with variables  |
+ * | 24  | Running maximum with variables                   | Aggregate Logic     | Tests MAX calculation with variables          |
+ */
+
+-- Test UPDATE
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_int SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 60
+GO
+
+-- Test SELECT
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_int;
+SELECT @sum2 AS result; -- Expected: 60
+GO
+
+-- Test UPDATE
+DECLARE @concat VARCHAR(200) = '';
+UPDATE jira_babel_update_with_var_assign.test_str SET name = name, @concat = @concat + name;
+SELECT @concat AS result; -- Expected: 'ABC'
+GO
+
+-- Test with delimiter
+DECLARE @concat2 VARCHAR(200) = '';
+UPDATE jira_babel_1290.test_str SET name = name, @concat2 = @concat2 + CASE WHEN @concat2 = '' THEN '' ELSE ',' END + name;
+SELECT @concat2 AS result; -- Expected: ',A,B,C' or similar
+GO
+
+-- Test UPDATE with multiple variables
+DECLARE @sum INT = 0, @concat VARCHAR(200) = '', @count INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_multi 
+SET val = val, 
+    @sum = @sum + val, 
+    @concat = @concat + name + '|',
+    @count = @count + 1;
+SELECT @sum AS sum_result, @concat AS concat_result, @count AS count_result;
+GO
+-- Expected: sum=600, concat='First|Second|Third|', count=3
+
+
+
+-- Test UPDATE with WHERE
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_where SET val = val, @sum = @sum + val WHERE status = 'active';
+SELECT @sum AS result; -- Expected: 40 (10+30)
+GO
+
+-- Test SELECT with WHERE
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_where WHERE status = 'inactive';
+SELECT @sum2 AS result; -- Expected: 60 (20+40)
+GO
+
+-- Test with NULL values in numeric column
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_null SET val = val, @sum = @sum + ISNULL(val, 0);
+SELECT @sum AS result; -- Expected: 80
+GO
+
+-- Test with NULL values in string column
+DECLARE @concat VARCHAR(200) = '';
+UPDATE jira_babel_update_with_var_assign.test_null SET name = name, @concat = @concat + ISNULL(name, '');
+SELECT @concat AS result; -- Expected: 'ABD'
+GO
+
+-- Test UPDATE on empty table
+DECLARE @sum INT = 100;
+UPDATE jira_babel_update_with_var_assign.test_empty SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 100 (unchanged)
+GO
+
+-- Test SELECT on empty table
+DECLARE @sum2 INT = 100;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_empty;
+SELECT @sum2 AS result; -- Expected: 100 (unchanged)
+GO
+
+-- Test UPDATE
+DECLARE @sum INT = 10;
+UPDATE jira_babel_update_with_var_assign.test_single SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 60
+GO
+
+-- Test with DECIMAL
+DECLARE @dec_sum DECIMAL(10,2) = 0;
+UPDATE jira_babel_update_with_var_assign.test_numeric SET int_val = int_val, @dec_sum = @dec_sum + decimal_val;
+SELECT @dec_sum AS result; -- Expected: 31.00
+
+-- Test with FLOAT
+DECLARE @float_sum FLOAT = 0;
+UPDATE jira_babel_update_with_var_assign.test_numeric SET int_val = int_val, @float_sum = @float_sum + float_val;
+SELECT @float_sum AS result; -- Expected: 30.5
+GO
+
+-- Test with BIGINT
+DECLARE @bigint_sum BIGINT = 0;
+UPDATE jira_babel_update_with_var_assign.test_numeric SET int_val = int_val, @bigint_sum = @bigint_sum + bigint_val;
+SELECT @bigint_sum AS result; -- Expected: 3000000000
+GO
+
+
+
+-- Test multiplication
+DECLARE @product INT = 1;
+UPDATE jira_babel_update_with_var_assign.test_math SET val = val, @product = @product * val;
+SELECT @product AS result; -- Expected: 24 (1*2*3*4)
+GO
+
+-- Test subtraction
+DECLARE @diff INT = 100;
+UPDATE jira_babel_update_with_var_assign.test_math SET val = val, @diff = @diff - val;
+SELECT @diff AS result; -- Expected: 91 (100-2-3-4)
+GO
+
+-- Test mixed operations
+DECLARE @mixed INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_math SET val = val, @mixed = @mixed + val * 2;
+SELECT @mixed AS result; -- Expected: 18 (2*2 + 3*2 + 4*2)
+GO
+
+-- Test UPDATE where variable is used to update column
+DECLARE @running INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_col_assign 
+SET @running = @running + val, 
+    running_total = @running;
+SELECT * FROM jira_babel_update_with_var_assign.test_col_assign ORDER BY id;
+-- Expected: rows with running_total showing cumulative sum
+GO
+
+-- Test UPDATE with JOIN
+DECLARE @sum INT = 0;
+UPDATE m 
+SET m.val = m.val, 
+    @sum = @sum + m.val * l.multiplier
+FROM jira_babel_update_with_var_assign.test_main m
+INNER JOIN jira_babel_update_with_var_assign.test_lookup l ON m.id = l.id;
+SELECT @sum AS result; -- Expected: 200 (10*2 + 20*3 + 30*4)
+GO
+
+-- Test SELECT with JOIN
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + m.val * l.multiplier
+FROM jira_babel_update_with_var_assign.test_main m
+INNER JOIN jira_babel_update_with_var_assign.test_lookup l ON m.id = l.id;
+SELECT @sum2 AS result; -- Expected: 200
+GO
+
+-- Insert 1000 rows
+DECLARE @i INT = 1;
+WHILE @i <= 1000
+BEGIN
+    INSERT INTO jira_babel_update_with_var_assign.test_large VALUES (@i, @i);
+    SET @i = @i + 1;
+END
+GO
+
+-- Test UPDATE
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_large SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 500500 (sum of 1 to 1000)
+GO
+
+-- Test SELECT
+DECLARE @sum2 INT = 0;
+SELECT @sum2 = @sum2 + val FROM jira_babel_update_with_var_assign.test_large;
+SELECT @sum2 AS result; -- Expected: 500500
+GO
+
+-- Test complex string concatenation
+DECLARE @result VARCHAR(200) = '';
+UPDATE jira_babel_update_with_var_assign.test_str_complex 
+SET prefix = prefix, 
+    @result = @result + '[' + prefix + '-' + suffix + ']';
+SELECT @result AS result; -- Expected: '[A-X][B-Y][C-Z]'
+GO
+
+-- Test UPDATE with CASE
+DECLARE @sum_a INT = 0, @sum_b INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_case 
+SET val = val,
+    @sum_a = CASE WHEN category = 'A' THEN @sum_a + val ELSE @sum_a END,
+    @sum_b = CASE WHEN category = 'B' THEN @sum_b + val ELSE @sum_b END;
+SELECT @sum_a AS sum_a, @sum_b AS sum_b; -- Expected: sum_a=40, sum_b=60
+GO
+
+-- Test row counter
+DECLARE @counter INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_counter SET val = val, @counter = @counter + 1;
+SELECT @counter AS result; -- Expected: 3
+GO
+
+-- Test with initial non-zero value
+DECLARE @sum INT = 100;
+UPDATE jira_babel_update_with_var_assign.test_init SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: 130 (100+5+10+15)
+GO
+
+-- Test with initial string
+DECLARE @str VARCHAR(100) = 'START:';
+UPDATE jira_babel_update_with_var_assign.test_init SET val = val, @str = @str + CAST(val AS VARCHAR(10)) + ',';
+SELECT @str AS result; -- Expected: 'START:5,10,15,'
+GO
+
+-- Test where variable affects the update
+DECLARE @prev INT = 0, @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_self 
+SET @sum = @sum + val,
+    val = val + @prev,
+    @prev = val;
+SELECT @sum AS sum_result, @prev AS prev_result;
+SELECT * FROM jira_babel_update_with_var_assign.test_self ORDER BY id;
+GO
+
+-- Test with datetime
+DECLARE @date DATETIME = '2024-01-01', @total_days INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_datetime 
+SET days_to_add = days_to_add, 
+    @total_days = @total_days + days_to_add;
+SELECT @total_days AS result; -- Expected: 6
+GO
+
+BEGIN TRANSACTION;
+    DECLARE @sum INT = 0;
+    UPDATE jira_babel_update_with_var_assign.test_tran SET val = val, @sum = @sum + val;
+    SELECT @sum AS result; -- Expected: 30
+ROLLBACK TRANSACTION;
+GO
+
+-- Verify rollback doesn't affect variable
+DECLARE @sum2 INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_tran SET val = val, @sum2 = @sum2 + val;
+SELECT @sum2 AS result; -- Expected: 30 (data unchanged by rollback)
+GO
+
+-- Test UPDATE with TOP
+DECLARE @sum INT = 0;
+UPDATE TOP(2) jira_babel_update_with_var_assign.test_top SET val = val, @sum = @sum + val;
+SELECT @sum AS result; -- Expected: Sum of first 2 rows processed
+GO
+
+-- Test conversion during accumulation
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_convert 
+SET int_val = int_val, 
+    @sum = @sum + int_val + CAST(str_val AS INT);
+SELECT @sum AS result; -- Expected: 425 (100+50+200+75)
+GO
+
+-- Nested subqueries with variables
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_nested 
+SET val = val, 
+    @sum = @sum + (SELECT COUNT(*) FROM jira_babel_update_with_var_assign.test_other WHERE jira_babel_update_with_var_assign.test_other.id = jira_babel_update_with_var_assign.test_nested.id);
+SELECT @sum AS result;
+GO
+
+-- Variable used in WHERE clause of same UPDATE
+DECLARE @threshold INT = 10;
+UPDATE jira_babel_update_with_var_assign.test_dynamic 
+SET val = val, 
+    @threshold = @threshold + 5
+WHERE val > @threshold;
+SELECT @threshold AS result;
+GO
+
+-- Multiple variables with different data types in single UPDATE
+DECLARE @int_sum INT = 0, @str_concat NVARCHAR(100) = N'', @float_avg FLOAT = 0, @count INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_mixed_types 
+SET val = val,
+    @int_sum = @int_sum + int_col,
+    @str_concat = @str_concat + nvarchar_col + N'|',
+    @float_avg = (@float_avg * @count + float_col) / (@count + 1),
+    @count = @count + 1;
+SELECT @int_sum, @str_concat, @float_avg, @count;
+GO
+
+-- Variable assignment with COALESCE/ISNULL
+DECLARE @first_non_null VARCHAR(50) = NULL;
+UPDATE jira_babel_update_with_var_assign.test_coalesce 
+SET val = val,
+    @first_non_null = COALESCE(@first_non_null, nullable_col);
+SELECT @first_non_null AS result;
+GO
+
+-- Variable assignment with aggregate functions
+DECLARE @max_so_far INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_running_max 
+SET val = val,
+    @max_so_far = CASE WHEN val > @max_so_far THEN val ELSE @max_so_far END;
+SELECT @max_so_far AS result;
+GO
+
+-- Cross-database UPDATE with variables (if applicable)
+CREATE DATABASE test;
+USE test;
+DECLARE @sum INT = 0;
+UPDATE master.dbo.jira_babel_update_with_var_assign.test_cross_db 
+SET val = val, 
+    @sum = @sum + val;
+SELECT @sum AS result;
+GO
+
+use master
+GO
+
+-- UPDATE with MERGE-like behavior using variables
+DECLARE @inserted_count INT = 0, @updated_count INT = 0;
+UPDATE target 
+SET target.val = source.val,
+    @updated_count = @updated_count + 1
+FROM jira_babel_update_with_var_assign.test_target target
+INNER JOIN jira_babel_update_with_var_assign.test_source source ON target.id = source.id;
+
+INSERT INTO jira_babel_update_with_var_assign.test_target (id, val)
+SELECT id, val FROM jira_babel_update_with_var_assign.test_source 
+WHERE id NOT IN (SELECT id FROM jira_babel_update_with_var_assign.test_target);
+SET @inserted_count = @@ROWCOUNT;
+
+SELECT @updated_count, @inserted_count;
+
+-- Variable with user-defined functions
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_udf 
+SET val = val,
+    @sum = @sum + jira_babel_update_with_var_assign.custom_function(val);
+SELECT @sum AS result;
+GO
+
+-- Concurrent variable updates
+DECLARE @counter1 INT = 0, @counter2 INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_concurrent 
+SET val = val,
+    @counter1 = @counter1 + CASE WHEN val % 2 = 0 THEN 1 ELSE 0 END,
+    @counter2 = @counter2 + CASE WHEN val % 2 = 1 THEN 1 ELSE 0 END;
+SELECT @counter1 AS even_count, @counter2 AS odd_count;
+GO
+
+-- Variable overflow scenarios
+DECLARE @tiny TINYINT = 250;
+UPDATE jira_babel_update_with_var_assign.test_overflow 
+SET val = val,
+    @tiny = @tiny + val;
+SELECT @tiny AS result;
+GO
+
+-- Unicode string concatenation
+DECLARE @unicode NVARCHAR(100) = N'';
+UPDATE jira_babel_update_with_var_assign.test_unicode 
+SET name = name,
+    @unicode = @unicode + unicode_col + N'→';
+SELECT @unicode AS result;
+GO
+
+-- Variable assignment with computed columns
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_computed 
+SET base_val = base_val,
+    @sum = @sum + computed_col;
+SELECT @sum AS result;
+GO
+
+-- Recursive CTE with UPDATE and variables
+DECLARE @total_levels INT = 0;
+
+WITH recursive_cte AS (
+    SELECT id, val, 1 as level 
+    FROM jira_babel_update_with_var_assign.test_recursive 
+    WHERE parent_id IS NULL
+
+    UNION ALL
+
+    SELECT t.id, t.val, r.level + 1 
+    FROM jira_babel_update_with_var_assign.test_recursive t
+    INNER JOIN recursive_cte r ON t.parent_id = r.id
+)
+UPDATE t
+SET processed = 1,
+    @total_levels = @total_levels + ISNULL(r.level, 0)
+FROM jira_babel_update_with_var_assign.test_recursive t
+LEFT JOIN recursive_cte r ON t.id = r.id;
+
+SELECT @total_levels AS total_accumulated_levels;
+GO
+SELECT * FROM jira_babel_update_with_var_assign.test_recursive ORDER BY id;
+GO
+
+----------------------------------------------------------------------------------------------------------------------
+-- These tests are error cases that differ compared to sql server output
+----------------------------------------------------------------------------------------------------------------------
+-- trigger scenarios
+CREATE TABLE jira_babel_update_with_var_assign.simple_test (id INT, val INT);
+INSERT INTO jira_babel_update_with_var_assign.simple_test VALUES (1, 10), (2, 20);
+GO
+
+CREATE TRIGGER trg_simple_test ON jira_babel_update_with_var_assign.simple_test
+AFTER UPDATE AS
+BEGIN
+    INSERT INTO jira_babel_update_with_var_assign.simple_test VALUES (99, 99);
+END;
+GO
+
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.simple_test SET val = val, @sum = @sum + val;
+SELECT @sum AS result;
+GO
+
+DROP TRIGGER IF EXISTS trg_simple_test;
+DROP TABLE jira_babel_update_with_var_assign.simple_test;
+GO
+
+
+CREATE TABLE jira_babel_update_with_var_assign.minimal_test (val INT);
+INSERT INTO jira_babel_update_with_var_assign.minimal_test VALUES (5);
+GO
+
+CREATE TRIGGER trg_minimal ON jira_babel_update_with_var_assign.minimal_test
+AFTER UPDATE AS BEGIN
+    SELECT 1;
+END;
+GO
+
+DECLARE @result INT = 0;
+UPDATE jira_babel_update_with_var_assign.minimal_test SET val = val, @result = @result + val;
+SELECT @result;
+GO
+
+DROP TRIGGER IF EXISTS trg_minimal;
+DROP TABLE jira_babel_update_with_var_assign.minimal_test;
+GO
+
+-- UPDATE with OUTPUT clause and variables
+DECLARE @sum INT = 0;
+UPDATE jira_babel_update_with_var_assign.test_output 
+SET val = val * 2,
+    @sum = @sum + val
+OUTPUT inserted.val, deleted.val;
+SELECT @sum AS accumulated_original_values;
+GO

--- a/test/JDBC/src/main/java/com/sqlsamples/BabelOutputClauseConcurrencyTest.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/BabelOutputClauseConcurrencyTest.java
@@ -1,0 +1,642 @@
+/*
+ * This will be a concurrency test for OUTPUT clause operations to ensure no issues or crashes are encountered.
+ * Tests EPQ (EvalPlanQual) handling with OUTPUT clauses in concurrent scenarios.
+ */
+
+package com.sqlsamples;
+
+import org.apache.logging.log4j.Logger;
+import java.io.*;
+import java.util.*;
+import java.sql.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.sqlsamples.Config.*;
+import static com.sqlsamples.Statistics.curr_exec_time;
+
+public class BabelOutputClauseConcurrencyTest {
+    static AtomicInteger errorCount = new AtomicInteger(0);
+    
+    private static String initializeConnectionString() {
+        String url = properties.getProperty("URL");
+        String port = properties.getProperty("tsql_port");
+        String databaseName = properties.getProperty("databaseName");
+        String user = properties.getProperty("user");
+        String password = properties.getProperty("password");
+
+        return createSQLServerConnectionString(url, port, databaseName, user, password);
+    }
+
+    public static void runTest(BufferedWriter bw, Logger logger) {
+        long startTime = System.nanoTime();
+
+        try {
+            setupTestData(bw);
+            babel_output_concurrency_test(bw);
+            cleanupTestData(bw);
+            
+            if (errorCount.get() > 0) {
+                bw.write("Test failed with " + errorCount.get() + " errors");
+                bw.newLine();
+            }
+            else {
+                bw.write("Test passed");
+                bw.newLine();
+            }
+        } catch (Exception e) {
+            try {
+                bw.write(e.getMessage());
+                bw.newLine();
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+            }
+        }
+
+        long endTime = System.nanoTime();
+        curr_exec_time = endTime - startTime;
+    }
+    
+    private static void setupTestData(BufferedWriter bw) throws Exception {
+        String connectionString = initializeConnectionString();
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            Statement stmt = conn.createStatement();
+            
+            // Create test table
+            stmt.execute("CREATE TABLE TestTable_jira_4880 (TestID INT, Param1 VARCHAR(50), LockProcessID INT DEFAULT 0)");
+            stmt.execute("INSERT INTO TestTable_jira_4880 VALUES (1, 'InitialValue', 100)");
+            stmt.execute("INSERT INTO TestTable_jira_4880 VALUES (2, NULL, 100)");
+            
+            bw.write("Test data created successfully");
+            bw.newLine();
+        }
+    }
+    
+    private static void cleanupTestData(BufferedWriter bw) throws Exception {
+        String connectionString = initializeConnectionString();
+        try (Connection conn = DriverManager.getConnection(connectionString)) {
+            Statement stmt = conn.createStatement();
+            stmt.execute("DROP TABLE IF EXISTS TestTable_jira_4880");
+        }
+    }
+    
+    
+    private static void babel_output_concurrency_test(BufferedWriter bw) throws Exception {
+        String connectionString = initializeConnectionString();
+        
+        // Test 1: UPDATE with OUTPUT EPQ
+        test_update_output_epq(connectionString, bw);
+        bw.write("Test Case 1 completed: UPDATE with OUTPUT EPQ");
+        bw.newLine();
+        
+        // Test 2: DELETE with OUTPUT EPQ
+        test_delete_output_epq(connectionString, bw);
+        bw.write("Test Case 2 completed: DELETE with OUTPUT EPQ");
+        bw.newLine();
+        
+        // Test 3: INSERT with OUTPUT during concurrent operations
+        test_insert_output_concurrent(connectionString, bw);
+        bw.write("Test Case 3 completed: INSERT with OUTPUT during concurrent operations");
+        bw.newLine();
+        
+        // Test 4: Mixed DML - INSERT, UPDATE, DELETE in sequence
+        test_mixed_dml_output(connectionString, bw);
+        bw.write("Test Case 4 completed: Mixed DML - INSERT, UPDATE, DELETE in sequence");
+        bw.newLine();
+    }
+    
+    /*
+     * Test Case 1: UPDATE with OUTPUT EPQ
+     * Verifying: EPQ correctly re-evaluates row after concurrent modification and OUTPUT shows updated values
+     * Success Criteria: OUTPUT displays Session1's modified Param1 value in both deleted and inserted columns
+     */
+    private static void test_update_output_epq(String connectionString, BufferedWriter bw) throws Exception {
+        ArrayList<Connection> cxns = new ArrayList<>();
+        ArrayList<Thread> threads = new ArrayList<>();
+
+        Connection conn1 = DriverManager.getConnection(connectionString);
+        Connection conn2 = DriverManager.getConnection(connectionString);
+        cxns.add(conn1);
+        cxns.add(conn2);
+        
+        CountDownLatch session1Ready = new CountDownLatch(1);
+        CountDownLatch session1Commit = new CountDownLatch(1);
+        
+        threads.add(new Thread(new EPQSession1Worker(conn1, session1Ready, session1Commit, bw)));
+        threads.add(new Thread(new EPQSession2Worker(conn2, session1Ready, session1Commit, bw)));
+        
+        for (Thread t : threads) {
+            t.start();
+        }
+        
+        for (Thread t : threads) {
+            t.join();
+        }
+        
+        for (Connection cxn : cxns) {
+            cxn.close();
+        }
+    }
+    
+    /*
+     * Test Case 2: DELETE with OUTPUT EPQ
+     * Verifying: DELETE with OUTPUT processes EPQ-updated row values from concurrent session
+     * Success Criteria: OUTPUT shows Session1's updated Param1 value ('UpdatedBeforeDelete') in deleted row
+     */
+    private static void test_delete_output_epq(String connectionString, BufferedWriter bw) throws Exception {
+        ArrayList<Connection> cxns = new ArrayList<>();
+        ArrayList<Thread> threads = new ArrayList<>();
+
+        Connection conn1 = DriverManager.getConnection(connectionString);
+        Connection conn2 = DriverManager.getConnection(connectionString);
+        cxns.add(conn1);
+        cxns.add(conn2);
+        
+        // Insert test data for DELETE test
+        try (Statement stmt = conn1.createStatement()) {
+            stmt.execute("INSERT INTO TestTable_jira_4880 VALUES (2, 'ToBeDeleted', 200)");
+        }
+        
+        CountDownLatch session1Ready = new CountDownLatch(1);
+        CountDownLatch session1Commit = new CountDownLatch(1);
+        
+        threads.add(new Thread(new EPQDeleteSession1Worker(conn1, session1Ready, session1Commit, bw)));
+        threads.add(new Thread(new EPQDeleteSession2Worker(conn2, session1Ready, session1Commit, bw)));
+        
+        for (Thread t : threads) {
+            t.start();
+        }
+        
+        for (Thread t : threads) {
+            t.join();
+        }
+        
+        for (Connection cxn : cxns) {
+            cxn.close();
+        }
+    }
+    
+    /*
+     * Test Case 3: INSERT with OUTPUT during concurrent operations
+     * Verifying: INSERT with OUTPUT executes successfully despite concurrent lock contention
+     * Success Criteria: OUTPUT returns inserted values (TestID=4, Param1='ConcurrentInsert', LockProcessID=400)
+     */
+    private static void test_insert_output_concurrent(String connectionString, BufferedWriter bw) throws Exception {
+        ArrayList<Connection> cxns = new ArrayList<>();
+        ArrayList<Thread> threads = new ArrayList<>();
+
+        Connection conn1 = DriverManager.getConnection(connectionString);
+        Connection conn2 = DriverManager.getConnection(connectionString);
+        cxns.add(conn1);
+        cxns.add(conn2);
+        
+        CountDownLatch session1Ready = new CountDownLatch(1);
+        CountDownLatch session1Commit = new CountDownLatch(1);
+        
+        threads.add(new Thread(new EPQInsertSession1Worker(conn1, session1Ready, session1Commit, bw)));
+        threads.add(new Thread(new EPQInsertSession2Worker(conn2, session1Ready, session1Commit, bw)));
+        
+        for (Thread t : threads) {
+            t.start();
+        }
+        
+        for (Thread t : threads) {
+            t.join();
+        }
+        
+        for (Connection cxn : cxns) {
+            cxn.close();
+        }
+    }
+    
+    /*
+     * Test Case 4: Mixed DML with OUTPUT clauses
+     * Verifying: Sequential INSERT/UPDATE/DELETE with OUTPUT under EPQ conditions in single transaction
+     * Success Criteria: All three OUTPUT operations return correct values, UPDATE/DELETE show EPQ-processed data
+     */
+    private static void test_mixed_dml_output(String connectionString, BufferedWriter bw) throws Exception {
+        ArrayList<Connection> cxns = new ArrayList<>();
+        ArrayList<Thread> threads = new ArrayList<>();
+
+        Connection conn1 = DriverManager.getConnection(connectionString);
+        Connection conn2 = DriverManager.getConnection(connectionString);
+        cxns.add(conn1);
+        cxns.add(conn2);
+        
+        // Add Param2 column for NULL alignment test
+        try (Statement stmt = conn1.createStatement()) {
+            try {
+                stmt.execute("ALTER TABLE TestTable_jira_4880 ADD Param2 VARCHAR(50)");
+            } catch (SQLException e) {
+                // Column might already exist, ignore
+            }
+            // Ensure record 3 exists for the test
+            stmt.execute("DELETE FROM TestTable_jira_4880 WHERE TestID = 3");
+            stmt.execute("INSERT INTO TestTable_jira_4880 (TestID, Param1, LockProcessID, Param2) VALUES (3, 'TestRecord', 300, NULL)");
+        }
+        
+        CountDownLatch session1Ready = new CountDownLatch(1);
+        CountDownLatch session1Commit = new CountDownLatch(1);
+        
+        threads.add(new Thread(new EPQMixedSession1Worker(conn1, session1Ready, session1Commit, bw)));
+        threads.add(new Thread(new EPQMixedSession2Worker(conn2, session1Ready, session1Commit, bw)));
+        
+        for (Thread t : threads) {
+            t.start();
+        }
+        
+        for (Thread t : threads) {
+            t.join();
+        }
+        
+        for (Connection cxn : cxns) {
+            cxn.close();
+        }
+    }
+    
+}
+
+class EPQSession1Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQSession1Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // Session 1 - Start transaction and lock the row
+            stmt.execute("UPDATE TestTable_jira_4880 SET Param1 = 'ModifiedBySession1' WHERE TestID = 1");
+            
+            // Signal that Session 1 has locked the row
+            session1Ready.countDown();
+            
+            // Wait a bit to ensure Session 2 is blocked
+            Thread.sleep(2000);
+            
+            // Commit to release lock and trigger EPQ in Session 2
+            conn.commit();
+            session1Commit.countDown();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+        }
+    }
+}
+
+class EPQSession2Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQSession2Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            // Wait for Session 1 to lock the row
+            session1Ready.await();
+            
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // This will be blocked until Session 1 commits, then EPQ will process it
+            ResultSet rs = stmt.executeQuery("UPDATE TestTable_jira_4880 SET LockProcessID = 7 " +
+                       "OUTPUT deleted.Param1 as old_param1, inserted.Param1 as new_param1, " +
+                       "deleted.LockProcessID as old_lock, inserted.LockProcessID as new_lock " +
+                       "WHERE TestID = 1");
+            
+            bw.write("=== Test Case 1: UPDATE with OUTPUT EPQ ===");
+            bw.newLine();
+            bw.write("Description: Tests EPQ handling when UPDATE with OUTPUT clause is blocked by concurrent transaction");
+            bw.newLine();
+            bw.write("UPDATE OUTPUT Results:");
+            bw.newLine();
+            while (rs.next()) {
+                bw.write("old_param1: " + rs.getString("old_param1") + ", new_param1: " + rs.getString("new_param1") + 
+                        ", old_lock: " + rs.getInt("old_lock") + ", new_lock: " + rs.getInt("new_lock"));
+                bw.newLine();
+            }
+            rs.close();
+            
+            conn.commit();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+        }
+    }
+}
+
+class EPQDeleteSession1Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQDeleteSession1Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // Session 1 - Update the row that will be deleted by Session 2
+            stmt.execute("UPDATE TestTable_jira_4880 SET Param1 = 'UpdatedBeforeDelete' WHERE TestID = 2");
+            
+            // Signal that Session 1 has locked the row
+            session1Ready.countDown();
+            
+            // Wait to ensure Session 2 is blocked
+            Thread.sleep(2000);
+            
+            // Commit to trigger EPQ in Session 2
+            conn.commit();
+            session1Commit.countDown();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+        }
+    }
+}
+
+class EPQDeleteSession2Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQDeleteSession2Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            // Wait for Session 1 to lock the row
+            session1Ready.await();
+            
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // DELETE with OUTPUT - should see EPQ-processed values
+            ResultSet rs = stmt.executeQuery("DELETE FROM TestTable_jira_4880 " +
+                       "OUTPUT deleted.Param1, deleted.LockProcessID " +
+                       "WHERE TestID = 2");
+            
+            bw.write("=== Test Case 2: DELETE with OUTPUT EPQ ===");
+            bw.newLine();
+            bw.write("Description: Tests EPQ handling when DELETE with OUTPUT clause processes updated row values");
+            bw.newLine();
+            bw.write("DELETE OUTPUT Results:");
+            bw.newLine();
+            while (rs.next()) {
+                bw.write("Param1: " + rs.getString("Param1") + ", LockProcessID: " + rs.getInt("LockProcessID"));
+                bw.newLine();
+            }
+            rs.close();
+            
+            conn.commit();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+        }
+    }
+}
+
+class EPQInsertSession1Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQInsertSession1Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // Session 1 - Create lock contention
+            stmt.execute("UPDATE TestTable_jira_4880 SET LockProcessID = 999 WHERE TestID = 1");
+            
+            // Signal that Session 1 has created lock contention
+            session1Ready.countDown();
+            
+            // Keep transaction open for a while
+            Thread.sleep(2000);
+            
+            // Commit to release lock
+            conn.commit();
+            session1Commit.countDown();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+        }
+    }
+}
+
+class EPQInsertSession2Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQInsertSession2Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            // Wait for Session 1 to create lock contention
+            session1Ready.await();
+            
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // INSERT with OUTPUT during concurrent operations
+            ResultSet rs = stmt.executeQuery("INSERT INTO TestTable_jira_4880 (TestID, Param1, LockProcessID) " +
+                       "OUTPUT inserted.TestID, inserted.Param1, inserted.LockProcessID " +
+                       "VALUES (4, 'ConcurrentInsert', 400)");
+            
+            bw.write("=== Test Case 3: INSERT with OUTPUT during concurrent operations ===");
+            bw.newLine();
+            bw.write("Description: Tests INSERT with OUTPUT clause execution during concurrent lock contention");
+            bw.newLine();
+            bw.write("INSERT OUTPUT Results:");
+            bw.newLine();
+            while (rs.next()) {
+                bw.write("TestID: " + rs.getInt("TestID") + ", Param1: " + rs.getString("Param1") + 
+                        ", LockProcessID: " + rs.getInt("LockProcessID"));
+                bw.newLine();
+            }
+            rs.close();
+            
+            conn.commit();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+        }
+    }
+}
+
+class EPQMixedSession1Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQMixedSession1Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // Complex transaction affecting multiple rows
+            stmt.execute("UPDATE TestTable_jira_4880 SET Param1 = 'Session1Modified' WHERE TestID IN (1, 2, 3)");
+            stmt.execute("UPDATE TestTable_jira_4880 SET Param2 = NULL WHERE TestID = 1");
+            
+            // Signal that Session 1 has locked rows
+            session1Ready.countDown();
+            
+            // Keep transaction open for mixed DML operations
+            Thread.sleep(3000);
+            
+            // Commit to trigger EPQ for UPDATE and DELETE
+            conn.commit();
+            session1Commit.countDown();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+            try {
+                bw.write("EPQMixedSession1Worker error: " + e.getMessage());
+                bw.newLine();
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+            }
+        }
+    }
+}
+
+class EPQMixedSession2Worker implements Runnable {
+    private final Connection conn;
+    private final CountDownLatch session1Ready;
+    private final CountDownLatch session1Commit;
+    private final BufferedWriter bw;
+    
+    EPQMixedSession2Worker(Connection conn, CountDownLatch session1Ready, CountDownLatch session1Commit, BufferedWriter bw) {
+        this.conn = conn;
+        this.session1Ready = session1Ready;
+        this.session1Commit = session1Commit;
+        this.bw = bw;
+    }
+    
+    public void run() {
+        try {
+            // Wait for Session 1 to lock rows
+            session1Ready.await();
+            
+            conn.setAutoCommit(false);
+            Statement stmt = conn.createStatement();
+            
+            // First: INSERT new record
+            ResultSet rs1 = stmt.executeQuery("INSERT INTO TestTable_jira_4880 (TestID, Param1, LockProcessID) " +
+                       "OUTPUT inserted.TestID, inserted.Param1, inserted.LockProcessID " +
+                       "VALUES (5, 'NewRecord', 500)");
+            
+            bw.write("=== Test Case 4: Mixed DML with OUTPUT clauses ===");
+            bw.newLine();
+            bw.write("Description: Tests sequence of INSERT, UPDATE, DELETE with OUTPUT clauses under EPQ conditions");
+            bw.newLine();
+            bw.write("Mixed DML - INSERT OUTPUT Results:");
+            bw.newLine();
+            while (rs1.next()) {
+                bw.write("TestID: " + rs1.getInt("TestID") + ", Param1: " + rs1.getString("Param1") + 
+                        ", LockProcessID: " + rs1.getInt("LockProcessID"));
+                bw.newLine();
+            }
+            rs1.close();
+            
+            // Second: UPDATE existing record (will trigger EPQ)
+            ResultSet rs2 = stmt.executeQuery("UPDATE TestTable_jira_4880 " +
+                       "SET LockProcessID = TestTable_jira_4880.LockProcessID + 100, Param1 = 'EPQ_Updated' " +
+                       "OUTPUT deleted.TestID, deleted.Param1 as old_param, " +
+                       "deleted.LockProcessID as old_lock, " +
+                       "inserted.TestID, inserted.Param1 as new_param, " +
+                       "inserted.LockProcessID as new_lock " +
+                       "WHERE TestID = 1");
+            
+            bw.write("Mixed DML - UPDATE OUTPUT Results:");
+            bw.newLine();
+            while (rs2.next()) {
+                bw.write("deleted - TestID: " + rs2.getInt(1) + ", old_param: " + rs2.getString("old_param") + 
+                        ", old_lock: " + rs2.getInt("old_lock"));
+                bw.newLine();
+                bw.write("inserted - TestID: " + rs2.getInt(4) + ", new_param: " + rs2.getString("new_param") + 
+                        ", new_lock: " + rs2.getInt("new_lock"));
+                bw.newLine();
+            }
+            rs2.close();
+            
+            // Third: DELETE another record (will trigger EPQ)
+            ResultSet rs3 = stmt.executeQuery("DELETE FROM TestTable_jira_4880 " +
+                       "OUTPUT deleted.TestID, deleted.LockProcessID, " +
+                       "deleted.Param1 " +
+                       "WHERE TestID = 2");
+            
+            bw.write("Mixed DML - DELETE OUTPUT Results:");
+            bw.newLine();
+            while (rs3.next()) {
+                bw.write("TestID: " + rs3.getInt("TestID") + ", LockProcessID: " + rs3.getInt("LockProcessID") + 
+                        ", Param1: " + rs3.getString("Param1"));
+                bw.newLine();
+            }
+            rs3.close();
+            
+            conn.commit();
+            
+        } catch (Exception e) {
+            BabelOutputClauseConcurrencyTest.errorCount.incrementAndGet();
+            try {
+                bw.write("EPQMixedSession2Worker error: " + e.getMessage());
+                bw.newLine();
+            } catch (IOException ioe) {
+                ioe.printStackTrace();
+            }
+        }
+    }
+}

--- a/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
+++ b/test/JDBC/src/test/java/com/sqlsamples/TestQueryFile.java
@@ -537,6 +537,9 @@ public class TestQueryFile {
         if (inputFileName.equals("temp_table_jdbc")) {
             JDBCTempTable.runTest(bw, logger);
             sla = defaultSLA*1000000L * 2; /* Increase SLA to avoid flakiness */
+        } else if (inputFileName.equals("babel_output_clause_concurrency_test")) {
+            BabelOutputClauseConcurrencyTest.runTest(bw, logger);
+            sla = defaultSLA*1000000L * 3; /* Increase SLA for concurrency test */
         } else {
             batch_run.batch_run_sql(connection_bbl, bw, testFilePath, logger);
         }

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -653,3 +653,5 @@ babel_string_to_money
 BABEL-4271
 sys-fn_varbintohexstr
 babel_binary
+test_output_clause
+update_with_var


### PR DESCRIPTION
(cherry picked from commit 113beed0fc6ae97574258bd42a130d939c18057f)

### Description

We are dealing with a critical crash bug in Babelfish's EPQ (EvalPlanQual) handling during concurrent UPDATE operations with OUTPUT clauses. The crash occurs when two sessions simultaneously modify the same row, where the column is of type "varchar" causing tuple alignment problems during EPQ re-evaluation. This is a memory corruption issue where PostgreSQL's EPQ mechanism fails to properly handle tuple structure changes when Babelfish processes OUTPUT clauses, leading to segmentation faults or assertion failures.

### The Problem
Babelfish was processing the OUTPUT clause (RETURNING clause) BEFORE EPQ evaluation, which created a race condition crash because:

1. Original Design Rationale: OUTPUT clause was moved before EPQ to ensure it executed before triggers
2. Race Condition: When EPQ re-evaluation occurred, the OUTPUT clause had already processed using stale tuple data
3. Crash Point: EPQ tried to re-evaluate with changed tuple structure, but OUTPUT processing was already complete with wrong memory references

### The Solution
Align Babelfish OUTPUT clause execution with PostgreSQL's native RETURNING clause flow:

### Key Insights from Fix

1. Trigger Execution Order: Analysis revealed that OUTPUT clause doesn't actually need to run before triggers in Babelfish context
2.  PostgreSQL Alignment: Following PostgreSQL's native RETURNING execution flow eliminates the race condition
3.  EPQ Compatibility: Processing OUTPUT after EPQ ensures it always works with the correct, final tuple data
4.  Memory Safety: Eliminates tuple alignment crashes by ensuring OUTPUT clause processes current data structure

### Related PR
https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/666

### Issues Resolved
BABEL-4880, BABEL-1290

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).