### PR TITLE
Block ALTER .. OWNER .. of TSQL objects via PG port (#4319)

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -70,6 +70,7 @@ char	   *pltsql_host_release = NULL;
 char	   *pltsql_host_service_pack_level = NULL;
 
 bool		pltsql_enable_create_alter_view_from_pg = false;
+bool		pltsql_enable_alter_owner_from_pg = false;
 
 static const struct config_enum_entry explain_format_options[] = {
 	{"text", EXPLAIN_FORMAT_TEXT, false},
@@ -1122,6 +1123,17 @@ define_custom_variables(void)
 							 gettext_noop("Enables blocked DDL statements from PG endpoint"),
 							 NULL,
 							 &pltsql_enable_create_alter_view_from_pg,
+							 false,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+	/*
+	 * Block ALTER .. OWNER .. from PG endpoint executed on TSQL objects.
+	 */
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_alter_owner_from_pg",
+							 gettext_noop("Enables blocked ALTER .. OWNER .. statements on TSQL objects from PG endpoint"),
+							 NULL,
+							 &pltsql_enable_alter_owner_from_pg,
 							 false,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -17,6 +17,7 @@ typedef enum IsolationOptions
 
 extern bool pltsql_fmtonly;
 extern bool pltsql_enable_create_alter_view_from_pg;
+extern bool	pltsql_enable_alter_owner_from_pg;
 extern bool pltsql_enable_linked_servers;
 extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -3388,6 +3388,28 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				{
 					bbf_alter_handle_partitioned_table(atstmt);
 				}
+
+				/*
+				 * Block ALTER .. OWNER TO .. statements from PG dialect
+				 * executed on TSQL objects except superuser.
+				 */
+				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !pltsql_enable_alter_owner_from_pg && !superuser())
+				{
+					restrict_alter_table_stmt(atstmt);
+				}
+				break;
+			}
+			case T_AlterOwnerStmt:
+			{
+				/*
+				 * Block ALTER .. OWNER TO .. statements from PG dialect
+				 * executed on TSQL objects except superuser.
+				 */
+				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !pltsql_enable_alter_owner_from_pg && !superuser())
+				{
+					AlterOwnerStmt *stmt = (AlterOwnerStmt *) parsetree;
+					restrict_alter_owner_stmt(stmt);
+				}
 				break;
 			}
 		case T_TruncateStmt:

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2086,6 +2086,8 @@ extern bool pltsql_support_tsql_transactions(void);
 extern bool pltsql_sys_function_pop(void);
 extern uint64 execute_bulk_load_insert(int ncol, int nrow,
 									   Datum *Values, bool *Nulls);
+extern void restrict_alter_owner_stmt(AlterOwnerStmt *stmt);
+extern void restrict_alter_table_stmt(AlterTableStmt *stmt);
 
 /*
  * Functions in pl_exec.c
@@ -2262,7 +2264,6 @@ extern bool is_tsql_datatype_with_max_scale_expr_allowed(Oid oid); /* sys.varcha
 extern bool is_tsql_text_ntext_or_image_datatype(Oid oid); /* sys.text, sys.ntext, sys.image */
 extern bool is_tsql_geometry_or_geography_datatype(Oid oid); /* sys.geometry / sys.geography */
 extern void downcase_truncate_split_object_name(char *four_part_object_name, char** server_name, char** db_name, char** schema_name, char** object_name);
-
 typedef struct
 {
 	bool		success;

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -2768,3 +2768,112 @@ downcase_truncate_split_object_name(char *four_part_object_name, char **server_n
 	if (object_name != NULL)
 		*object_name = temp_object_name;
 }
+
+/*
+ * restrict_alter_owner_stmt
+ * Blocks ALTER OWNER statements from PG endpoint on TSQL objects.
+ */
+void
+restrict_alter_owner_stmt(AlterOwnerStmt *stmt)
+{
+    Oid			schema_oid = InvalidOid;
+    char		*schema_name = NULL;
+    ObjectAddress	address;
+    Relation		relation = NULL;
+    Node			*object = stmt->object;
+
+    /* Only handle specific object types */
+    if (stmt->objectType != OBJECT_TYPE && stmt->objectType != OBJECT_SCHEMA &&
+        stmt->objectType != OBJECT_FUNCTION && stmt->objectType != OBJECT_PROCEDURE)
+        return;
+    
+    /* For OBJECT_TYPE, convert List to TypeName if needed */
+    if (stmt->objectType == OBJECT_TYPE && IsA(stmt->object, List))
+    {
+        TypeName *typename = makeTypeNameFromNameList((List *) stmt->object);
+        object = (Node *) typename;
+    }
+    
+    /* Get object address to determine schema */
+    address = get_object_address(stmt->objectType, object, &relation, AccessShareLock, false);
+    
+    if (stmt->objectType == OBJECT_SCHEMA)
+    {
+		/* For schema objects, the object itself is the schema */
+        schema_oid = address.objectId;
+    }
+    else
+    {
+		/* For other objects, get their containing schema */
+        schema_oid = get_object_namespace(&address);
+    }
+
+	if (!OidIsValid(schema_oid))
+	{
+		if (relation)
+			RelationClose(relation);
+		return;
+	}
+    
+    schema_name = get_namespace_name(schema_oid);
+    if (relation)
+        RelationClose(relation);
+    
+    if (!schema_name)
+        return;
+
+    /* Check if it's a Babelfish schema */
+    if (physical_schema_name_exists(schema_name))
+    {
+        pfree(schema_name);
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.")));
+    }
+}
+
+/*
+ * restrict_alter_table_stmt  
+ * Blocks ALTER TABLE statements from PG dialect on TSQL objects.
+ * Extracts schema name from the table relation and checks if it belongs to Babelfish.
+ */
+void
+restrict_alter_table_stmt(AlterTableStmt *stmt)
+{
+    char *schema_name = NULL;
+    Oid schema_oid = InvalidOid;
+    ListCell *lcmd;
+
+    /* Skip if this is ALTER VIEW - handled with babelfishpg_tsql.enable_create_alter_view_from_pg */
+    if (stmt->objtype == OBJECT_VIEW)
+        return;
+
+    /* Extract schema from RangeVar */
+    if (stmt->relation)
+    {
+        if (stmt->relation->schemaname)
+            schema_name = stmt->relation->schemaname;
+        else
+        {
+            schema_oid = RangeVarGetRelid(stmt->relation, AccessExclusiveLock, true);
+            if (OidIsValid(schema_oid))
+                schema_name = get_namespace_name(schema_oid);
+        }
+    }
+
+    /* Check if any command is AT_ChangeOwner */
+    foreach(lcmd, stmt->cmds)
+    {
+        AlterTableCmd *cmd = (AlterTableCmd *) lfirst(lcmd);
+        if (cmd->subtype != AT_ChangeOwner)
+            continue;
+
+        /* Check if it's a Babelfish schema */
+        if (schema_name && physical_schema_name_exists(schema_name))
+        {
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.")));
+        }
+    }
+}

--- a/test/JDBC/expected/BABEL-3326-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3326-vu-verify.out
@@ -741,6 +741,7 @@ GO
 -- psql
 -- Test cases if user tries to enable/disable trigger <schema-1>.<trigger-1> on table <schema-2>.<table-1> 
 -- if both schemas have tables with same name and each table have trigger with same trigger name
+-- ALTER .. OWNER .. on TSQL objects are blocked.
 ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_babel_3326_u1;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_babel_3326_u1;
@@ -886,7 +887,6 @@ ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_dbo;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_dbo;
 GO
-
 
 -- tsql user=jdbc_user password=12345678
 

--- a/test/JDBC/expected/object_ownership-before-16_8-or-17_4-vu-verify.out
+++ b/test/JDBC/expected/object_ownership-before-16_8-or-17_4-vu-verify.out
@@ -298,6 +298,10 @@ SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
 
 -- psql
 /*** EXECUTES THE ALTER STATEMENTS ***/
+-- Set the respective GUCs to allow ALTER .. OWNER .. on TSQL objects via PG endpoint.
+SET babelfishpg_tsql.enable_alter_owner_from_pg = true;
+SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
+GO
 ALTER TABLE object_ownership_db_object_ownership_s2."2bc43500e5a904447227cb4121181c74_partition_0" OWNER TO object_ownership_db_object_ownership_u1;
 ALTER TABLE object_ownership_db_object_ownership_s2."2bc43500e5a904447227cb4121181c74_partition_1" OWNER TO object_ownership_db_object_ownership_u1;
 ALTER TABLE object_ownership_db_object_ownership_s2."2bc43500e5a904447227cb4121181c74_partition_2" OWNER TO object_ownership_db_object_ownership_u1;
@@ -307,9 +311,7 @@ ALTER PROCEDURE object_ownership_db_object_ownership_s2.old_p OWNER TO object_ow
 ALTER SEQUENCE object_ownership_db_object_ownership_s2.old_sq OWNER TO object_ownership_db_object_ownership_u1;
 ALTER TABLE object_ownership_db_object_ownership_s2.old_t OWNER TO object_ownership_db_object_ownership_u1;
 ALTER SEQUENCE object_ownership_db_object_ownership_s2.old_t_id_seq OWNER TO object_ownership_db_object_ownership_u1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
 ALTER VIEW object_ownership_db_object_ownership_s2.old_v OWNER TO object_ownership_db_object_ownership_u1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
 ALTER TABLE object_ownership_db_object_ownership_s2.pt2 OWNER TO object_ownership_db_object_ownership_u1;
 ALTER SEQUENCE object_ownership_db_object_ownership_s2.pt2_saleid_seq OWNER TO object_ownership_db_object_ownership_u1;
 ALTER FUNCTION object_ownership_db_object_ownership_s3.old_f OWNER TO object_ownership_db_object_ownership_r1;
@@ -331,11 +333,9 @@ ALTER FUNCTION object_ownership_db_object_ownership_s3.old_tvf OWNER TO object_o
 ALTER FUNCTION object_ownership_db_object_ownership_s3.old_tvf1 OWNER TO object_ownership_db_object_ownership_r1;
 ALTER TYPE object_ownership_db_object_ownership_s3.old_type OWNER TO object_ownership_db_object_ownership_r1;
 ALTER TYPE object_ownership_db_object_ownership_s3.old_type1 OWNER TO object_ownership_db_object_ownership_r1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
 ALTER VIEW object_ownership_db_object_ownership_s3.old_v OWNER TO object_ownership_db_object_ownership_r1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
 ALTER VIEW object_ownership_db_object_ownership_s3.old_v1 OWNER TO object_ownership_db_object_ownership_r1;
+SET babelfishpg_tsql.enable_alter_owner_from_pg = false;
 SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
 GO
 

--- a/test/JDBC/expected/object_ownership.out
+++ b/test/JDBC/expected/object_ownership.out
@@ -673,6 +673,109 @@ text
 ~~END~~
 
 
+-- psql user=object_ownership_l1 password=123
+-- Test changing ownership to master_dbo as non-superuser
+-- ALTER .. OWNER .. should be blocked
+ALTER TABLE object_ownership_db_object_ownership_s2.t1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER VIEW object_ownership_db_object_ownership_s2.v1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER VIEW is blocked in PG dialect on TSQL view present in babelfish_view_def catalog. Please set babelfishpg_tsql.enable_create_alter_view_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION object_ownership_db_object_ownership_s2.f1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER PROCEDURE object_ownership_db_object_ownership_s2.p1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER SEQUENCE object_ownership_db_object_ownership_s2.sq1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION object_ownership_db_object_ownership_s2.tvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION object_ownership_db_object_ownership_s2.mtvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TYPE object_ownership_db_object_ownership_s2.type1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TYPE object_ownership_db_object_ownership_s2.ttype1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TABLE object_ownership_db_guest.t OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER VIEW object_ownership_db_guest.v OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER VIEW is blocked in PG dialect on TSQL view present in babelfish_view_def catalog. Please set babelfishpg_tsql.enable_create_alter_view_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION object_ownership_db_guest.f OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER PROCEDURE object_ownership_db_guest.p OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER SEQUENCE object_ownership_db_guest.sq OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+
+-- tsql
 /** DROP OBJECTS **/
 drop table guest.t;
 go
@@ -823,6 +926,7 @@ go
 ~~START~~
 bool
 t
+t
 ~~END~~
 
 
@@ -904,4 +1008,147 @@ go
 drop login object_ownership_l4;
 go
 drop database object_ownership_db
+go
+
+-- psql
+-- Test ALTER .. OWNER .. on TSQL objects via PG endpoint
+-- Create a test login for non-superuser ALTER OWNER tests
+CREATE ROLE test_alter_owner_l1 WITH LOGIN PASSWORD '123';
+GO
+
+-- tsql
+use master;
+go
+
+-- Create test objects in master database (similar to object_ownership_s2 objects)
+create table t1(a int, b int);
+go
+create view v1 as select 1;
+go
+create proc p1 as select 2;
+go
+create function f1() returns int begin declare @a int; set @a = 1; return @a; END
+go
+create sequence sq1 start with 1 increment by 1;
+go
+create index idx1 on t1(a);
+go
+create trigger tr1 on t1 after insert as select 1;
+go
+create function tvf1() returns table as return (select '1' as col);
+go
+create function mtvf1()
+returns @result table([Id] int) AS
+begin
+    insert into @result values (1) return 
+end
+go
+create type type1 from sys.varchar(10);
+go
+create type ttype1 as table (id int);
+go
+
+-- psql user=test_alter_owner_l1 password=123
+-- Test ALTER OWNER on master database objects as non-superuser
+ALTER TABLE master_dbo.t1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER VIEW master_dbo.v1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER VIEW is blocked in PG dialect on TSQL view present in babelfish_view_def catalog. Please set babelfishpg_tsql.enable_create_alter_view_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION master_dbo.f1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER PROCEDURE master_dbo.p1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER SEQUENCE master_dbo.sq1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION master_dbo.tvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION master_dbo.mtvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TYPE master_dbo.type1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TYPE master_dbo.ttype1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER SCHEMA master_dbo OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+
+-- tsql
+use master;
+go
+
+-- Drop the test objects
+drop index idx1 on t1;
+go
+drop trigger tr1;
+go
+drop function tvf1;
+go
+drop function mtvf1;
+go
+drop type type1;
+go
+drop type ttype1;
+go
+drop table t1;
+go
+drop view v1;
+go
+drop procedure p1;
+go
+drop function f1;
+go
+drop sequence sq1;
+go
+
+-- psql
+drop user test_alter_owner_l1;
 go

--- a/test/JDBC/expected/securityadmin_role-vu-verify.out
+++ b/test/JDBC/expected/securityadmin_role-vu-verify.out
@@ -1491,32 +1491,32 @@ ALTER schema master_securityadmin_scm1 owner to securityadmin;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must be able to SET ROLE "securityadmin"
-    Server SQLState: 42501)~~
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
 
 
 ALTER table master_dbo.securityadmin_tb1 owner to securityadmin;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must be able to SET ROLE "securityadmin"
-    Server SQLState: 42501)~~
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
 
 
 ALTER procedure master_dbo.securityadmin_proc1 owner to securityadmin;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must be able to SET ROLE "securityadmin"
-    Server SQLState: 42501)~~
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
 
 
 ALTER function master_dbo.securityadmin_func1 owner to securityadmin;
 go
 ~~ERROR (Code: 0)~~
 
-~~ERROR (Message: ERROR: must be able to SET ROLE "securityadmin"
-    Server SQLState: 42501)~~
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
 
 
 -- psql

--- a/test/JDBC/expected/single_db/object_ownership.out
+++ b/test/JDBC/expected/single_db/object_ownership.out
@@ -661,6 +661,109 @@ text
 ~~END~~
 
 
+-- psql user=object_ownership_l1 password=123
+-- Test changing ownership to master_dbo as non-superuser
+-- ALTER .. OWNER .. should be blocked
+ALTER TABLE object_ownership_db_object_ownership_s2.t1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER VIEW object_ownership_db_object_ownership_s2.v1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER FUNCTION object_ownership_db_object_ownership_s2.f1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER PROCEDURE object_ownership_db_object_ownership_s2.p1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER SEQUENCE object_ownership_db_object_ownership_s2.sq1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER FUNCTION object_ownership_db_object_ownership_s2.tvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER FUNCTION object_ownership_db_object_ownership_s2.mtvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER TYPE object_ownership_db_object_ownership_s2.type1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER TYPE object_ownership_db_object_ownership_s2.ttype1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_object_ownership_s2" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER TABLE object_ownership_db_guest.t OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_guest" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER VIEW object_ownership_db_guest.v OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_guest" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER FUNCTION object_ownership_db_guest.f OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_guest" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER PROCEDURE object_ownership_db_guest.p OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_guest" does not exist
+    Server SQLState: 3F000)~~
+
+ALTER SEQUENCE object_ownership_db_guest.sq OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "object_ownership_db_guest" does not exist
+    Server SQLState: 3F000)~~
+
+
+-- tsql
 /** DROP OBJECTS **/
 drop table guest.t;
 go
@@ -811,6 +914,7 @@ go
 ~~START~~
 bool
 t
+t
 ~~END~~
 
 
@@ -892,4 +996,147 @@ go
 drop login object_ownership_l4;
 go
 drop database object_ownership_db
+go
+
+-- psql
+-- Test ALTER .. OWNER .. on TSQL objects via PG endpoint
+-- Create a test login for non-superuser ALTER OWNER tests
+CREATE ROLE test_alter_owner_l1 WITH LOGIN PASSWORD '123';
+GO
+
+-- tsql
+use master;
+go
+
+-- Create test objects in master database (similar to object_ownership_s2 objects)
+create table t1(a int, b int);
+go
+create view v1 as select 1;
+go
+create proc p1 as select 2;
+go
+create function f1() returns int begin declare @a int; set @a = 1; return @a; END
+go
+create sequence sq1 start with 1 increment by 1;
+go
+create index idx1 on t1(a);
+go
+create trigger tr1 on t1 after insert as select 1;
+go
+create function tvf1() returns table as return (select '1' as col);
+go
+create function mtvf1()
+returns @result table([Id] int) AS
+begin
+    insert into @result values (1) return 
+end
+go
+create type type1 from sys.varchar(10);
+go
+create type ttype1 as table (id int);
+go
+
+-- psql user=test_alter_owner_l1 password=123
+-- Test ALTER OWNER on master database objects as non-superuser
+ALTER TABLE master_dbo.t1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER VIEW master_dbo.v1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER VIEW is blocked in PG dialect on TSQL view present in babelfish_view_def catalog. Please set babelfishpg_tsql.enable_create_alter_view_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION master_dbo.f1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER PROCEDURE master_dbo.p1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER SEQUENCE master_dbo.sq1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION master_dbo.tvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER FUNCTION master_dbo.mtvf1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TYPE master_dbo.type1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER TYPE master_dbo.ttype1 OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+ALTER SCHEMA master_dbo OWNER TO master_dbo;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. OWNER .. is blocked in PG dialect on TSQL objects. Please set babelfishpg_tsql.enable_alter_owner_from_pg to true to enable.
+    Server SQLState: 0A000)~~
+
+
+-- tsql
+use master;
+go
+
+-- Drop the test objects
+drop index idx1 on t1;
+go
+drop trigger tr1;
+go
+drop function tvf1;
+go
+drop function mtvf1;
+go
+drop type type1;
+go
+drop type ttype1;
+go
+drop table t1;
+go
+drop view v1;
+go
+drop procedure p1;
+go
+drop function f1;
+go
+drop sequence sq1;
+go
+
+-- psql
+drop user test_alter_owner_l1;
 go

--- a/test/JDBC/input/BABEL-3326-vu-verify.mix
+++ b/test/JDBC/input/BABEL-3326-vu-verify.mix
@@ -385,6 +385,7 @@ GO
 -- if both schemas have tables with same name and each table have trigger with same trigger name
 
 -- psql
+-- ALTER .. OWNER .. on TSQL objects are blocked.
 ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_babel_3326_u1;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_babel_3326_u1;
@@ -498,7 +499,6 @@ ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_dbo;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_dbo;
 GO
-
 
 -- tsql user=jdbc_user password=12345678
 -- Test cases for behaviour of enable/disable of trigger in transactions

--- a/test/JDBC/input/object_ownership-before-16_8-or-17_4-vu-verify.mix
+++ b/test/JDBC/input/object_ownership-before-16_8-or-17_4-vu-verify.mix
@@ -105,6 +105,10 @@ go
 
 /*** EXECUTES THE ALTER STATEMENTS ***/
 -- psql
+-- Set the respective GUCs to allow ALTER .. OWNER .. on TSQL objects via PG endpoint.
+SET babelfishpg_tsql.enable_alter_owner_from_pg = true;
+SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
+GO
 ALTER TABLE object_ownership_db_object_ownership_s2."2bc43500e5a904447227cb4121181c74_partition_0" OWNER TO object_ownership_db_object_ownership_u1;
 ALTER TABLE object_ownership_db_object_ownership_s2."2bc43500e5a904447227cb4121181c74_partition_1" OWNER TO object_ownership_db_object_ownership_u1;
 ALTER TABLE object_ownership_db_object_ownership_s2."2bc43500e5a904447227cb4121181c74_partition_2" OWNER TO object_ownership_db_object_ownership_u1;
@@ -114,9 +118,7 @@ ALTER PROCEDURE object_ownership_db_object_ownership_s2.old_p OWNER TO object_ow
 ALTER SEQUENCE object_ownership_db_object_ownership_s2.old_sq OWNER TO object_ownership_db_object_ownership_u1;
 ALTER TABLE object_ownership_db_object_ownership_s2.old_t OWNER TO object_ownership_db_object_ownership_u1;
 ALTER SEQUENCE object_ownership_db_object_ownership_s2.old_t_id_seq OWNER TO object_ownership_db_object_ownership_u1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
 ALTER VIEW object_ownership_db_object_ownership_s2.old_v OWNER TO object_ownership_db_object_ownership_u1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
 ALTER TABLE object_ownership_db_object_ownership_s2.pt2 OWNER TO object_ownership_db_object_ownership_u1;
 ALTER SEQUENCE object_ownership_db_object_ownership_s2.pt2_saleid_seq OWNER TO object_ownership_db_object_ownership_u1;
 ALTER FUNCTION object_ownership_db_object_ownership_s3.old_f OWNER TO object_ownership_db_object_ownership_r1;
@@ -138,11 +140,9 @@ ALTER FUNCTION object_ownership_db_object_ownership_s3.old_tvf OWNER TO object_o
 ALTER FUNCTION object_ownership_db_object_ownership_s3.old_tvf1 OWNER TO object_ownership_db_object_ownership_r1;
 ALTER TYPE object_ownership_db_object_ownership_s3.old_type OWNER TO object_ownership_db_object_ownership_r1;
 ALTER TYPE object_ownership_db_object_ownership_s3.old_type1 OWNER TO object_ownership_db_object_ownership_r1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
 ALTER VIEW object_ownership_db_object_ownership_s3.old_v OWNER TO object_ownership_db_object_ownership_r1;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
-SET babelfishpg_tsql.enable_create_alter_view_from_pg = true;
 ALTER VIEW object_ownership_db_object_ownership_s3.old_v1 OWNER TO object_ownership_db_object_ownership_r1;
+SET babelfishpg_tsql.enable_alter_owner_from_pg = false;
 SET babelfishpg_tsql.enable_create_alter_view_from_pg = false;
 GO
 

--- a/test/JDBC/input/object_ownership.mix
+++ b/test/JDBC/input/object_ownership.mix
@@ -362,6 +362,39 @@ go
 select * from generate_alter_ownership_statements();
 go
 
+-- psql user=object_ownership_l1 password=123
+-- Test changing ownership to master_dbo as non-superuser
+-- ALTER .. OWNER .. should be blocked
+ALTER TABLE object_ownership_db_object_ownership_s2.t1 OWNER TO master_dbo;
+GO
+ALTER VIEW object_ownership_db_object_ownership_s2.v1 OWNER TO master_dbo;
+GO
+ALTER FUNCTION object_ownership_db_object_ownership_s2.f1 OWNER TO master_dbo;
+GO
+ALTER PROCEDURE object_ownership_db_object_ownership_s2.p1 OWNER TO master_dbo;
+GO
+ALTER SEQUENCE object_ownership_db_object_ownership_s2.sq1 OWNER TO master_dbo;
+GO
+ALTER FUNCTION object_ownership_db_object_ownership_s2.tvf1 OWNER TO master_dbo;
+GO
+ALTER FUNCTION object_ownership_db_object_ownership_s2.mtvf1 OWNER TO master_dbo;
+GO
+ALTER TYPE object_ownership_db_object_ownership_s2.type1 OWNER TO master_dbo;
+GO
+ALTER TYPE object_ownership_db_object_ownership_s2.ttype1 OWNER TO master_dbo;
+GO
+ALTER TABLE object_ownership_db_guest.t OWNER TO master_dbo;
+GO
+ALTER VIEW object_ownership_db_guest.v OWNER TO master_dbo;
+GO
+ALTER FUNCTION object_ownership_db_guest.f OWNER TO master_dbo;
+GO
+ALTER PROCEDURE object_ownership_db_guest.p OWNER TO master_dbo;
+GO
+ALTER SEQUENCE object_ownership_db_guest.sq OWNER TO master_dbo;
+GO
+
+-- tsql
 /** DROP OBJECTS **/
 drop table guest.t;
 go
@@ -553,4 +586,97 @@ go
 drop login object_ownership_l4;
 go
 drop database object_ownership_db
+go
+
+-- Test ALTER .. OWNER .. on TSQL objects via PG endpoint
+-- psql
+-- Create a test login for non-superuser ALTER OWNER tests
+CREATE ROLE test_alter_owner_l1 WITH LOGIN PASSWORD '123';
+GO
+
+-- tsql
+use master;
+go
+
+-- Create test objects in master database (similar to object_ownership_s2 objects)
+create table t1(a int, b int);
+go
+create view v1 as select 1;
+go
+create proc p1 as select 2;
+go
+create function f1() returns int begin declare @a int; set @a = 1; return @a; END
+go
+create sequence sq1 start with 1 increment by 1;
+go
+create index idx1 on t1(a);
+go
+create trigger tr1 on t1 after insert as select 1;
+go
+create function tvf1() returns table as return (select '1' as col);
+go
+create function mtvf1()
+returns @result table([Id] int) AS
+begin
+    insert into @result values (1) return 
+end
+go
+create type type1 from sys.varchar(10);
+go
+create type ttype1 as table (id int);
+go
+
+-- psql user=test_alter_owner_l1 password=123
+-- Test ALTER OWNER on master database objects as non-superuser
+ALTER TABLE master_dbo.t1 OWNER TO master_dbo;
+GO
+ALTER VIEW master_dbo.v1 OWNER TO master_dbo;
+GO
+ALTER FUNCTION master_dbo.f1 OWNER TO master_dbo;
+GO
+ALTER PROCEDURE master_dbo.p1 OWNER TO master_dbo;
+GO
+ALTER SEQUENCE master_dbo.sq1 OWNER TO master_dbo;
+GO
+ALTER FUNCTION master_dbo.tvf1 OWNER TO master_dbo;
+GO
+ALTER FUNCTION master_dbo.mtvf1 OWNER TO master_dbo;
+GO
+ALTER TYPE master_dbo.type1 OWNER TO master_dbo;
+GO
+ALTER TYPE master_dbo.ttype1 OWNER TO master_dbo;
+GO
+ALTER SCHEMA master_dbo OWNER TO master_dbo;
+GO
+
+-- tsql
+use master;
+go
+
+-- Drop the test objects
+drop index idx1 on t1;
+go
+drop trigger tr1;
+go
+drop function tvf1;
+go
+drop function mtvf1;
+go
+drop type type1;
+go
+drop type ttype1;
+go
+drop table t1;
+go
+drop view v1;
+go
+drop procedure p1;
+go
+drop function f1;
+go
+drop sequence sq1;
+go
+
+-- psql
+drop user test_alter_owner_l1;
 go


### PR DESCRIPTION
### Description
Block ALTER .. OWNER .. of TSQL objects via PG port except for the cases when the GUC babelfishpg_tsql.dump_restore or babelfishpg_tsql.enable_alter_owner_from_pg is set to true.

### Issue
Task: BABEL-6142
Signed-off-by: Shalini Lohia <lshalini@amazon.com>