### PR TITLE
Fix various whitespaces in system function ISNUMERIC

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2253,6 +2253,43 @@ search_partition(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(result);
 }
 
+/* 
+ * Check whitespace type in string
+ * Returns:
+ *   1  - Contains only special whitespace (\t, \n, \v, \f, \r)
+ *   0  - Empty string or contains only spaces
+ *   -1 - Contains other characters (needs numeric conversion)
+ */
+static int
+checkWhitespaceType(const char *str)
+{
+	size_t i, len;
+	bool has_special_ws = false;
+	bool has_other_char = false;
+
+	if (!str || (len = strlen(str)) == 0)
+		return 0;
+
+	for (i = 0; i < len; i++)
+	{
+		char c = str[i];
+		
+		if (c == '\b')
+			return 0;
+		
+		if (c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r')
+		{
+			if (has_other_char)
+				return 0;
+			has_special_ws = true;
+		}
+		else if (c != ' ')
+			has_other_char = true;
+	}
+
+	return has_other_char ? -1 : (has_special_ws ? 1 : 0);
+}
+
 /*
  * Structure to cache metadata needed in isnumeric().
  */
@@ -2282,6 +2319,7 @@ isnumeric(PG_FUNCTION_ARGS)
 	Oid		argtypeid;
 	Oid		numeric_typiofunc;
 	Oid		money_typiofunc;
+	int		ws_check;
 	char		*value_str;
 	bool		result = false;
 	Datum		converted;
@@ -2328,9 +2366,18 @@ isnumeric(PG_FUNCTION_ARGS)
 		value_str = OidOutputFunctionCall(typoutput, PG_GETARG_DATUM(0));
 	}
 
-	/* Handling empty string. */
-	if ((*common_utility_plugin_ptr->isEmptyOrWhitespace)(value_str))
+	/* Check whitespace type */
+	ws_check = checkWhitespaceType(value_str);
+	
+	if (ws_check == 1)
 	{
+		/* Contains only special whitespace - return 1 */
+		pfree(value_str);
+		PG_RETURN_INT32(1);
+	}
+	else if (ws_check == 0)
+	{
+		/* Empty or only spaces - return 0 */
 		pfree(value_str);
 		PG_RETURN_INT32(0);
 	}

--- a/test/JDBC/expected/babel_isnumeric-vu-verify.out
+++ b/test/JDBC/expected/babel_isnumeric-vu-verify.out
@@ -1095,3 +1095,1813 @@ int#!#int
 0#!#0
 ~~END~~
 
+
+
+
+-- Special whitespace Test cases
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = '  ' + CHAR(10) + '   '
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(13)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10) + CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(13) + CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10) + CHAR(13)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10) + CHAR(10)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9) + CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9) + CHAR(10)
+SELECT isnumeric(cast(@a AS CHAR))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9) + CHAR(10)
+SELECT isnumeric(cast(@a AS NCHAR))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a VARCHAR(50)
+SET @a = CHAR(9) + CHAR(13)
+SELECT isnumeric(cast(@a AS NVARCHAR))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a VARCHAR(50)
+SET @a = CHAR(10) + CHAR(9)
+SELECT isnumeric(cast(@a as binary))
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+
+-- basic tests
+select isnumeric(char(9)) -- Horizontal Tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(char(10)) -- Newline (Line Feed)
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(char(13)) -- Carriage Return
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(char(32)) -- Space 
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric(char(11)) -- Vertical Tab
+go
+~~START~~
+int
+1
+~~END~~
+
+
+select isnumeric(char(12)) -- Form Feed
+go
+~~START~~
+int
+1
+~~END~~
+
+
+
+select isnumeric(char(8)) -- Backspace
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- extra works 
+select isnumeric(cast('' as char(33)))
+go
+~~START~~
+int
+0
+~~END~~
+
+
+
+select isnumeric ('  ') -- TAB
+go
+~~START~~
+int
+0
+~~END~~
+
+
+select isnumeric ('  ') -- combination of space and tab
+go
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT ISNUMERIC(CHAR(0));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(1));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(2));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(3));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(4));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(5));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(6));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(7));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(8));    -- \b backspace
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9));    -- \t tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(10));   -- \n newline
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(11));   -- \v vertical tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(12));   -- \f form feed
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(13));   -- \r carriage return
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(14));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(15));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(16));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(17));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(18));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(19));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(20));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(21));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(22));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(23));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(24));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(25));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(26));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(27));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(28));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(29));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(30));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(31));
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(32));   -- space
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(33));   -- !
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(34));   -- "
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(35));   -- #
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(36));   -- $
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(37));   -- %
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(38));   -- &
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(39));   -- '
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(40));   -- (
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(41));   -- )
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(42));   -- *
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(43));   -- +
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(44));   -- ,
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(45));   -- -
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(46));   -- .
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(47));   -- /
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(48));   -- 0
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(49));   -- 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(50));   -- 2
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(51));   -- 3
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(52));   -- 4
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(53));   -- 5
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(54));   -- 6
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(55));   -- 7
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(56));   -- 8
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(57));   -- 9
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(58));   -- :
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(59));   -- ;
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(60));   -- <
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(61));   -- =
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(62));   -- >
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(63));   -- ?
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(64));   -- @
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(65));   -- A
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(66));   -- B
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(67));   -- C
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(68));   -- D
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(69));   -- E
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(70));   -- F
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(71));   -- G
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(72));   -- H
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(73));   -- I
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(74));   -- J
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(75));   -- K
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(76));   -- L
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(77));   -- M
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(78));   -- N
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(79));   -- O
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(80));   -- P
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(81));   -- Q
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(82));   -- R
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(83));   -- S
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(84));   -- T
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(85));   -- U
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(86));   -- V
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(87));   -- W
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(88));   -- X
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(89));   -- Y
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(90));   -- Z
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(91));   -- [
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(92));   -- \
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(93));   -- ]
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(94));   -- ^
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(95));   -- _
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(96));   -- `
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(97));   -- a
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(98));   -- b
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(99));   -- c
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(100));  -- d
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(101));  -- e
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(102));  -- f
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(103));  -- g
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(104));  -- h
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(105));  -- i
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(106));  -- j
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(107));  -- k
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(108));  -- l
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(109));  -- m
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(110));  -- n
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(111));  -- o
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(112));  -- p
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(113));  -- q
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(114));  -- r
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(115));  -- s
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(116));  -- t
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(117));  -- u
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(118));  -- v
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(119));  -- w
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(120));  -- x
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(121));  -- y
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(122));  -- z
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(123));  -- {
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(124));  -- |
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(125));  -- }
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(126));  -- ~
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(127));  -- DEL
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+-- Multiple same characters
+SELECT ISNUMERIC('   ');                  -- multiple spaces
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(9));      -- multiple tabs
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(10) + CHAR(10));    -- multiple newlines
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Space + special whitespace combinations
+SELECT ISNUMERIC(' ' + CHAR(9));          -- space + tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + ' ');          -- tab + space
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(10));         -- space + newline
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(10) + ' ');         -- newline + space
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(13));         -- space + carriage return
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(13) + ' ');         -- carriage return + space
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(12));         -- space + form feed
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(11));         -- space + vertical tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(8));          -- space + backspace
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Special whitespace combinations (no space)
+SELECT ISNUMERIC(CHAR(9) + CHAR(10));     -- tab + newline
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(13));     -- tab + carriage return
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(10) + CHAR(13));    -- newline + carriage return
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(13) + CHAR(10));    -- carriage return + newline (CRLF)
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(11));     -- tab + vertical tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(12));     -- tab + form feed
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(8));      -- tab + backspace
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(10) + CHAR(11));    -- newline + vertical tab
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(11) + CHAR(12));    -- vertical tab + form feed
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(8) + CHAR(9));      -- backspace + tab
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Three character combinations with space
+SELECT ISNUMERIC(' ' + CHAR(9) + CHAR(10));     -- space + tab + newline
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + ' ' + CHAR(10));     -- tab + space + newline
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(10) + ' ');     -- tab + newline + space
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(13) + CHAR(10));    -- space + CRLF
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(9) + CHAR(13));     -- space + tab + CR
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Three character combinations without space
+SELECT ISNUMERIC(CHAR(9) + CHAR(10) + CHAR(13));     -- tab + newline + CR
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + CHAR(10));      -- backspace + tab + newline
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(11) + CHAR(12) + CHAR(13));    -- VT + FF + CR
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(11) + CHAR(12));     -- tab + VT + FF
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- All special whitespace characters (no space)
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13));
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- All special whitespace with space at start
+SELECT ISNUMERIC(' ' + CHAR(8) + CHAR(9) + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13));
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- All special whitespace with space in middle
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + ' ' + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13));
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- All special whitespace with space at end
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13) + ' ');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Whitespace + numeric
+SELECT ISNUMERIC(' 123');                 -- space + number
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + '123');        -- tab + number
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(10) + '123');       -- newline + number
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC('123 ');                 -- number + space
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC('123' + CHAR(9));        -- number + tab, tsql 0, trailing whitespaces not allowed
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(char(9) + '123')         -- tab + number, tsql:1, leading whitespace is allowed
+go 
+SELECT ISNUMERIC(' ' + CHAR(9) + '123');  -- space + tab + number
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(10) + '123');  -- tab + newline + number
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Whitespace around numeric
+SELECT ISNUMERIC(' 123 ');                -- space + number + space
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + '123' + CHAR(9));  -- tab + number + tab
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + '123' + CHAR(9)+ '123');
+go
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(' ' + CHAR(9) + '123' + CHAR(10) + ' ');  -- mixed whitespace around number
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Complex combinations
+SELECT ISNUMERIC('  ' + CHAR(9) + '  ');  -- spaces + tab + spaces
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(9) + CHAR(9) + ' ' + ' ');  -- tabs + spaces
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CHAR(13) + CHAR(10) + CHAR(13) + CHAR(10));  -- double CRLF
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- These are working already.
+-- Non breaking space
+select isnumeric(CHAR(160)) -- TSQL: 1
+go
+~~START~~
+int
+0
+~~END~~
+
+
+-- misc tests
+select isnumeric('- 1')  -- TSQL: 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+select isnumeric(' -1 ') -- TSQL: 1
+GO
+~~START~~
+int
+1
+~~END~~
+
+select isnumeric('-\n1') -- TSQL: 0
+GO
+~~START~~
+int
+0
+~~END~~
+
+select isnumeric('-1\n') -- TSQL: 0
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+
+-- non-breaking space
+select isnumeric(char(160))
+select isnumeric(nchar(160))
+go
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- zero width space
+select isnumeric(char(8203))
+select isnumeric(nchar(8203))
+go
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- narrow no-break space
+select isnumeric(char(8239))
+select isnumeric(nchar(8239))
+go
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- ideographic space
+select isnumeric(char(12288))
+select isnumeric(nchar(12288))
+select isnumeric(char(12288) + char(9))
+Go
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT ISNUMERIC('\0') -- tsql 1
+go
+~~START~~
+int
+0
+~~END~~
+
+
+
+
+-- Unicode whitespace test cases
+-- Non-breaking space (U+00A0) - should behave like regular space
+SELECT ISNUMERIC(NCHAR(160));  -- non-breaking space alone
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(NCHAR(160) + '123');  -- non-breaking space + number
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC('123' + NCHAR(160));  -- number + non-breaking space
+GO
+~~START~~
+int
+0
+~~END~~
+
+SELECT ISNUMERIC(NCHAR(160) + NCHAR(160));  -- multiple non-breaking spaces
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Test casting numeric strings with special whitespace to numeric
+SELECT ISNUMERIC(CAST(CHAR(8) AS NUMERIC));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST(CHAR(9) AS NUMERIC(18,5)));  -- tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "	")~~
+
+SELECT ISNUMERIC(CAST(CHAR(10) AS NUMERIC));  -- newline
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "
+")~~
+
+SELECT ISNUMERIC(CAST(CHAR(11) AS NUMERIC)); -- vertical tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST(CHAR(12) AS NUMERIC));  -- form feed
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST(CHAR(13) AS NUMERIC));  -- carriage return
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST(CHAR(9) + CHAR(10) AS NUMERIC));  -- tab + newline
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "	
+")~~
+
+SELECT ISNUMERIC(CAST(CHAR(13) + CHAR(10) AS NUMERIC));  -- CRLF
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "
+")~~
+
+SELECT ISNUMERIC(CAST(CHAR(9) + CHAR(13) AS NUMERIC));  -- tab + CR
+GO
+~~START~~
+int
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "	")~~
+
+SELECT ISNUMERIC(CAST((CHAR(9) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "	")~~
+
+SELECT ISNUMERIC(CAST((CHAR(10) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "
+")~~
+
+SELECT ISNUMERIC(CAST((CHAR(11) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST((CHAR(12) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST((CHAR(13) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(9)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "	")~~
+
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(10)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "
+")~~
+
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(11)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(12)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(13)) AS NUMERIC(18,5)));
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type numeric: "")~~
+
+SELECT ISNUMERIC(CAST((123 + CHAR(9)) AS NUMERIC(18,5)));  -- tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "	")~~
+
+SELECT ISNUMERIC(CAST((123 + CHAR(10)) AS NUMERIC(18,5)));  -- tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "
+")~~
+
+SELECT ISNUMERIC(CAST((123 + CHAR(11)) AS NUMERIC(18,5)));  -- tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "")~~
+
+SELECT ISNUMERIC(CAST((123 + CHAR(12)) AS NUMERIC(18,5)));  -- tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "")~~
+
+SELECT ISNUMERIC(CAST((123 + CHAR(13)) AS NUMERIC(18,5)));  -- tab
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid input syntax for type integer: "")~~
+
+SELECT ISNUMERIC(CAST('123  ' as numeric)) -- numeric + tab
+Go
+~~START~~
+int
+1
+~~END~~
+
+SELECT ISNUMERIC(CAST(' 123' as numeric)) -- tab +numeric
+Go
+~~START~~
+int
+1
+~~END~~
+

--- a/test/JDBC/input/babel_isnumeric-vu-verify.sql
+++ b/test/JDBC/input/babel_isnumeric-vu-verify.sql
@@ -448,3 +448,595 @@ DECLARE @inputString sql_variant = CAST ('6F9619FF-8B86-D011-B42D-00C04FC964FF' 
 DECLARE @inputEmptyString sql_variant = '';
 select isnumeric(@inputString), isnumeric(@inputEmptyString);
 GO
+
+
+-- Special whitespace Test cases
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = '  ' + CHAR(10) + '   '
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(13)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10) + CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(13) + CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10) + CHAR(13)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(10) + CHAR(10)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9) + CHAR(9)
+SELECT ISNUMERIC(@a)
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9) + CHAR(10)
+SELECT isnumeric(cast(@a AS CHAR))
+GO
+
+DECLARE @a NVARCHAR(max)
+SET @a = CHAR(9) + CHAR(10)
+SELECT isnumeric(cast(@a AS NCHAR))
+GO
+
+DECLARE @a VARCHAR(50)
+SET @a = CHAR(9) + CHAR(13)
+SELECT isnumeric(cast(@a AS NVARCHAR))
+GO
+
+DECLARE @a VARCHAR(50)
+SET @a = CHAR(10) + CHAR(9)
+SELECT isnumeric(cast(@a as binary))
+GO
+
+-- basic tests
+
+select isnumeric(char(9)) -- Horizontal Tab
+GO
+
+select isnumeric(char(10)) -- Newline (Line Feed)
+go
+
+select isnumeric(char(13)) -- Carriage Return
+go
+
+select isnumeric(char(32)) -- Space 
+go
+
+select isnumeric(char(11)) -- Vertical Tab
+go
+
+select isnumeric(char(12)) -- Form Feed
+go
+
+
+select isnumeric(char(8)) -- Backspace
+go
+
+-- extra works 
+select isnumeric(cast('' as char(33)))
+go
+
+
+select isnumeric ('  ') -- TAB
+go
+
+select isnumeric ('  ') -- combination of space and tab
+go
+
+SELECT ISNUMERIC(CHAR(0));
+GO
+SELECT ISNUMERIC(CHAR(1));
+GO
+SELECT ISNUMERIC(CHAR(2));
+GO
+SELECT ISNUMERIC(CHAR(3));
+GO
+SELECT ISNUMERIC(CHAR(4));
+GO
+SELECT ISNUMERIC(CHAR(5));
+GO
+SELECT ISNUMERIC(CHAR(6));
+GO
+SELECT ISNUMERIC(CHAR(7));
+GO
+SELECT ISNUMERIC(CHAR(8));    -- \b backspace
+GO
+SELECT ISNUMERIC(CHAR(9));    -- \t tab
+GO
+SELECT ISNUMERIC(CHAR(10));   -- \n newline
+GO
+SELECT ISNUMERIC(CHAR(11));   -- \v vertical tab
+GO
+SELECT ISNUMERIC(CHAR(12));   -- \f form feed
+GO
+SELECT ISNUMERIC(CHAR(13));   -- \r carriage return
+GO
+SELECT ISNUMERIC(CHAR(14));
+GO
+SELECT ISNUMERIC(CHAR(15));
+GO
+SELECT ISNUMERIC(CHAR(16));
+GO
+SELECT ISNUMERIC(CHAR(17));
+GO
+SELECT ISNUMERIC(CHAR(18));
+GO
+SELECT ISNUMERIC(CHAR(19));
+GO
+SELECT ISNUMERIC(CHAR(20));
+GO
+SELECT ISNUMERIC(CHAR(21));
+GO
+SELECT ISNUMERIC(CHAR(22));
+GO
+SELECT ISNUMERIC(CHAR(23));
+GO
+SELECT ISNUMERIC(CHAR(24));
+GO
+SELECT ISNUMERIC(CHAR(25));
+GO
+SELECT ISNUMERIC(CHAR(26));
+GO
+SELECT ISNUMERIC(CHAR(27));
+GO
+SELECT ISNUMERIC(CHAR(28));
+GO
+SELECT ISNUMERIC(CHAR(29));
+GO
+SELECT ISNUMERIC(CHAR(30));
+GO
+SELECT ISNUMERIC(CHAR(31));
+GO
+SELECT ISNUMERIC(CHAR(32));   -- space
+GO
+SELECT ISNUMERIC(CHAR(33));   -- !
+GO
+SELECT ISNUMERIC(CHAR(34));   -- "
+GO
+SELECT ISNUMERIC(CHAR(35));   -- #
+GO
+SELECT ISNUMERIC(CHAR(36));   -- $
+GO
+SELECT ISNUMERIC(CHAR(37));   -- %
+GO
+SELECT ISNUMERIC(CHAR(38));   -- &
+GO
+SELECT ISNUMERIC(CHAR(39));   -- '
+GO
+SELECT ISNUMERIC(CHAR(40));   -- (
+GO
+SELECT ISNUMERIC(CHAR(41));   -- )
+GO
+SELECT ISNUMERIC(CHAR(42));   -- *
+GO
+SELECT ISNUMERIC(CHAR(43));   -- +
+GO
+SELECT ISNUMERIC(CHAR(44));   -- ,
+GO
+SELECT ISNUMERIC(CHAR(45));   -- -
+GO
+SELECT ISNUMERIC(CHAR(46));   -- .
+GO
+SELECT ISNUMERIC(CHAR(47));   -- /
+GO
+SELECT ISNUMERIC(CHAR(48));   -- 0
+GO
+SELECT ISNUMERIC(CHAR(49));   -- 1
+GO
+SELECT ISNUMERIC(CHAR(50));   -- 2
+GO
+SELECT ISNUMERIC(CHAR(51));   -- 3
+GO
+SELECT ISNUMERIC(CHAR(52));   -- 4
+GO
+SELECT ISNUMERIC(CHAR(53));   -- 5
+GO
+SELECT ISNUMERIC(CHAR(54));   -- 6
+GO
+SELECT ISNUMERIC(CHAR(55));   -- 7
+GO
+SELECT ISNUMERIC(CHAR(56));   -- 8
+GO
+SELECT ISNUMERIC(CHAR(57));   -- 9
+GO
+SELECT ISNUMERIC(CHAR(58));   -- :
+GO
+SELECT ISNUMERIC(CHAR(59));   -- ;
+GO
+SELECT ISNUMERIC(CHAR(60));   -- <
+GO
+SELECT ISNUMERIC(CHAR(61));   -- =
+GO
+SELECT ISNUMERIC(CHAR(62));   -- >
+GO
+SELECT ISNUMERIC(CHAR(63));   -- ?
+GO
+SELECT ISNUMERIC(CHAR(64));   -- @
+GO
+SELECT ISNUMERIC(CHAR(65));   -- A
+GO
+SELECT ISNUMERIC(CHAR(66));   -- B
+GO
+SELECT ISNUMERIC(CHAR(67));   -- C
+GO
+SELECT ISNUMERIC(CHAR(68));   -- D
+GO
+SELECT ISNUMERIC(CHAR(69));   -- E
+GO
+SELECT ISNUMERIC(CHAR(70));   -- F
+GO
+SELECT ISNUMERIC(CHAR(71));   -- G
+GO
+SELECT ISNUMERIC(CHAR(72));   -- H
+GO
+SELECT ISNUMERIC(CHAR(73));   -- I
+GO
+SELECT ISNUMERIC(CHAR(74));   -- J
+GO
+SELECT ISNUMERIC(CHAR(75));   -- K
+GO
+SELECT ISNUMERIC(CHAR(76));   -- L
+GO
+SELECT ISNUMERIC(CHAR(77));   -- M
+GO
+SELECT ISNUMERIC(CHAR(78));   -- N
+GO
+SELECT ISNUMERIC(CHAR(79));   -- O
+GO
+SELECT ISNUMERIC(CHAR(80));   -- P
+GO
+SELECT ISNUMERIC(CHAR(81));   -- Q
+GO
+SELECT ISNUMERIC(CHAR(82));   -- R
+GO
+SELECT ISNUMERIC(CHAR(83));   -- S
+GO
+SELECT ISNUMERIC(CHAR(84));   -- T
+GO
+SELECT ISNUMERIC(CHAR(85));   -- U
+GO
+SELECT ISNUMERIC(CHAR(86));   -- V
+GO
+SELECT ISNUMERIC(CHAR(87));   -- W
+GO
+SELECT ISNUMERIC(CHAR(88));   -- X
+GO
+SELECT ISNUMERIC(CHAR(89));   -- Y
+GO
+SELECT ISNUMERIC(CHAR(90));   -- Z
+GO
+SELECT ISNUMERIC(CHAR(91));   -- [
+GO
+SELECT ISNUMERIC(CHAR(92));   -- \
+GO
+SELECT ISNUMERIC(CHAR(93));   -- ]
+GO
+SELECT ISNUMERIC(CHAR(94));   -- ^
+GO
+SELECT ISNUMERIC(CHAR(95));   -- _
+GO
+SELECT ISNUMERIC(CHAR(96));   -- `
+GO
+SELECT ISNUMERIC(CHAR(97));   -- a
+GO
+SELECT ISNUMERIC(CHAR(98));   -- b
+GO
+SELECT ISNUMERIC(CHAR(99));   -- c
+GO
+SELECT ISNUMERIC(CHAR(100));  -- d
+GO
+SELECT ISNUMERIC(CHAR(101));  -- e
+GO
+SELECT ISNUMERIC(CHAR(102));  -- f
+GO
+SELECT ISNUMERIC(CHAR(103));  -- g
+GO
+SELECT ISNUMERIC(CHAR(104));  -- h
+GO
+SELECT ISNUMERIC(CHAR(105));  -- i
+GO
+SELECT ISNUMERIC(CHAR(106));  -- j
+GO
+SELECT ISNUMERIC(CHAR(107));  -- k
+GO
+SELECT ISNUMERIC(CHAR(108));  -- l
+GO
+SELECT ISNUMERIC(CHAR(109));  -- m
+GO
+SELECT ISNUMERIC(CHAR(110));  -- n
+GO
+SELECT ISNUMERIC(CHAR(111));  -- o
+GO
+SELECT ISNUMERIC(CHAR(112));  -- p
+GO
+SELECT ISNUMERIC(CHAR(113));  -- q
+GO
+SELECT ISNUMERIC(CHAR(114));  -- r
+GO
+SELECT ISNUMERIC(CHAR(115));  -- s
+GO
+SELECT ISNUMERIC(CHAR(116));  -- t
+GO
+SELECT ISNUMERIC(CHAR(117));  -- u
+GO
+SELECT ISNUMERIC(CHAR(118));  -- v
+GO
+SELECT ISNUMERIC(CHAR(119));  -- w
+GO
+SELECT ISNUMERIC(CHAR(120));  -- x
+GO
+SELECT ISNUMERIC(CHAR(121));  -- y
+GO
+SELECT ISNUMERIC(CHAR(122));  -- z
+GO
+SELECT ISNUMERIC(CHAR(123));  -- {
+GO
+SELECT ISNUMERIC(CHAR(124));  -- |
+GO
+SELECT ISNUMERIC(CHAR(125));  -- }
+GO
+SELECT ISNUMERIC(CHAR(126));  -- ~
+GO
+SELECT ISNUMERIC(CHAR(127));  -- DEL
+GO
+
+
+-- Multiple same characters
+SELECT ISNUMERIC('   ');                  -- multiple spaces
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(9));      -- multiple tabs
+GO
+SELECT ISNUMERIC(CHAR(10) + CHAR(10));    -- multiple newlines
+GO
+
+-- Space + special whitespace combinations
+SELECT ISNUMERIC(' ' + CHAR(9));          -- space + tab
+GO
+SELECT ISNUMERIC(CHAR(9) + ' ');          -- tab + space
+GO
+SELECT ISNUMERIC(' ' + CHAR(10));         -- space + newline
+GO
+SELECT ISNUMERIC(CHAR(10) + ' ');         -- newline + space
+GO
+SELECT ISNUMERIC(' ' + CHAR(13));         -- space + carriage return
+GO
+SELECT ISNUMERIC(CHAR(13) + ' ');         -- carriage return + space
+GO
+SELECT ISNUMERIC(' ' + CHAR(12));         -- space + form feed
+GO
+SELECT ISNUMERIC(' ' + CHAR(11));         -- space + vertical tab
+GO
+SELECT ISNUMERIC(' ' + CHAR(8));          -- space + backspace
+GO
+
+-- Special whitespace combinations (no space)
+SELECT ISNUMERIC(CHAR(9) + CHAR(10));     -- tab + newline
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(13));     -- tab + carriage return
+GO
+SELECT ISNUMERIC(CHAR(10) + CHAR(13));    -- newline + carriage return
+GO
+SELECT ISNUMERIC(CHAR(13) + CHAR(10));    -- carriage return + newline (CRLF)
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(11));     -- tab + vertical tab
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(12));     -- tab + form feed
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(8));      -- tab + backspace
+GO
+SELECT ISNUMERIC(CHAR(10) + CHAR(11));    -- newline + vertical tab
+GO
+SELECT ISNUMERIC(CHAR(11) + CHAR(12));    -- vertical tab + form feed
+GO
+SELECT ISNUMERIC(CHAR(8) + CHAR(9));      -- backspace + tab
+GO
+
+-- Three character combinations with space
+SELECT ISNUMERIC(' ' + CHAR(9) + CHAR(10));     -- space + tab + newline
+GO
+SELECT ISNUMERIC(CHAR(9) + ' ' + CHAR(10));     -- tab + space + newline
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(10) + ' ');     -- tab + newline + space
+GO
+SELECT ISNUMERIC(' ' + CHAR(13) + CHAR(10));    -- space + CRLF
+GO
+SELECT ISNUMERIC(' ' + CHAR(9) + CHAR(13));     -- space + tab + CR
+GO
+
+-- Three character combinations without space
+SELECT ISNUMERIC(CHAR(9) + CHAR(10) + CHAR(13));     -- tab + newline + CR
+GO
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + CHAR(10));      -- backspace + tab + newline
+GO
+SELECT ISNUMERIC(CHAR(11) + CHAR(12) + CHAR(13));    -- VT + FF + CR
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(11) + CHAR(12));     -- tab + VT + FF
+GO
+
+-- All special whitespace characters (no space)
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13));
+GO
+
+-- All special whitespace with space at start
+SELECT ISNUMERIC(' ' + CHAR(8) + CHAR(9) + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13));
+GO
+
+-- All special whitespace with space in middle
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + ' ' + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13));
+GO
+
+-- All special whitespace with space at end
+SELECT ISNUMERIC(CHAR(8) + CHAR(9) + CHAR(10) + CHAR(11) + CHAR(12) + CHAR(13) + ' ');
+GO
+
+-- Whitespace + numeric
+SELECT ISNUMERIC(' 123');                 -- space + number
+GO
+SELECT ISNUMERIC(CHAR(9) + '123');        -- tab + number
+GO
+SELECT ISNUMERIC(CHAR(10) + '123');       -- newline + number
+GO
+SELECT ISNUMERIC('123 ');                 -- number + space
+GO
+SELECT ISNUMERIC('123' + CHAR(9));        -- number + tab, tsql 0, trailing whitespaces not allowed
+GO
+SELECT ISNUMERIC(char(9) + '123')         -- tab + number, tsql:1, leading whitespace is allowed
+go 
+SELECT ISNUMERIC(' ' + CHAR(9) + '123');  -- space + tab + number
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(10) + '123');  -- tab + newline + number
+GO
+
+-- Whitespace around numeric
+SELECT ISNUMERIC(' 123 ');                -- space + number + space
+GO
+SELECT ISNUMERIC(CHAR(9) + '123' + CHAR(9));  -- tab + number + tab
+GO
+SELECT ISNUMERIC(CHAR(9) + '123' + CHAR(9)+ '123');
+go
+SELECT ISNUMERIC(' ' + CHAR(9) + '123' + CHAR(10) + ' ');  -- mixed whitespace around number
+GO
+
+-- Complex combinations
+SELECT ISNUMERIC('  ' + CHAR(9) + '  ');  -- spaces + tab + spaces
+GO
+SELECT ISNUMERIC(CHAR(9) + CHAR(9) + ' ' + ' ');  -- tabs + spaces
+GO
+SELECT ISNUMERIC(CHAR(13) + CHAR(10) + CHAR(13) + CHAR(10));  -- double CRLF
+GO
+
+-- These are working already.
+-- Non breaking space
+select isnumeric(CHAR(160)) -- TSQL: 1
+go
+
+-- misc tests
+select isnumeric('- 1')  -- TSQL: 1
+GO
+select isnumeric(' -1 ') -- TSQL: 1
+GO
+select isnumeric('-\n1') -- TSQL: 0
+GO
+select isnumeric('-1\n') -- TSQL: 0
+GO
+
+
+-- non-breaking space
+select isnumeric(char(160))
+select isnumeric(nchar(160))
+go
+
+-- zero width space
+select isnumeric(char(8203))
+select isnumeric(nchar(8203))
+go
+
+-- narrow no-break space
+select isnumeric(char(8239))
+select isnumeric(nchar(8239))
+go
+
+-- ideographic space
+select isnumeric(char(12288))
+select isnumeric(nchar(12288))
+select isnumeric(char(12288) + char(9))
+Go
+
+SELECT ISNUMERIC('\0') -- tsql 1
+go
+
+
+-- Unicode whitespace test cases
+
+-- Non-breaking space (U+00A0) - should behave like regular space
+SELECT ISNUMERIC(NCHAR(160));  -- non-breaking space alone
+GO
+SELECT ISNUMERIC(NCHAR(160) + '123');  -- non-breaking space + number
+GO
+SELECT ISNUMERIC('123' + NCHAR(160));  -- number + non-breaking space
+GO
+SELECT ISNUMERIC(NCHAR(160) + NCHAR(160));  -- multiple non-breaking spaces
+GO
+
+-- Test casting numeric strings with special whitespace to numeric
+SELECT ISNUMERIC(CAST(CHAR(8) AS NUMERIC));
+GO
+SELECT ISNUMERIC(CAST(CHAR(9) AS NUMERIC(18,5)));  -- tab
+GO
+SELECT ISNUMERIC(CAST(CHAR(10) AS NUMERIC));  -- newline
+GO
+SELECT ISNUMERIC(CAST(CHAR(11) AS NUMERIC)); -- vertical tab
+GO
+SELECT ISNUMERIC(CAST(CHAR(12) AS NUMERIC));  -- form feed
+GO
+SELECT ISNUMERIC(CAST(CHAR(13) AS NUMERIC));  -- carriage return
+GO
+SELECT ISNUMERIC(CAST(CHAR(9) + CHAR(10) AS NUMERIC));  -- tab + newline
+GO
+SELECT ISNUMERIC(CAST(CHAR(13) + CHAR(10) AS NUMERIC));  -- CRLF
+GO
+SELECT ISNUMERIC(CAST(CHAR(9) + CHAR(13) AS NUMERIC));  -- tab + CR
+GO
+SELECT ISNUMERIC(CAST((CHAR(9) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CHAR(10) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CHAR(11) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CHAR(12) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CHAR(13) + cast('123' as numeric)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(9)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(10)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(11)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(12)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((CAST('123' as numeric) + CHAR(13)) AS NUMERIC(18,5)));
+GO
+SELECT ISNUMERIC(CAST((123 + CHAR(9)) AS NUMERIC(18,5)));  -- tab
+GO
+SELECT ISNUMERIC(CAST((123 + CHAR(10)) AS NUMERIC(18,5)));  -- tab
+GO
+SELECT ISNUMERIC(CAST((123 + CHAR(11)) AS NUMERIC(18,5)));  -- tab
+GO
+SELECT ISNUMERIC(CAST((123 + CHAR(12)) AS NUMERIC(18,5)));  -- tab
+GO
+SELECT ISNUMERIC(CAST((123 + CHAR(13)) AS NUMERIC(18,5)));  -- tab
+GO
+SELECT ISNUMERIC(CAST('123  ' as numeric)) -- numeric + tab
+Go
+SELECT ISNUMERIC(CAST(' 123' as numeric)) -- tab +numeric
+Go


### PR DESCRIPTION
### Description

This commit handles various types of whitespaces in Babelfish for isnumeric(), ensuring compatibility with T-SQL behavior. T-SQL allows leading special whitespace to be trimmed but treats trailing special whitespace after numeric content as non-numeric. We have also handled arithmetic operations between these whitespaces and other characters. Following are the result:

*  1  - Contains only special whitespace (\t, \n, \v, \f, \r)
*  0  - Empty string or contains only spaces
* -1  - Contains other characters (needs numeric conversion)
*  0  - Contains other characters and ends with special whitespace

Cherry-pick from PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4275

### Issues Resolved

BABEL-6174

### Test Scenarios Covered ###
* **Use case based -** Yes
 

* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -**NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).