### PR TITLE
Disable babel_output_clause_concurrency_test in JDBC

### DIFF
--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -625,3 +625,6 @@ ignore#!#babel_timezoneinfo_before_17_7-vu-cleanup
 ignore#!#datetime_roundoff-before-17_8-or-16_12-vu-prepare
 ignore#!#datetime_roundoff-before-17_8-or-16_12-vu-verify
 ignore#!#datetime_roundoff-before-17_8-or-16_12-vu-cleanup
+
+# TODO: BABEL-6276
+ignore#!#babel_output_clause_concurrency_test


### PR DESCRIPTION
### Description

Disable babel_output_clause_concurrency_test in JDBC until BABEL-6276 is fixed

### Issues Resolved

[NO-JIRA]

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).