### PR TITLE
Restrict argument of datatype timestamp in DATEADD() function

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -2058,7 +2058,7 @@ BEGIN
     IF arg_datatype = 'smalldatetime' THEN
         return sys.dateadd_internal_datetime(datepart, num, startdate, 2);
     END IF;
-    IF (arg_datatype = 'datetime' OR arg_datatype = 'timestamp') THEN
+    IF arg_datatype = 'datetime' THEN
         return sys.dateadd_internal_datetime(datepart, num, startdate, 3);
     END IF;
     IF arg_datatype = 'datetime2' THEN
@@ -2067,7 +2067,7 @@ BEGIN
     IF arg_datatype = 'datetimeoffset' THEN
         return sys.dateadd_internal_df(datepart, num, startdate);
     END IF;
-    RAISE EXCEPTION 'Conversion failed when converting date and/or time from %.', pg_typeof(startdate);
+    RAISE EXCEPTION 'Conversion failed when converting date and/or time from %.', arg_datatype;
 END;
 $$
 STRICT

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.8.0--4.9.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.8.0--4.9.0.sql
@@ -145,7 +145,7 @@ BEGIN
     IF arg_datatype = 'smalldatetime' THEN
         return sys.dateadd_internal_datetime(datepart, num, startdate, 2);
     END IF;
-    IF (arg_datatype = 'datetime' OR arg_datatype = 'timestamp') THEN
+    IF arg_datatype = 'datetime' THEN
         return sys.dateadd_internal_datetime(datepart, num, startdate, 3);
     END IF;
     IF arg_datatype = 'datetime2' THEN
@@ -154,7 +154,7 @@ BEGIN
     IF arg_datatype = 'datetimeoffset' THEN
         return sys.dateadd_internal_df(datepart, num, startdate);
     END IF;
-    RAISE EXCEPTION 'Conversion failed when converting date and/or time from %.', pg_typeof(startdate);
+    RAISE EXCEPTION 'Conversion failed when converting date and/or time from %.', arg_datatype;
 END;
 $$
 STRICT

--- a/test/JDBC/expected/dateadd-vu-verify.out
+++ b/test/JDBC/expected/dateadd-vu-verify.out
@@ -315,16 +315,31 @@ int#!#datetime2#!#datetime2
 ~~END~~
 
 
+SELECT ID, UdtTimestamp, DATEADD (DAY, 2, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
+GO
+~~START~~
+int#!#binary#!#binary
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from timestamp.)~~
+
+
 SELECT ID, UdtTimestamp, DATEADD (MONTH, 45, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
 GO
 ~~START~~
 int#!#binary#!#binary
-1#!#323032342D31322D#!#323030382D30332D
-2#!#323033382D30312D#!#323030382D30332D
-3#!#313930302D30312D#!#323030382D30332D
-4#!#323033382D30312D#!#323030382D30332D
-5#!#3230323431323132#!#323030382D30332D
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from timestamp.)~~
+
+
+SELECT ID, UdtTimestamp, DATEADD (SECOND, 464, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
+GO
+~~START~~
+int#!#binary#!#binary
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Conversion failed when converting date and/or time from timestamp.)~~
 
 
 SELECT ID, UdtSmalldatetime, DATEADD (YEAR, 9, UdtSmalldatetime) AS UDTSMALLDATETIME FROM UdtTable

--- a/test/JDBC/input/dateFunctions/dateadd-vu-verify.sql
+++ b/test/JDBC/input/dateFunctions/dateadd-vu-verify.sql
@@ -127,7 +127,13 @@ GO
 SELECT ID, UdtDatetime2, DATEADD (WEEK, 15, UdtDatetime2) AS UDTDATETIME2 FROM UdtTable
 GO
 
+SELECT ID, UdtTimestamp, DATEADD (DAY, 2, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
+GO
+
 SELECT ID, UdtTimestamp, DATEADD (MONTH, 45, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
+GO
+
+SELECT ID, UdtTimestamp, DATEADD (SECOND, 464, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
 GO
 
 SELECT ID, UdtSmalldatetime, DATEADD (YEAR, 9, UdtSmalldatetime) AS UDTSMALLDATETIME FROM UdtTable


### PR DESCRIPTION
### Raise exception while calling DATEADD() on UDT from timestamp datatype

Currently in Babelfish, we can implement `DATEADD()` function on UDT from timestamp. But in TSQL we do not support creation of UDT on timestamp datatype
   ```
   -- TSQL
   1> CREATE TYPE UDT_TIMESTAMP FROM TIMESTAMP NOT NULL
   2> GO
   Msg 222, Level 16, State 1, Server EC2AMAZ-AEV9H40, Line 1
   The base type "timestamp" is not a valid base type for the alias data type.
   ```
With this change we raise an exception while calling `DATEADD()` on UDT from timestamp datatype in Babelfish
   ```
   -- Babelfish
   1> SELECT ID, UdtTimestamp, DATEADD (MONTH, 45, UdtTimestamp) AS UDTTIMESTAMP FROM UdtTable
   2> GO
   Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
   Conversion failed when converting date and/or time from timestamp.
   ```

Authored-by: Jaspal Singh [ijaspals@amazon.com](mailto:ijaspals@amazon.com)
Signed-off-by: Jaspal Singh [ijaspals@amazon.com](mailto:ijaspals@amazon.com)

### Issues Resolved
BABEL-5844

### Test Scenarios Covered ###
* **Use case based -** YES


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**  YES


* **Minor version upgrade tests -**  YES


* **Major version upgrade tests -**  YES


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).