### PR TITLE
Fix excessive locking in functions accessing Babelfish catalogs

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -4295,7 +4295,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 					SysScanDesc scan;
 					HeapTuple	tup;
 
-					depRel = table_open(DependRelationId, RowExclusiveLock);
+					depRel = table_open(DependRelationId, AccessShareLock);
 
 					ScanKeyInit(&key[0],
 								Anum_pg_depend_objid,
@@ -4319,7 +4319,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 
 					systable_endscan(scan);
 
-					table_close(depRel, RowExclusiveLock);
+					table_close(depRel, AccessShareLock);
 				}
 				ReleaseSysCache(tp);
 			}
@@ -4429,7 +4429,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 				pg_attribute_aclcheck(atdform->adrelid, atdform->adnum, user_id, ACL_UPDATE) &&
 				pg_attribute_aclcheck(atdform->adrelid, atdform->adnum, user_id, ACL_REFERENCES))
 			{
-				attrRel = table_open(AttributeRelationId, RowExclusiveLock);
+				attrRel = table_open(AttributeRelationId, AccessShareLock);
 
 				ScanKeyInit(&key[0],
 							Anum_pg_attribute_attrelid,
@@ -4458,7 +4458,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 
 				systable_endscan(scan);
 
-				table_close(attrRel, RowExclusiveLock);
+				table_close(attrRel, AccessShareLock);
 			}
 
 		}
@@ -4781,7 +4781,7 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 		if (type != OBJECT_TYPE_TABLE)
 			PG_RETURN_INT32(0);
 
-		indRel = table_open(IndexRelationId, RowExclusiveLock);
+		indRel = table_open(IndexRelationId, AccessShareLock);
 
 		ScanKeyInit(&key,
 				Anum_pg_index_indrelid,
@@ -4794,13 +4794,13 @@ objectproperty_internal(PG_FUNCTION_ARGS)
 		if (HeapTupleIsValid(tup = systable_getnext(scan)))
 		{
 			systable_endscan(scan);
-			table_close(indRel, RowExclusiveLock);
+			table_close(indRel, AccessShareLock);
 			pfree(property);
 			PG_RETURN_INT32(1);
 		}
 
 		systable_endscan(scan);
-		table_close(indRel, RowExclusiveLock);
+		table_close(indRel, AccessShareLock);
 		pfree(property);
 
 		PG_RETURN_INT32(0);

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -979,7 +979,7 @@ get_authid_user_ext_physical_name(const char *db_name, const char *login)
 		return NULL;
 
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 
 	login_name = (NameData *) palloc0(NAMEDATALEN);
 	snprintf(login_name->data, NAMEDATALEN, "%s", login);
@@ -1012,7 +1012,7 @@ get_authid_user_ext_physical_name(const char *db_name, const char *login)
 	}
 
 	systable_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
 
 	return user_name;
 }
@@ -1065,7 +1065,7 @@ get_authid_user_ext_db_users(const char *db_name, const char *dbo_name, Oid db_o
 		return NULL;
 
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 
 	ScanKeyInit(&key,
 				Anum_bbf_authid_user_ext_database_name,
@@ -1100,7 +1100,7 @@ get_authid_user_ext_db_users(const char *db_name, const char *dbo_name, Oid db_o
 	}
 
 	table_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
 
 	return db_users_list;
 }
@@ -1398,7 +1398,7 @@ get_timeout_from_server_name(char *servername, int attnum)
 	int		timeout = 0;
 
 	bbf_servers_def_rel = table_open(get_bbf_servers_def_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 
 	ScanKeyInit(&key,
 				Anum_bbf_servers_def_servername,
@@ -1418,7 +1418,7 @@ get_timeout_from_server_name(char *servername, int attnum)
 	}
 
 	table_endscan(scan);
-	table_close(bbf_servers_def_rel, RowExclusiveLock);
+	table_close(bbf_servers_def_rel, AccessShareLock);
 	return timeout;
 }
 
@@ -3069,7 +3069,7 @@ guest_has_dbaccess(const char *db_name)
 	bool		has_access = false;
 
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 	ScanKeyInit(&key[0],
 				Anum_bbf_authid_user_ext_orig_username,
 				BTEqualStrategyNumber, F_TEXTEQ,
@@ -3090,7 +3090,7 @@ guest_has_dbaccess(const char *db_name)
 		has_access = true;
 
 	table_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
 	return has_access;
 }
 
@@ -3315,7 +3315,7 @@ get_db_owner_role_name(const char *dbname)
 	char	   *db_owner_role = NULL;
 
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 	ScanKeyInit(&key[0],
 				Anum_bbf_authid_user_ext_orig_username,
 				BTEqualStrategyNumber, F_TEXTEQ,
@@ -3336,7 +3336,7 @@ get_db_owner_role_name(const char *dbname)
 	}
 
 	table_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
 	return db_owner_role;
 }
 

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -1352,7 +1352,7 @@ create_guest_schema_for_all_dbs(PG_FUNCTION_ARGS)
 		 */
 		creating_extension = false;
 
-		sysdatabase_rel = table_open(sysdatabases_oid, RowExclusiveLock);
+		sysdatabase_rel = table_open(sysdatabases_oid, AccessShareLock);
 		scan = table_beginscan_catalog(sysdatabase_rel, 0, NULL);
 		tuple = heap_getnext(scan, ForwardScanDirection);
 
@@ -1366,7 +1366,7 @@ create_guest_schema_for_all_dbs(PG_FUNCTION_ARGS)
 			tuple = heap_getnext(scan, ForwardScanDirection);
 		}
 		table_endscan(scan);
-		table_close(sysdatabase_rel, RowExclusiveLock);
+		table_close(sysdatabase_rel, AccessShareLock);
 
 		creating_extension = creating_extension_backup;
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
@@ -1402,7 +1402,7 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 	char		*dbname = get_db_name(dbid);
 	MigrationMode	baseline_mode = is_user_database_singledb(dbname) ? SINGLE_DB : MULTI_DB;
 
-	namespace_rel = table_open(namespace_ext_oid, RowExclusiveLock);
+	namespace_rel = table_open(namespace_ext_oid, AccessShareLock);
 	namespace_rel_descr = RelationGetDescr(namespace_rel);
 
 	initStringInfo(&query);
@@ -1497,7 +1497,7 @@ grant_perms_to_dbreader_dbwriter_ddladmin(const uint16 dbid,
 
 	/* Cleanup. */
 	table_endscan(tblscan);
-	table_close(namespace_rel, RowExclusiveLock);
+	table_close(namespace_rel, AccessShareLock);
 	pfree(dbname);
 	pfree(query.data);
 }
@@ -1668,7 +1668,7 @@ create_db_roles_during_upgrade(PG_FUNCTION_ARGS)
 
 		Assert(list_length(parsetree_list) == 8);
 
-		sysdatabase_rel = table_open(sysdatabases_oid, RowExclusiveLock);
+		sysdatabase_rel = table_open(sysdatabases_oid, AccessShareLock);
 		scan = table_beginscan_catalog(sysdatabase_rel, 0, NULL);
 
 		while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
@@ -1698,7 +1698,7 @@ create_db_roles_during_upgrade(PG_FUNCTION_ARGS)
 	pfree(query.data);
 	AtEOXact_GUC(false, save_nestlevel);
 	table_endscan(scan);
-	table_close(sysdatabase_rel, RowExclusiveLock);
+	table_close(sysdatabase_rel, AccessShareLock);
 
 	PG_RETURN_INT32(0);
 }

--- a/contrib/babelfishpg_tsql/src/extendedproperty.c
+++ b/contrib/babelfishpg_tsql/src/extendedproperty.c
@@ -907,7 +907,7 @@ fn_listextendedproperty(PG_FUNCTION_ARGS)
 	}
 
 	systable_endscan(scan);
-	table_close(rel, RowExclusiveLock);
+	table_close(rel, AccessShareLock);
 
 	/* clean up and return the tuplestore */
 	tuplestore_donestoring(tupstore);

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -7077,12 +7077,12 @@ bbf_view_set_broken(Oid viewOid, bool mark_broken)
 	bool 		is_broken;
 	bool 		updated = false;
 	
-	brel = table_open(get_bbf_view_def_oid(), RowExclusiveLock);
+	brel = table_open(get_bbf_view_def_oid(), AccessShareLock);
 	tuple = search_bbf_view_def(brel, viewOid);
 	
 	if (!HeapTupleIsValid(tuple))
 	{
-		table_close(brel, RowExclusiveLock);
+		table_close(brel, AccessShareLock);
 		return false;
 	}
 	values_datum = heap_getattr(tuple, Anum_bbf_view_def_flag_values,
@@ -7090,7 +7090,7 @@ bbf_view_set_broken(Oid viewOid, bool mark_broken)
 	if (isnull)
 	{
 		heap_freetuple(tuple);
-		table_close(brel, RowExclusiveLock);
+		table_close(brel, AccessShareLock);
 		return false;
 	}
 	
@@ -7120,7 +7120,7 @@ bbf_view_set_broken(Oid viewOid, bool mark_broken)
 	if (is_broken == mark_broken)
 	{
 		heap_freetuple(tuple);
-		table_close(brel, RowExclusiveLock);
+		table_close(brel, AccessShareLock);
 		return false;
 	}
 	
@@ -7131,7 +7131,7 @@ bbf_view_set_broken(Oid viewOid, bool mark_broken)
 		updated = update_bbf_view_flags(viewOid, 0, BBF_VIEW_DEF_FLAG_IS_BROKEN, true);
 	
 	heap_freetuple(tuple);
-	table_close(brel, RowExclusiveLock);
+	table_close(brel, AccessShareLock);
 	return updated;
 }
 

--- a/contrib/babelfishpg_tsql/src/rolecmds.c
+++ b/contrib/babelfishpg_tsql/src/rolecmds.c
@@ -829,7 +829,7 @@ user_name(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 
 	/* Search and obtain the tuple on the role name */
 	physical_user_name = (NameData *) palloc0(NAMEDATALEN);
@@ -847,7 +847,7 @@ user_name(PG_FUNCTION_ARGS)
 	if (!HeapTupleIsValid(tuple))
 	{
 		systable_endscan(scan);
-		table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+		table_close(bbf_authid_user_ext_rel, AccessShareLock);
 		PG_RETURN_NULL();
 	}
 
@@ -858,7 +858,7 @@ user_name(PG_FUNCTION_ARGS)
 	user = pstrdup(TextDatumGetCString(datum));
 
 	systable_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
 
 	PG_RETURN_TEXT_P(cstring_to_text(user));
 }
@@ -2301,7 +2301,7 @@ has_user_in_db(const char *login, char **db_name)
 
 	/* open the table to scane */
 	bbf_authid_user_ext_rel = table_open(get_authid_user_ext_oid(),
-										 RowExclusiveLock);
+										 AccessShareLock);
 
 	/* change the target name to NameData for search */
 	login_name = (NameData *) palloc0(NAMEDATALEN);
@@ -2325,11 +2325,11 @@ has_user_in_db(const char *login, char **db_name)
 		*db_name = pstrdup(TextDatumGetCString(name));
 
 		table_endscan(scan);
-		table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+		table_close(bbf_authid_user_ext_rel, AccessShareLock);
 		return true;
 	}
 	table_endscan(scan);
-	table_close(bbf_authid_user_ext_rel, RowExclusiveLock);
+	table_close(bbf_authid_user_ext_rel, AccessShareLock);
 
 	return false;
 }
@@ -2352,7 +2352,7 @@ get_fully_qualified_domain_name(char *netbios_domain)
 	HeapTuple	tuple;
 	char	   *fq_domain_name;
 
-	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), RowShareLock);
+	bbf_domain_mapping_rel = table_open(get_bbf_domain_mapping_oid(), AccessShareLock);
 
 	dsc = RelationGetDescr(bbf_domain_mapping_rel);
 
@@ -2404,7 +2404,7 @@ get_fully_qualified_domain_name(char *netbios_domain)
 	}
 
 	systable_endscan(scan);
-	table_close(bbf_domain_mapping_rel, RowShareLock);
+	table_close(bbf_domain_mapping_rel, AccessShareLock);
 
 	return fq_domain_name;
 }

--- a/contrib/babelfishpg_tsql/src/tablecmds.c
+++ b/contrib/babelfishpg_tsql/src/tablecmds.c
@@ -219,7 +219,7 @@ pltsql_PreDropColumnHook(Relation rel, AttrNumber attnum)
 	 * TSQL: Find everything that depends on the column.  If we can find a
 	 * computed column dependent on this column, will throw an error.
 	 */
-	depRel = table_open(DependRelationId, RowExclusiveLock);
+	depRel = table_open(DependRelationId, AccessShareLock);
 
 	ScanKeyInit(&key[0],
 				Anum_pg_depend_refclassid,
@@ -276,7 +276,7 @@ pltsql_PreDropColumnHook(Relation rel, AttrNumber attnum)
 
 	systable_endscan(scan);
 
-	table_close(depRel, RowExclusiveLock);
+	table_close(depRel, AccessShareLock);
 
 	/* Delete extended property as well */
 


### PR DESCRIPTION
### Description

Currently, some functions that access Babelfish catalog tables acquire locks of higher level than necessary even though they only perform read-only operations. This excessive locking can reduce concurrency and cause unnecessary contention on frequently accessed catalogs. This fix modifies the functions to use appropriate lock level where excessive locking occurs on Babelfish catalogs. It also resolves lock mismatch issue where table_open and table_close calls use different lock levels.

### Issues Resolved

Cherry picked from #4320 
BABEL-6205

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com) 

### Test Scenarios Covered ###

Note: Currently we do not have any framework to test this change.
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).