### PR TITLE
Replace GETDATE() with fixed date in test function for deterministic results

### DIFF
--- a/test/JDBC/expected/alter-function-with-weak-view-vu-verify.out
+++ b/test/JDBC/expected/alter-function-with-weak-view-vu-verify.out
@@ -380,7 +380,7 @@ AS
 BEGIN
     RETURN UPPER(LEFT(@category, 3)) + '-' + 
            FORMAT(@order_id, 'D5') + '-' +  -- Changed format
-           FORMAT(GETDATE(), 'yy')
+           FORMAT(CAST('2026-01-01' AS DATE), 'yy')
 END
 GO
 
@@ -388,10 +388,10 @@ SELECT * FROM dbo.order_details_extended -- Should show new order code format
 GO
 ~~START~~
 int#!#varchar#!#numeric#!#varchar#!#int#!#numeric
-1#!#ELE-00001-25#!#100.00#!#Regular#!#10#!#10.00
-2#!#BOO-00002-25#!#200.00#!#Premium#!#45#!#10.00
-3#!#ELE-00003-25#!#500.00#!#Regular#!#10#!#50.00
-4#!#FUR-00004-25#!#1000.00#!#Premium#!#45#!#50.00
+1#!#ELE-00001-26#!#100.00#!#Regular#!#10#!#10.00
+2#!#BOO-00002-26#!#200.00#!#Premium#!#45#!#10.00
+3#!#ELE-00003-26#!#500.00#!#Regular#!#10#!#50.00
+4#!#FUR-00004-26#!#1000.00#!#Premium#!#45#!#50.00
 ~~END~~
 
 

--- a/test/JDBC/input/alter/alter-function-with-weak-view-vu-verify.sql
+++ b/test/JDBC/input/alter/alter-function-with-weak-view-vu-verify.sql
@@ -258,7 +258,7 @@ AS
 BEGIN
     RETURN UPPER(LEFT(@category, 3)) + '-' + 
            FORMAT(@order_id, 'D5') + '-' +  -- Changed format
-           FORMAT(GETDATE(), 'yy')
+           FORMAT(CAST('2026-01-01' AS DATE), 'yy')
 END
 GO
 


### PR DESCRIPTION
### Description

In test file `alter-function-with-weak-view-vu-verify` we were using the dynamic GETDATE() which was returning the current year. As this is not maintainable in the long term, so updating it with a fixed date for deterministic results

Cherry-pick from PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4366
Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).