### PR TITLE
ANTLR crash at exitSecurity_statement during 'GRANT/REVOKE CONNECT ON SCHEMA'

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2340,6 +2340,10 @@ public:
 					for (auto perm: grant->permissions()->permission())
 					{
 						auto single_perm = perm->single_permission();
+						if (single_perm->CONNECT())
+						{
+							throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, format_errmsg("Incorrect syntax near '%s'.", ::getFullText(single_perm->CONNECT()).c_str()),  getLineAndPos(single_perm));
+						}
 						if (single_perm->EXECUTE()
 							|| single_perm->EXEC()
 							|| single_perm->SELECT()
@@ -2377,6 +2381,10 @@ public:
 					for (auto perm: revoke->permissions()->permission())
 					{
 						auto single_perm = perm->single_permission();
+						if (single_perm->CONNECT())
+						{
+							throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR, format_errmsg("Incorrect syntax near '%s'.", ::getFullText(single_perm->CONNECT()).c_str()),  getLineAndPos(single_perm));
+						}
 						if (single_perm->EXECUTE()
 							|| single_perm->EXEC()
 							|| single_perm->SELECT()

--- a/test/JDBC/expected/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/GRANT_SCHEMA.out
@@ -1390,6 +1390,34 @@ go
 drop schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
 go
 
+grant connect on schema::dbo to babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 'connect'.)~~
+
+
+revoke connect on schema::dbo from babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 'connect'.)~~
+
+
+grant connect on object::babel_4344_t1 to babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid privilege type CONNECT for relation)~~
+
+
+revoke connect on object::babel_4344_t1 from babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid privilege type CONNECT for relation)~~
+
+
 use babel_4344_d1;
 go
 revoke select on schema::babel_4344_s1 from public, αιώνια, ログイン;

--- a/test/JDBC/expected/single_db/GRANT_SCHEMA.out
+++ b/test/JDBC/expected/single_db/GRANT_SCHEMA.out
@@ -1390,6 +1390,34 @@ go
 drop schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
 go
 
+grant connect on schema::dbo to babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 'connect'.)~~
+
+
+revoke connect on schema::dbo from babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Incorrect syntax near 'connect'.)~~
+
+
+grant connect on object::babel_4344_t1 to babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid privilege type CONNECT for relation)~~
+
+
+revoke connect on object::babel_4344_t1 from babel_4344_u1;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: invalid privilege type CONNECT for relation)~~
+
+
 use babel_4344_d1;
 go
 revoke select on schema::babel_4344_s1 from public, αιώνια, ログイン;

--- a/test/JDBC/input/GRANT_SCHEMA.mix
+++ b/test/JDBC/input/GRANT_SCHEMA.mix
@@ -927,6 +927,18 @@ go
 drop schema abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwzyzabcdefghijklmnopqrstuvwzyz
 go
 
+grant connect on schema::dbo to babel_4344_u1;
+go
+
+revoke connect on schema::dbo from babel_4344_u1;
+go
+
+grant connect on object::babel_4344_t1 to babel_4344_u1;
+go
+
+revoke connect on object::babel_4344_t1 from babel_4344_u1;
+go
+
 use babel_4344_d1;
 go
 revoke select on schema::babel_4344_s1 from public, αιώνια, ログイン;


### PR DESCRIPTION
### Description

This commit fixes crash happening at exitSecurity_statement when encountering invalid CONNECT permission in GRANT/REVOKE CONNECT ON SCHEMA statements. Added validation checks in tsqlIface.cpp to detect CONNECT permissions in both GRANT and REVOKE operations on schema objects. It throws appropriate syntax error with message when invalid CONNECT permission is encountered.

### Issues Resolved

BABEL-6032

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).