### PR TITLE
Redefining SP_DATATYPE_INFO and SP_DATATYPE_INFO_100 Procedures via Views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/babelfishpg_tsql.sql
@@ -194,37 +194,95 @@ INSERT INTO sys.spt_datatype_info_table VALUES (N'datetime2', 93, 27, N'''', N''
 INSERT INTO sys.spt_datatype_info_table VALUES (N'datetime', 93, 23, N'''', N'''', NULL, 1, 0, 3, NULL, 0, NULL, N'datetime', 3, 3, 9, 3, NULL, NULL, 12, 16, 111, 'datetime');
 INSERT INTO sys.spt_datatype_info_table VALUES (N'smalldatetime', 93, 16, N'''', N'''', NULL, 1, 0, 3, NULL, 0, NULL, N'smalldatetime', 0, 0, 9, 3, NULL, NULL, 22, 16, 111, 'smalldatetime');
 
-CREATE OR REPLACE PROCEDURE sys.sp_datatype_info (
-	"@data_type" int = 0,
-	"@odbcver" smallint = 2)
-AS $$
-BEGIN
-        select TYPE_NAME, DATA_TYPE, PRECISION, LITERAL_PREFIX, LITERAL_SUFFIX,
-              CAST(CREATE_PARAMS AS CHAR(20)), NULLABLE, CASE_SENSITIVE, SEARCHABLE,
-              UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
-              MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
-              NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
-        from sys.sp_datatype_info_helper(@odbcver, false) where @data_type = 0 or data_type = @data_type
-        order by DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
-END;
-$$
-LANGUAGE 'pltsql';
+CREATE OR REPLACE VIEW sys.sp_datatype_info_view_odbc_version_2 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(2::smallint, false) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
 
-CREATE OR REPLACE PROCEDURE sys.sp_datatype_info_100 (
-	"@data_type" int = 0,
-	"@odbcver" smallint = 2)
+GRANT SELECT ON sys.sp_datatype_info_view_odbc_version_2 TO PUBLIC;
+
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_view_odbc_version_3 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(3::smallint, false) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_view_odbc_version_3 TO PUBLIC;
+
+
+CREATE OR REPLACE PROCEDURE sys.sp_datatype_info(
+    "@data_type" int = 0, 
+    "@odbcver" smallint = 2)
 AS $$
 BEGIN
-        select TYPE_NAME, DATA_TYPE, PRECISION, LITERAL_PREFIX, LITERAL_SUFFIX,
-              CAST(CREATE_PARAMS AS CHAR(20)), NULLABLE, CASE_SENSITIVE, SEARCHABLE,
-              UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
-              MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
-              NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
-        from sys.sp_datatype_info_helper(@odbcver, true) where @data_type = 0 or data_type = @data_type
-        order by DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+    IF @odbcver = 3
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_view_odbc_version_3
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+    ELSE
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_view_odbc_version_2
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
 END;
 $$
-LANGUAGE 'pltsql';
+LANGUAGE pltsql;
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_100_view_odbc_version_2 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(2::smallint, true) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_100_view_odbc_version_2 TO PUBLIC;
+
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_100_view_odbc_version_3 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(3::smallint, true) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_100_view_odbc_version_3 TO PUBLIC;
+
+
+CREATE OR REPLACE PROCEDURE sys.sp_datatype_info_100(
+    "@data_type" int = 0,
+    "@odbcver" smallint = 2)
+AS $$
+BEGIN
+    IF @odbcver = 3
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_100_view_odbc_version_3
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+    ELSE
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_100_view_odbc_version_2
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+END;
+$$
+LANGUAGE pltsql;
 
 CREATE OR REPLACE FUNCTION sys.tsql_type_radix_for_sp_columns_helper(IN type TEXT)
 RETURNS SMALLINT

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.8.0--4.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.8.0--4.9.0.sql
@@ -23,6 +23,97 @@ END;
 $$ 
 LANGUAGE plpgsql IMMUTABLE STRICT;
 
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_view_version_2 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(2::smallint, false) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_view_version_2 TO PUBLIC;
+
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_view_version_3 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(3::smallint, false) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_view_version_3 TO PUBLIC;
+
+
+CREATE OR REPLACE PROCEDURE sys.sp_datatype_info(
+    "@data_type" int = 0, 
+    "@odbcver" smallint = 2)
+AS $$
+BEGIN
+    IF @odbcver = 3
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_view_version_3
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+    ELSE
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_view_version_2
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+END;
+$$
+LANGUAGE pltsql;
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_100_view_version_2 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(2::smallint, true) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_100_view_version_2 TO PUBLIC;
+
+
+CREATE OR REPLACE VIEW sys.sp_datatype_info_100_view_version_3 AS 
+SELECT TYPE_NAME, DATA_TYPE, "PRECISION", LITERAL_PREFIX, LITERAL_SUFFIX,
+       CAST(CREATE_PARAMS AS CHAR(20)) AS CREATE_PARAMS, 
+       NULLABLE, CASE_SENSITIVE, SEARCHABLE,
+       UNSIGNED_ATTRIBUTE, MONEY, AUTO_INCREMENT, LOCAL_TYPE_NAME,
+       MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE, SQL_DATETIME_SUB,
+       NUM_PREC_RADIX, INTERVAL_PRECISION, USERTYPE
+FROM sys.sp_datatype_info_helper(3::smallint, true) 
+ORDER BY DATA_TYPE, AUTO_INCREMENT, MONEY, USERTYPE;
+
+GRANT SELECT ON sys.sp_datatype_info_100_view_version_3 TO PUBLIC;
+
+
+CREATE OR REPLACE PROCEDURE sys.sp_datatype_info_100(
+    "@data_type" int = 0,
+    "@odbcver" smallint = 2)
+AS $$
+BEGIN
+    IF @odbcver = 3
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_100_view_version_3
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+    ELSE
+    BEGIN
+        SELECT * FROM sys.sp_datatype_info_100_view_version_2
+        WHERE @data_type = 0 OR DATA_TYPE = @data_type;
+    END
+END;
+$$
+LANGUAGE pltsql;
+
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();
 -- Reset search_path to not affect any subsequent scripts

--- a/test/JDBC/expected/BABEL-SP_DATATYPE_INFO-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-SP_DATATYPE_INFO-vu-cleanup.out
@@ -1,0 +1,71 @@
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_p1;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_p2;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_p3;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_int_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_string_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_binary_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_datetime_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_decimal_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_float_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_special_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_odbcver;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_edge_cases;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_p1;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_p2;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_p3;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_int_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_string_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_binary_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_datetime_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_decimal_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_float_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_special_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_odbcver;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_edge_cases;
+GO

--- a/test/JDBC/expected/BABEL-SP_DATATYPE_INFO-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-SP_DATATYPE_INFO-vu-prepare.out
@@ -1,0 +1,215 @@
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_p1
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_p2
+    @data_type int = 0
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = @data_type;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_p3
+    @data_type int = 0,
+    @odbcver smallint = 2
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = @data_type, @odbcver = @odbcver;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_int_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 4;
+    EXEC sys.sp_datatype_info_100 @data_type = -5;
+    EXEC sys.sp_datatype_info_100 @data_type = 5;
+    EXEC sys.sp_datatype_info_100 @data_type = -6;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_string_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 1;
+    EXEC sys.sp_datatype_info_100 @data_type = 12;
+    EXEC sys.sp_datatype_info_100 @data_type = -1;
+    EXEC sys.sp_datatype_info_100 @data_type = -8;
+    EXEC sys.sp_datatype_info_100 @data_type = -9;
+    EXEC sys.sp_datatype_info_100 @data_type = -10;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_binary_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = -2;
+    EXEC sys.sp_datatype_info_100 @data_type = -3;
+    EXEC sys.sp_datatype_info_100 @data_type = -4;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_datetime_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 9;
+    EXEC sys.sp_datatype_info_100 @data_type = 11;
+    EXEC sys.sp_datatype_info_100 @data_type = -154;
+    EXEC sys.sp_datatype_info_100 @data_type = -155;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_decimal_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 3;
+    EXEC sys.sp_datatype_info_100 @data_type = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_float_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 6;
+    EXEC sys.sp_datatype_info_100 @data_type = 7;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_special_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = -7;
+    EXEC sys.sp_datatype_info_100 @data_type = -11;
+    EXEC sys.sp_datatype_info_100 @data_type = -150;
+    EXEC sys.sp_datatype_info_100 @data_type = -152;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_odbcver
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 0, @odbcver = 2;
+    EXEC sys.sp_datatype_info_100 @data_type = 4, @odbcver = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_edge_cases
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 9999;
+    EXEC sys.sp_datatype_info_100 @data_type = -9999;
+    EXEC sys.sp_datatype_info_100 @data_type = 0;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_p1
+AS
+BEGIN
+    EXEC sys.sp_datatype_info;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_p2
+    @data_type int = 0
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = @data_type;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_p3
+    @data_type int = 0,
+    @odbcver smallint = 2
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = @data_type, @odbcver = @odbcver;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_int_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 4;
+    EXEC sys.sp_datatype_info @data_type = -5;
+    EXEC sys.sp_datatype_info @data_type = 5;
+    EXEC sys.sp_datatype_info @data_type = -6;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_string_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 1;
+    EXEC sys.sp_datatype_info @data_type = 12;
+    EXEC sys.sp_datatype_info @data_type = -1;
+    EXEC sys.sp_datatype_info @data_type = -8;
+    EXEC sys.sp_datatype_info @data_type = -9;
+    EXEC sys.sp_datatype_info @data_type = -10;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_binary_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = -2;
+    EXEC sys.sp_datatype_info @data_type = -3;
+    EXEC sys.sp_datatype_info @data_type = -4;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_datetime_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 9;
+    EXEC sys.sp_datatype_info @data_type = 11;
+    EXEC sys.sp_datatype_info @data_type = -154;
+    EXEC sys.sp_datatype_info @data_type = -155;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_decimal_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 3;
+    EXEC sys.sp_datatype_info @data_type = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_float_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 6;
+    EXEC sys.sp_datatype_info @data_type = 7;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_special_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = -7;
+    EXEC sys.sp_datatype_info @data_type = -11;
+    EXEC sys.sp_datatype_info @data_type = -150;
+    EXEC sys.sp_datatype_info @data_type = -152;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_odbcver
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 0, @odbcver = 2;
+    EXEC sys.sp_datatype_info @data_type = 4, @odbcver = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_edge_cases
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 9999;
+    EXEC sys.sp_datatype_info @data_type = -9999;
+    EXEC sys.sp_datatype_info @data_type = 0;
+END;
+GO

--- a/test/JDBC/expected/BABEL-SP_DATATYPE_INFO-vu-verify.out
+++ b/test/JDBC/expected/BABEL-SP_DATATYPE_INFO-vu-verify.out
@@ -47,3 +47,1952 @@ datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime
 smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
 ~~END~~
 
+
+
+-- PyODBC Driver Metadata Calls
+EXEC sp_datatype_info_100 @data_type = 12   -- varchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+
+EXEC sp_datatype_info_100 @data_type = 93   -- (may be empty - not in table)
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+
+-- Positive types - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = 1   -- char
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 2   -- numeric
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 3   -- decimal, money, smallmoney
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 4   -- int
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 5   -- smallint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 6   -- float
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 7   -- real
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 9   -- date
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 12  -- varchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Positive types - sp_datatype_info
+EXEC sp_datatype_info @data_type = 1   -- char
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+EXEC sp_datatype_info @data_type = 2   -- numeric
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+~~END~~
+
+EXEC sp_datatype_info @data_type = 3   -- decimal, money, smallmoney
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+~~END~~
+
+EXEC sp_datatype_info @data_type = 4   -- int
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+EXEC sp_datatype_info @data_type = 5   -- smallint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+~~END~~
+
+EXEC sp_datatype_info @data_type = 6   -- float
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+~~END~~
+
+EXEC sp_datatype_info @data_type = 7   -- real
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+~~END~~
+
+EXEC sp_datatype_info @data_type = 9   -- date
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+~~END~~
+
+EXEC sp_datatype_info @data_type = 12  -- varchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Negative types - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = -1   -- text
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -2   -- binary, timestamp
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -4   -- image
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -5   -- bigint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -6   -- tinyint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -7   -- bit
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -8   -- nchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -10  -- ntext
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -11  -- uniqueidentifier
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+
+-- Negative types - sp_datatype_info
+EXEC sp_datatype_info @data_type = -1   -- text
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+~~END~~
+
+EXEC sp_datatype_info @data_type = -2   -- binary, timestamp
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+~~END~~
+
+EXEC sp_datatype_info @data_type = -3   -- varbinary
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+EXEC sp_datatype_info @data_type = -4   -- image
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+~~END~~
+
+EXEC sp_datatype_info @data_type = -5   -- bigint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -6   -- tinyint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+~~END~~
+
+EXEC sp_datatype_info @data_type = -7   -- bit
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+~~END~~
+
+EXEC sp_datatype_info @data_type = -8   -- nchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -9   -- nvarchar, sysname
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info @data_type = -10  -- ntext
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -11  -- uniqueidentifier
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+
+-- Other types - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = -150  -- sql_variant
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -151  -- geography, geometry
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -152  -- xml
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -154  -- time
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -155  -- datetimeoffset
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -2147483648  -- vector
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+~~END~~
+
+
+
+-- Other types - sp_datatype_info
+EXEC sp_datatype_info @data_type = -150  -- sql_variant
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -151  -- geography, geometry
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -152  -- xml
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -154  -- time
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -155  -- datetimeoffset
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -2147483648  -- vector
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+~~END~~
+
+
+
+-- @odbcver parameter tests - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+
+
+-- @odbcver parameter tests - sp_datatype_info
+EXEC sp_datatype_info @data_type = 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info @data_type = 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info @data_type = -9, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info @data_type = -9, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+
+
+-- No parameters (return all data types)
+EXEC sp_datatype_info
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- NULL parameter handling
+EXEC sp_datatype_info @data_type = NULL
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = NULL
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+
+-- Positional parameters
+EXEC sp_datatype_info 1
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+EXEC sp_datatype_info_100 1
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+
+EXEC sp_datatype_info 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info 12, 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info 12, 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Mixed positional and named parameters
+EXEC sp_datatype_info 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Fully qualified name (sys schema)
+EXEC sys.sp_datatype_info @data_type = 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sys.sp_datatype_info_100 @data_type = 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sys.sp_datatype_info_100 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Invalid/Edge cases
+-- Return all types (data_type = 0)
+EXEC sp_datatype_info @data_type = 0
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 0
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+-- Non-existent data type
+EXEC sp_datatype_info @data_type = 999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+EXEC sp_datatype_info @data_type = -999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+-- Wrapper Procedures
+EXEC sp_datatype_info_100_vu_prepare_p1;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_p2 @data_type = 0;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_p3 @data_type = 0, @odbcver = 2;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_int_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_string_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_binary_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_datetime_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_decimal_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_float_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_special_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_odbcver;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sp_datatype_info_100_vu_prepare_edge_cases;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_p1;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_p2 @data_type = 0;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_p3 @data_type = 0, @odbcver = 2;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_int_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_string_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_binary_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_datetime_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_decimal_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_float_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_special_types;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_odbcver;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sp_datatype_info_vu_prepare_edge_cases;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info_100;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info_100 @data_type = 4;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sys.sp_datatype_info_100 @data_type = 4, @odbcver = 2;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sys.sp_datatype_info_100 0, 2;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info_100 @odbcver = 2, @data_type = 4;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sys.sp_datatype_info;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info @data_type = 4;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sys.sp_datatype_info @data_type = 4, @odbcver = 2;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+
+EXEC sys.sp_datatype_info 0, 2;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info @odbcver = 2, @data_type = 4;
+GO
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+

--- a/test/JDBC/expected/BABEL-SP_DATATYPE_INFO.out
+++ b/test/JDBC/expected/BABEL-SP_DATATYPE_INFO.out
@@ -47,3 +47,893 @@ datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime
 smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
 ~~END~~
 
+
+
+-- PyODBC Driver Metadata Calls
+EXEC sp_datatype_info_100 @data_type = 12   -- varchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+
+EXEC sp_datatype_info_100 @data_type = 93   -- (may be empty - not in table)
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+
+-- Positive types - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = 1   -- char
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 2   -- numeric
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 3   -- decimal, money, smallmoney
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 4   -- int
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 5   -- smallint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 6   -- float
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 7   -- real
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 9   -- date
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 12  -- varchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Positive types - sp_datatype_info
+EXEC sp_datatype_info @data_type = 1   -- char
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+EXEC sp_datatype_info @data_type = 2   -- numeric
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+~~END~~
+
+EXEC sp_datatype_info @data_type = 3   -- decimal, money, smallmoney
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+~~END~~
+
+EXEC sp_datatype_info @data_type = 4   -- int
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+~~END~~
+
+EXEC sp_datatype_info @data_type = 5   -- smallint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+~~END~~
+
+EXEC sp_datatype_info @data_type = 6   -- float
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+~~END~~
+
+EXEC sp_datatype_info @data_type = 7   -- real
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+~~END~~
+
+EXEC sp_datatype_info @data_type = 9   -- date
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+~~END~~
+
+EXEC sp_datatype_info @data_type = 12  -- varchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Negative types - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = -1   -- text
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -2   -- binary, timestamp
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -4   -- image
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -5   -- bigint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -6   -- tinyint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -7   -- bit
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -8   -- nchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -10  -- ntext
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -11  -- uniqueidentifier
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+
+-- Negative types - sp_datatype_info
+EXEC sp_datatype_info @data_type = -1   -- text
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+~~END~~
+
+EXEC sp_datatype_info @data_type = -2   -- binary, timestamp
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+~~END~~
+
+EXEC sp_datatype_info @data_type = -3   -- varbinary
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+~~END~~
+
+EXEC sp_datatype_info @data_type = -4   -- image
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+~~END~~
+
+EXEC sp_datatype_info @data_type = -5   -- bigint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -6   -- tinyint
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+~~END~~
+
+EXEC sp_datatype_info @data_type = -7   -- bit
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+~~END~~
+
+EXEC sp_datatype_info @data_type = -8   -- nchar
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -9   -- nvarchar, sysname
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info @data_type = -10  -- ntext
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -11  -- uniqueidentifier
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+
+
+-- Other types - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = -150  -- sql_variant
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -151  -- geography, geometry
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -152  -- xml
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -154  -- time
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -155  -- datetimeoffset
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -2147483648  -- vector
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+~~END~~
+
+
+
+-- Other types - sp_datatype_info
+EXEC sp_datatype_info @data_type = -150  -- sql_variant
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+~~END~~
+
+EXEC sp_datatype_info @data_type = -151  -- geography, geometry
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -152  -- xml
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -154  -- time
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -155  -- datetimeoffset
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info @data_type = -2147483648  -- vector
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+~~END~~
+
+
+
+-- @odbcver parameter tests - sp_datatype_info_100
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+
+
+-- @odbcver parameter tests - sp_datatype_info
+EXEC sp_datatype_info @data_type = 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info @data_type = 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info @data_type = -9, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+EXEC sp_datatype_info @data_type = -9, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+~~END~~
+
+
+
+-- No parameters (return all data types)
+EXEC sp_datatype_info
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info_100
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- NULL parameter handling
+EXEC sp_datatype_info @data_type = NULL
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = NULL
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+
+-- Positional parameters
+EXEC sp_datatype_info 1
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+EXEC sp_datatype_info_100 1
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+~~END~~
+
+
+EXEC sp_datatype_info 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info 12, 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info 12, 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Mixed positional and named parameters
+EXEC sp_datatype_info 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sp_datatype_info 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 12, @odbcver = 3
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Fully qualified name (sys schema)
+EXEC sys.sp_datatype_info @data_type = 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sys.sp_datatype_info_100 @data_type = 12
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+EXEC sys.sp_datatype_info 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sys.sp_datatype_info_100 12, @odbcver = 2
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+
+-- Invalid/Edge cases
+-- Return all types (data_type = 0)
+EXEC sp_datatype_info @data_type = 0
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+xml#!#-10#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+date#!#-9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+time#!#-9#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+datetimeoffset#!#-9#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+datetime2#!#-9#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+geography#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-4#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 0
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+vector#!#-2147483648#!#0#!#'#!#'#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#vector#!#<NULL>#!#<NULL>#!#-2147483648#!#<NULL>#!#<NULL>#!#<NULL>#!#-2147483648
+datetimeoffset#!#-155#!#34#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetimeoffset#!#0#!#7#!#-155#!#0#!#<NULL>#!#<NULL>#!#0
+time#!#-154#!#16#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#time#!#0#!#7#!#-154#!#0#!#<NULL>#!#<NULL>#!#0
+xml#!#-152#!#0#!#N'#!#'#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#xml#!#<NULL>#!#<NULL>#!#-152#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geography#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geography#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+geometry#!#-151#!#0#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#1#!#0#!#<NULL>#!#0#!#<NULL>#!#geometry#!#<NULL>#!#<NULL>#!#-151#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sql_variant#!#-150#!#8000#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#sql_variant#!#0#!#0#!#-150#!#<NULL>#!#10#!#<NULL>#!#0
+uniqueidentifier#!#-11#!#36#!#'#!#'#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#uniqueidentifier#!#<NULL>#!#<NULL>#!#-11#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+ntext#!#-10#!#1073741823#!#N'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#ntext#!#<NULL>#!#<NULL>#!#-10#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+nvarchar#!#-9#!#4000#!#N'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nvarchar#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+sysname#!#-9#!#128#!#N'#!#'#!#<NULL>#!#0#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#sysname#!#<NULL>#!#<NULL>#!#-9#!#<NULL>#!#<NULL>#!#<NULL>#!#18
+nchar#!#-8#!#4000#!#N'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#nchar#!#<NULL>#!#<NULL>#!#-8#!#<NULL>#!#<NULL>#!#<NULL>#!#0
+bit#!#-7#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#bit#!#0#!#0#!#-7#!#<NULL>#!#<NULL>#!#<NULL>#!#16
+tinyint#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#1#!#0#!#0#!#tinyint#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+tinyint identity#!#-6#!#3#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#1#!#0#!#1#!#tinyint identity#!#0#!#0#!#-6#!#<NULL>#!#10#!#<NULL>#!#5
+bigint#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#bigint#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+bigint identity#!#-5#!#19#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#bigint identity#!#0#!#0#!#-5#!#<NULL>#!#10#!#<NULL>#!#0
+image#!#-4#!#2147483647#!#0x#!#<NULL>#!#<NULL>#!#1#!#0#!#0#!#<NULL>#!#0#!#<NULL>#!#image#!#<NULL>#!#<NULL>#!#-4#!#<NULL>#!#<NULL>#!#<NULL>#!#20
+varbinary#!#-3#!#8000#!#0x#!#<NULL>#!#max length          #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#varbinary#!#<NULL>#!#<NULL>#!#-3#!#<NULL>#!#<NULL>#!#<NULL>#!#4
+binary#!#-2#!#8000#!#0x#!#<NULL>#!#length              #!#1#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#binary#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#3
+timestamp#!#-2#!#8#!#0x#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#<NULL>#!#0#!#<NULL>#!#timestamp#!#<NULL>#!#<NULL>#!#-2#!#<NULL>#!#<NULL>#!#<NULL>#!#80
+text#!#-1#!#2147483647#!#'#!#'#!#<NULL>#!#1#!#1#!#1#!#<NULL>#!#0#!#<NULL>#!#text#!#<NULL>#!#<NULL>#!#-1#!#<NULL>#!#<NULL>#!#<NULL>#!#19
+char#!#1#!#8000#!#'#!#'#!#length              #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#char#!#<NULL>#!#<NULL>#!#1#!#<NULL>#!#<NULL>#!#<NULL>#!#1
+numeric#!#2#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#numeric#!#0#!#38#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+numeric() identity#!#2#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#numeric() identity#!#0#!#0#!#2#!#<NULL>#!#10#!#<NULL>#!#10
+decimal#!#3#!#38#!#<NULL>#!#<NULL>#!#precision,scale     #!#1#!#0#!#2#!#0#!#0#!#0#!#decimal#!#0#!#38#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+money#!#3#!#19#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#money#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#11
+smallmoney#!#3#!#10#!#$#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#1#!#0#!#smallmoney#!#4#!#4#!#3#!#<NULL>#!#10#!#<NULL>#!#21
+decimal() identity#!#3#!#38#!#<NULL>#!#<NULL>#!#precision           #!#0#!#0#!#2#!#0#!#0#!#1#!#decimal() identity#!#0#!#0#!#3#!#<NULL>#!#10#!#<NULL>#!#24
+int#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#int#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+int identity#!#4#!#10#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#int identity#!#0#!#0#!#4#!#<NULL>#!#10#!#<NULL>#!#7
+smallint#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#smallint#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+smallint identity#!#5#!#5#!#<NULL>#!#<NULL>#!#<NULL>#!#0#!#0#!#2#!#0#!#0#!#1#!#smallint identity#!#0#!#0#!#5#!#<NULL>#!#10#!#<NULL>#!#6
+float#!#6#!#53#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#float#!#<NULL>#!#<NULL>#!#6#!#<NULL>#!#2#!#<NULL>#!#8
+real#!#7#!#24#!#<NULL>#!#<NULL>#!#<NULL>#!#1#!#0#!#2#!#0#!#0#!#0#!#real#!#<NULL>#!#<NULL>#!#7#!#<NULL>#!#2#!#<NULL>#!#23
+date#!#9#!#10#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#date#!#<NULL>#!#0#!#9#!#1#!#<NULL>#!#<NULL>#!#0
+datetime2#!#11#!#27#!#'#!#'#!#scale               #!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime2#!#0#!#7#!#9#!#3#!#<NULL>#!#<NULL>#!#0
+datetime#!#11#!#23#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#datetime#!#3#!#3#!#9#!#3#!#<NULL>#!#<NULL>#!#12
+smalldatetime#!#11#!#16#!#'#!#'#!#<NULL>#!#1#!#0#!#3#!#<NULL>#!#0#!#<NULL>#!#smalldatetime#!#0#!#0#!#9#!#3#!#<NULL>#!#<NULL>#!#22
+varchar#!#12#!#8000#!#'#!#'#!#max length          #!#1#!#1#!#3#!#<NULL>#!#0#!#<NULL>#!#varchar#!#<NULL>#!#<NULL>#!#12#!#<NULL>#!#<NULL>#!#<NULL>#!#2
+~~END~~
+
+
+-- Non-existent data type
+EXEC sp_datatype_info @data_type = 999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = 999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+
+EXEC sp_datatype_info @data_type = -999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+
+EXEC sp_datatype_info_100 @data_type = -999
+go
+~~START~~
+varchar#!#int#!#bigint#!#varchar#!#varchar#!#char#!#int#!#int#!#int#!#int#!#int#!#int#!#varchar#!#int#!#int#!#int#!#int#!#int#!#int#!#int
+~~END~~
+

--- a/test/JDBC/input/BABEL-SP_DATATYPE_INFO-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-SP_DATATYPE_INFO-vu-cleanup.sql
@@ -1,0 +1,71 @@
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_p1;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_p2;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_p3;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_int_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_string_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_binary_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_datetime_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_decimal_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_float_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_special_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_odbcver;
+GO
+
+DROP PROCEDURE sp_datatype_info_100_vu_prepare_edge_cases;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_p1;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_p2;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_p3;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_int_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_string_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_binary_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_datetime_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_decimal_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_float_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_special_types;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_odbcver;
+GO
+
+DROP PROCEDURE sp_datatype_info_vu_prepare_edge_cases;
+GO

--- a/test/JDBC/input/BABEL-SP_DATATYPE_INFO-vu-prepare.sql
+++ b/test/JDBC/input/BABEL-SP_DATATYPE_INFO-vu-prepare.sql
@@ -1,0 +1,215 @@
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_p1
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_p2
+    @data_type int = 0
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = @data_type;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_p3
+    @data_type int = 0,
+    @odbcver smallint = 2
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = @data_type, @odbcver = @odbcver;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_int_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 4;
+    EXEC sys.sp_datatype_info_100 @data_type = -5;
+    EXEC sys.sp_datatype_info_100 @data_type = 5;
+    EXEC sys.sp_datatype_info_100 @data_type = -6;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_string_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 1;
+    EXEC sys.sp_datatype_info_100 @data_type = 12;
+    EXEC sys.sp_datatype_info_100 @data_type = -1;
+    EXEC sys.sp_datatype_info_100 @data_type = -8;
+    EXEC sys.sp_datatype_info_100 @data_type = -9;
+    EXEC sys.sp_datatype_info_100 @data_type = -10;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_binary_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = -2;
+    EXEC sys.sp_datatype_info_100 @data_type = -3;
+    EXEC sys.sp_datatype_info_100 @data_type = -4;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_datetime_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 9;
+    EXEC sys.sp_datatype_info_100 @data_type = 11;
+    EXEC sys.sp_datatype_info_100 @data_type = -154;
+    EXEC sys.sp_datatype_info_100 @data_type = -155;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_decimal_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 3;
+    EXEC sys.sp_datatype_info_100 @data_type = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_float_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 6;
+    EXEC sys.sp_datatype_info_100 @data_type = 7;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_special_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = -7;
+    EXEC sys.sp_datatype_info_100 @data_type = -11;
+    EXEC sys.sp_datatype_info_100 @data_type = -150;
+    EXEC sys.sp_datatype_info_100 @data_type = -152;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_odbcver
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 0, @odbcver = 2;
+    EXEC sys.sp_datatype_info_100 @data_type = 4, @odbcver = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_100_vu_prepare_edge_cases
+AS
+BEGIN
+    EXEC sys.sp_datatype_info_100 @data_type = 9999;
+    EXEC sys.sp_datatype_info_100 @data_type = -9999;
+    EXEC sys.sp_datatype_info_100 @data_type = 0;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_p1
+AS
+BEGIN
+    EXEC sys.sp_datatype_info;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_p2
+    @data_type int = 0
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = @data_type;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_p3
+    @data_type int = 0,
+    @odbcver smallint = 2
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = @data_type, @odbcver = @odbcver;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_int_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 4;
+    EXEC sys.sp_datatype_info @data_type = -5;
+    EXEC sys.sp_datatype_info @data_type = 5;
+    EXEC sys.sp_datatype_info @data_type = -6;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_string_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 1;
+    EXEC sys.sp_datatype_info @data_type = 12;
+    EXEC sys.sp_datatype_info @data_type = -1;
+    EXEC sys.sp_datatype_info @data_type = -8;
+    EXEC sys.sp_datatype_info @data_type = -9;
+    EXEC sys.sp_datatype_info @data_type = -10;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_binary_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = -2;
+    EXEC sys.sp_datatype_info @data_type = -3;
+    EXEC sys.sp_datatype_info @data_type = -4;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_datetime_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 9;
+    EXEC sys.sp_datatype_info @data_type = 11;
+    EXEC sys.sp_datatype_info @data_type = -154;
+    EXEC sys.sp_datatype_info @data_type = -155;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_decimal_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 3;
+    EXEC sys.sp_datatype_info @data_type = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_float_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 6;
+    EXEC sys.sp_datatype_info @data_type = 7;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_special_types
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = -7;
+    EXEC sys.sp_datatype_info @data_type = -11;
+    EXEC sys.sp_datatype_info @data_type = -150;
+    EXEC sys.sp_datatype_info @data_type = -152;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_odbcver
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 0, @odbcver = 2;
+    EXEC sys.sp_datatype_info @data_type = 4, @odbcver = 2;
+END;
+GO
+
+CREATE PROCEDURE sp_datatype_info_vu_prepare_edge_cases
+AS
+BEGIN
+    EXEC sys.sp_datatype_info @data_type = 9999;
+    EXEC sys.sp_datatype_info @data_type = -9999;
+    EXEC sys.sp_datatype_info @data_type = 0;
+END;
+GO

--- a/test/JDBC/input/BABEL-SP_DATATYPE_INFO-vu-verify.sql
+++ b/test/JDBC/input/BABEL-SP_DATATYPE_INFO-vu-verify.sql
@@ -15,3 +15,348 @@ go
 -- Should show datetime data type
 EXEC sp_datatype_info @data_type = 11
 go
+
+-- PyODBC Driver Metadata Calls
+
+EXEC sp_datatype_info_100 @data_type = 12   -- varchar
+go
+
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+
+EXEC sp_datatype_info_100 @data_type = 93   -- (may be empty - not in table)
+go
+
+-- Positive types - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = 1   -- char
+go
+EXEC sp_datatype_info_100 @data_type = 2   -- numeric
+go
+EXEC sp_datatype_info_100 @data_type = 3   -- decimal, money, smallmoney
+go
+EXEC sp_datatype_info_100 @data_type = 4   -- int
+go
+EXEC sp_datatype_info_100 @data_type = 5   -- smallint
+go
+EXEC sp_datatype_info_100 @data_type = 6   -- float
+go
+EXEC sp_datatype_info_100 @data_type = 7   -- real
+go
+EXEC sp_datatype_info_100 @data_type = 9   -- date
+go
+EXEC sp_datatype_info_100 @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+EXEC sp_datatype_info_100 @data_type = 12  -- varchar
+go
+
+-- Positive types - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = 1   -- char
+go
+EXEC sp_datatype_info @data_type = 2   -- numeric
+go
+EXEC sp_datatype_info @data_type = 3   -- decimal, money, smallmoney
+go
+EXEC sp_datatype_info @data_type = 4   -- int
+go
+EXEC sp_datatype_info @data_type = 5   -- smallint
+go
+EXEC sp_datatype_info @data_type = 6   -- float
+go
+EXEC sp_datatype_info @data_type = 7   -- real
+go
+EXEC sp_datatype_info @data_type = 9   -- date
+go
+EXEC sp_datatype_info @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+EXEC sp_datatype_info @data_type = 12  -- varchar
+go
+
+-- Negative types - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = -1   -- text
+go
+EXEC sp_datatype_info_100 @data_type = -2   -- binary, timestamp
+go
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+EXEC sp_datatype_info_100 @data_type = -4   -- image
+go
+EXEC sp_datatype_info_100 @data_type = -5   -- bigint
+go
+EXEC sp_datatype_info_100 @data_type = -6   -- tinyint
+go
+EXEC sp_datatype_info_100 @data_type = -7   -- bit
+go
+EXEC sp_datatype_info_100 @data_type = -8   -- nchar
+go
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+EXEC sp_datatype_info_100 @data_type = -10  -- ntext
+go
+EXEC sp_datatype_info_100 @data_type = -11  -- uniqueidentifier
+go
+
+-- Negative types - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = -1   -- text
+go
+EXEC sp_datatype_info @data_type = -2   -- binary, timestamp
+go
+EXEC sp_datatype_info @data_type = -3   -- varbinary
+go
+EXEC sp_datatype_info @data_type = -4   -- image
+go
+EXEC sp_datatype_info @data_type = -5   -- bigint
+go
+EXEC sp_datatype_info @data_type = -6   -- tinyint
+go
+EXEC sp_datatype_info @data_type = -7   -- bit
+go
+EXEC sp_datatype_info @data_type = -8   -- nchar
+go
+EXEC sp_datatype_info @data_type = -9   -- nvarchar, sysname
+go
+EXEC sp_datatype_info @data_type = -10  -- ntext
+go
+EXEC sp_datatype_info @data_type = -11  -- uniqueidentifier
+go
+
+-- Other types - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = -150  -- sql_variant
+go
+EXEC sp_datatype_info_100 @data_type = -151  -- geography, geometry
+go
+EXEC sp_datatype_info_100 @data_type = -152  -- xml
+go
+EXEC sp_datatype_info_100 @data_type = -154  -- time
+go
+EXEC sp_datatype_info_100 @data_type = -155  -- datetimeoffset
+go
+EXEC sp_datatype_info_100 @data_type = -2147483648  -- vector
+go
+
+-- Other types - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = -150  -- sql_variant
+go
+EXEC sp_datatype_info @data_type = -151  -- geography, geometry
+go
+EXEC sp_datatype_info @data_type = -152  -- xml
+go
+EXEC sp_datatype_info @data_type = -154  -- time
+go
+EXEC sp_datatype_info @data_type = -155  -- datetimeoffset
+go
+EXEC sp_datatype_info @data_type = -2147483648  -- vector
+go
+
+-- @odbcver parameter tests - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 2
+go
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 3
+go
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 2
+go
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 3
+go
+
+-- @odbcver parameter tests - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = 12, @odbcver = 2
+go
+EXEC sp_datatype_info @data_type = 12, @odbcver = 3
+go
+EXEC sp_datatype_info @data_type = -9, @odbcver = 2
+go
+EXEC sp_datatype_info @data_type = -9, @odbcver = 3
+go
+
+-- No parameters (return all data types)
+
+EXEC sp_datatype_info
+go
+
+EXEC sp_datatype_info_100
+go
+
+-- NULL parameter handling
+
+EXEC sp_datatype_info @data_type = NULL
+go
+EXEC sp_datatype_info_100 @data_type = NULL
+go
+
+-- Positional parameters
+
+EXEC sp_datatype_info 1
+go
+EXEC sp_datatype_info_100 1
+go
+
+EXEC sp_datatype_info 12
+go
+EXEC sp_datatype_info_100 12
+go
+
+EXEC sp_datatype_info 12, 2
+go
+EXEC sp_datatype_info_100 12, 2
+go
+
+EXEC sp_datatype_info 12, 3
+go
+EXEC sp_datatype_info_100 12, 3
+go
+
+-- Mixed positional and named parameters
+
+EXEC sp_datatype_info 12, @odbcver = 2
+go
+EXEC sp_datatype_info_100 12, @odbcver = 2
+go
+
+EXEC sp_datatype_info 12, @odbcver = 3
+go
+EXEC sp_datatype_info_100 12, @odbcver = 3
+go
+
+-- Fully qualified name (sys schema)
+
+EXEC sys.sp_datatype_info @data_type = 12
+go
+EXEC sys.sp_datatype_info_100 @data_type = 12
+go
+
+EXEC sys.sp_datatype_info 12, @odbcver = 2
+go
+EXEC sys.sp_datatype_info_100 12, @odbcver = 2
+go
+
+-- Invalid/Edge cases
+
+-- Return all types (data_type = 0)
+EXEC sp_datatype_info @data_type = 0
+go
+EXEC sp_datatype_info_100 @data_type = 0
+go
+
+-- Non-existent data type
+EXEC sp_datatype_info @data_type = 999
+go
+EXEC sp_datatype_info_100 @data_type = 999
+go
+
+EXEC sp_datatype_info @data_type = -999
+go
+EXEC sp_datatype_info_100 @data_type = -999
+go
+
+-- Wrapper Procedures
+EXEC sp_datatype_info_100_vu_prepare_p1;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_p2 @data_type = 0;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_p3 @data_type = 0, @odbcver = 2;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_int_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_string_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_binary_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_datetime_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_decimal_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_float_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_special_types;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_odbcver;
+GO
+
+EXEC sp_datatype_info_100_vu_prepare_edge_cases;
+GO
+
+EXEC sp_datatype_info_vu_prepare_p1;
+GO
+
+EXEC sp_datatype_info_vu_prepare_p2 @data_type = 0;
+GO
+
+EXEC sp_datatype_info_vu_prepare_p3 @data_type = 0, @odbcver = 2;
+GO
+
+EXEC sp_datatype_info_vu_prepare_int_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_string_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_binary_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_datetime_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_decimal_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_float_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_special_types;
+GO
+
+EXEC sp_datatype_info_vu_prepare_odbcver;
+GO
+
+EXEC sp_datatype_info_vu_prepare_edge_cases;
+GO
+
+EXEC sys.sp_datatype_info_100;
+GO
+
+EXEC sys.sp_datatype_info_100 @data_type = 4;
+GO
+
+EXEC sys.sp_datatype_info_100 @data_type = 4, @odbcver = 2;
+GO
+
+EXEC sys.sp_datatype_info_100 0, 2;
+GO
+
+EXEC sys.sp_datatype_info_100 @odbcver = 2, @data_type = 4;
+GO
+
+EXEC sys.sp_datatype_info;
+GO
+
+EXEC sys.sp_datatype_info @data_type = 4;
+GO
+
+EXEC sys.sp_datatype_info @data_type = 4, @odbcver = 2;
+GO
+
+EXEC sys.sp_datatype_info 0, 2;
+GO
+
+EXEC sys.sp_datatype_info @odbcver = 2, @data_type = 4;
+GO

--- a/test/JDBC/input/BABEL-SP_DATATYPE_INFO.sql
+++ b/test/JDBC/input/BABEL-SP_DATATYPE_INFO.sql
@@ -15,3 +15,245 @@ go
 -- Should show datetime data type
 EXEC sp_datatype_info @data_type = 11
 go
+
+-- PyODBC Driver Metadata Calls
+
+EXEC sp_datatype_info_100 @data_type = 12   -- varchar
+go
+
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+
+EXEC sp_datatype_info_100 @data_type = 93   -- (may be empty - not in table)
+go
+
+-- Positive types - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = 1   -- char
+go
+EXEC sp_datatype_info_100 @data_type = 2   -- numeric
+go
+EXEC sp_datatype_info_100 @data_type = 3   -- decimal, money, smallmoney
+go
+EXEC sp_datatype_info_100 @data_type = 4   -- int
+go
+EXEC sp_datatype_info_100 @data_type = 5   -- smallint
+go
+EXEC sp_datatype_info_100 @data_type = 6   -- float
+go
+EXEC sp_datatype_info_100 @data_type = 7   -- real
+go
+EXEC sp_datatype_info_100 @data_type = 9   -- date
+go
+EXEC sp_datatype_info_100 @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+EXEC sp_datatype_info_100 @data_type = 12  -- varchar
+go
+
+-- Positive types - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = 1   -- char
+go
+EXEC sp_datatype_info @data_type = 2   -- numeric
+go
+EXEC sp_datatype_info @data_type = 3   -- decimal, money, smallmoney
+go
+EXEC sp_datatype_info @data_type = 4   -- int
+go
+EXEC sp_datatype_info @data_type = 5   -- smallint
+go
+EXEC sp_datatype_info @data_type = 6   -- float
+go
+EXEC sp_datatype_info @data_type = 7   -- real
+go
+EXEC sp_datatype_info @data_type = 9   -- date
+go
+EXEC sp_datatype_info @data_type = 11  -- datetime, datetime2, smalldatetime
+go
+EXEC sp_datatype_info @data_type = 12  -- varchar
+go
+
+-- Negative types - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = -1   -- text
+go
+EXEC sp_datatype_info_100 @data_type = -2   -- binary, timestamp
+go
+EXEC sp_datatype_info_100 @data_type = -3   -- varbinary
+go
+EXEC sp_datatype_info_100 @data_type = -4   -- image
+go
+EXEC sp_datatype_info_100 @data_type = -5   -- bigint
+go
+EXEC sp_datatype_info_100 @data_type = -6   -- tinyint
+go
+EXEC sp_datatype_info_100 @data_type = -7   -- bit
+go
+EXEC sp_datatype_info_100 @data_type = -8   -- nchar
+go
+EXEC sp_datatype_info_100 @data_type = -9   -- nvarchar, sysname
+go
+EXEC sp_datatype_info_100 @data_type = -10  -- ntext
+go
+EXEC sp_datatype_info_100 @data_type = -11  -- uniqueidentifier
+go
+
+-- Negative types - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = -1   -- text
+go
+EXEC sp_datatype_info @data_type = -2   -- binary, timestamp
+go
+EXEC sp_datatype_info @data_type = -3   -- varbinary
+go
+EXEC sp_datatype_info @data_type = -4   -- image
+go
+EXEC sp_datatype_info @data_type = -5   -- bigint
+go
+EXEC sp_datatype_info @data_type = -6   -- tinyint
+go
+EXEC sp_datatype_info @data_type = -7   -- bit
+go
+EXEC sp_datatype_info @data_type = -8   -- nchar
+go
+EXEC sp_datatype_info @data_type = -9   -- nvarchar, sysname
+go
+EXEC sp_datatype_info @data_type = -10  -- ntext
+go
+EXEC sp_datatype_info @data_type = -11  -- uniqueidentifier
+go
+
+-- Other types - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = -150  -- sql_variant
+go
+EXEC sp_datatype_info_100 @data_type = -151  -- geography, geometry
+go
+EXEC sp_datatype_info_100 @data_type = -152  -- xml
+go
+EXEC sp_datatype_info_100 @data_type = -154  -- time
+go
+EXEC sp_datatype_info_100 @data_type = -155  -- datetimeoffset
+go
+EXEC sp_datatype_info_100 @data_type = -2147483648  -- vector
+go
+
+-- Other types - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = -150  -- sql_variant
+go
+EXEC sp_datatype_info @data_type = -151  -- geography, geometry
+go
+EXEC sp_datatype_info @data_type = -152  -- xml
+go
+EXEC sp_datatype_info @data_type = -154  -- time
+go
+EXEC sp_datatype_info @data_type = -155  -- datetimeoffset
+go
+EXEC sp_datatype_info @data_type = -2147483648  -- vector
+go
+
+-- @odbcver parameter tests - sp_datatype_info_100
+
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 2
+go
+EXEC sp_datatype_info_100 @data_type = 12, @odbcver = 3
+go
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 2
+go
+EXEC sp_datatype_info_100 @data_type = -9, @odbcver = 3
+go
+
+-- @odbcver parameter tests - sp_datatype_info
+
+EXEC sp_datatype_info @data_type = 12, @odbcver = 2
+go
+EXEC sp_datatype_info @data_type = 12, @odbcver = 3
+go
+EXEC sp_datatype_info @data_type = -9, @odbcver = 2
+go
+EXEC sp_datatype_info @data_type = -9, @odbcver = 3
+go
+
+-- No parameters (return all data types)
+
+EXEC sp_datatype_info
+go
+
+EXEC sp_datatype_info_100
+go
+
+-- NULL parameter handling
+
+EXEC sp_datatype_info @data_type = NULL
+go
+EXEC sp_datatype_info_100 @data_type = NULL
+go
+
+-- Positional parameters
+
+EXEC sp_datatype_info 1
+go
+EXEC sp_datatype_info_100 1
+go
+
+EXEC sp_datatype_info 12
+go
+EXEC sp_datatype_info_100 12
+go
+
+EXEC sp_datatype_info 12, 2
+go
+EXEC sp_datatype_info_100 12, 2
+go
+
+EXEC sp_datatype_info 12, 3
+go
+EXEC sp_datatype_info_100 12, 3
+go
+
+-- Mixed positional and named parameters
+
+EXEC sp_datatype_info 12, @odbcver = 2
+go
+EXEC sp_datatype_info_100 12, @odbcver = 2
+go
+
+EXEC sp_datatype_info 12, @odbcver = 3
+go
+EXEC sp_datatype_info_100 12, @odbcver = 3
+go
+
+-- Fully qualified name (sys schema)
+
+EXEC sys.sp_datatype_info @data_type = 12
+go
+EXEC sys.sp_datatype_info_100 @data_type = 12
+go
+
+EXEC sys.sp_datatype_info 12, @odbcver = 2
+go
+EXEC sys.sp_datatype_info_100 12, @odbcver = 2
+go
+
+-- Invalid/Edge cases
+
+-- Return all types (data_type = 0)
+EXEC sp_datatype_info @data_type = 0
+go
+EXEC sp_datatype_info_100 @data_type = 0
+go
+
+-- Non-existent data type
+EXEC sp_datatype_info @data_type = 999
+go
+EXEC sp_datatype_info_100 @data_type = 999
+go
+
+EXEC sp_datatype_info @data_type = -999
+go
+EXEC sp_datatype_info_100 @data_type = -999
+go

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -416,3 +416,4 @@ babel_numeric_smallmoney_oper-before-16_10-or-17_6
 babel_assign_nchar
 mathematical_func_tests-before-17_7-or-16_11
 ascii_function_before-17_7-or-16_11
+BABEL-SP_DATATYPE_INFO

--- a/test/python/expected/sql_validation_framework/expected_create.out
+++ b/test/python/expected/sql_validation_framework/expected_create.out
@@ -90,6 +90,10 @@ Could not find tests for view sys.all_sql_modules_internal
 Could not find tests for view sys.pg_namespace_ext
 Could not find tests for view sys.shipped_objects_not_in_sys
 Could not find tests for view sys.sp_column_privileges_view
+Could not find tests for view sys.sp_datatype_info_100_view_odbc_version_2
+Could not find tests for view sys.sp_datatype_info_100_view_odbc_version_3
+Could not find tests for view sys.sp_datatype_info_view_odbc_version_2
+Could not find tests for view sys.sp_datatype_info_view_odbc_version_3
 Could not find tests for view sys.sp_fkeys_view
 Could not find tests for view sys.sp_special_columns_view
 Could not find tests for view sys.sp_statistics_view
@@ -206,6 +210,10 @@ Could not find upgrade tests for view sys.all_sql_modules_internal
 Could not find upgrade tests for view sys.pg_namespace_ext
 Could not find upgrade tests for view sys.shipped_objects_not_in_sys
 Could not find upgrade tests for view sys.sp_column_privileges_view
+Could not find upgrade tests for view sys.sp_datatype_info_100_view_odbc_version_2
+Could not find upgrade tests for view sys.sp_datatype_info_100_view_odbc_version_3
+Could not find upgrade tests for view sys.sp_datatype_info_view_odbc_version_2
+Could not find upgrade tests for view sys.sp_datatype_info_view_odbc_version_3
 Could not find upgrade tests for view sys.sp_fkeys_view
 Could not find upgrade tests for view sys.sp_special_columns_view
 Could not find upgrade tests for view sys.sp_statistics_view

--- a/test/python/expected/upgrade_validation/expected_dependency.out
+++ b/test/python/expected/upgrade_validation/expected_dependency.out
@@ -973,6 +973,10 @@ View sys.selective_xml_index_paths
 View sys.shipped_objects_not_in_sys
 View sys.sp_column_privileges_view
 View sys.sp_columns_100_view
+View sys.sp_datatype_info_100_view_odbc_version_2
+View sys.sp_datatype_info_100_view_odbc_version_3
+View sys.sp_datatype_info_view_odbc_version_2
+View sys.sp_datatype_info_view_odbc_version_3
 View sys.sp_fkeys_view
 View sys.sp_pkeys_view
 View sys.sp_special_columns_view


### PR DESCRIPTION
### Description

Aurora Babelfish exhibits high CPU consumption during concurrent connection establishment. Investigation reveals this is due to ANTLR parsing overhead. PyODBC connections call `sp_datatype_info_100` during connection setup, causing CPU spikes from intensive ANTLR parsing.

Hence we are defining `sp_datatype_info` and `sp_datatype_info_100` to use pre-compiled views instead of directly calling the C helper function. Views are cached and avoid repeated ANTLR parsing, resulting in lower CPU utilization during connection establishment.

We observed performance improvement as below with this view approach:

| No. of Concurrent Connections | Current CPU usage with PyODBC | CPU usage after this View Approach | CPU Reduction |
|-----------------------:|------------------:|--------------:|--------------:|
| 100                    | 9.83%             | 6.72%         | 3.11%         |
| 200                    | 18.51%            | 11.91%        | 6.60%         |
| 400                    | 31.75%            | 20.79%        | 10.96%        |
| 600                    | 44.56%            | 27.22%        | 17.34%        |
| 800                    | 56.35%            | 21.96%        | 34.39%        |

### Issues Resolved

Cherry-pick from #4309 
BABEL-6184
Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com) 

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).