### PR TITLE
[OSS-ONLY] Added hook for checking if an object is part of a ENR temp table or not (#4378)

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -16,7 +16,10 @@
 #include "catalog/objectaccess.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_attrdef_d.h"
+#include "catalog/pg_attrdef.h"
 #include "catalog/pg_authid.h"
+#include "catalog/pg_constraint.h"
+#include "catalog/pg_database.h"
 #include "catalog/pg_db_role_setting.h"
 #include "catalog/pg_depend.h"	/* Required in handle_bbf_view_binding_on_object_drop to access pg_rewrite dependencies */
 #include "catalog/pg_namespace.h"
@@ -27,6 +30,7 @@
 #include "catalog/pg_rewrite.h"
 #include "catalog/pg_operator.h"
 #include "catalog/pg_tablespace.h"
+#include "catalog/pg_sequence.h"
 #include "commands/copy.h"
 #include "commands/comment.h"
 #include "commands/dbcommands.h"
@@ -76,6 +80,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/numeric.h"
+#include "utils/queryenvironment.h"
 #include <math.h>
 #include "pgstat.h"
 #include "executor/nodeFunctionscan.h"
@@ -268,6 +273,9 @@ static Oid 	pltsql_GetNewTempOidWithIndex(Relation relation, Oid indexId, AttrNu
 static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
 static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
 static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
+static EphemeralNamedRelation find_object_in_enr(Oid catalog_oid, Oid object_id);
+static bool verify_stmt_alterdatabaseset(Node* n, const char* dbname, const char* config);
+PG_FUNCTION_INFO_V1(persist_temp_oid_buffer_start_internal);
 
 /*********************************************************
  * 			Weak Binding Views Related Declarations
@@ -309,6 +317,7 @@ static GetNewTempObjectId_hook_type prev_GetNewTempObjectId_hook = NULL;
 static GetNewTempOidWithIndex_hook_type prev_GetNewTempOidWithIndex_hook = NULL;
 static pltsql_is_local_only_inval_msg_hook_type prev_pltsql_is_local_only_inval_msg_hook = NULL;
 static pltsql_get_tsql_enr_from_oid_hook_type prev_pltsql_get_tsql_enr_from_oid_hook = NULL;
+static find_object_in_enr_hook_type prev_find_object_in_enr_hook = NULL;
 static inherit_view_constraints_from_table_hook_type prev_inherit_view_constraints_from_table = NULL;
 static bbfViewHasInsteadofTrigger_hook_type prev_bbfViewHasInsteadofTrigger_hook = NULL;
 static adjust_numeric_result_hook_type prev_adjust_numeric_result_hook = NULL;
@@ -453,6 +462,9 @@ InstallExtendedHooks(void)
 
 	prev_pltsql_get_tsql_enr_from_oid_hook = pltsql_get_tsql_enr_from_oid_hook;
 	pltsql_get_tsql_enr_from_oid_hook = pltsql_get_tsql_enr_from_oid;
+
+	prev_find_object_in_enr_hook = find_object_in_enr_hook;
+	find_object_in_enr_hook = find_object_in_enr;
 
 	prev_inherit_view_constraints_from_table = inherit_view_constraints_from_table_hook;
 	inherit_view_constraints_from_table_hook = preserve_view_constraints_from_base_table;
@@ -640,6 +652,7 @@ UninstallExtendedHooks(void)
 	GetNewObjectId_hook = prev_GetNewObjectId_hook;
 	GetNewTempObjectId_hook = prev_GetNewTempObjectId_hook;
 	GetNewTempOidWithIndex_hook = prev_GetNewTempOidWithIndex_hook;
+	find_object_in_enr_hook = prev_find_object_in_enr_hook;
 	inherit_view_constraints_from_table_hook = prev_inherit_view_constraints_from_table;
 	bbfViewHasInsteadofTrigger_hook = prev_bbfViewHasInsteadofTrigger_hook;
 	adjust_numeric_result_hook = prev_adjust_numeric_result_hook;
@@ -7822,6 +7835,119 @@ tsql_set_typmod_aggref(ParseState *pstate, Node *AggExp)
 	if (aggFuncName)
 		pfree(aggFuncName);
 	return AggExp;
+}
+
+/*
+ * For find_object_in_enr_hook
+ *
+ * Returns the ENR in which the given object (denoted by its catalog oid and object id)
+ * exists. Based on the catalog we are searching the object in, the search criteria changes.
+ */
+static EphemeralNamedRelation
+find_object_in_enr(Oid catalog_oid, Oid object_id)
+{
+	QueryEnvironment 		*queryEnv = currentQueryEnv;
+	ListCell         		*curlc;
+	EphemeralNamedRelation	enr;
+
+	while (queryEnv)
+	{
+		switch (catalog_oid) {
+			case RelationRelationId:
+				{
+					if ((enr = get_ENR_withoid(queryEnv, object_id, ENR_TSQL_TEMP, false)))
+						return enr;
+					break;
+				}
+			case TypeRelationId:
+				{
+					foreach(curlc, queryEnv->namedRelList) {
+						EphemeralNamedRelation tmp_enr;
+						ListCell *type_lc;
+
+						tmp_enr = (EphemeralNamedRelation) lfirst(curlc);
+						if (tmp_enr->md.enrtype != ENR_TSQL_TEMP)
+							continue;
+
+						foreach(type_lc, tmp_enr->md.cattups[ENR_CATTUP_TYPE])
+						{
+							Form_pg_type tup = ((Form_pg_type)GETSTRUCT((HeapTuple)lfirst(type_lc)));
+							if (tup->oid == object_id)
+								return tmp_enr;
+						}
+						foreach(type_lc, tmp_enr->md.cattups[ENR_CATTUP_ARRAYTYPE])
+						{
+							Form_pg_type tup = ((Form_pg_type)GETSTRUCT((HeapTuple)lfirst(type_lc)));
+							if (tup->oid == object_id)
+								return tmp_enr;
+						}
+					}
+					break;
+				}
+			case ConstraintRelationId:
+				{
+					foreach(curlc, queryEnv->namedRelList) {
+						EphemeralNamedRelation tmp_enr;
+						ListCell *cons_lc;
+
+						tmp_enr = (EphemeralNamedRelation) lfirst(curlc);
+						if (tmp_enr->md.enrtype != ENR_TSQL_TEMP)
+							continue;
+
+						foreach(cons_lc, tmp_enr->md.cattups[ENR_CATTUP_CONSTRAINT])
+						{
+							Form_pg_constraint tup = ((Form_pg_constraint)GETSTRUCT((HeapTuple)lfirst(cons_lc)));
+							if (tup->oid == object_id)
+								return tmp_enr;
+						}
+					}
+					break;
+				}
+			case AttrDefaultRelationId:
+				{
+					foreach(curlc, queryEnv->namedRelList) {
+						EphemeralNamedRelation tmp_enr;
+						ListCell *attrdef_lc;
+
+						tmp_enr = (EphemeralNamedRelation) lfirst(curlc);
+						if (tmp_enr->md.enrtype != ENR_TSQL_TEMP)
+							continue;
+
+						foreach(attrdef_lc, tmp_enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL])
+						{
+							Form_pg_attrdef tup = ((Form_pg_attrdef)GETSTRUCT((HeapTuple)lfirst(attrdef_lc)));
+							if (tup->oid == object_id)
+								return tmp_enr;
+						}
+					}
+					break;
+				}
+			case SequenceRelationId:
+				{
+					foreach(curlc, queryEnv->namedRelList) {
+						EphemeralNamedRelation tmp_enr;
+						ListCell *seq_lc;
+
+						tmp_enr = (EphemeralNamedRelation) lfirst(curlc);
+						if (tmp_enr->md.enrtype != ENR_TSQL_TEMP)
+							continue;
+
+						foreach(seq_lc, tmp_enr->md.cattups[ENR_CATTUP_SEQUENCE])
+						{
+							Form_pg_sequence tup = ((Form_pg_sequence)GETSTRUCT((HeapTuple)lfirst(seq_lc)));
+							if (tup->seqrelid == object_id)
+								return tmp_enr;
+						}
+					}
+					break;
+				}
+
+			default:
+				break;
+		}
+		queryEnv = queryEnv->parentEnv;
+	}
+	return NULL;
 }
 
 static Node*

--- a/test/JDBC/expected/temp_tables_concurrent-vu-cleanup.out
+++ b/test/JDBC/expected/temp_tables_concurrent-vu-cleanup.out
@@ -7,3 +7,10 @@ GO
 --tsql user=u2 password=123
 DROP TABLE non_temp_table_2
 GO
+
+-- tsql
+DROP LOGIN templogin1
+GO
+
+DROP LOGIN templogin2
+GO

--- a/test/JDBC/expected/temp_tables_concurrent-vu-prepare.out
+++ b/test/JDBC/expected/temp_tables_concurrent-vu-prepare.out
@@ -7,3 +7,10 @@ GO
 --tsql user=u2 password=123
 CREATE TABLE non_temp_table_2(a int)
 GO
+
+-- tsql
+CREATE LOGIN templogin1 WITH PASSWORD='123'
+GO
+
+CREATE LOGIN templogin2 WITH PASSWORD='123'
+GO

--- a/test/JDBC/expected/temp_tables_concurrent-vu-verify.out
+++ b/test/JDBC/expected/temp_tables_concurrent-vu-verify.out
@@ -43,3 +43,31 @@ int
 DROP TABLE #temp_table_t1
 DROP TABLE #temp_table_t2
 GO
+
+-- tsql user=templogin1 password=123
+CREATE TABLE #temptable1(a INT);
+GO
+
+-- tsql user=templogin2 password=123
+CREATE TABLE #temptable1(a INT);
+GO
+
+-- tsql user=templogin1 password=123
+BEGIN TRAN
+GO
+DROP TABLE #temptable1
+GO
+
+-- tsql user=templogin2 password=123
+BEGIN TRAN
+GO
+DROP TABLE #temptable1
+GO
+
+-- tsql user=templogin1 password=123
+COMMIT
+GO
+
+-- tsql user=templogin2 password=123
+ROLLBACK
+GO

--- a/test/JDBC/input/temp_tables/temp_tables_concurrent-vu-cleanup.mix
+++ b/test/JDBC/input/temp_tables/temp_tables_concurrent-vu-cleanup.mix
@@ -7,3 +7,10 @@ GO
 
 DROP TABLE non_temp_table_2
 GO
+
+-- tsql
+DROP LOGIN templogin1
+GO
+
+DROP LOGIN templogin2
+GO

--- a/test/JDBC/input/temp_tables/temp_tables_concurrent-vu-prepare.mix
+++ b/test/JDBC/input/temp_tables/temp_tables_concurrent-vu-prepare.mix
@@ -7,3 +7,10 @@ GO
 
 CREATE TABLE non_temp_table_2(a int)
 GO
+
+-- tsql
+CREATE LOGIN templogin1 WITH PASSWORD='123'
+GO
+
+CREATE LOGIN templogin2 WITH PASSWORD='123'
+GO

--- a/test/JDBC/input/temp_tables/temp_tables_concurrent-vu-verify.mix
+++ b/test/JDBC/input/temp_tables/temp_tables_concurrent-vu-verify.mix
@@ -33,3 +33,31 @@ GO
 DROP TABLE #temp_table_t1
 DROP TABLE #temp_table_t2
 GO
+
+-- tsql user=templogin1 password=123
+CREATE TABLE #temptable1(a INT);
+GO
+
+-- tsql user=templogin2 password=123
+CREATE TABLE #temptable1(a INT);
+GO
+
+-- tsql user=templogin1 password=123
+BEGIN TRAN
+GO
+DROP TABLE #temptable1
+GO
+
+-- tsql user=templogin2 password=123
+BEGIN TRAN
+GO
+DROP TABLE #temptable1
+GO
+
+-- tsql user=templogin1 password=123
+COMMIT
+GO
+
+-- tsql user=templogin2 password=123
+ROLLBACK
+GO


### PR DESCRIPTION

### Description

Added a hook which, given a catalog id and object id, checks if it is part of a ENR temp table Added tests for checking concurrent operations on temp tables should not be blocking.

Task: BABEL-5971
Original PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4378

#### Merge conflict

```
>>>> HEAD
/*
 * For find_object_in_enr_hook
 *
 * Returns the ENR in which the given object (denoted by its catalog oid and object id)
 * exists. Based on the catalog we are searching the object in, the search criteria changes.
 */
static EphemeralNamedRelation
find_object_in_enr(Oid catalog_oid, Oid object_id)
====== 
static Node*
tsql_set_typmod_aggref(ParseState *pstate, Node *AggExp)
```

(cherry picked from commit 3e1f4836339afe99d58375a1b7f46d2aec44b038)

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).