### PR TITLE
Setting recurse to true for cases where we want to find the ENRs by traversing parent queryEnvs (#4334)

### DIFF
--- a/contrib/babelfishpg_tsql/runtime/functions.c
+++ b/contrib/babelfishpg_tsql/runtime/functions.c
@@ -2799,7 +2799,7 @@ object_name(PG_FUNCTION_ARGS)
 	 * search in list of ENRs registered in the current query environment by
 	 * object_id
 	 */
-	enr = GetENRTempTableWithOid(object_id);
+	enr = GetENRTempTableWithOid(object_id, false);
 	if (enr != NULL && enr->md.enrtype == ENR_TSQL_TEMP)
 	{
 		PG_RETURN_VARCHAR_P((VarChar *) cstring_to_text(enr->md.name));

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -5165,7 +5165,7 @@ pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg)
 static EphemeralNamedRelation
 pltsql_get_tsql_enr_from_oid(const Oid oid)
 {
-	return temp_oid_buffer_size > 0 ? GetENRTempTableWithOid(oid) : NULL;
+	return temp_oid_buffer_size > 0 ? GetENRTempTableWithOid(oid, true) : NULL;
 }
 
 /*

--- a/test/JDBC/expected/temp_table_visibility-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-cleanup.out
@@ -15,3 +15,27 @@ go
 
 drop procedure object_id_inner_proc
 go
+
+drop procedure p_truncate
+go
+
+drop procedure p_nested
+go
+
+drop procedure p_insert
+go
+
+drop procedure p_alter_add_col
+go
+
+drop procedure p_nested_2
+go
+
+drop procedure p_index_create
+go
+
+drop procedure p_drop
+go
+
+drop view enr_view
+go

--- a/test/JDBC/expected/temp_table_visibility-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-prepare.out
@@ -8,6 +8,16 @@ AS
     end
 go
 
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
 
 
 CREATE PROCEDURE object_id_outer_proc
@@ -50,3 +60,43 @@ create proc babel_4122_proc @tabname varchar(30) as
     end
 go
 
+CREATE PROC p_truncate AS TRUNCATE TABLE #temptable5605
+GO
+CREATE PROC p_nested AS 
+BEGIN
+	CREATE TABLE #temptable5605(a INT);
+	INSERT INTO #temptable5605 VALUES (GENERATE_SERIES(1,100));
+	EXEC p_truncate
+	SELECT COUNT(*) FROM #temptable5605;
+	EXEC p_insert 100;
+	SELECT COUNT(*) FROM #temptable5605;
+END;
+GO
+CREATE PROC p_insert(@a INT) AS INSERT INTO #temptable5605 VALUES (@a);
+GO
+CREATE PROC p_alter_add_col AS ALTER TABLE #temptable5605 ADD newcol BIGINT DEFAULT 0;
+GO
+CREATE PROC p_nested_2 AS
+BEGIN
+	INSERT INTO #temptable5605 VALUES (GENERATE_SERIES(1,100)); -- inserts 100 tuples
+	SELECT COUNT(*) FROM #temptable5605; 						-- shows 200 tuples
+	EXEC p_insert 101										-- inserts 1 tuple
+	SELECT COUNT(*) FROM #temptable5605;						-- shows 201 tuples
+	CREATE TABLE #temptable5605(a INT, b INT IDENTITY(1,1));	-- noOp; creates temp table
+	INSERT INTO #temptable5605(a) VALUES (1), (2);				-- inserts 2 tuple
+	SELECT COUNT(*) FROM #temptable5605;						-- shows 2 tuples
+	EXEC p_nested;
+	SELECT COUNT(*) FROM #temptable5605;						-- shows 2 tuples
+	EXEC p_alter_add_col									-- add newcol
+	SELECT SUM(newcol) FROM #temptable5605						-- returns 0 as sum
+END;
+GO
+CREATE PROC p_drop AS DROP TABLE #temptable5605;
+GO
+CREATE PROC p_index_create
+AS 
+BEGIN
+	CREATE INDEX idx ON #temptable5605(generate_series);
+	SELECT * FROM enr_view;
+END;
+GO

--- a/test/JDBC/expected/temp_table_visibility-vu-verify.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-verify.out
@@ -49,3 +49,93 @@ int
 456
 ~~END~~
 
+
+SELECT * INTO #temptable5605 FROM generate_series(1,100);
+GO
+EXEC p_nested
+GO
+~~ROW COUNT: 100~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+SELECT COUNT(*) FROM #temptable5605
+GO
+~~START~~
+int
+100
+~~END~~
+
+EXEC p_nested_2
+GO
+~~ROW COUNT: 100~~
+
+~~START~~
+int
+200
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+201
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~ROW COUNT: 100~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+bigint
+0
+~~END~~
+
+EXEC p_index_create
+GO
+~~START~~
+text
+idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
+#t4122
+#temptable5605
+~~END~~
+
+EXEC p_drop
+GO
+SELECT * FROM #temptable5605
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "#temptable5605" does not exist)~~
+

--- a/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
+++ b/test/JDBC/input/BABEL-SP_COLUMN_PRIVILEGES.mix
@@ -1,3 +1,4 @@
+-- sla 60000
 -- tsql
 CREATE DATABASE db1
 GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-cleanup.sql
@@ -15,3 +15,27 @@ go
 
 drop procedure object_id_inner_proc
 go
+
+drop procedure p_truncate
+go
+
+drop procedure p_nested
+go
+
+drop procedure p_insert
+go
+
+drop procedure p_alter_add_col
+go
+
+drop procedure p_nested_2
+go
+
+drop procedure p_index_create
+go
+
+drop procedure p_drop
+go
+
+drop view enr_view
+go

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-prepare.sql
@@ -8,6 +8,16 @@ AS
     end
 go
 
+CREATE VIEW enr_view AS
+    SELECT
+        CASE
+            WHEN relname LIKE '#pg_toast%' AND relname LIKE '%index%' THEN '#pg_toast_#oid_masked#_index'
+            WHEN relname LIKE '#pg_toast%' THEN '#pg_toast_#oid_masked#'
+            ELSE relname
+        END AS relname
+    FROM sys.babelfish_get_enr_list()
+GO
+
 CREATE PROCEDURE object_id_outer_proc
 AS
     CREATE TABLE #tmp(i INT)    
@@ -50,3 +60,43 @@ create proc babel_4122_proc @tabname varchar(30) as
     end
 go
 
+CREATE PROC p_truncate AS TRUNCATE TABLE #temptable5605
+GO
+CREATE PROC p_nested AS 
+BEGIN
+	CREATE TABLE #temptable5605(a INT);
+	INSERT INTO #temptable5605 VALUES (GENERATE_SERIES(1,100));
+	EXEC p_truncate
+	SELECT COUNT(*) FROM #temptable5605;
+	EXEC p_insert 100;
+	SELECT COUNT(*) FROM #temptable5605;
+END;
+GO
+CREATE PROC p_insert(@a INT) AS INSERT INTO #temptable5605 VALUES (@a);
+GO
+CREATE PROC p_alter_add_col AS ALTER TABLE #temptable5605 ADD newcol BIGINT DEFAULT 0;
+GO
+CREATE PROC p_nested_2 AS
+BEGIN
+	INSERT INTO #temptable5605 VALUES (GENERATE_SERIES(1,100)); -- inserts 100 tuples
+	SELECT COUNT(*) FROM #temptable5605; 						-- shows 200 tuples
+	EXEC p_insert 101										-- inserts 1 tuple
+	SELECT COUNT(*) FROM #temptable5605;						-- shows 201 tuples
+	CREATE TABLE #temptable5605(a INT, b INT IDENTITY(1,1));	-- noOp; creates temp table
+	INSERT INTO #temptable5605(a) VALUES (1), (2);				-- inserts 2 tuple
+	SELECT COUNT(*) FROM #temptable5605;						-- shows 2 tuples
+	EXEC p_nested;
+	SELECT COUNT(*) FROM #temptable5605;						-- shows 2 tuples
+	EXEC p_alter_add_col									-- add newcol
+	SELECT SUM(newcol) FROM #temptable5605						-- returns 0 as sum
+END;
+GO
+CREATE PROC p_drop AS DROP TABLE #temptable5605;
+GO
+CREATE PROC p_index_create
+AS 
+BEGIN
+	CREATE INDEX idx ON #temptable5605(generate_series);
+	SELECT * FROM enr_view;
+END;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
@@ -18,3 +18,18 @@ go
 
 exec babel_4122_proc '#t4122'
 go
+
+SELECT * INTO #temptable5605 FROM generate_series(1,100);
+GO
+EXEC p_nested
+GO
+SELECT COUNT(*) FROM #temptable5605
+GO
+EXEC p_nested_2
+GO
+EXEC p_index_create
+GO
+EXEC p_drop
+GO
+SELECT * FROM #temptable5605
+GO


### PR DESCRIPTION
### Description

    Function - pltsql_get_tsql_enr_from_oid is used in the below cases -
        lmgr -> within CheckRelationLockedByMe to check if the given relation is locked by a bknd. this is safe to go over parent queryEnvs.
        lock -> when trying to acquire a lock on a rel. This is what causes the waiting when trying to operate on temp table in the parent queryEnv scope. we've also verified the behaviour with TSQL.
        inval -> when deciding whether we want to put inval msg in the SI queue. This is also not a problem.
        We will want to go recursively to search for ENR in all cases; hence setting recurse to true.

    Function - object_name is used for getting the name given obj_oid and db_oid. But in TSQL, temp tables do not have a object_id and hence object_name also does not work. Hence, in this case, we will keep the recurse = false.

Tasks: BABEL-5605, BABEL-6192

Original Extension PR: babelfish-for-postgresql/babelfish_extensions#4334


(cherry picked from commit 1c3395ef9860c7fcfb803c2a7d44fe4a87adfdaf)

#### No merge conflicts


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).