### PR TITLE
Restrict non superuser to alter babelfish defined procedures/functions (#4219)

### DIFF
--- a/.github/workflows/manual_tags.yml
+++ b/.github/workflows/manual_tags.yml
@@ -26,15 +26,18 @@ jobs:
           fetch-depth: 0
       - name: Run create-tag script
         env:
+          TAG_ID: ${{ github.event.inputs.tagId }}
           message: ${{ github.event.inputs.message }}
         # Run when commit hash is not provided (then the tag will be created on the latest commit of the current branch)
-        if: ${{github.event.inputs.commit_hash == ''}} 
+        if: ${{ github.event.inputs.commit_hash == '' }}
         run: |
-            bash ./.github/scripts/create-tag.sh -t ${{github.event.inputs.tagId}}
+            bash ./.github/scripts/create-tag.sh -t "$TAG_ID"
       - name: Run create-tag script when commit hash is provided
         env:
+          TAG_ID: ${{ github.event.inputs.tagId }}
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
           message: ${{ github.event.inputs.message }}
         # Run when commit hash is provided, tag will be created on top of the commit hash
-        if: ${{github.event.inputs.commit_hash != ''}} 
+        if: ${{ github.event.inputs.commit_hash != '' }}
         run: |
-            bash ./.github/scripts/create-tag.sh -c ${{github.event.inputs.commit_hash}} -t ${{github.event.inputs.tagId}}
+            bash ./.github/scripts/create-tag.sh -c "$COMMIT_HASH" -t "$TAG_ID"

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -188,6 +188,7 @@ static void revoke_type_permission_from_public(PlannedStmt *pstmt, const char *q
 											   ProcessUtilityContext context, ParamListInfo params, QueryEnvironment *queryEnv, DestReceiver *dest, QueryCompletion *qc, List *type_name);
 static void set_current_query_is_create_tbl_check_constraint(Node *expr);
 static void validateUserAndRole(char *name);
+static void validate_sys_schema_permissions(List *funcname);
 
 static void bbf_ExecDropStmt(DropStmt *stmt);
 
@@ -5027,6 +5028,12 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				revoke_type_permission_from_public(pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc, create_domain->domainname);
 				return;
 			}
+		case T_CreateFunctionStmt:
+			{
+				CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
+        		validate_sys_schema_permissions(stmt->funcname);
+				break;
+			}
 		case T_VariableSetStmt:
 			{
 				VariableSetStmt *variable_set = (VariableSetStmt *) parsetree;
@@ -5412,6 +5419,27 @@ call_prev_ProcessUtility(PlannedStmt *pstmt,
 	else
 		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context, params,
 								queryEnv, dest, qc);
+}
+
+static void
+validate_sys_schema_permissions(List *funcname)
+{
+	char *objname = NULL;
+    Oid schemaOid;
+    Oid sysSchemaOid;
+
+    if (superuser_arg(GetSessionUserId()))
+        return;
+        
+    schemaOid = QualifiedNameGetCreationNamespace(funcname, &objname);
+    sysSchemaOid = get_namespace_oid("sys", true);
+    
+    if (OidIsValid(sysSchemaOid) && schemaOid == sysSchemaOid)
+    {
+        ereport(ERROR,
+                (errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+                errmsg("permission denied to create or modify objects in sys schema")));
+    }
 }
 
 /*

--- a/test/JDBC/expected/TEST-INTERNAL-PROC.out
+++ b/test/JDBC/expected/TEST-INTERNAL-PROC.out
@@ -59,3 +59,133 @@ GO
 ~~ERROR (Message: ERROR: remove_createrole_from_logins() can only be called from an SQL script executed by CREATE/ALTER EXTENSION
     Server SQLState: 0A000)~~
 
+-- psql
+  
+-- setup
+CREATE ROLE test_regular_user WITH LOGIN PASSWORD '12345678';
+GO
+
+GRANT jdbc_user TO test_regular_user;
+GO
+
+-- Test superuser permissions first
+CREATE OR REPLACE PROCEDURE sys.test_sys_proc_creation()
+AS $$
+BEGIN 
+    RAISE NOTICE 'rewrite babel sys procedure';
+END; $$ LANGUAGE plpgsql;
+GO
+
+CALL sys.test_sys_proc_creation();
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: rewrite babel sys procedure  Server SQLState: 00000)~~
+
+
+CREATE FUNCTION sys.test_sys_function_creation()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Create babel sys function';
+END;
+$$;
+GO
+
+SELECT sys.test_sys_function_creation();
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Create babel sys function  Server SQLState: 00000)~~
+
+~~START~~
+void
+
+~~END~~
+
+
+-- psql user=test_regular_user password=12345678
+-- Verify current user is not superuser initially
+SELECT current_user, session_user;
+GO
+~~START~~
+name#!#name
+test_regular_user#!#test_regular_user
+~~END~~
+
+
+-- Test 1: CREATE PROCEDURE should fail
+CREATE OR REPLACE PROCEDURE sys.test_regular_proc()
+AS $$
+BEGIN 
+    RAISE NOTICE 'This should fail';
+END; $$ LANGUAGE plpgsql;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create or modify objects in sys schema
+    Server SQLState: 42501)~~
+
+
+-- Test 2: CREATE FUNCTION should fail  
+CREATE FUNCTION sys.test_regular_function()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'This should fail';
+END;
+$$;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create or modify objects in sys schema
+    Server SQLState: 42501)~~
+
+
+-- Test 3: Role switching scenario
+SET ROLE jdbc_user;
+GO
+
+SELECT current_user, session_user;
+GO
+~~START~~
+name#!#name
+jdbc_user#!#test_regular_user
+~~END~~
+
+
+-- Test after role switch - should still fail
+CREATE OR REPLACE FUNCTION sys.test_after_role_switch()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Function created after role switch';
+END;
+$$;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: permission denied to create or modify objects in sys schema
+    Server SQLState: 42501)~~
+
+
+RESET ROLE;
+GO
+-- terminate-psql-conn user=test_regular_user password=12345678
+
+-- psql
+-- Clean up
+REVOKE jdbc_user FROM test_regular_user;
+GO
+
+DROP PROCEDURE IF EXISTS sys.test_sys_proc_creation;
+GO
+
+DROP FUNCTION IF EXISTS sys.test_sys_function_creation;
+GO
+
+DROP ROLE test_regular_user;
+GO

--- a/test/JDBC/input/TEST-INTERNAL-PROC.mix
+++ b/test/JDBC/input/TEST-INTERNAL-PROC.mix
@@ -39,3 +39,95 @@ GO
 
 CALL sys.bbf_remove_createrole_from_logins();
 GO
+  
+-- psql
+-- setup
+CREATE ROLE test_regular_user WITH LOGIN PASSWORD '12345678';
+GO
+
+GRANT jdbc_user TO test_regular_user;
+GO
+
+-- Test superuser permissions first
+CREATE OR REPLACE PROCEDURE sys.test_sys_proc_creation()
+AS $$
+BEGIN 
+    RAISE NOTICE 'rewrite babel sys procedure';
+END; $$ LANGUAGE plpgsql;
+GO
+
+CALL sys.test_sys_proc_creation();
+GO
+
+CREATE FUNCTION sys.test_sys_function_creation()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Create babel sys function';
+END;
+$$;
+GO
+
+SELECT sys.test_sys_function_creation();
+GO
+
+-- psql user=test_regular_user password=12345678
+-- Verify current user is not superuser initially
+SELECT current_user, session_user;
+GO
+
+-- Test 1: CREATE PROCEDURE should fail
+CREATE OR REPLACE PROCEDURE sys.test_regular_proc()
+AS $$
+BEGIN 
+    RAISE NOTICE 'This should fail';
+END; $$ LANGUAGE plpgsql;
+GO
+
+-- Test 2: CREATE FUNCTION should fail  
+CREATE FUNCTION sys.test_regular_function()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'This should fail';
+END;
+$$;
+GO
+
+-- Test 3: Role switching scenario
+SET ROLE jdbc_user;
+GO
+
+SELECT current_user, session_user;
+GO
+
+-- Test after role switch - should still fail
+CREATE OR REPLACE FUNCTION sys.test_after_role_switch()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Function created after role switch';
+END;
+$$;
+GO
+
+RESET ROLE;
+GO
+-- terminate-psql-conn user=test_regular_user password=12345678
+
+-- Clean up
+-- psql
+REVOKE jdbc_user FROM test_regular_user;
+GO
+
+DROP PROCEDURE IF EXISTS sys.test_sys_proc_creation;
+GO
+
+DROP FUNCTION IF EXISTS sys.test_sys_function_creation;
+GO
+
+DROP ROLE test_regular_user;
+GO


### PR DESCRIPTION
### Description

Currently non superuser and non owners can alter the procedures and function in sys schema. This will restrict non owners from altering sys schema procedures/function as they are created by Babelfish.

Task: BABEL-6131

(cherry picked from commit ce56f3b2370d1e8270c07f30a276a24312c80971)

### Issues Resolved
BABEL-6131

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
Yes

* **Major version upgrade tests -**
Yes

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).