### PR TITLE
Fixing typmod for MIN()/MAX() on CHAR/NCHAR datatypes

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -8303,6 +8303,44 @@ find_all_view_references(Node *node, List **view_oids)
 }
 
 static Node*
+tsql_set_typmod_aggref(ParseState *pstate, Node *AggExp)
+{
+	Aggref		*aggref = (Aggref *) AggExp;
+	char		*aggFuncName = get_func_name(aggref->aggfnoid);
+
+	/* Handle MIN/MAX for char/nchar types to preserve typmod */
+	if (aggref->args && aggFuncName && strlen(aggFuncName) == 3 &&
+		(strncmp(aggFuncName, "min", 3) == 0 || strncmp(aggFuncName, "max", 3) == 0) &&
+		((*common_utility_plugin_ptr->is_tsql_bpchar_datatype)(aggref->aggtype) ||
+		 (*common_utility_plugin_ptr->is_tsql_nchar_datatype)(aggref->aggtype)))
+	{
+		TargetEntry	*te = (TargetEntry *) linitial(aggref->args);
+		Oid			expr_type = exprType((Node *) te->expr);
+
+		/* Only process if input type matches aggregate type */
+		if ((*common_utility_plugin_ptr->is_tsql_bpchar_datatype)(expr_type) ||
+			(*common_utility_plugin_ptr->is_tsql_nchar_datatype)(expr_type))
+		{
+			int32	rettypmod = exprTypmod((Node *) te->expr);
+
+			if (rettypmod != -1)
+			{
+				AggExp = coerce_to_target_type(pstate, AggExp,
+											 exprType(AggExp),
+											 aggref->aggtype,
+											 rettypmod,
+											 COERCION_IMPLICIT,
+											 COERCE_IMPLICIT_CAST,
+											 -1);
+			}
+		}
+	}
+	if (aggFuncName)
+		pfree(aggFuncName);
+	return AggExp;
+}
+
+static Node*
 tsql_set_typmod_op_expr(ParseState *pstate, Node *OpExp, Node *lexpr, Node* rexpr)
 {
 		OpExpr				*op = (OpExpr *) OpExp;
@@ -8387,6 +8425,11 @@ pltsql_post_transform_expr_recurse(ParseState *pstate, Node *expr)
 			}
 			break;
 		}
+		case T_Aggref:
+			{
+				expr = tsql_set_typmod_aggref(pstate, expr);
+				break;
+			}
 
 		default:
 			break;

--- a/test/JDBC/expected/TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup.out
+++ b/test/JDBC/expected/TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup.out
@@ -1,0 +1,33 @@
+DROP VIEW TestDatatypeAggSort_vu_prepare_char_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_char_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_varchar_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_varchar_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_min
+go
+
+DROP PROCEDURE TestDatatypeAggSort_vu_prepare_proc
+go
+
+DROP TABLE TestDatatypeAggSort_vu_prepare_tbl
+go
+
+DROP TABLE TestDatatypeAggSort_vu_prepare_tbl2
+go

--- a/test/JDBC/expected/TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare.out
+++ b/test/JDBC/expected/TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare.out
@@ -1,0 +1,165 @@
+CREATE TABLE TestDatatypeAggSort_vu_prepare_tbl (
+	char_col CHAR(10), 
+	varchar_col VARCHAR(10),
+	datetime_col DATETIME,
+	datetime2_col DATETIME2,
+	datetimeoffset_col DATETIMEOFFSET,
+	smalldatetime_col SMALLDATETIME,
+);
+go
+
+INSERT INTO TestDatatypeAggSort_vu_prepare_tbl VALUES (
+	'abc', 'abc',
+	'1900-01-01 00:00:00.000',
+	'1900-01-01 00:00:00.000',
+	'1900-01-01 00:00:00.000 +0:00',
+	'1900-01-01 00:00:00.000'
+), (
+	'def', 'def',
+	'1950-01-01 00:00:00.000',
+	'1950-01-01 00:00:00.000',
+	'1950-01-01 00:00:00.000 +0:00',
+	'1950-01-01 00:00:00.000'
+), (
+	'ghi', 'ghi',
+	'2000-01-01 00:00:00.000',
+	'2000-01-01 00:00:00.000',
+	'2000-01-01 00:00:00.000 +0:00',
+	'2000-01-01 00:00:00.000'
+), (
+	'jkl', 'jkl',
+	'2005-01-01 00:00:00.000',
+	'2005-01-01 00:00:00.000',
+	'2005-01-01 00:00:00.000 +0:00',
+	'2005-01-01 00:00:00.000'
+), (
+	'mno', 'mno',
+	'2010-01-01 00:00:00.000',
+	'2010-01-01 00:00:00.000',
+	'2010-01-01 00:00:00.000 +0:00',
+	'2010-01-01 00:00:00.000'
+), (
+	'pqr', 'pqr',
+	'2015-01-01 00:00:00.000',
+	'2015-01-01 00:00:00.000',
+	'2015-01-01 00:00:00.000 +0:00',
+	'2015-01-01 00:00:00.000'
+), (
+	'stu', 'stu',
+	'2020-01-01 00:00:00.000',
+	'2020-01-01 00:00:00.000',
+	'2020-01-01 00:00:00.000 +0:00',
+	'2020-01-01 00:00:00.000'
+), (
+	'xyz', 'xyz',
+	'2023-11-06 00:00:00.000',
+	'2023-11-06 00:00:00.000',
+	'2023-11-06 00:00:00.000 +0:00',
+	'2023-11-06 00:00:00.000'
+), (
+	NULL, NULL, NULL, NULL, NULL, NULL
+);
+go
+~~ROW COUNT: 9~~
+
+
+CREATE INDEX TestDatatypeAggSort_vu_prepare_char_idx ON TestDatatypeAggSort_vu_prepare_tbl (char_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_varchar_idx ON TestDatatypeAggSort_vu_prepare_tbl (varchar_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_datetime_idx ON TestDatatypeAggSort_vu_prepare_tbl (datetime_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_datetime2_idx ON TestDatatypeAggSort_vu_prepare_tbl (datetime2_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_datetimeoffset_idx ON TestDatatypeAggSort_vu_prepare_tbl (datetimeoffset_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_smalldatetime_idx ON TestDatatypeAggSort_vu_prepare_tbl (smalldatetime_col)
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_char_view_max AS
+SELECT MAX(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_char_view_min AS
+SELECT MIN(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_varchar_view_max AS
+SELECT MAX(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_varchar_view_min AS
+SELECT MIN(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime_view_max AS
+SELECT MAX(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime_view_min AS
+SELECT MIN(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_max AS
+SELECT MAX(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_min AS
+SELECT MIN(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_max AS
+SELECT MAX(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_min AS
+SELECT MIN(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_max AS
+SELECT MAX(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_min AS
+SELECT MIN(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE TABLE TestDatatypeAggSort_vu_prepare_tbl2 (
+	max_min VARCHAR(3),
+	char_col CHAR(10), 
+	varchar_col VARCHAR(10),
+	datetime_col DATETIME,
+	datetime2_col DATETIME2(6),
+	datetimeoffset_col DATETIMEOFFSET,
+	smalldatetime_col SMALLDATETIME,
+);
+go
+
+
+
+
+
+CREATE PROCEDURE TestDatatypeAggSort_vu_prepare_proc AS
+BEGIN
+	DECLARE @char_val CHAR(10)
+	DECLARE @varchar_val VARCHAR(10)
+	DECLARE @datetime_val DATETIME
+	DECLARE @datetime2_val DATETIME2
+	DECLARE @datetimeoffset_val DATETIMEOFFSET
+	DECLARE @smalldatetime_val SMALLDATETIME
+	SET @char_val = (SELECT MAX(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @varchar_val = (SELECT MAX(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime_val = (SELECT MAX(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime2_val = (SELECT MAX(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetimeoffset_val = (SELECT MAX(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @smalldatetime_val = (SELECT MAX(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	INSERT INTO TestDatatypeAggSort_vu_prepare_tbl2 VALUES (
+		'max', @char_val, @varchar_val, @datetime_val, @datetime2_val,
+		@datetimeoffset_val, @smalldatetime_val
+	)
+	SET @char_val = (SELECT MIN(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @varchar_val = (SELECT MIN(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime_val = (SELECT MIN(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime2_val = (SELECT MIN(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetimeoffset_val = (SELECT MIN(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @smalldatetime_val = (SELECT MIN(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	INSERT INTO TestDatatypeAggSort_vu_prepare_tbl2 VALUES (
+		'min', @char_val, @varchar_val, @datetime_val, @datetime2_val,
+		@datetimeoffset_val, @smalldatetime_val
+	)
+END
+go

--- a/test/JDBC/expected/TestDatatypeAggSort-before-16_12-or-17_8-vu-verify.out
+++ b/test/JDBC/expected/TestDatatypeAggSort-before-16_12-or-17_8-vu-verify.out
@@ -1,16 +1,14 @@
 SELECT * FROM TestDatatypeAggSort_vu_prepare_char_view_max
 go
-~~START~~
-char
-xyz       
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The string size for the given CHAR/NCHAR data is not defined. Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n))~~
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_char_view_min
 go
-~~START~~
-char
-abc       
-~~END~~
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: The string size for the given CHAR/NCHAR data is not defined. Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n))~~
 
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_varchar_view_max

--- a/test/JDBC/expected/db_collation/string_aggregate-vu-verify.out
+++ b/test/JDBC/expected/db_collation/string_aggregate-vu-verify.out
@@ -1,0 +1,1315 @@
+-- Test basic
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar, MAX(col_varchar) AS max_varchar 
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               #!# Apple #!#Zebra#!# Apple #!#Zebra
+~~END~~
+
+
+
+-- Test with GROUP BY and ORDER BY
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              #!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          
+NullTest#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+NumericStr#!#1                   #!#1                   #!#1                   #!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#!Special            #!##Hash               
+~~END~~
+
+
+select min(col_char) FROM babel_5688_all_types GROUP BY col_nchar ORDER BY col_nchar
+go
+~~START~~
+char
+<NULL>
+ Apple              
+!Special            
+#Hash               
+1                   
+AAAAAAAAAA          
+Apple               
+Orange              
+Zebra               
+~~END~~
+
+
+
+-- Test with having clause 
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar,
+    COUNT(*) AS cnt
+FROM babel_5688_all_types
+GROUP BY col_category
+HAVING MIN(col_nchar) IS NOT NULL AND MAX(col_nchar) IS NOT NULL
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#int
+Animal#!#Zebra               #!#Zebra               #!#1
+Fruit#!# Apple              #!#Orange              #!#3
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#1
+NumericStr#!#1                   #!#1                   #!#1
+SpecialChar#!#!Special            #!##Hash               #!#2
+~~END~~
+
+
+
+-- Test Where clause 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar
+FROM babel_5688_all_types
+WHERE col_category = 'Fruit';
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+ Apple              #!#Orange              #!# Apple              #!#Orange              #!# Apple #!#Orange#!# Apple 
+~~END~~
+
+
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               
+~~END~~
+
+
+
+-- Test distinct
+SELECT 
+    MIN(DISTINCT col_nchar) AS min_distinct_nchar, MAX(DISTINCT col_nchar) AS max_distinct_nchar,
+    MIN(DISTINCT col_char) AS min_distinct_char, MAX(DISTINCT col_char) AS max_distinct_char,
+    MIN(DISTINCT col_nvarchar) AS min_distinct_nvarchar, MAX(DISTINCT col_nvarchar) AS max_distinct_nvarchar,
+    MIN(DISTINCT col_varchar) AS min_distinct_varchar
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               #!# Apple #!#Zebra#!# Apple 
+~~END~~
+
+
+
+-- Test subquery
+SELECT * FROM babel_5688_all_types WHERE col_nchar = (SELECT MIN(col_nchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_char = (SELECT MIN(col_char) FROM babel_5688_all_types WHERE col_char IS NOT NULL);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_nvarchar = (SELECT MIN(col_nvarchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_varchar = (SELECT MIN(col_varchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+
+
+-- Test UNION ALL
+SELECT 'NCHAR' AS col_type, MIN(col_nchar) AS min_val, MAX(col_nchar) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT 'CHAR' AS col_type, MIN(col_char) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_char IS NOT NULL
+UNION ALL
+SELECT 'NVARCHAR' AS col_type, MIN(col_nvarchar) AS min_val, MAX(col_nvarchar) AS max_val FROM babel_5688_all_types WHERE col_nvarchar IS NOT NULL
+ORDER BY col_type;
+GO
+~~START~~
+varchar#!#nvarchar#!#nvarchar
+CHAR#!# Apple              #!#Zebra               
+NCHAR#!# Apple              #!#Zebra               
+NVARCHAR#!# Apple #!#Zebra
+~~END~~
+
+
+SELECT MIN(col_nchar) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table2 WHERE col1_char IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table3 WHERE col1_char IS NOT NULL
+ORDER BY min_val;
+GO
+~~START~~
+nchar#!#char
+<NULL>#!#<NULL>
+ Apple              #!#Zebra               
+Cherry              #!#Date                
+~~END~~
+
+
+
+-- Test CTEs
+WITH MinMaxCTE AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_nchar,
+        MAX(col_nchar) AS max_nchar,
+        MIN(col_char) AS min_char,
+        MAX(col_char) AS max_char
+    FROM babel_5688_all_types
+    GROUP BY col_category
+)
+SELECT * FROM MinMaxCTE WHERE min_nchar IS NOT NULL ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              #!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          
+NumericStr#!#1                   #!#1                   #!#1                   #!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#!Special            #!##Hash               
+~~END~~
+
+
+WITH CategoryStats AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val,
+        COUNT(*) AS cnt
+    FROM babel_5688_all_types
+    WHERE col_nchar IS NOT NULL
+    GROUP BY col_category
+)
+SELECT 
+    cs.col_category, 
+    cs.min_val, 
+    cs.max_val, 
+    cs.cnt,
+    t.col_nchar AS sample_value
+FROM CategoryStats cs
+JOIN babel_5688_all_types t ON t.col_category = cs.col_category AND t.col_nchar = cs.min_val
+ORDER BY cs.col_category, sample_value;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#int#!#nchar
+Animal#!#Zebra               #!#Zebra               #!#1#!#Zebra               
+Fruit#!# Apple              #!#Orange              #!#3#!# Apple              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#1#!#AAAAAAAAAA          
+NumericStr#!#1                   #!#1                   #!#1#!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#2#!#!Special            
+~~END~~
+
+
+-- Test CASE EXPRESSION
+SELECT 
+    col_category,
+    CASE 
+        WHEN MIN(col_nchar) = MAX(col_nchar) THEN 'Same'
+        WHEN MIN(col_nchar) IS NULL OR MAX(col_nchar) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS nchar_status,
+    CASE 
+        WHEN MIN(col_char) = MAX(col_char) THEN 'Same'
+        WHEN MIN(col_char) IS NULL OR MAX(col_char) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS varchar_status
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#varchar#!#varchar
+Animal#!#Same#!#Same
+Fruit#!#Different#!#Different
+LongStr#!#Same#!#Same
+NullTest#!#Has Nulls#!#Has Nulls
+NumericStr#!#Same#!#Same
+SpecialChar#!#Different#!#Different
+~~END~~
+
+
+-- Test expressions inside min/max
+SELECT  
+    MIN(UPPER(col_nchar)) AS min_upper_nchar,
+    MAX(UPPER(col_nchar)) AS max_upper_nchar,
+    MIN(LOWER(col_nchar)) AS min_lower_nchar,
+    MAX(LOWER(col_nchar)) AS max_lower_nchar,
+    MIN(UPPER(col_char)) AS min_upper_char,
+    MAX(UPPER(col_char)) AS max_upper_char,
+    MIN(LOWER(col_char)) AS min_lower_char,
+    MAX(LOWER(col_char)) AS max_lower_char 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+ APPLE              #!#ZEBRA               #!# apple              #!#zebra               #!# APPLE              #!#ZEBRA               #!# apple              #!#zebra               
+~~END~~
+
+
+-- Test TOP WITH MIN/MAX
+SELECT TOP 5 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL 
+GROUP BY col_category 
+ORDER BY min_nchar, max_nchar;
+GO
+~~START~~
+varchar#!#nchar#!#nchar
+Fruit#!# Apple              #!#Orange              
+SpecialChar#!#!Special            #!##Hash               
+NumericStr#!#1                   #!#1                   
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          
+Animal#!#Zebra               #!#Zebra               
+~~END~~
+
+
+SELECT TOP 3
+    col_category,
+    MIN(col_char) AS min_char,
+    MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_char IS NOT NULL
+GROUP BY col_category
+ORDER BY MAX(col_char) DESC;
+GO
+~~START~~
+varchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          
+~~END~~
+
+
+
+-- Test COALESCE/ISNULL 
+SELECT COALESCE(MIN(col1_nchar), N'No Value') AS min_nchar FROM babel_5688_table2;
+GO
+~~START~~
+nvarchar
+Apple               
+~~END~~
+
+SELECT ISNULL(MAX(col1_nchar), N'No Value') AS max_nchar FROM babel_5688_table2;
+GO
+~~START~~
+nchar
+Cherry              
+~~END~~
+
+SELECT COALESCE(MIN(col1_char), 'No Value') AS min_char FROM babel_5688_table2;
+GO
+~~START~~
+varchar
+Banana              
+~~END~~
+
+SELECT ISNULL(MAX(col1_char), 'No Value') AS max_char FROM babel_5688_table2;
+GO
+~~START~~
+char
+Date                
+~~END~~
+
+
+-- All null values in tables
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MIN(col1_char) AS min_char FROM babel_5688_table3;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MAX(col1_char) AS min_char FROM babel_5688_table3;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+
+-- Test Empty table
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MIN(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MAX(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+
+
+-- Test JOINs
+-- Inner Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+INNER JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#nchar#!#char
+~~END~~
+
+
+-- Left Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char,
+    CASE WHEN t2.col1_nchar IS NULL THEN 'No Match' ELSE 'Matched' END AS match_status
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+LEFT JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#nchar#!#char#!#varchar
+Animal#!#Zebra               #!#Zebra               #!#<NULL>#!#<NULL>#!#No Match
+Fruit#!# Apple              #!#Orange              #!#<NULL>#!#<NULL>#!#No Match
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#<NULL>#!#<NULL>#!#No Match
+NullTest#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#No Match
+NumericStr#!#1                   #!#1                   #!#<NULL>#!#<NULL>#!#No Match
+SpecialChar#!#!Special            #!##Hash               #!#<NULL>#!#<NULL>#!#No Match
+~~END~~
+
+
+-- Complex query combining all elements
+SELECT 
+    source_info,
+    col_category,
+    min_val,
+    max_val,
+    CASE 
+        WHEN min_val IS NULL AND max_val IS NULL THEN 'Empty/All NULL'
+        WHEN min_val = max_val THEN 'Single Unique Value'
+        ELSE 'Multiple Values'
+    END AS data_status
+FROM (
+    -- From babel_5688_all_types grouped by col_category
+    SELECT 
+        'AllTypes-ByCategory' AS source_info,
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val
+    FROM babel_5688_all_types
+    GROUP BY col_category
+    
+    UNION ALL
+    
+    -- From babel_5688_table2
+    SELECT 
+        'Table2-All' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table2
+    
+    UNION ALL
+    
+    -- From babel_5688_table3 (all nulls)
+    SELECT 
+        'Table3-AllNulls' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table3
+    
+    UNION ALL
+    
+    -- From babel_5688_table4 (empty)
+    SELECT 
+        'Table4-Empty' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table4
+) combined_data
+ORDER BY source_info, col_category;
+GO
+~~START~~
+varchar#!#varchar#!#nchar#!#nchar#!#varchar
+AllTypes-ByCategory#!#Animal#!#Zebra               #!#Zebra               #!#Single Unique Value
+AllTypes-ByCategory#!#Fruit#!# Apple              #!#Orange              #!#Multiple Values
+AllTypes-ByCategory#!#LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#Single Unique Value
+AllTypes-ByCategory#!#NullTest#!#<NULL>#!#<NULL>#!#Empty/All NULL
+AllTypes-ByCategory#!#NumericStr#!#1                   #!#1                   #!#Single Unique Value
+AllTypes-ByCategory#!#SpecialChar#!#!Special            #!##Hash               #!#Multiple Values
+Table2-All#!#N/A#!#Apple               #!#Cherry              #!#Multiple Values
+Table3-AllNulls#!#N/A#!#<NULL>#!#<NULL>#!#Empty/All NULL
+Table4-Empty#!#N/A#!#<NULL>#!#<NULL>#!#Empty/All NULL
+~~END~~
+
+
+-- Test Unicode characters 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_table5;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+中文                  #!#日本語                 #!#??                  #!#???                 
+~~END~~
+
+
+-- Test: Empty strings and spaces
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('', '', '', '', 'EmptyTest', 0),
+('   ', '   ', '   ', '   ', 'SpaceTest', 0)
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+                    #!#Zebra               #!#                    #!#Zebra               
+~~END~~
+
+
+-- Test declare statements
+DECLARE @nchar_var nchar(20) = N'abc';
+DECLARE @nchar_var1 nchar(20) = N'日本語';
+DECLARE @nchar_var2 nchar(20) = N'';
+DECLARE @nchar_var3 nchar(20) = NULL;
+SELECT 
+    min(@nchar_var), max(@nchar_var), 
+    min(@nchar_var1), max(@nchar_var1),
+    min(@nchar_var2), max(@nchar_var2),
+    min(@nchar_var3), max(@nchar_var3)
+go
+~~START~~
+nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar
+abc                 #!#abc                 #!#日本語                 #!#日本語                 #!#                    #!#                    #!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @char_var char(20) = 'abc';
+DECLARE @char_var1 char(20) = N'日本語';
+DECLARE @char_var2 char(20) = '';
+DECLARE @char_var3 char(20) = NULL;
+SELECT 
+    min(@char_var), max(@char_var), 
+    min(@char_var1), max(@char_var1),
+    min(@char_var2), max(@char_var2),
+    min(@char_var3), max(@char_var3)
+GO
+~~START~~
+char#!#char#!#char#!#char#!#char#!#char#!#char#!#char
+abc                 #!#abc                 #!#???                 #!#???                 #!#                    #!#                    #!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @nvarchar_var nvarchar(25) = N'test';
+DECLARE @nvarchar_var1 nvarchar(25) = N'unicode日本語';
+DECLARE @nvarchar_var2 nvarchar(25) = N'';
+DECLARE @nvarchar_var3 nvarchar(25) = NULL;
+SELECT 
+    min(@nvarchar_var), max(@nvarchar_var), 
+    min(@nvarchar_var1), max(@nvarchar_var1),
+    min(@nvarchar_var2), max(@nvarchar_var2),
+    min(@nvarchar_var3), max(@nvarchar_var3)
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+test#!#test#!#unicode日本語#!#unicode日本語#!##!##!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @varchar_var varchar(25) = 'hello';
+DECLARE @varchar_var1 varchar(25) = 'world';
+DECLARE @varchar_var2 varchar(25) = '';
+DECLARE @varchar_var3 varchar(25) = NULL;
+SELECT 
+    min(@varchar_var), max(@varchar_var), 
+    min(@varchar_var1), max(@varchar_var1),
+    min(@varchar_var2), max(@varchar_var2),
+    min(@varchar_var3), max(@varchar_var3)
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+hello#!#hello#!#world#!#world#!##!##!#<NULL>#!#<NULL>
+~~END~~
+
+
+
+
+-- Basic test using babel_5688_all_types columns
+DECLARE @min_nchar NCHAR(20);
+DECLARE @max_nchar NCHAR(20);
+DECLARE @min_char CHAR(20);
+DECLARE @max_char CHAR(20);
+DECLARE @min_nvarchar NVARCHAR(25);
+DECLARE @max_nvarchar NVARCHAR(25);
+DECLARE @min_varchar VARCHAR(25);
+SELECT @min_nchar = MIN(col_nchar) FROM babel_5688_all_types;
+SELECT @max_nchar = MAX(col_nchar) FROM babel_5688_all_types;
+SELECT @min_char = MIN(col_char) FROM babel_5688_all_types;
+SELECT @max_char = MAX(col_char) FROM babel_5688_all_types;
+SELECT @min_nvarchar = MIN(col_nvarchar) FROM babel_5688_all_types;
+SELECT @max_nvarchar = MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT @min_varchar = MIN(col_varchar) FROM babel_5688_all_types;
+SELECT 
+    @min_nchar AS min_nchar, @max_nchar AS max_nchar,
+    @min_char AS min_char, @max_char AS max_char,
+    @min_nvarchar AS min_nvarchar, @max_nvarchar AS max_nvarchar,
+    @min_varchar AS min_varchar;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+                    #!#Zebra               #!#                    #!#Zebra               #!##!#Zebra#!#
+~~END~~
+
+
+-- Test Declare with table variable
+SELECT 'TEST D7: DECLARE with table variable' AS TestName;
+GO
+~~START~~
+varchar
+TEST D7: DECLARE with table variable
+~~END~~
+
+
+
+
+
+
+DECLARE @results TABLE (
+    col_type VARCHAR(20),
+    min_val NVARCHAR(25),
+    max_val NVARCHAR(25)
+);
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NCHAR', MIN(col_nchar), MAX(col_nchar) FROM babel_5688_all_types;
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'CHAR', MIN(col_char), MAX(col_char) FROM babel_5688_all_types;
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NVARCHAR', MIN(col_nvarchar), MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT * FROM @results;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#nvarchar#!#nvarchar
+NCHAR#!#                    #!#Zebra               
+CHAR#!#                    #!#Zebra               
+NVARCHAR#!##!#Zebra
+~~END~~
+
+
+
+-- Functions 
+-- Procedures
+-- Test Functions
+SELECT dbo.babel_5688_f1() AS f1_min_nchar;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f2() AS f2_max_nchar;
+GO
+~~START~~
+nchar
+Zebra               
+~~END~~
+
+SELECT dbo.babel_5688_f3() AS f3_min_char;
+GO
+~~START~~
+char
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f4() AS f4_max_char;
+GO
+~~START~~
+char
+Zebra               
+~~END~~
+
+SELECT dbo.babel_5688_f5(N'default') AS f8_coalesce;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f5(N'') AS result_empty_default;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f6('Fruit') AS f9_category_min;
+GO
+~~START~~
+nchar
+ Apple              
+~~END~~
+
+SELECT dbo.babel_5688_f7() AS f10_var_min;
+GO
+~~START~~
+nchar
+abc                 
+~~END~~
+
+
+-- Test Procedures
+EXEC babel_5688_p1;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#varchar#!#varchar#!#nvarchar#!#nvarchar
+                    #!#Zebra               #!#                    #!#Zebra               #!##!#Zebra#!##!#Zebra
+~~END~~
+
+EXEC babel_5688_p2 'Fruit';
+GO
+~~START~~
+nchar
+Orange              
+~~END~~
+
+EXEC babel_5688_p3 N'test_var';
+GO
+~~START~~
+nchar#!#nchar
+test_var            #!#test_var            
+~~END~~
+
+EXEC babel_5688_p4 N'default_value';
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+EXEC babel_5688_p5;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+nchar_value         #!#nchar_value         #!#char_value          #!#char_value          #!#nvarchar_value#!#nvarchar_value#!#varchar_value#!#varchar_value
+~~END~~
+
+EXEC babel_5688_p6 'Animal';
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+Zebra               #!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra#!#Zebra#!#Zebra#!#Zebra
+~~END~~
+
+
+-- Test explicit COLLATE clause on aggregate functions for CHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT MAX(col1) FROM babel_5688_table6;
+GO
+~~START~~
+char
+A         
+~~END~~
+
+SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+~~START~~
+char
+A         
+~~END~~
+
+
+-- Test explicit COLLATE clause on aggregate functions for NCHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT MAX(col2) FROM babel_5688_table6;
+GO
+~~START~~
+nchar
+A         
+~~END~~
+
+SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+~~START~~
+nchar
+A         
+~~END~~
+
+
+
+-- Testing index scan 
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_bitmapscan', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('enable_seqscan', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+-- All permutation queries for index scan testing
+-- MAX/MIN with same column in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Only Scan Backward using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: ((col_char IS NOT NULL) AND (col_char <= 'cbd'::bpchar))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 9.032 ms
+~~END~~
+
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Only Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: ((col_char IS NOT NULL) AND (col_char <= 'cbd'::bpchar))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.125 ms
+~~END~~
+
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Aggregate
+  ->  Index Only Scan using ix_testdatatypeaggsort_ncharbab22b6ccf3ad272c9e2c3aca6debfc63b6 on babel_5688_table7
+        Index Cond: (col_nchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.103 ms
+~~END~~
+
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Aggregate
+  ->  Index Only Scan using ix_testdatatypeaggsort_ncharbab22b6ccf3ad272c9e2c3aca6debfc63b6 on babel_5688_table7
+        Index Cond: (col_nchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.148 ms
+~~END~~
+
+
+-- MAX/MIN with different columns in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Scan Backward using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: (col_char IS NOT NULL)
+                Filter: ((col_nchar)::bpchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.110 ms
+~~END~~
+
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: (col_char IS NOT NULL)
+                Filter: ((col_nchar)::bpchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.126 ms
+~~END~~
+
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Aggregate
+  ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+        Index Cond: (col_char <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.105 ms
+~~END~~
+
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Aggregate
+  ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+        Index Cond: (col_char <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.104 ms
+~~END~~
+
+
+-- Reset
+SET BABELFISH_SHOWPLAN_ALL OFF
+go
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+SELECT set_config('enable_seqscan', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+
+
+-- Test cases for MIN/MAX with CAST combinations across data types
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+
+-- MAX versions of the same combinations
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/string_aggregate-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/string_aggregate-vu-verify.out
@@ -1,0 +1,1315 @@
+-- Test basic
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar, MAX(col_varchar) AS max_varchar 
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               #!# Apple #!#Zebra#!# Apple #!#Zebra
+~~END~~
+
+
+
+-- Test with GROUP BY and ORDER BY
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              #!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          
+NullTest#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+NumericStr#!#1                   #!#1                   #!#1                   #!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#!Special            #!##Hash               
+~~END~~
+
+
+select min(col_char) FROM babel_5688_all_types GROUP BY col_nchar ORDER BY col_nchar
+go
+~~START~~
+char
+<NULL>
+ Apple              
+!Special            
+#Hash               
+1                   
+AAAAAAAAAA          
+Apple               
+Orange              
+Zebra               
+~~END~~
+
+
+
+-- Test with having clause 
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar,
+    COUNT(*) AS cnt
+FROM babel_5688_all_types
+GROUP BY col_category
+HAVING MIN(col_nchar) IS NOT NULL AND MAX(col_nchar) IS NOT NULL
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#int
+Animal#!#Zebra               #!#Zebra               #!#1
+Fruit#!# Apple              #!#Orange              #!#3
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#1
+NumericStr#!#1                   #!#1                   #!#1
+SpecialChar#!#!Special            #!##Hash               #!#2
+~~END~~
+
+
+
+-- Test Where clause 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar
+FROM babel_5688_all_types
+WHERE col_category = 'Fruit';
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+ Apple              #!#Orange              #!# Apple              #!#Orange              #!# Apple #!#Orange#!# Apple 
+~~END~~
+
+
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               
+~~END~~
+
+
+
+-- Test distinct
+SELECT 
+    MIN(DISTINCT col_nchar) AS min_distinct_nchar, MAX(DISTINCT col_nchar) AS max_distinct_nchar,
+    MIN(DISTINCT col_char) AS min_distinct_char, MAX(DISTINCT col_char) AS max_distinct_char,
+    MIN(DISTINCT col_nvarchar) AS min_distinct_nvarchar, MAX(DISTINCT col_nvarchar) AS max_distinct_nvarchar,
+    MIN(DISTINCT col_varchar) AS min_distinct_varchar
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               #!# Apple #!#Zebra#!# Apple 
+~~END~~
+
+
+
+-- Test subquery
+SELECT * FROM babel_5688_all_types WHERE col_nchar = (SELECT MIN(col_nchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_char = (SELECT MIN(col_char) FROM babel_5688_all_types WHERE col_char IS NOT NULL);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_nvarchar = (SELECT MIN(col_nvarchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_varchar = (SELECT MIN(col_varchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+
+
+-- Test UNION ALL
+SELECT 'NCHAR' AS col_type, MIN(col_nchar) AS min_val, MAX(col_nchar) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT 'CHAR' AS col_type, MIN(col_char) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_char IS NOT NULL
+UNION ALL
+SELECT 'NVARCHAR' AS col_type, MIN(col_nvarchar) AS min_val, MAX(col_nvarchar) AS max_val FROM babel_5688_all_types WHERE col_nvarchar IS NOT NULL
+ORDER BY col_type;
+GO
+~~START~~
+varchar#!#nvarchar#!#nvarchar
+CHAR#!# Apple              #!#Zebra               
+NCHAR#!# Apple              #!#Zebra               
+NVARCHAR#!# Apple #!#Zebra
+~~END~~
+
+
+SELECT MIN(col_nchar) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table2 WHERE col1_char IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table3 WHERE col1_char IS NOT NULL
+ORDER BY min_val;
+GO
+~~START~~
+nchar#!#char
+<NULL>#!#<NULL>
+ Apple              #!#Zebra               
+Cherry              #!#Date                
+~~END~~
+
+
+
+-- Test CTEs
+WITH MinMaxCTE AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_nchar,
+        MAX(col_nchar) AS max_nchar,
+        MIN(col_char) AS min_char,
+        MAX(col_char) AS max_char
+    FROM babel_5688_all_types
+    GROUP BY col_category
+)
+SELECT * FROM MinMaxCTE WHERE min_nchar IS NOT NULL ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              #!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          
+NumericStr#!#1                   #!#1                   #!#1                   #!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#!Special            #!##Hash               
+~~END~~
+
+
+WITH CategoryStats AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val,
+        COUNT(*) AS cnt
+    FROM babel_5688_all_types
+    WHERE col_nchar IS NOT NULL
+    GROUP BY col_category
+)
+SELECT 
+    cs.col_category, 
+    cs.min_val, 
+    cs.max_val, 
+    cs.cnt,
+    t.col_nchar AS sample_value
+FROM CategoryStats cs
+JOIN babel_5688_all_types t ON t.col_category = cs.col_category AND t.col_nchar = cs.min_val
+ORDER BY cs.col_category, sample_value;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#int#!#nchar
+Animal#!#Zebra               #!#Zebra               #!#1#!#Zebra               
+Fruit#!# Apple              #!#Orange              #!#3#!# Apple              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#1#!#AAAAAAAAAA          
+NumericStr#!#1                   #!#1                   #!#1#!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#2#!#!Special            
+~~END~~
+
+
+-- Test CASE EXPRESSION
+SELECT 
+    col_category,
+    CASE 
+        WHEN MIN(col_nchar) = MAX(col_nchar) THEN 'Same'
+        WHEN MIN(col_nchar) IS NULL OR MAX(col_nchar) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS nchar_status,
+    CASE 
+        WHEN MIN(col_char) = MAX(col_char) THEN 'Same'
+        WHEN MIN(col_char) IS NULL OR MAX(col_char) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS varchar_status
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#varchar#!#varchar
+Animal#!#Same#!#Same
+Fruit#!#Different#!#Different
+LongStr#!#Same#!#Same
+NullTest#!#Has Nulls#!#Has Nulls
+NumericStr#!#Same#!#Same
+SpecialChar#!#Different#!#Different
+~~END~~
+
+
+-- Test expressions inside min/max
+SELECT  
+    MIN(UPPER(col_nchar)) AS min_upper_nchar,
+    MAX(UPPER(col_nchar)) AS max_upper_nchar,
+    MIN(LOWER(col_nchar)) AS min_lower_nchar,
+    MAX(LOWER(col_nchar)) AS max_lower_nchar,
+    MIN(UPPER(col_char)) AS min_upper_char,
+    MAX(UPPER(col_char)) AS max_upper_char,
+    MIN(LOWER(col_char)) AS min_lower_char,
+    MAX(LOWER(col_char)) AS max_lower_char 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+ APPLE              #!#ZEBRA               #!# apple              #!#zebra               #!# APPLE              #!#ZEBRA               #!# apple              #!#zebra               
+~~END~~
+
+
+-- Test TOP WITH MIN/MAX
+SELECT TOP 5 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL 
+GROUP BY col_category 
+ORDER BY min_nchar, max_nchar;
+GO
+~~START~~
+varchar#!#nchar#!#nchar
+Fruit#!# Apple              #!#Orange              
+SpecialChar#!#!Special            #!##Hash               
+NumericStr#!#1                   #!#1                   
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          
+Animal#!#Zebra               #!#Zebra               
+~~END~~
+
+
+SELECT TOP 3
+    col_category,
+    MIN(col_char) AS min_char,
+    MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_char IS NOT NULL
+GROUP BY col_category
+ORDER BY MAX(col_char) DESC;
+GO
+~~START~~
+varchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          
+~~END~~
+
+
+
+-- Test COALESCE/ISNULL 
+SELECT COALESCE(MIN(col1_nchar), N'No Value') AS min_nchar FROM babel_5688_table2;
+GO
+~~START~~
+nvarchar
+Apple               
+~~END~~
+
+SELECT ISNULL(MAX(col1_nchar), N'No Value') AS max_nchar FROM babel_5688_table2;
+GO
+~~START~~
+nchar
+Cherry              
+~~END~~
+
+SELECT COALESCE(MIN(col1_char), 'No Value') AS min_char FROM babel_5688_table2;
+GO
+~~START~~
+varchar
+Banana              
+~~END~~
+
+SELECT ISNULL(MAX(col1_char), 'No Value') AS max_char FROM babel_5688_table2;
+GO
+~~START~~
+char
+Date                
+~~END~~
+
+
+-- All null values in tables
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MIN(col1_char) AS min_char FROM babel_5688_table3;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MAX(col1_char) AS min_char FROM babel_5688_table3;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+
+-- Test Empty table
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MIN(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MAX(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+
+
+-- Test JOINs
+-- Inner Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+INNER JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#nchar#!#char
+~~END~~
+
+
+-- Left Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char,
+    CASE WHEN t2.col1_nchar IS NULL THEN 'No Match' ELSE 'Matched' END AS match_status
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+LEFT JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#nchar#!#char#!#varchar
+Animal#!#Zebra               #!#Zebra               #!#<NULL>#!#<NULL>#!#No Match
+Fruit#!# Apple              #!#Orange              #!#<NULL>#!#<NULL>#!#No Match
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#<NULL>#!#<NULL>#!#No Match
+NullTest#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#No Match
+NumericStr#!#1                   #!#1                   #!#<NULL>#!#<NULL>#!#No Match
+SpecialChar#!#!Special            #!##Hash               #!#<NULL>#!#<NULL>#!#No Match
+~~END~~
+
+
+-- Complex query combining all elements
+SELECT 
+    source_info,
+    col_category,
+    min_val,
+    max_val,
+    CASE 
+        WHEN min_val IS NULL AND max_val IS NULL THEN 'Empty/All NULL'
+        WHEN min_val = max_val THEN 'Single Unique Value'
+        ELSE 'Multiple Values'
+    END AS data_status
+FROM (
+    -- From babel_5688_all_types grouped by col_category
+    SELECT 
+        'AllTypes-ByCategory' AS source_info,
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val
+    FROM babel_5688_all_types
+    GROUP BY col_category
+    
+    UNION ALL
+    
+    -- From babel_5688_table2
+    SELECT 
+        'Table2-All' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table2
+    
+    UNION ALL
+    
+    -- From babel_5688_table3 (all nulls)
+    SELECT 
+        'Table3-AllNulls' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table3
+    
+    UNION ALL
+    
+    -- From babel_5688_table4 (empty)
+    SELECT 
+        'Table4-Empty' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table4
+) combined_data
+ORDER BY source_info, col_category;
+GO
+~~START~~
+varchar#!#varchar#!#nchar#!#nchar#!#varchar
+AllTypes-ByCategory#!#Animal#!#Zebra               #!#Zebra               #!#Single Unique Value
+AllTypes-ByCategory#!#Fruit#!# Apple              #!#Orange              #!#Multiple Values
+AllTypes-ByCategory#!#LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#Single Unique Value
+AllTypes-ByCategory#!#NullTest#!#<NULL>#!#<NULL>#!#Empty/All NULL
+AllTypes-ByCategory#!#NumericStr#!#1                   #!#1                   #!#Single Unique Value
+AllTypes-ByCategory#!#SpecialChar#!#!Special            #!##Hash               #!#Multiple Values
+Table2-All#!#N/A#!#Apple               #!#Cherry              #!#Multiple Values
+Table3-AllNulls#!#N/A#!#<NULL>#!#<NULL>#!#Empty/All NULL
+Table4-Empty#!#N/A#!#<NULL>#!#<NULL>#!#Empty/All NULL
+~~END~~
+
+
+-- Test Unicode characters 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_table5;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+日本語                 #!#中文                  #!#日本語              #!#中文                
+~~END~~
+
+
+-- Test: Empty strings and spaces
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('', '', '', '', 'EmptyTest', 0),
+('   ', '   ', '   ', '   ', 'SpaceTest', 0)
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+                    #!#Zebra               #!#                    #!#Zebra               
+~~END~~
+
+
+-- Test declare statements
+DECLARE @nchar_var nchar(20) = N'abc';
+DECLARE @nchar_var1 nchar(20) = N'日本語';
+DECLARE @nchar_var2 nchar(20) = N'';
+DECLARE @nchar_var3 nchar(20) = NULL;
+SELECT 
+    min(@nchar_var), max(@nchar_var), 
+    min(@nchar_var1), max(@nchar_var1),
+    min(@nchar_var2), max(@nchar_var2),
+    min(@nchar_var3), max(@nchar_var3)
+go
+~~START~~
+nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar
+abc                 #!#abc                 #!#日本語                 #!#日本語                 #!#                    #!#                    #!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @char_var char(20) = 'abc';
+DECLARE @char_var1 char(20) = N'日本語';
+DECLARE @char_var2 char(20) = '';
+DECLARE @char_var3 char(20) = NULL;
+SELECT 
+    min(@char_var), max(@char_var), 
+    min(@char_var1), max(@char_var1),
+    min(@char_var2), max(@char_var2),
+    min(@char_var3), max(@char_var3)
+GO
+~~START~~
+char#!#char#!#char#!#char#!#char#!#char#!#char#!#char
+abc                 #!#abc                 #!#日本語              #!#日本語              #!#                    #!#                    #!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @nvarchar_var nvarchar(25) = N'test';
+DECLARE @nvarchar_var1 nvarchar(25) = N'unicode日本語';
+DECLARE @nvarchar_var2 nvarchar(25) = N'';
+DECLARE @nvarchar_var3 nvarchar(25) = NULL;
+SELECT 
+    min(@nvarchar_var), max(@nvarchar_var), 
+    min(@nvarchar_var1), max(@nvarchar_var1),
+    min(@nvarchar_var2), max(@nvarchar_var2),
+    min(@nvarchar_var3), max(@nvarchar_var3)
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+test#!#test#!#unicode日本語#!#unicode日本語#!##!##!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @varchar_var varchar(25) = 'hello';
+DECLARE @varchar_var1 varchar(25) = 'world';
+DECLARE @varchar_var2 varchar(25) = '';
+DECLARE @varchar_var3 varchar(25) = NULL;
+SELECT 
+    min(@varchar_var), max(@varchar_var), 
+    min(@varchar_var1), max(@varchar_var1),
+    min(@varchar_var2), max(@varchar_var2),
+    min(@varchar_var3), max(@varchar_var3)
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+hello#!#hello#!#world#!#world#!##!##!#<NULL>#!#<NULL>
+~~END~~
+
+
+
+
+-- Basic test using babel_5688_all_types columns
+DECLARE @min_nchar NCHAR(20);
+DECLARE @max_nchar NCHAR(20);
+DECLARE @min_char CHAR(20);
+DECLARE @max_char CHAR(20);
+DECLARE @min_nvarchar NVARCHAR(25);
+DECLARE @max_nvarchar NVARCHAR(25);
+DECLARE @min_varchar VARCHAR(25);
+SELECT @min_nchar = MIN(col_nchar) FROM babel_5688_all_types;
+SELECT @max_nchar = MAX(col_nchar) FROM babel_5688_all_types;
+SELECT @min_char = MIN(col_char) FROM babel_5688_all_types;
+SELECT @max_char = MAX(col_char) FROM babel_5688_all_types;
+SELECT @min_nvarchar = MIN(col_nvarchar) FROM babel_5688_all_types;
+SELECT @max_nvarchar = MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT @min_varchar = MIN(col_varchar) FROM babel_5688_all_types;
+SELECT 
+    @min_nchar AS min_nchar, @max_nchar AS max_nchar,
+    @min_char AS min_char, @max_char AS max_char,
+    @min_nvarchar AS min_nvarchar, @max_nvarchar AS max_nvarchar,
+    @min_varchar AS min_varchar;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+                    #!#Zebra               #!#                    #!#Zebra               #!##!#Zebra#!#
+~~END~~
+
+
+-- Test Declare with table variable
+SELECT 'TEST D7: DECLARE with table variable' AS TestName;
+GO
+~~START~~
+varchar
+TEST D7: DECLARE with table variable
+~~END~~
+
+
+
+
+
+
+DECLARE @results TABLE (
+    col_type VARCHAR(20),
+    min_val NVARCHAR(25),
+    max_val NVARCHAR(25)
+);
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NCHAR', MIN(col_nchar), MAX(col_nchar) FROM babel_5688_all_types;
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'CHAR', MIN(col_char), MAX(col_char) FROM babel_5688_all_types;
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NVARCHAR', MIN(col_nvarchar), MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT * FROM @results;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#nvarchar#!#nvarchar
+NCHAR#!#                    #!#Zebra               
+CHAR#!#                    #!#Zebra               
+NVARCHAR#!##!#Zebra
+~~END~~
+
+
+
+-- Functions 
+-- Procedures
+-- Test Functions
+SELECT dbo.babel_5688_f1() AS f1_min_nchar;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f2() AS f2_max_nchar;
+GO
+~~START~~
+nchar
+Zebra               
+~~END~~
+
+SELECT dbo.babel_5688_f3() AS f3_min_char;
+GO
+~~START~~
+char
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f4() AS f4_max_char;
+GO
+~~START~~
+char
+Zebra               
+~~END~~
+
+SELECT dbo.babel_5688_f5(N'default') AS f8_coalesce;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f5(N'') AS result_empty_default;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f6('Fruit') AS f9_category_min;
+GO
+~~START~~
+nchar
+ Apple              
+~~END~~
+
+SELECT dbo.babel_5688_f7() AS f10_var_min;
+GO
+~~START~~
+nchar
+abc                 
+~~END~~
+
+
+-- Test Procedures
+EXEC babel_5688_p1;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#varchar#!#varchar#!#nvarchar#!#nvarchar
+                    #!#Zebra               #!#                    #!#Zebra               #!##!#Zebra#!##!#Zebra
+~~END~~
+
+EXEC babel_5688_p2 'Fruit';
+GO
+~~START~~
+nchar
+Orange              
+~~END~~
+
+EXEC babel_5688_p3 N'test_var';
+GO
+~~START~~
+nchar#!#nchar
+test_var            #!#test_var            
+~~END~~
+
+EXEC babel_5688_p4 N'default_value';
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+EXEC babel_5688_p5;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+nchar_value         #!#nchar_value         #!#char_value          #!#char_value          #!#nvarchar_value#!#nvarchar_value#!#varchar_value#!#varchar_value
+~~END~~
+
+EXEC babel_5688_p6 'Animal';
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+Zebra               #!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra#!#Zebra#!#Zebra#!#Zebra
+~~END~~
+
+
+-- Test explicit COLLATE clause on aggregate functions for CHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT MAX(col1) FROM babel_5688_table6;
+GO
+~~START~~
+char
+A         
+~~END~~
+
+SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+~~START~~
+char
+A         
+~~END~~
+
+
+-- Test explicit COLLATE clause on aggregate functions for NCHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT MAX(col2) FROM babel_5688_table6;
+GO
+~~START~~
+nchar
+A         
+~~END~~
+
+SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+~~START~~
+nchar
+A         
+~~END~~
+
+
+
+-- Testing index scan 
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_bitmapscan', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('enable_seqscan', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+-- All permutation queries for index scan testing
+-- MAX/MIN with same column in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Only Scan Backward using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: ((col_char IS NOT NULL) AND (col_char <= 'cbd'::bpchar))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 9.140 ms
+~~END~~
+
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Only Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: ((col_char IS NOT NULL) AND (col_char <= 'cbd'::bpchar))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.113 ms
+~~END~~
+
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Aggregate
+  ->  Index Only Scan using ix_testdatatypeaggsort_ncharbab22b6ccf3ad272c9e2c3aca6debfc63b6 on babel_5688_table7
+        Index Cond: (col_nchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
+~~END~~
+
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Aggregate
+  ->  Index Only Scan using ix_testdatatypeaggsort_ncharbab22b6ccf3ad272c9e2c3aca6debfc63b6 on babel_5688_table7
+        Index Cond: (col_nchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
+~~END~~
+
+
+-- MAX/MIN with different columns in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Scan Backward using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: (col_char IS NOT NULL)
+                Filter: ((col_nchar)::bpchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.107 ms
+~~END~~
+
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: (col_char IS NOT NULL)
+                Filter: ((col_nchar)::bpchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.101 ms
+~~END~~
+
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Aggregate
+  ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+        Index Cond: (col_char <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.103 ms
+~~END~~
+
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Aggregate
+  ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+        Index Cond: (col_char <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.102 ms
+~~END~~
+
+
+-- Reset
+SET BABELFISH_SHOWPLAN_ALL OFF
+go
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+SELECT set_config('enable_seqscan', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+
+
+-- Test cases for MIN/MAX with CAST combinations across data types
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+
+-- MAX versions of the same combinations
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+

--- a/test/JDBC/expected/string_aggregate-vu-cleanup.out
+++ b/test/JDBC/expected/string_aggregate-vu-cleanup.out
@@ -1,0 +1,45 @@
+-- Drop procedures
+DROP PROCEDURE babel_5688_p1;
+GO
+DROP PROCEDURE babel_5688_p2;
+GO
+DROP PROCEDURE babel_5688_p3;
+GO
+DROP PROCEDURE babel_5688_p4;
+GO
+DROP PROCEDURE babel_5688_p5;
+GO
+DROP PROCEDURE babel_5688_p6;
+GO
+
+-- Drop functions
+DROP FUNCTION babel_5688_f1;
+GO
+DROP FUNCTION babel_5688_f2;
+GO
+DROP FUNCTION babel_5688_f3;
+GO
+DROP FUNCTION babel_5688_f4;
+GO
+DROP FUNCTION babel_5688_f5;
+GO
+DROP FUNCTION babel_5688_f6;
+GO
+DROP FUNCTION babel_5688_f7;
+GO
+
+-- Drop tables
+DROP TABLE babel_5688_all_types;
+GO
+DROP TABLE babel_5688_table2;
+GO
+DROP TABLE babel_5688_table3;
+GO
+DROP TABLE babel_5688_table4;
+GO
+DROP TABLE babel_5688_table5;
+GO
+DROP TABLE babel_5688_table6;
+GO
+DROP TABLE babel_5688_table7;
+GO

--- a/test/JDBC/expected/string_aggregate-vu-prepare.out
+++ b/test/JDBC/expected/string_aggregate-vu-prepare.out
@@ -1,0 +1,310 @@
+-- Create single table with all character types
+CREATE TABLE babel_5688_all_types (
+    id INT IDENTITY(1,1),
+    col_nchar NCHAR(20),
+    col_char CHAR(20),
+    col_nvarchar NVARCHAR(25),
+    col_varchar VARCHAR(25),
+    col_category VARCHAR(20),
+    col_amount INT
+);
+GO
+
+-- Test Case 1: Basic values
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('Apple', 'Apple', 'Apple', 'Apple', 'Fruit', 200),
+(' Apple ', ' Apple ', ' Apple ', ' Apple ', 'Fruit', 200),
+('Orange', 'Orange', 'Orange', 'Orange', 'Fruit', 120),
+('Zebra', 'Zebra', 'Zebra', 'Zebra', 'Animal', 500);
+GO
+~~ROW COUNT: 4~~
+
+
+-- Test Case 2: NULL values
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+(NULL, NULL, NULL, NULL, 'NullTest', 0)
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- Test Case 3: Special characters
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('!Special', '!Special', '!Special', '!Special', 'SpecialChar', 40),
+('#Hash', '#Hash', '#Hash', '#Hash', 'SpecialChar', 60)
+GO
+~~ROW COUNT: 2~~
+
+
+-- Test Case 4: Numeric strings
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('1', '1', '1', '1', 'NumericStr', 1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- Test Case 5: Long strings
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('AAAAAAAAAA', 'AAAAAAAAAA', 'AAAAAAAAAAAAAAAAAA', 'AAAAAAAAAAAAAAAAAA', 'LongStr', 1)
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- COALESCE/ISNULL 
+CREATE TABLE babel_5688_table2 (col1_nchar NCHAR(20), col1_char CHAR(20));
+GO
+
+INSERT INTO babel_5688_table2 (col1_nchar, col1_char) VALUES 
+('Apple', NULL), 
+(NULL, 'Banana'), 
+('Cherry', 'Date'),
+(NULL, NULL);
+GO
+~~ROW COUNT: 4~~
+
+
+
+-- All null values
+CREATE TABLE babel_5688_table3 (col1_nchar NCHAR(20), col1_char CHAR(20));
+GO
+
+INSERT INTO babel_5688_table3 (col1_nchar, col1_char) VALUES 
+(NULL, NULL), 
+(NULL, NULL), 
+(NULL, NULL);
+GO
+~~ROW COUNT: 3~~
+
+
+
+-- Empty table
+CREATE TABLE babel_5688_table4 (col1_nchar NCHAR(20), col1_char CHAR(20));
+GO
+
+
+CREATE TABLE babel_5688_table5 (
+    id INT IDENTITY(1,1),
+    col_nchar NCHAR(20),
+    col_char CHAR(20)
+);
+GO
+
+-- Test Case 6: Unicode characters (for NCHAR, NVARCHAR)
+INSERT INTO babel_5688_table5 (col_nchar, col_char) VALUES 
+(N'日本語', '日本語'), (N'中文', '中文')
+GO
+~~ROW COUNT: 2~~
+
+
+-- Functions 
+CREATE FUNCTION babel_5688_f1()
+RETURNS NCHAR(20)
+AS
+BEGIN
+    RETURN (SELECT MIN(col_nchar) FROM babel_5688_all_types);
+END;
+GO
+
+CREATE FUNCTION babel_5688_f2()
+RETURNS NCHAR(20)
+AS
+BEGIN
+    RETURN (SELECT MAX(col_nchar) FROM babel_5688_all_types);
+END;
+GO
+
+CREATE FUNCTION babel_5688_f3() 
+RETURNS CHAR(20) 
+AS 
+BEGIN 
+    RETURN (SELECT MIN(col_char) FROM babel_5688_all_types);
+END;
+GO
+
+CREATE FUNCTION babel_5688_f4()
+RETURNS CHAR(20)
+AS
+BEGIN
+    RETURN (SELECT MAX(col_char) FROM babel_5688_all_types);
+END;
+GO
+
+
+-- FUNCTIONS WITH COALESCE
+CREATE FUNCTION babel_5688_f5(@default NCHAR(20))
+RETURNS NCHAR(20)
+AS
+BEGIN
+    RETURN (SELECT COALESCE(MIN(col_nchar), @default) FROM babel_5688_all_types);
+END;
+GO
+
+-- Function with declare
+CREATE FUNCTION babel_5688_f6(@col_category VARCHAR(20))
+RETURNS NCHAR(20)
+AS
+BEGIN
+    DECLARE @result NCHAR(20);
+    SELECT @result = MIN(col_nchar) 
+    FROM babel_5688_all_types 
+    WHERE col_category = @col_category;
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION babel_5688_f7()
+RETURNS NCHAR(20)
+AS
+BEGIN
+    DECLARE @nchar_var nchar(20) = N'abc';
+    RETURN (SELECT MIN(@nchar_var));
+END;
+GO
+
+-- Procedure
+CREATE PROCEDURE babel_5688_p1
+AS
+BEGIN
+    SELECT MIN(col_nchar), MAX(col_nchar), MIN(col_char), MAX(col_char), MIN(col_varchar), MAX(col_varchar), MIN(col_nvarchar), MAX(col_nvarchar)
+    FROM babel_5688_all_types;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p2 @col_category VARCHAR(20)
+AS
+BEGIN
+    SELECT MAX(col_nchar) AS max_nchar FROM babel_5688_all_types WHERE col_category = @col_category;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p3 @var NCHAR(20)
+AS
+BEGIN
+    SELECT MAX(@var), MIN(@var) AS max_var FROM babel_5688_all_types;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p4 @default NCHAR(20)
+AS
+BEGIN
+    SELECT COALESCE(MIN(col_nchar), @default) AS min_nchar_coalesce FROM babel_5688_all_types;
+END;
+GO
+
+-- Multiple DECLARE
+CREATE PROCEDURE babel_5688_p5
+AS
+BEGIN
+    DECLARE @nchar_var NCHAR(20) = N'nchar_value';
+    DECLARE @char_var CHAR(20) = 'char_value';
+    DECLARE @nvarchar_var NVARCHAR(25) = N'nvarchar_value';
+    DECLARE @varchar_var VARCHAR(25) = 'varchar_value';
+    
+    SELECT 
+        MIN(@nchar_var) AS min_nchar,
+        MAX(@nchar_var) AS max_nchar,
+        MIN(@char_var) AS min_char,
+        MAX(@char_var) AS max_char,
+        MIN(@nvarchar_var) AS min_nvarchar,
+        MAX(@nvarchar_var) AS max_nvarchar,
+        MIN(@varchar_var) AS min_varchar,
+        MAX(@varchar_var) AS max_varchar;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p6 @col_category VARCHAR(20)
+AS
+BEGIN
+    DECLARE @min_nchar NCHAR(20);
+    DECLARE @max_nchar NCHAR(20);
+    DECLARE @min_char CHAR(20);
+    DECLARE @max_char CHAR(20);
+    DECLARE @min_nvarchar NVARCHAR(25);
+    DECLARE @max_nvarchar NVARCHAR(25);
+    DECLARE @min_varchar VARCHAR(25);
+    DECLARE @max_varchar VARCHAR(25);
+    
+    SELECT 
+        @min_nchar = MIN(col_nchar),
+        @max_nchar = MAX(col_nchar),
+        @min_char = MIN(col_char),
+        @max_char = MAX(col_char),
+        @min_nvarchar = MIN(col_nvarchar),
+        @max_nvarchar = MAX(col_nvarchar),
+        @min_varchar = MIN(col_varchar),
+        @max_varchar = MAX(col_varchar)
+    FROM babel_5688_all_types 
+    WHERE col_category = @col_category;
+    
+    SELECT 
+        @min_nchar AS min_nchar, @max_nchar AS max_nchar,
+        @min_char AS min_char, @max_char AS max_char,
+        @min_nvarchar AS min_nvarchar, @max_nvarchar AS max_nvarchar,
+        @min_varchar AS min_varchar, @max_varchar AS max_varchar;
+END;
+GO
+
+
+-- Create tables for COLLATE clause aggregate testing with different data types
+CREATE TABLE babel_5688_table6 (
+    col1 CHAR(10), col2 NCHAR(10)
+);
+GO
+
+-- Insert test data for VARCHAR
+INSERT INTO babel_5688_table6 VALUES ('A', 'A');
+INSERT INTO babel_5688_table6 VALUES ('a', 'a');
+INSERT INTO babel_5688_table6 VALUES ('À', 'À');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- Index scan 
+-- Create table with both char and nchar columns for index scan testing
+CREATE TABLE babel_5688_table7 (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    col_char CHAR(50),
+    col_nchar NCHAR(50)
+);
+GO
+
+-- Create indexes on both columns to enable index scans
+CREATE INDEX IX_TestDatatypeAggSort_char ON babel_5688_table7(col_char);
+GO
+CREATE INDEX IX_TestDatatypeAggSort_nchar ON babel_5688_table7(col_nchar);
+GO
+
+-- Insert 10,000 rows with varied col_nchar data
+WITH NumberSeries AS (
+    SELECT 1 as n
+    UNION ALL
+    SELECT n + 1
+    FROM NumberSeries
+    WHERE n < 10000
+)
+INSERT INTO babel_5688_table7 (col_char, col_nchar)
+SELECT 
+    CASE 
+        WHEN n % 4 = 0 THEN CHAR(97 + (n % 26)) + CHAR(97 + ((n/26) % 26)) + CHAR(97 + ((n/676) % 26))
+        WHEN n % 4 = 1 THEN CHAR(98 + (n % 25)) + CHAR(98 + ((n/25) % 25)) + CHAR(98 + ((n/625) % 25))
+        WHEN n % 4 = 2 THEN CHAR(99 + (n % 24)) + CHAR(99 + ((n/24) % 24)) + CHAR(99 + ((n/576) % 24))
+        ELSE CHAR(100 + (n % 23)) + CHAR(100 + ((n/23) % 23)) + CHAR(100 + ((n/529) % 23))
+    END,
+    CASE 
+        WHEN n % 4 = 0 THEN CHAR(97 + (n % 26)) + CHAR(97 + ((n/26) % 26)) + CHAR(97 + ((n/676) % 26))
+        WHEN n % 4 = 1 THEN CHAR(98 + (n % 25)) + CHAR(98 + ((n/25) % 25)) + CHAR(98 + ((n/625) % 25))
+        WHEN n % 4 = 2 THEN CHAR(99 + (n % 24)) + CHAR(99 + ((n/24) % 24)) + CHAR(99 + ((n/576) % 24))
+        ELSE CHAR(100 + (n % 23)) + CHAR(100 + ((n/23) % 23)) + CHAR(100 + ((n/529) % 23))
+    END 
+FROM NumberSeries  
+OPTION (MAXRECURSION 10000);
+GO
+~~ROW COUNT: 10000~~
+
+

--- a/test/JDBC/expected/string_aggregate-vu-verify.out
+++ b/test/JDBC/expected/string_aggregate-vu-verify.out
@@ -1,0 +1,1315 @@
+-- Test basic
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar, MAX(col_varchar) AS max_varchar 
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               #!# Apple #!#Zebra#!# Apple #!#Zebra
+~~END~~
+
+
+
+-- Test with GROUP BY and ORDER BY
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              #!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          
+NullTest#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>
+NumericStr#!#1                   #!#1                   #!#1                   #!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#!Special            #!##Hash               
+~~END~~
+
+
+select min(col_char) FROM babel_5688_all_types GROUP BY col_nchar ORDER BY col_nchar
+go
+~~START~~
+char
+<NULL>
+ Apple              
+!Special            
+#Hash               
+1                   
+AAAAAAAAAA          
+Apple               
+Orange              
+Zebra               
+~~END~~
+
+
+
+-- Test with having clause 
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar,
+    COUNT(*) AS cnt
+FROM babel_5688_all_types
+GROUP BY col_category
+HAVING MIN(col_nchar) IS NOT NULL AND MAX(col_nchar) IS NOT NULL
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#int
+Animal#!#Zebra               #!#Zebra               #!#1
+Fruit#!# Apple              #!#Orange              #!#3
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#1
+NumericStr#!#1                   #!#1                   #!#1
+SpecialChar#!#!Special            #!##Hash               #!#2
+~~END~~
+
+
+
+-- Test Where clause 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar
+FROM babel_5688_all_types
+WHERE col_category = 'Fruit';
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+ Apple              #!#Orange              #!# Apple              #!#Orange              #!# Apple #!#Orange#!# Apple 
+~~END~~
+
+
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               
+~~END~~
+
+
+
+-- Test distinct
+SELECT 
+    MIN(DISTINCT col_nchar) AS min_distinct_nchar, MAX(DISTINCT col_nchar) AS max_distinct_nchar,
+    MIN(DISTINCT col_char) AS min_distinct_char, MAX(DISTINCT col_char) AS max_distinct_char,
+    MIN(DISTINCT col_nvarchar) AS min_distinct_nvarchar, MAX(DISTINCT col_nvarchar) AS max_distinct_nvarchar,
+    MIN(DISTINCT col_varchar) AS min_distinct_varchar
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+ Apple              #!#Zebra               #!# Apple              #!#Zebra               #!# Apple #!#Zebra#!# Apple 
+~~END~~
+
+
+
+-- Test subquery
+SELECT * FROM babel_5688_all_types WHERE col_nchar = (SELECT MIN(col_nchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_char = (SELECT MIN(col_char) FROM babel_5688_all_types WHERE col_char IS NOT NULL);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_nvarchar = (SELECT MIN(col_nvarchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+SELECT * FROM babel_5688_all_types WHERE col_varchar = (SELECT MIN(col_varchar) FROM babel_5688_all_types);
+GO
+~~START~~
+int#!#nchar#!#char#!#nvarchar#!#varchar#!#varchar#!#int
+2#!# Apple              #!# Apple              #!# Apple #!# Apple #!#Fruit#!#200
+~~END~~
+
+
+
+-- Test UNION ALL
+SELECT 'NCHAR' AS col_type, MIN(col_nchar) AS min_val, MAX(col_nchar) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT 'CHAR' AS col_type, MIN(col_char) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_char IS NOT NULL
+UNION ALL
+SELECT 'NVARCHAR' AS col_type, MIN(col_nvarchar) AS min_val, MAX(col_nvarchar) AS max_val FROM babel_5688_all_types WHERE col_nvarchar IS NOT NULL
+ORDER BY col_type;
+GO
+~~START~~
+varchar#!#nvarchar#!#nvarchar
+CHAR#!# Apple              #!#Zebra               
+NCHAR#!# Apple              #!#Zebra               
+NVARCHAR#!# Apple #!#Zebra
+~~END~~
+
+
+SELECT MIN(col_nchar) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table2 WHERE col1_char IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table3 WHERE col1_char IS NOT NULL
+ORDER BY min_val;
+GO
+~~START~~
+nchar#!#char
+<NULL>#!#<NULL>
+ Apple              #!#Zebra               
+Cherry              #!#Date                
+~~END~~
+
+
+
+-- Test CTEs
+WITH MinMaxCTE AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_nchar,
+        MAX(col_nchar) AS max_nchar,
+        MIN(col_char) AS min_char,
+        MAX(col_char) AS max_char
+    FROM babel_5688_all_types
+    GROUP BY col_category
+)
+SELECT * FROM MinMaxCTE WHERE min_nchar IS NOT NULL ORDER BY col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              #!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#AAAAAAAAAA          
+NumericStr#!#1                   #!#1                   #!#1                   #!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#!Special            #!##Hash               
+~~END~~
+
+
+WITH CategoryStats AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val,
+        COUNT(*) AS cnt
+    FROM babel_5688_all_types
+    WHERE col_nchar IS NOT NULL
+    GROUP BY col_category
+)
+SELECT 
+    cs.col_category, 
+    cs.min_val, 
+    cs.max_val, 
+    cs.cnt,
+    t.col_nchar AS sample_value
+FROM CategoryStats cs
+JOIN babel_5688_all_types t ON t.col_category = cs.col_category AND t.col_nchar = cs.min_val
+ORDER BY cs.col_category, sample_value;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#int#!#nchar
+Animal#!#Zebra               #!#Zebra               #!#1#!#Zebra               
+Fruit#!# Apple              #!#Orange              #!#3#!# Apple              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#1#!#AAAAAAAAAA          
+NumericStr#!#1                   #!#1                   #!#1#!#1                   
+SpecialChar#!#!Special            #!##Hash               #!#2#!#!Special            
+~~END~~
+
+
+-- Test CASE EXPRESSION
+SELECT 
+    col_category,
+    CASE 
+        WHEN MIN(col_nchar) = MAX(col_nchar) THEN 'Same'
+        WHEN MIN(col_nchar) IS NULL OR MAX(col_nchar) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS nchar_status,
+    CASE 
+        WHEN MIN(col_char) = MAX(col_char) THEN 'Same'
+        WHEN MIN(col_char) IS NULL OR MAX(col_char) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS varchar_status
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+~~START~~
+varchar#!#varchar#!#varchar
+Animal#!#Same#!#Same
+Fruit#!#Different#!#Different
+LongStr#!#Same#!#Same
+NullTest#!#Has Nulls#!#Has Nulls
+NumericStr#!#Same#!#Same
+SpecialChar#!#Different#!#Different
+~~END~~
+
+
+-- Test expressions inside min/max
+SELECT  
+    MIN(UPPER(col_nchar)) AS min_upper_nchar,
+    MAX(UPPER(col_nchar)) AS max_upper_nchar,
+    MIN(LOWER(col_nchar)) AS min_lower_nchar,
+    MAX(LOWER(col_nchar)) AS max_lower_nchar,
+    MIN(UPPER(col_char)) AS min_upper_char,
+    MAX(UPPER(col_char)) AS max_upper_char,
+    MIN(LOWER(col_char)) AS min_lower_char,
+    MAX(LOWER(col_char)) AS max_lower_char 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#varchar#!#varchar#!#varchar#!#varchar
+ APPLE              #!#ZEBRA               #!# apple              #!#zebra               #!# APPLE              #!#ZEBRA               #!# apple              #!#zebra               
+~~END~~
+
+
+-- Test TOP WITH MIN/MAX
+SELECT TOP 5 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL 
+GROUP BY col_category 
+ORDER BY min_nchar, max_nchar;
+GO
+~~START~~
+varchar#!#nchar#!#nchar
+Fruit#!# Apple              #!#Orange              
+SpecialChar#!#!Special            #!##Hash               
+NumericStr#!#1                   #!#1                   
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          
+Animal#!#Zebra               #!#Zebra               
+~~END~~
+
+
+SELECT TOP 3
+    col_category,
+    MIN(col_char) AS min_char,
+    MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_char IS NOT NULL
+GROUP BY col_category
+ORDER BY MAX(col_char) DESC;
+GO
+~~START~~
+varchar#!#char#!#char
+Animal#!#Zebra               #!#Zebra               
+Fruit#!# Apple              #!#Orange              
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          
+~~END~~
+
+
+
+-- Test COALESCE/ISNULL 
+SELECT COALESCE(MIN(col1_nchar), N'No Value') AS min_nchar FROM babel_5688_table2;
+GO
+~~START~~
+nvarchar
+Apple               
+~~END~~
+
+SELECT ISNULL(MAX(col1_nchar), N'No Value') AS max_nchar FROM babel_5688_table2;
+GO
+~~START~~
+nchar
+Cherry              
+~~END~~
+
+SELECT COALESCE(MIN(col1_char), 'No Value') AS min_char FROM babel_5688_table2;
+GO
+~~START~~
+varchar
+Banana              
+~~END~~
+
+SELECT ISNULL(MAX(col1_char), 'No Value') AS max_char FROM babel_5688_table2;
+GO
+~~START~~
+char
+Date                
+~~END~~
+
+
+-- All null values in tables
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MIN(col1_char) AS min_char FROM babel_5688_table3;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MAX(col1_char) AS min_char FROM babel_5688_table3;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+
+-- Test Empty table
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MIN(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+nchar
+<NULL>
+~~END~~
+
+SELECT MAX(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+~~START~~
+char
+<NULL>
+~~END~~
+
+
+
+-- Test JOINs
+-- Inner Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+INNER JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#nchar#!#char
+~~END~~
+
+
+-- Left Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char,
+    CASE WHEN t2.col1_nchar IS NULL THEN 'No Match' ELSE 'Matched' END AS match_status
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+LEFT JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+~~START~~
+varchar#!#nchar#!#nchar#!#nchar#!#char#!#varchar
+Animal#!#Zebra               #!#Zebra               #!#<NULL>#!#<NULL>#!#No Match
+Fruit#!# Apple              #!#Orange              #!#<NULL>#!#<NULL>#!#No Match
+LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#<NULL>#!#<NULL>#!#No Match
+NullTest#!#<NULL>#!#<NULL>#!#<NULL>#!#<NULL>#!#No Match
+NumericStr#!#1                   #!#1                   #!#<NULL>#!#<NULL>#!#No Match
+SpecialChar#!#!Special            #!##Hash               #!#<NULL>#!#<NULL>#!#No Match
+~~END~~
+
+
+-- Complex query combining all elements
+SELECT 
+    source_info,
+    col_category,
+    min_val,
+    max_val,
+    CASE 
+        WHEN min_val IS NULL AND max_val IS NULL THEN 'Empty/All NULL'
+        WHEN min_val = max_val THEN 'Single Unique Value'
+        ELSE 'Multiple Values'
+    END AS data_status
+FROM (
+    -- From babel_5688_all_types grouped by col_category
+    SELECT 
+        'AllTypes-ByCategory' AS source_info,
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val
+    FROM babel_5688_all_types
+    GROUP BY col_category
+    
+    UNION ALL
+    
+    -- From babel_5688_table2
+    SELECT 
+        'Table2-All' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table2
+    
+    UNION ALL
+    
+    -- From babel_5688_table3 (all nulls)
+    SELECT 
+        'Table3-AllNulls' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table3
+    
+    UNION ALL
+    
+    -- From babel_5688_table4 (empty)
+    SELECT 
+        'Table4-Empty' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table4
+) combined_data
+ORDER BY source_info, col_category;
+GO
+~~START~~
+varchar#!#varchar#!#nchar#!#nchar#!#varchar
+AllTypes-ByCategory#!#Animal#!#Zebra               #!#Zebra               #!#Single Unique Value
+AllTypes-ByCategory#!#Fruit#!# Apple              #!#Orange              #!#Multiple Values
+AllTypes-ByCategory#!#LongStr#!#AAAAAAAAAA          #!#AAAAAAAAAA          #!#Single Unique Value
+AllTypes-ByCategory#!#NullTest#!#<NULL>#!#<NULL>#!#Empty/All NULL
+AllTypes-ByCategory#!#NumericStr#!#1                   #!#1                   #!#Single Unique Value
+AllTypes-ByCategory#!#SpecialChar#!#!Special            #!##Hash               #!#Multiple Values
+Table2-All#!#N/A#!#Apple               #!#Cherry              #!#Multiple Values
+Table3-AllNulls#!#N/A#!#<NULL>#!#<NULL>#!#Empty/All NULL
+Table4-Empty#!#N/A#!#<NULL>#!#<NULL>#!#Empty/All NULL
+~~END~~
+
+
+-- Test Unicode characters 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_table5;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+中文                  #!#日本語                 #!#??                  #!#???                 
+~~END~~
+
+
+-- Test: Empty strings and spaces
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('', '', '', '', 'EmptyTest', 0),
+('   ', '   ', '   ', '   ', 'SpaceTest', 0)
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char
+                    #!#Zebra               #!#                    #!#Zebra               
+~~END~~
+
+
+-- Test declare statements
+DECLARE @nchar_var nchar(20) = N'abc';
+DECLARE @nchar_var1 nchar(20) = N'日本語';
+DECLARE @nchar_var2 nchar(20) = N'';
+DECLARE @nchar_var3 nchar(20) = NULL;
+SELECT 
+    min(@nchar_var), max(@nchar_var), 
+    min(@nchar_var1), max(@nchar_var1),
+    min(@nchar_var2), max(@nchar_var2),
+    min(@nchar_var3), max(@nchar_var3)
+go
+~~START~~
+nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar#!#nchar
+abc                 #!#abc                 #!#日本語                 #!#日本語                 #!#                    #!#                    #!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @char_var char(20) = 'abc';
+DECLARE @char_var1 char(20) = N'日本語';
+DECLARE @char_var2 char(20) = '';
+DECLARE @char_var3 char(20) = NULL;
+SELECT 
+    min(@char_var), max(@char_var), 
+    min(@char_var1), max(@char_var1),
+    min(@char_var2), max(@char_var2),
+    min(@char_var3), max(@char_var3)
+GO
+~~START~~
+char#!#char#!#char#!#char#!#char#!#char#!#char#!#char
+abc                 #!#abc                 #!#???                 #!#???                 #!#                    #!#                    #!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @nvarchar_var nvarchar(25) = N'test';
+DECLARE @nvarchar_var1 nvarchar(25) = N'unicode日本語';
+DECLARE @nvarchar_var2 nvarchar(25) = N'';
+DECLARE @nvarchar_var3 nvarchar(25) = NULL;
+SELECT 
+    min(@nvarchar_var), max(@nvarchar_var), 
+    min(@nvarchar_var1), max(@nvarchar_var1),
+    min(@nvarchar_var2), max(@nvarchar_var2),
+    min(@nvarchar_var3), max(@nvarchar_var3)
+GO
+~~START~~
+nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar#!#nvarchar
+test#!#test#!#unicode日本語#!#unicode日本語#!##!##!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @varchar_var varchar(25) = 'hello';
+DECLARE @varchar_var1 varchar(25) = 'world';
+DECLARE @varchar_var2 varchar(25) = '';
+DECLARE @varchar_var3 varchar(25) = NULL;
+SELECT 
+    min(@varchar_var), max(@varchar_var), 
+    min(@varchar_var1), max(@varchar_var1),
+    min(@varchar_var2), max(@varchar_var2),
+    min(@varchar_var3), max(@varchar_var3)
+GO
+~~START~~
+varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar#!#varchar
+hello#!#hello#!#world#!#world#!##!##!#<NULL>#!#<NULL>
+~~END~~
+
+
+
+
+-- Basic test using babel_5688_all_types columns
+DECLARE @min_nchar NCHAR(20);
+DECLARE @max_nchar NCHAR(20);
+DECLARE @min_char CHAR(20);
+DECLARE @max_char CHAR(20);
+DECLARE @min_nvarchar NVARCHAR(25);
+DECLARE @max_nvarchar NVARCHAR(25);
+DECLARE @min_varchar VARCHAR(25);
+SELECT @min_nchar = MIN(col_nchar) FROM babel_5688_all_types;
+SELECT @max_nchar = MAX(col_nchar) FROM babel_5688_all_types;
+SELECT @min_char = MIN(col_char) FROM babel_5688_all_types;
+SELECT @max_char = MAX(col_char) FROM babel_5688_all_types;
+SELECT @min_nvarchar = MIN(col_nvarchar) FROM babel_5688_all_types;
+SELECT @max_nvarchar = MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT @min_varchar = MIN(col_varchar) FROM babel_5688_all_types;
+SELECT 
+    @min_nchar AS min_nchar, @max_nchar AS max_nchar,
+    @min_char AS min_char, @max_char AS max_char,
+    @min_nvarchar AS min_nvarchar, @max_nvarchar AS max_nvarchar,
+    @min_varchar AS min_varchar;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar
+                    #!#Zebra               #!#                    #!#Zebra               #!##!#Zebra#!#
+~~END~~
+
+
+-- Test Declare with table variable
+SELECT 'TEST D7: DECLARE with table variable' AS TestName;
+GO
+~~START~~
+varchar
+TEST D7: DECLARE with table variable
+~~END~~
+
+
+
+
+
+
+DECLARE @results TABLE (
+    col_type VARCHAR(20),
+    min_val NVARCHAR(25),
+    max_val NVARCHAR(25)
+);
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NCHAR', MIN(col_nchar), MAX(col_nchar) FROM babel_5688_all_types;
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'CHAR', MIN(col_char), MAX(col_char) FROM babel_5688_all_types;
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NVARCHAR', MIN(col_nvarchar), MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT * FROM @results;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar#!#nvarchar#!#nvarchar
+NCHAR#!#                    #!#Zebra               
+CHAR#!#                    #!#Zebra               
+NVARCHAR#!##!#Zebra
+~~END~~
+
+
+
+-- Functions 
+-- Procedures
+-- Test Functions
+SELECT dbo.babel_5688_f1() AS f1_min_nchar;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f2() AS f2_max_nchar;
+GO
+~~START~~
+nchar
+Zebra               
+~~END~~
+
+SELECT dbo.babel_5688_f3() AS f3_min_char;
+GO
+~~START~~
+char
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f4() AS f4_max_char;
+GO
+~~START~~
+char
+Zebra               
+~~END~~
+
+SELECT dbo.babel_5688_f5(N'default') AS f8_coalesce;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f5(N'') AS result_empty_default;
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+SELECT dbo.babel_5688_f6('Fruit') AS f9_category_min;
+GO
+~~START~~
+nchar
+ Apple              
+~~END~~
+
+SELECT dbo.babel_5688_f7() AS f10_var_min;
+GO
+~~START~~
+nchar
+abc                 
+~~END~~
+
+
+-- Test Procedures
+EXEC babel_5688_p1;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#varchar#!#varchar#!#nvarchar#!#nvarchar
+                    #!#Zebra               #!#                    #!#Zebra               #!##!#Zebra#!##!#Zebra
+~~END~~
+
+EXEC babel_5688_p2 'Fruit';
+GO
+~~START~~
+nchar
+Orange              
+~~END~~
+
+EXEC babel_5688_p3 N'test_var';
+GO
+~~START~~
+nchar#!#nchar
+test_var            #!#test_var            
+~~END~~
+
+EXEC babel_5688_p4 N'default_value';
+GO
+~~START~~
+nchar
+                    
+~~END~~
+
+EXEC babel_5688_p5;
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+nchar_value         #!#nchar_value         #!#char_value          #!#char_value          #!#nvarchar_value#!#nvarchar_value#!#varchar_value#!#varchar_value
+~~END~~
+
+EXEC babel_5688_p6 'Animal';
+GO
+~~START~~
+nchar#!#nchar#!#char#!#char#!#nvarchar#!#nvarchar#!#varchar#!#varchar
+Zebra               #!#Zebra               #!#Zebra               #!#Zebra               #!#Zebra#!#Zebra#!#Zebra#!#Zebra
+~~END~~
+
+
+-- Test explicit COLLATE clause on aggregate functions for CHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT MAX(col1) FROM babel_5688_table6;
+GO
+~~START~~
+char
+À         
+~~END~~
+
+SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+~~START~~
+char
+A         
+~~END~~
+
+
+-- Test explicit COLLATE clause on aggregate functions for NCHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+~~START~~
+int
+1
+~~END~~
+
+SELECT MAX(col2) FROM babel_5688_table6;
+GO
+~~START~~
+nchar
+À         
+~~END~~
+
+SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+~~START~~
+nchar
+A         
+~~END~~
+
+
+
+-- Testing index scan 
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+~~START~~
+text
+0
+~~END~~
+
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_bitmapscan', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+SELECT set_config('enable_seqscan', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+-- All permutation queries for index scan testing
+-- MAX/MIN with same column in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Only Scan Backward using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: ((col_char IS NOT NULL) AND (col_char <= 'cbd'::bpchar))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 8.955 ms
+~~END~~
+
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Only Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: ((col_char IS NOT NULL) AND (col_char <= 'cbd'::bpchar))
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.113 ms
+~~END~~
+
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Aggregate
+  ->  Index Only Scan using ix_testdatatypeaggsort_ncharbab22b6ccf3ad272c9e2c3aca6debfc63b6 on babel_5688_table7
+        Index Cond: (col_nchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.104 ms
+~~END~~
+
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Aggregate
+  ->  Index Only Scan using ix_testdatatypeaggsort_ncharbab22b6ccf3ad272c9e2c3aca6debfc63b6 on babel_5688_table7
+        Index Cond: (col_nchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.104 ms
+~~END~~
+
+
+-- MAX/MIN with different columns in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Scan Backward using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: (col_char IS NOT NULL)
+                Filter: ((col_nchar)::bpchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.107 ms
+~~END~~
+
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd'
+Result
+  InitPlan 1
+    ->  Limit
+          ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+                Index Cond: (col_char IS NOT NULL)
+                Filter: ((col_nchar)::bpchar <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.107 ms
+~~END~~
+
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Aggregate
+  ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+        Index Cond: (col_char <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.124 ms
+~~END~~
+
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+~~START~~
+text
+Query Text: SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd'
+Aggregate
+  ->  Index Scan using ix_testdatatypeaggsort_charbabe569e60362c5f617aa361d4154dc67a55 on babel_5688_table7
+        Index Cond: (col_char <= 'cbd'::bpchar)
+~~END~~
+
+~~START~~
+text
+Babelfish T-SQL Batch Parsing Time: 0.121 ms
+~~END~~
+
+
+-- Reset
+SET BABELFISH_SHOWPLAN_ALL OFF
+go
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+SELECT set_config('enable_seqscan', 'on', false)
+go
+~~START~~
+text
+on
+~~END~~
+
+SELECT set_config('enable_bitmapscan', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+
+
+-- Test cases for MIN/MAX with CAST combinations across data types
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+
+-- MAX versions of the same combinations
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+~~START~~
+nchar
+1         
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+~~START~~
+nvarchar
+1
+~~END~~
+
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+~~START~~
+char
+1         
+~~END~~
+

--- a/test/JDBC/input/datatypes/TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup.sql
+++ b/test/JDBC/input/datatypes/TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup.sql
@@ -1,0 +1,33 @@
+DROP VIEW TestDatatypeAggSort_vu_prepare_char_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_char_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_varchar_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_varchar_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_min
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_max
+go
+DROP VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_min
+go
+
+DROP PROCEDURE TestDatatypeAggSort_vu_prepare_proc
+go
+
+DROP TABLE TestDatatypeAggSort_vu_prepare_tbl
+go
+
+DROP TABLE TestDatatypeAggSort_vu_prepare_tbl2
+go

--- a/test/JDBC/input/datatypes/TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare.sql
+++ b/test/JDBC/input/datatypes/TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare.sql
@@ -1,0 +1,163 @@
+CREATE TABLE TestDatatypeAggSort_vu_prepare_tbl (
+	char_col CHAR(10), 
+	varchar_col VARCHAR(10),
+	datetime_col DATETIME,
+	datetime2_col DATETIME2,
+	datetimeoffset_col DATETIMEOFFSET,
+	smalldatetime_col SMALLDATETIME,
+);
+go
+
+INSERT INTO TestDatatypeAggSort_vu_prepare_tbl VALUES (
+	'abc', 'abc',
+	'1900-01-01 00:00:00.000',
+	'1900-01-01 00:00:00.000',
+	'1900-01-01 00:00:00.000 +0:00',
+	'1900-01-01 00:00:00.000'
+), (
+	'def', 'def',
+	'1950-01-01 00:00:00.000',
+	'1950-01-01 00:00:00.000',
+	'1950-01-01 00:00:00.000 +0:00',
+	'1950-01-01 00:00:00.000'
+), (
+	'ghi', 'ghi',
+	'2000-01-01 00:00:00.000',
+	'2000-01-01 00:00:00.000',
+	'2000-01-01 00:00:00.000 +0:00',
+	'2000-01-01 00:00:00.000'
+), (
+	'jkl', 'jkl',
+	'2005-01-01 00:00:00.000',
+	'2005-01-01 00:00:00.000',
+	'2005-01-01 00:00:00.000 +0:00',
+	'2005-01-01 00:00:00.000'
+), (
+	'mno', 'mno',
+	'2010-01-01 00:00:00.000',
+	'2010-01-01 00:00:00.000',
+	'2010-01-01 00:00:00.000 +0:00',
+	'2010-01-01 00:00:00.000'
+), (
+	'pqr', 'pqr',
+	'2015-01-01 00:00:00.000',
+	'2015-01-01 00:00:00.000',
+	'2015-01-01 00:00:00.000 +0:00',
+	'2015-01-01 00:00:00.000'
+), (
+	'stu', 'stu',
+	'2020-01-01 00:00:00.000',
+	'2020-01-01 00:00:00.000',
+	'2020-01-01 00:00:00.000 +0:00',
+	'2020-01-01 00:00:00.000'
+), (
+	'xyz', 'xyz',
+	'2023-11-06 00:00:00.000',
+	'2023-11-06 00:00:00.000',
+	'2023-11-06 00:00:00.000 +0:00',
+	'2023-11-06 00:00:00.000'
+), (
+	NULL, NULL, NULL, NULL, NULL, NULL
+);
+go
+
+CREATE INDEX TestDatatypeAggSort_vu_prepare_char_idx ON TestDatatypeAggSort_vu_prepare_tbl (char_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_varchar_idx ON TestDatatypeAggSort_vu_prepare_tbl (varchar_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_datetime_idx ON TestDatatypeAggSort_vu_prepare_tbl (datetime_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_datetime2_idx ON TestDatatypeAggSort_vu_prepare_tbl (datetime2_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_datetimeoffset_idx ON TestDatatypeAggSort_vu_prepare_tbl (datetimeoffset_col)
+go
+CREATE INDEX TestDatatypeAggSort_vu_prepare_smalldatetime_idx ON TestDatatypeAggSort_vu_prepare_tbl (smalldatetime_col)
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_char_view_max AS
+SELECT MAX(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_char_view_min AS
+SELECT MIN(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_varchar_view_max AS
+SELECT MAX(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_varchar_view_min AS
+SELECT MIN(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime_view_max AS
+SELECT MAX(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime_view_min AS
+SELECT MIN(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_max AS
+SELECT MAX(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetime2_view_min AS
+SELECT MIN(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_max AS
+SELECT MAX(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_datetimeoffset_view_min AS
+SELECT MIN(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_max AS
+SELECT MAX(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+CREATE VIEW TestDatatypeAggSort_vu_prepare_smalldatetime_view_min AS
+SELECT MIN(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl
+go
+
+CREATE TABLE TestDatatypeAggSort_vu_prepare_tbl2 (
+	max_min VARCHAR(3),
+	char_col CHAR(10), 
+	varchar_col VARCHAR(10),
+	datetime_col DATETIME,
+	datetime2_col DATETIME2(6),
+	datetimeoffset_col DATETIMEOFFSET,
+	smalldatetime_col SMALLDATETIME,
+);
+go
+
+CREATE PROCEDURE TestDatatypeAggSort_vu_prepare_proc AS
+BEGIN
+	DECLARE @char_val CHAR(10)
+	DECLARE @varchar_val VARCHAR(10)
+	DECLARE @datetime_val DATETIME
+	DECLARE @datetime2_val DATETIME2
+	DECLARE @datetimeoffset_val DATETIMEOFFSET
+	DECLARE @smalldatetime_val SMALLDATETIME
+
+	SET @char_val = (SELECT MAX(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @varchar_val = (SELECT MAX(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime_val = (SELECT MAX(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime2_val = (SELECT MAX(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetimeoffset_val = (SELECT MAX(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @smalldatetime_val = (SELECT MAX(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+
+	INSERT INTO TestDatatypeAggSort_vu_prepare_tbl2 VALUES (
+		'max', @char_val, @varchar_val, @datetime_val, @datetime2_val,
+		@datetimeoffset_val, @smalldatetime_val
+	)
+
+	SET @char_val = (SELECT MIN(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @varchar_val = (SELECT MIN(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime_val = (SELECT MIN(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetime2_val = (SELECT MIN(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @datetimeoffset_val = (SELECT MIN(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+	SET @smalldatetime_val = (SELECT MIN(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl)
+
+	INSERT INTO TestDatatypeAggSort_vu_prepare_tbl2 VALUES (
+		'min', @char_val, @varchar_val, @datetime_val, @datetime2_val,
+		@datetimeoffset_val, @smalldatetime_val
+	)
+END
+go

--- a/test/JDBC/input/datatypes/TestDatatypeAggSort-before-16_12-or-17_8-vu-verify.sql
+++ b/test/JDBC/input/datatypes/TestDatatypeAggSort-before-16_12-or-17_8-vu-verify.sql
@@ -1,196 +1,66 @@
 SELECT * FROM TestDatatypeAggSort_vu_prepare_char_view_max
 go
-~~START~~
-char
-xyz       
-~~END~~
-
 SELECT * FROM TestDatatypeAggSort_vu_prepare_char_view_min
 go
-~~START~~
-char
-abc       
-~~END~~
-
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_varchar_view_max
 go
-~~START~~
-varchar
-xyz
-~~END~~
-
 SELECT * FROM TestDatatypeAggSort_vu_prepare_varchar_view_min
 go
-~~START~~
-varchar
-abc
-~~END~~
-
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_datetime_view_max
 go
-~~START~~
-datetime
-2023-11-06 00:00:00.0
-~~END~~
-
 SELECT * FROM TestDatatypeAggSort_vu_prepare_datetime_view_min
 go
-~~START~~
-datetime
-1900-01-01 00:00:00.0
-~~END~~
-
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_datetime2_view_max
 go
-~~START~~
-datetime2
-2023-11-06 00:00:00.0000000
-~~END~~
-
 SELECT * FROM TestDatatypeAggSort_vu_prepare_datetime2_view_min
 go
-~~START~~
-datetime2
-1900-01-01 00:00:00.0000000
-~~END~~
-
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_datetimeoffset_view_max
 go
-~~START~~
-datetimeoffset
-2023-11-06 00:00:00.0000000 +00:00
-~~END~~
-
 SELECT * FROM TestDatatypeAggSort_vu_prepare_datetimeoffset_view_min
 go
-~~START~~
-datetimeoffset
-1900-01-01 00:00:00.0000000 +00:00
-~~END~~
-
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_smalldatetime_view_max
 go
-~~START~~
-smalldatetime
-2023-11-06 00:00:00.0
-~~END~~
-
 SELECT * FROM TestDatatypeAggSort_vu_prepare_smalldatetime_view_min
 go
-~~START~~
-smalldatetime
-1900-01-01 00:00:00.0
-~~END~~
-
 
 EXEC TestDatatypeAggSort_vu_prepare_proc
 go
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM TestDatatypeAggSort_vu_prepare_tbl2 ORDER BY max_min
 go
-~~START~~
-varchar#!#char#!#varchar#!#datetime#!#datetime2#!#datetimeoffset#!#smalldatetime
-max#!#xyz       #!#xyz#!#2023-11-06 00:00:00.0#!#2023-11-06 00:00:00.000000#!#2023-11-06 00:00:00.0000000 +00:00#!#2023-11-06 00:00:00.0
-min#!#abc       #!#abc#!#1900-01-01 00:00:00.0#!#1900-01-01 00:00:00.000000#!#1900-01-01 00:00:00.0000000 +00:00#!#1900-01-01 00:00:00.0
-~~END~~
-
 
 -- This is failing because of BABEL-4332
 SELECT MAX(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE varchar_col <= 'xxx'
 go
-~~START~~
-char
-stu       
-~~END~~
-
 SELECT MIN(char_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE varchar_col <= 'xxx'
 go
-~~START~~
-char
-abc       
-~~END~~
-
 
 SELECT MAX(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE varchar_col <= 'xxx'
 go
-~~START~~
-varchar
-stu
-~~END~~
-
 SELECT MIN(varchar_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE varchar_col > 'xxx'
 go
-~~START~~
-varchar
-xyz
-~~END~~
-
 
 SELECT MAX(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE datetime_col <= '2020-12-31 23:59:59'
 go
-~~START~~
-datetime
-2020-01-01 00:00:00.0
-~~END~~
-
 SELECT MIN(datetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE datetime_col > '2020-12-31 23:59:59'
 go
-~~START~~
-datetime
-2023-11-06 00:00:00.0
-~~END~~
-
 
 SELECT MAX(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE datetime2_col <= '2020-12-31 23:59:59'
 go
-~~START~~
-datetime2
-2020-01-01 00:00:00.0000000
-~~END~~
-
 SELECT MIN(datetime2_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE datetime2_col > '2020-12-31 23:59:59'
 go
-~~START~~
-datetime2
-2023-11-06 00:00:00.0000000
-~~END~~
-
 
 SELECT MAX(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE datetimeoffset_col <= '2020-12-31 23:59:59'
 go
-~~START~~
-datetimeoffset
-2020-01-01 00:00:00.0000000 +00:00
-~~END~~
-
 SELECT MIN(datetimeoffset_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE datetimeoffset_col > '2020-12-31 23:59:59'
 go
-~~START~~
-datetimeoffset
-2023-11-06 00:00:00.0000000 +00:00
-~~END~~
-
 
 SELECT MAX(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE smalldatetime_col <= '2020-12-31 23:59:59'
 go
-~~START~~
-smalldatetime
-2020-01-01 00:00:00.0
-~~END~~
-
 SELECT MIN(smalldatetime_col) FROM TestDatatypeAggSort_vu_prepare_tbl WHERE smalldatetime_col > '2020-12-31 23:59:59'
 go
-~~START~~
-smalldatetime
-2023-11-06 00:00:00.0
-~~END~~
-

--- a/test/JDBC/input/string_aggregate-vu-cleanup.sql
+++ b/test/JDBC/input/string_aggregate-vu-cleanup.sql
@@ -1,0 +1,45 @@
+-- Drop procedures
+DROP PROCEDURE babel_5688_p1;
+GO
+DROP PROCEDURE babel_5688_p2;
+GO
+DROP PROCEDURE babel_5688_p3;
+GO
+DROP PROCEDURE babel_5688_p4;
+GO
+DROP PROCEDURE babel_5688_p5;
+GO
+DROP PROCEDURE babel_5688_p6;
+GO
+
+-- Drop functions
+DROP FUNCTION babel_5688_f1;
+GO
+DROP FUNCTION babel_5688_f2;
+GO
+DROP FUNCTION babel_5688_f3;
+GO
+DROP FUNCTION babel_5688_f4;
+GO
+DROP FUNCTION babel_5688_f5;
+GO
+DROP FUNCTION babel_5688_f6;
+GO
+DROP FUNCTION babel_5688_f7;
+GO
+
+-- Drop tables
+DROP TABLE babel_5688_all_types;
+GO
+DROP TABLE babel_5688_table2;
+GO
+DROP TABLE babel_5688_table3;
+GO
+DROP TABLE babel_5688_table4;
+GO
+DROP TABLE babel_5688_table5;
+GO
+DROP TABLE babel_5688_table6;
+GO
+DROP TABLE babel_5688_table7;
+GO

--- a/test/JDBC/input/string_aggregate-vu-prepare.sql
+++ b/test/JDBC/input/string_aggregate-vu-prepare.sql
@@ -1,0 +1,286 @@
+-- Create single table with all character types
+CREATE TABLE babel_5688_all_types (
+    id INT IDENTITY(1,1),
+    col_nchar NCHAR(20),
+    col_char CHAR(20),
+    col_nvarchar NVARCHAR(25),
+    col_varchar VARCHAR(25),
+    col_category VARCHAR(20),
+    col_amount INT
+);
+GO
+
+-- Test Case 1: Basic values
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('Apple', 'Apple', 'Apple', 'Apple', 'Fruit', 200),
+(' Apple ', ' Apple ', ' Apple ', ' Apple ', 'Fruit', 200),
+('Orange', 'Orange', 'Orange', 'Orange', 'Fruit', 120),
+('Zebra', 'Zebra', 'Zebra', 'Zebra', 'Animal', 500);
+GO
+
+-- Test Case 2: NULL values
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+(NULL, NULL, NULL, NULL, 'NullTest', 0)
+GO
+
+
+-- Test Case 3: Special characters
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('!Special', '!Special', '!Special', '!Special', 'SpecialChar', 40),
+('#Hash', '#Hash', '#Hash', '#Hash', 'SpecialChar', 60)
+GO
+
+-- Test Case 4: Numeric strings
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('1', '1', '1', '1', 'NumericStr', 1)
+GO
+
+-- Test Case 5: Long strings
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('AAAAAAAAAA', 'AAAAAAAAAA', 'AAAAAAAAAAAAAAAAAA', 'AAAAAAAAAAAAAAAAAA', 'LongStr', 1)
+GO
+
+
+-- COALESCE/ISNULL 
+CREATE TABLE babel_5688_table2 (col1_nchar NCHAR(20), col1_char CHAR(20));
+GO
+
+INSERT INTO babel_5688_table2 (col1_nchar, col1_char) VALUES 
+('Apple', NULL), 
+(NULL, 'Banana'), 
+('Cherry', 'Date'),
+(NULL, NULL);
+GO
+
+
+-- All null values
+CREATE TABLE babel_5688_table3 (col1_nchar NCHAR(20), col1_char CHAR(20));
+GO
+
+INSERT INTO babel_5688_table3 (col1_nchar, col1_char) VALUES 
+(NULL, NULL), 
+(NULL, NULL), 
+(NULL, NULL);
+GO
+
+
+-- Empty table
+CREATE TABLE babel_5688_table4 (col1_nchar NCHAR(20), col1_char CHAR(20));
+GO
+
+
+CREATE TABLE babel_5688_table5 (
+    id INT IDENTITY(1,1),
+    col_nchar NCHAR(20),
+    col_char CHAR(20)
+);
+GO
+
+-- Test Case 6: Unicode characters (for NCHAR, NVARCHAR)
+INSERT INTO babel_5688_table5 (col_nchar, col_char) VALUES 
+(N'日本語', '日本語'), (N'中文', '中文')
+GO
+
+-- Functions 
+CREATE FUNCTION babel_5688_f1()
+RETURNS NCHAR(20)
+AS
+BEGIN
+    RETURN (SELECT MIN(col_nchar) FROM babel_5688_all_types);
+END;
+GO
+
+CREATE FUNCTION babel_5688_f2()
+RETURNS NCHAR(20)
+AS
+BEGIN
+    RETURN (SELECT MAX(col_nchar) FROM babel_5688_all_types);
+END;
+GO
+
+CREATE FUNCTION babel_5688_f3() 
+RETURNS CHAR(20) 
+AS 
+BEGIN 
+    RETURN (SELECT MIN(col_char) FROM babel_5688_all_types);
+END;
+GO
+
+CREATE FUNCTION babel_5688_f4()
+RETURNS CHAR(20)
+AS
+BEGIN
+    RETURN (SELECT MAX(col_char) FROM babel_5688_all_types);
+END;
+GO
+
+
+-- FUNCTIONS WITH COALESCE
+CREATE FUNCTION babel_5688_f5(@default NCHAR(20))
+RETURNS NCHAR(20)
+AS
+BEGIN
+    RETURN (SELECT COALESCE(MIN(col_nchar), @default) FROM babel_5688_all_types);
+END;
+GO
+
+-- Function with declare
+CREATE FUNCTION babel_5688_f6(@col_category VARCHAR(20))
+RETURNS NCHAR(20)
+AS
+BEGIN
+    DECLARE @result NCHAR(20);
+    SELECT @result = MIN(col_nchar) 
+    FROM babel_5688_all_types 
+    WHERE col_category = @col_category;
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION babel_5688_f7()
+RETURNS NCHAR(20)
+AS
+BEGIN
+    DECLARE @nchar_var nchar(20) = N'abc';
+    RETURN (SELECT MIN(@nchar_var));
+END;
+GO
+
+-- Procedure
+CREATE PROCEDURE babel_5688_p1
+AS
+BEGIN
+    SELECT MIN(col_nchar), MAX(col_nchar), MIN(col_char), MAX(col_char), MIN(col_varchar), MAX(col_varchar), MIN(col_nvarchar), MAX(col_nvarchar)
+    FROM babel_5688_all_types;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p2 @col_category VARCHAR(20)
+AS
+BEGIN
+    SELECT MAX(col_nchar) AS max_nchar FROM babel_5688_all_types WHERE col_category = @col_category;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p3 @var NCHAR(20)
+AS
+BEGIN
+    SELECT MAX(@var), MIN(@var) AS max_var FROM babel_5688_all_types;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p4 @default NCHAR(20)
+AS
+BEGIN
+    SELECT COALESCE(MIN(col_nchar), @default) AS min_nchar_coalesce FROM babel_5688_all_types;
+END;
+GO
+
+-- Multiple DECLARE
+CREATE PROCEDURE babel_5688_p5
+AS
+BEGIN
+    DECLARE @nchar_var NCHAR(20) = N'nchar_value';
+    DECLARE @char_var CHAR(20) = 'char_value';
+    DECLARE @nvarchar_var NVARCHAR(25) = N'nvarchar_value';
+    DECLARE @varchar_var VARCHAR(25) = 'varchar_value';
+    
+    SELECT 
+        MIN(@nchar_var) AS min_nchar,
+        MAX(@nchar_var) AS max_nchar,
+        MIN(@char_var) AS min_char,
+        MAX(@char_var) AS max_char,
+        MIN(@nvarchar_var) AS min_nvarchar,
+        MAX(@nvarchar_var) AS max_nvarchar,
+        MIN(@varchar_var) AS min_varchar,
+        MAX(@varchar_var) AS max_varchar;
+END;
+GO
+
+CREATE PROCEDURE babel_5688_p6 @col_category VARCHAR(20)
+AS
+BEGIN
+    DECLARE @min_nchar NCHAR(20);
+    DECLARE @max_nchar NCHAR(20);
+    DECLARE @min_char CHAR(20);
+    DECLARE @max_char CHAR(20);
+    DECLARE @min_nvarchar NVARCHAR(25);
+    DECLARE @max_nvarchar NVARCHAR(25);
+    DECLARE @min_varchar VARCHAR(25);
+    DECLARE @max_varchar VARCHAR(25);
+    
+    SELECT 
+        @min_nchar = MIN(col_nchar),
+        @max_nchar = MAX(col_nchar),
+        @min_char = MIN(col_char),
+        @max_char = MAX(col_char),
+        @min_nvarchar = MIN(col_nvarchar),
+        @max_nvarchar = MAX(col_nvarchar),
+        @min_varchar = MIN(col_varchar),
+        @max_varchar = MAX(col_varchar)
+    FROM babel_5688_all_types 
+    WHERE col_category = @col_category;
+    
+    SELECT 
+        @min_nchar AS min_nchar, @max_nchar AS max_nchar,
+        @min_char AS min_char, @max_char AS max_char,
+        @min_nvarchar AS min_nvarchar, @max_nvarchar AS max_nvarchar,
+        @min_varchar AS min_varchar, @max_varchar AS max_varchar;
+END;
+GO
+
+
+-- Create tables for COLLATE clause aggregate testing with different data types
+CREATE TABLE babel_5688_table6 (
+    col1 CHAR(10), col2 NCHAR(10)
+);
+GO
+
+-- Insert test data for VARCHAR
+INSERT INTO babel_5688_table6 VALUES ('A', 'A');
+INSERT INTO babel_5688_table6 VALUES ('a', 'a');
+INSERT INTO babel_5688_table6 VALUES ('À', 'À');
+GO
+
+
+-- Index scan 
+-- Create table with both char and nchar columns for index scan testing
+CREATE TABLE babel_5688_table7 (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    col_char CHAR(50),
+    col_nchar NCHAR(50)
+);
+GO
+
+-- Create indexes on both columns to enable index scans
+CREATE INDEX IX_TestDatatypeAggSort_char ON babel_5688_table7(col_char);
+GO
+CREATE INDEX IX_TestDatatypeAggSort_nchar ON babel_5688_table7(col_nchar);
+GO
+
+-- Insert 10,000 rows with varied col_nchar data
+WITH NumberSeries AS (
+    SELECT 1 as n
+    UNION ALL
+    SELECT n + 1
+    FROM NumberSeries
+    WHERE n < 10000
+)
+INSERT INTO babel_5688_table7 (col_char, col_nchar)
+SELECT 
+    CASE 
+        WHEN n % 4 = 0 THEN CHAR(97 + (n % 26)) + CHAR(97 + ((n/26) % 26)) + CHAR(97 + ((n/676) % 26))
+        WHEN n % 4 = 1 THEN CHAR(98 + (n % 25)) + CHAR(98 + ((n/25) % 25)) + CHAR(98 + ((n/625) % 25))
+        WHEN n % 4 = 2 THEN CHAR(99 + (n % 24)) + CHAR(99 + ((n/24) % 24)) + CHAR(99 + ((n/576) % 24))
+        ELSE CHAR(100 + (n % 23)) + CHAR(100 + ((n/23) % 23)) + CHAR(100 + ((n/529) % 23))
+    END,
+    CASE 
+        WHEN n % 4 = 0 THEN CHAR(97 + (n % 26)) + CHAR(97 + ((n/26) % 26)) + CHAR(97 + ((n/676) % 26))
+        WHEN n % 4 = 1 THEN CHAR(98 + (n % 25)) + CHAR(98 + ((n/25) % 25)) + CHAR(98 + ((n/625) % 25))
+        WHEN n % 4 = 2 THEN CHAR(99 + (n % 24)) + CHAR(99 + ((n/24) % 24)) + CHAR(99 + ((n/576) % 24))
+        ELSE CHAR(100 + (n % 23)) + CHAR(100 + ((n/23) % 23)) + CHAR(100 + ((n/529) % 23))
+    END 
+FROM NumberSeries  
+OPTION (MAXRECURSION 10000);
+GO
+

--- a/test/JDBC/input/string_aggregate-vu-verify.sql
+++ b/test/JDBC/input/string_aggregate-vu-verify.sql
@@ -1,0 +1,599 @@
+-- Test basic
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar, MAX(col_varchar) AS max_varchar 
+FROM babel_5688_all_types;
+GO
+
+
+-- Test with GROUP BY and ORDER BY
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+
+select min(col_char) FROM babel_5688_all_types GROUP BY col_nchar ORDER BY col_nchar
+go
+
+
+-- Test with having clause 
+SELECT 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar,
+    COUNT(*) AS cnt
+FROM babel_5688_all_types
+GROUP BY col_category
+HAVING MIN(col_nchar) IS NOT NULL AND MAX(col_nchar) IS NOT NULL
+ORDER BY col_category;
+GO
+
+
+-- Test Where clause 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char,
+    MIN(col_nvarchar) AS min_nvarchar, MAX(col_nvarchar) AS max_nvarchar,
+    MIN(col_varchar) AS min_varchar
+FROM babel_5688_all_types
+WHERE col_category = 'Fruit';
+GO
+
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+
+
+-- Test distinct
+SELECT 
+    MIN(DISTINCT col_nchar) AS min_distinct_nchar, MAX(DISTINCT col_nchar) AS max_distinct_nchar,
+    MIN(DISTINCT col_char) AS min_distinct_char, MAX(DISTINCT col_char) AS max_distinct_char,
+    MIN(DISTINCT col_nvarchar) AS min_distinct_nvarchar, MAX(DISTINCT col_nvarchar) AS max_distinct_nvarchar,
+    MIN(DISTINCT col_varchar) AS min_distinct_varchar
+FROM babel_5688_all_types;
+GO
+
+
+-- Test subquery
+SELECT * FROM babel_5688_all_types WHERE col_nchar = (SELECT MIN(col_nchar) FROM babel_5688_all_types);
+GO
+SELECT * FROM babel_5688_all_types WHERE col_char = (SELECT MIN(col_char) FROM babel_5688_all_types WHERE col_char IS NOT NULL);
+GO
+SELECT * FROM babel_5688_all_types WHERE col_nvarchar = (SELECT MIN(col_nvarchar) FROM babel_5688_all_types);
+GO
+SELECT * FROM babel_5688_all_types WHERE col_varchar = (SELECT MIN(col_varchar) FROM babel_5688_all_types);
+GO
+
+
+-- Test UNION ALL
+SELECT 'NCHAR' AS col_type, MIN(col_nchar) AS min_val, MAX(col_nchar) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT 'CHAR' AS col_type, MIN(col_char) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_char IS NOT NULL
+UNION ALL
+SELECT 'NVARCHAR' AS col_type, MIN(col_nvarchar) AS min_val, MAX(col_nvarchar) AS max_val FROM babel_5688_all_types WHERE col_nvarchar IS NOT NULL
+ORDER BY col_type;
+GO
+
+SELECT MIN(col_nchar) AS min_val, MAX(col_char) AS max_val FROM babel_5688_all_types WHERE col_nchar IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table2 WHERE col1_char IS NOT NULL
+UNION ALL
+SELECT MIN(col1_nchar) AS min_val, MAX(col1_char) AS max_val FROM babel_5688_table3 WHERE col1_char IS NOT NULL
+ORDER BY min_val;
+GO
+
+
+-- Test CTEs
+WITH MinMaxCTE AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_nchar,
+        MAX(col_nchar) AS max_nchar,
+        MIN(col_char) AS min_char,
+        MAX(col_char) AS max_char
+    FROM babel_5688_all_types
+    GROUP BY col_category
+)
+SELECT * FROM MinMaxCTE WHERE min_nchar IS NOT NULL ORDER BY col_category;
+GO
+
+WITH CategoryStats AS (
+    SELECT 
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val,
+        COUNT(*) AS cnt
+    FROM babel_5688_all_types
+    WHERE col_nchar IS NOT NULL
+    GROUP BY col_category
+)
+SELECT 
+    cs.col_category, 
+    cs.min_val, 
+    cs.max_val, 
+    cs.cnt,
+    t.col_nchar AS sample_value
+FROM CategoryStats cs
+JOIN babel_5688_all_types t ON t.col_category = cs.col_category AND t.col_nchar = cs.min_val
+ORDER BY cs.col_category, sample_value;
+GO
+
+-- Test CASE EXPRESSION
+SELECT 
+    col_category,
+    CASE 
+        WHEN MIN(col_nchar) = MAX(col_nchar) THEN 'Same'
+        WHEN MIN(col_nchar) IS NULL OR MAX(col_nchar) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS nchar_status,
+    CASE 
+        WHEN MIN(col_char) = MAX(col_char) THEN 'Same'
+        WHEN MIN(col_char) IS NULL OR MAX(col_char) IS NULL THEN 'Has Nulls'
+        ELSE 'Different'
+    END AS varchar_status
+FROM babel_5688_all_types
+GROUP BY col_category
+ORDER BY col_category;
+GO
+
+-- Test expressions inside min/max
+SELECT  
+    MIN(UPPER(col_nchar)) AS min_upper_nchar,
+    MAX(UPPER(col_nchar)) AS max_upper_nchar,
+    MIN(LOWER(col_nchar)) AS min_lower_nchar,
+    MAX(LOWER(col_nchar)) AS max_lower_nchar,
+    MIN(UPPER(col_char)) AS min_upper_char,
+    MAX(UPPER(col_char)) AS max_upper_char,
+    MIN(LOWER(col_char)) AS min_lower_char,
+    MAX(LOWER(col_char)) AS max_lower_char 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL AND col_char IS NOT NULL;
+GO
+
+-- Test TOP WITH MIN/MAX
+SELECT TOP 5 
+    col_category,
+    MIN(col_nchar) AS min_nchar,
+    MAX(col_nchar) AS max_nchar 
+FROM babel_5688_all_types 
+WHERE col_nchar IS NOT NULL 
+GROUP BY col_category 
+ORDER BY min_nchar, max_nchar;
+GO
+
+SELECT TOP 3
+    col_category,
+    MIN(col_char) AS min_char,
+    MAX(col_char) AS max_char
+FROM babel_5688_all_types
+WHERE col_char IS NOT NULL
+GROUP BY col_category
+ORDER BY MAX(col_char) DESC;
+GO
+
+
+-- Test COALESCE/ISNULL 
+SELECT COALESCE(MIN(col1_nchar), N'No Value') AS min_nchar FROM babel_5688_table2;
+GO
+SELECT ISNULL(MAX(col1_nchar), N'No Value') AS max_nchar FROM babel_5688_table2;
+GO
+SELECT COALESCE(MIN(col1_char), 'No Value') AS min_char FROM babel_5688_table2;
+GO
+SELECT ISNULL(MAX(col1_char), 'No Value') AS max_char FROM babel_5688_table2;
+GO
+
+-- All null values in tables
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+SELECT MIN(col1_char) AS min_char FROM babel_5688_table3;
+GO
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table3;
+GO
+SELECT MAX(col1_char) AS min_char FROM babel_5688_table3;
+GO
+
+-- Test Empty table
+SELECT MIN(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+SELECT MIN(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+SELECT MAX(col1_nchar) AS min_nchar FROM babel_5688_table4;
+GO
+SELECT MAX(col1_char) AS min_nchar FROM babel_5688_table4;
+GO
+
+
+-- Test JOINs
+-- Inner Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+INNER JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+
+-- Left Join
+SELECT 
+    t1.col_category,
+    t1.min_nchar AS all_types_min,
+    t1.max_nchar AS all_types_max,
+    t2.col1_nchar AS table2_nchar,
+    t2.col1_char AS table2_char,
+    CASE WHEN t2.col1_nchar IS NULL THEN 'No Match' ELSE 'Matched' END AS match_status
+FROM (
+    SELECT col_category, MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar
+    FROM babel_5688_all_types
+    GROUP BY col_category
+) t1
+LEFT JOIN babel_5688_table2 t2 ON t1.min_nchar = t2.col1_nchar
+ORDER BY t1.col_category;
+GO
+
+-- Complex query combining all elements
+SELECT 
+    source_info,
+    col_category,
+    min_val,
+    max_val,
+    CASE 
+        WHEN min_val IS NULL AND max_val IS NULL THEN 'Empty/All NULL'
+        WHEN min_val = max_val THEN 'Single Unique Value'
+        ELSE 'Multiple Values'
+    END AS data_status
+FROM (
+    -- From babel_5688_all_types grouped by col_category
+    SELECT 
+        'AllTypes-ByCategory' AS source_info,
+        col_category,
+        MIN(col_nchar) AS min_val,
+        MAX(col_nchar) AS max_val
+    FROM babel_5688_all_types
+    GROUP BY col_category
+    
+    UNION ALL
+    
+    -- From babel_5688_table2
+    SELECT 
+        'Table2-All' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table2
+    
+    UNION ALL
+    
+    -- From babel_5688_table3 (all nulls)
+    SELECT 
+        'Table3-AllNulls' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table3
+    
+    UNION ALL
+    
+    -- From babel_5688_table4 (empty)
+    SELECT 
+        'Table4-Empty' AS source_info,
+        'N/A' AS col_category,
+        MIN(col1_nchar) AS min_val,
+        MAX(col1_nchar) AS max_val
+    FROM babel_5688_table4
+) combined_data
+ORDER BY source_info, col_category;
+GO
+
+-- Test Unicode characters 
+SELECT 
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_table5;
+GO
+
+-- Test: Empty strings and spaces
+INSERT INTO babel_5688_all_types (col_nchar, col_char, col_nvarchar, col_varchar, col_category, col_amount) VALUES 
+('', '', '', '', 'EmptyTest', 0),
+('   ', '   ', '   ', '   ', 'SpaceTest', 0)
+GO
+
+SELECT  
+    MIN(col_nchar) AS min_nchar, MAX(col_nchar) AS max_nchar,
+    MIN(col_char) AS min_char, MAX(col_char) AS max_char
+FROM babel_5688_all_types;
+GO
+
+-- Test declare statements
+DECLARE @nchar_var nchar(20) = N'abc';
+DECLARE @nchar_var1 nchar(20) = N'日本語';
+DECLARE @nchar_var2 nchar(20) = N'';
+DECLARE @nchar_var3 nchar(20) = NULL;
+SELECT 
+    min(@nchar_var), max(@nchar_var), 
+    min(@nchar_var1), max(@nchar_var1),
+    min(@nchar_var2), max(@nchar_var2),
+    min(@nchar_var3), max(@nchar_var3)
+go
+
+DECLARE @char_var char(20) = 'abc';
+DECLARE @char_var1 char(20) = N'日本語';
+DECLARE @char_var2 char(20) = '';
+DECLARE @char_var3 char(20) = NULL;
+SELECT 
+    min(@char_var), max(@char_var), 
+    min(@char_var1), max(@char_var1),
+    min(@char_var2), max(@char_var2),
+    min(@char_var3), max(@char_var3)
+GO
+
+DECLARE @nvarchar_var nvarchar(25) = N'test';
+DECLARE @nvarchar_var1 nvarchar(25) = N'unicode日本語';
+DECLARE @nvarchar_var2 nvarchar(25) = N'';
+DECLARE @nvarchar_var3 nvarchar(25) = NULL;
+SELECT 
+    min(@nvarchar_var), max(@nvarchar_var), 
+    min(@nvarchar_var1), max(@nvarchar_var1),
+    min(@nvarchar_var2), max(@nvarchar_var2),
+    min(@nvarchar_var3), max(@nvarchar_var3)
+GO
+
+DECLARE @varchar_var varchar(25) = 'hello';
+DECLARE @varchar_var1 varchar(25) = 'world';
+DECLARE @varchar_var2 varchar(25) = '';
+DECLARE @varchar_var3 varchar(25) = NULL;
+SELECT 
+    min(@varchar_var), max(@varchar_var), 
+    min(@varchar_var1), max(@varchar_var1),
+    min(@varchar_var2), max(@varchar_var2),
+    min(@varchar_var3), max(@varchar_var3)
+GO
+
+-- Basic test using babel_5688_all_types columns
+DECLARE @min_nchar NCHAR(20);
+DECLARE @max_nchar NCHAR(20);
+DECLARE @min_char CHAR(20);
+DECLARE @max_char CHAR(20);
+DECLARE @min_nvarchar NVARCHAR(25);
+DECLARE @max_nvarchar NVARCHAR(25);
+DECLARE @min_varchar VARCHAR(25);
+
+SELECT @min_nchar = MIN(col_nchar) FROM babel_5688_all_types;
+SELECT @max_nchar = MAX(col_nchar) FROM babel_5688_all_types;
+SELECT @min_char = MIN(col_char) FROM babel_5688_all_types;
+SELECT @max_char = MAX(col_char) FROM babel_5688_all_types;
+SELECT @min_nvarchar = MIN(col_nvarchar) FROM babel_5688_all_types;
+SELECT @max_nvarchar = MAX(col_nvarchar) FROM babel_5688_all_types;
+SELECT @min_varchar = MIN(col_varchar) FROM babel_5688_all_types;
+
+SELECT 
+    @min_nchar AS min_nchar, @max_nchar AS max_nchar,
+    @min_char AS min_char, @max_char AS max_char,
+    @min_nvarchar AS min_nvarchar, @max_nvarchar AS max_nvarchar,
+    @min_varchar AS min_varchar;
+GO
+
+-- Test Declare with table variable
+SELECT 'TEST D7: DECLARE with table variable' AS TestName;
+GO
+
+DECLARE @results TABLE (
+    col_type VARCHAR(20),
+    min_val NVARCHAR(25),
+    max_val NVARCHAR(25)
+);
+
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NCHAR', MIN(col_nchar), MAX(col_nchar) FROM babel_5688_all_types;
+
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'CHAR', MIN(col_char), MAX(col_char) FROM babel_5688_all_types;
+
+INSERT INTO @results (col_type, min_val, max_val)
+SELECT 'NVARCHAR', MIN(col_nvarchar), MAX(col_nvarchar) FROM babel_5688_all_types;
+
+SELECT * FROM @results;
+GO
+
+-- Functions 
+
+-- Procedures
+-- Test Functions
+SELECT dbo.babel_5688_f1() AS f1_min_nchar;
+GO
+SELECT dbo.babel_5688_f2() AS f2_max_nchar;
+GO
+SELECT dbo.babel_5688_f3() AS f3_min_char;
+GO
+SELECT dbo.babel_5688_f4() AS f4_max_char;
+GO
+SELECT dbo.babel_5688_f5(N'default') AS f8_coalesce;
+GO
+SELECT dbo.babel_5688_f5(N'') AS result_empty_default;
+GO
+SELECT dbo.babel_5688_f6('Fruit') AS f9_category_min;
+GO
+SELECT dbo.babel_5688_f7() AS f10_var_min;
+GO
+
+-- Test Procedures
+EXEC babel_5688_p1;
+GO
+EXEC babel_5688_p2 'Fruit';
+GO
+EXEC babel_5688_p3 N'test_var';
+GO
+EXEC babel_5688_p4 N'default_value';
+GO
+EXEC babel_5688_p5;
+GO
+EXEC babel_5688_p6 'Animal';
+GO
+
+-- Test explicit COLLATE clause on aggregate functions for CHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+SELECT MAX(col1) FROM babel_5688_table6;
+GO
+SELECT MAX(col1 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+
+-- Test explicit COLLATE clause on aggregate functions for NCHAR
+SELECT 1 WHERE 'ä' = (SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6);
+GO
+SELECT MAX(col2) FROM babel_5688_table6;
+GO
+SELECT MAX(col2 COLLATE Latin1_General_CI_AI) FROM babel_5688_table6;
+GO
+
+-- Testing index scan 
+
+-- tsql
+select set_config('max_parallel_workers_per_gather', '0', false);
+GO
+SELECT set_config('debug_parallel_query', '0', false);
+GO
+SELECT set_config('babelfishpg_tsql.explain_costs', 'off', false)
+GO
+SELECT set_config('enable_seqscan', 'off', false);
+SELECT set_config('enable_bitmapscan', 'off', false);
+GO
+SELECT set_config('enable_seqscan', 'off', false);
+GO
+
+SET BABELFISH_SHOWPLAN_ALL on
+GO
+
+-- All permutation queries for index scan testing
+-- MAX/MIN with same column in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+
+-- MAX/MIN with different columns in SELECT and WHERE
+SELECT MAX(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+SELECT MIN(col_char) FROM babel_5688_table7 WHERE col_nchar <= 'cbd';
+GO
+SELECT MAX(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+SELECT MIN(col_nchar) FROM babel_5688_table7 WHERE col_char <= 'cbd';
+GO
+
+-- Reset
+SET BABELFISH_SHOWPLAN_ALL OFF
+go
+SELECT set_config('babelfishpg_tsql.explain_costs', 'on', false)
+go
+SELECT set_config('enable_seqscan', 'on', false)
+go
+SELECT set_config('enable_bitmapscan', 'on', false);
+GO
+
+
+-- Test cases for MIN/MAX with CAST combinations across data types
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MIN(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+SELECT MIN(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+SELECT MIN(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+SELECT MIN(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO
+
+-- MAX versions of the same combinations
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NCHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NCHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NCHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NCHAR(10)));
+GO
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NCHAR(10)));
+GO
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NCHAR(10)));
+GO
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to NVARCHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS NVARCHAR(10)));
+GO
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS NVARCHAR(10)));
+GO
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS NVARCHAR(10)));
+GO
+
+-- NCHAR/CHAR/NVARCHAR/VARCHAR/BINARY/NUMERIC to CHAR
+SELECT MAX(CAST(CAST('1' AS VARCHAR(10)) AS CHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS CHAR(10)) AS CHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS NVARCHAR(10)) AS CHAR(10)));
+GO
+SELECT MAX(CAST(CAST('1' AS NCHAR(10)) AS CHAR(10)));
+GO
+SELECT MAX(CAST(CAST(0x31 AS BINARY(10)) AS CHAR(10)));
+GO
+SELECT MAX(CAST(CAST(1 AS NUMERIC(10)) AS CHAR(10)));
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -759,3 +759,6 @@ ignore#!#temp_catalog_inval-vu-cleanup
 
 # TODO: BABEL-6276
 ignore#!#babel_output_clause_concurrency_test
+ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare
+ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-verify
+ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -222,7 +222,7 @@ getdate-before-15_9-or-16_5
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -274,7 +274,7 @@ getdate-before-15_9-or-16_5
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -328,7 +328,7 @@ table_constraint_wo_comma-before-15_6-or-16_2
 getdate-before-15_9-or-16_5
 BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -323,7 +323,7 @@ getdate-before-15_9-or-16_5
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -323,7 +323,7 @@ getdate-before-15_9-or-16_5
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -326,7 +326,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -420,7 +420,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -421,7 +421,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_17/schedule
+++ b/test/JDBC/upgrade/14_17/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_18/schedule
+++ b/test/JDBC/upgrade/14_18/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_19/schedule
+++ b/test/JDBC/upgrade/14_19/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_20/schedule
+++ b/test/JDBC/upgrade/14_20/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_21/schedule
+++ b/test/JDBC/upgrade/14_21/schedule
@@ -419,7 +419,7 @@ default_params
 BABEL-3326
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -345,7 +345,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -361,7 +361,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -397,7 +397,7 @@ BABEL-4410
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -419,7 +419,7 @@ BABEL_4330-before-15_8-or-16_4
 AUTO_ANALYZE-before-15-5-or-14-10
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -418,7 +418,7 @@ AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -419,7 +419,7 @@ AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -395,7 +395,7 @@ AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_15/schedule
+++ b/test/JDBC/upgrade/15_15/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_16/schedule
+++ b/test/JDBC/upgrade/15_16/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -427,7 +427,7 @@ AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -450,7 +450,7 @@ AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -462,7 +462,7 @@ AUTO_ANALYZE-before-15-5-or-14-10
 default_params
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-15-5
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -490,7 +490,7 @@ pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
 order_by_offset_fetch_rows-before-15_6-or-16_2
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-15_5-or-15_6-or-16_1-or-16_2
 operator_binary_whitespace-before-15_6-or-16_2
 BABEL-2999

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -501,7 +501,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-15_5-or-15_6-or-16_1-or-16_2
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -502,7 +502,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -500,7 +500,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -492,7 +492,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -516,7 +516,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -516,7 +516,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -505,7 +505,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -506,7 +506,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -511,7 +511,7 @@ BABEL-4484
 pivot-before-15_9-or-16_5
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -512,7 +512,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -515,7 +515,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order-before-16_8-or-17_4
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -517,7 +517,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 babel_index_nulls_order
 BABEL-2999
 BABEL-4606

--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -512,7 +512,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 BABEL-2999
 BABEL-4606
 BABEL-4672

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -516,7 +516,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 BABEL-2999
 BABEL-4606
 BABEL-4672
@@ -656,3 +656,4 @@ BABEL-4271
 comparison_op_index_scan-before-17_8-or-16_12
 
 BABEL-1664-before-16_10-or-17_6
+string_aggregate

--- a/test/JDBC/upgrade/17_6/schedule
+++ b/test/JDBC/upgrade/17_6/schedule
@@ -521,7 +521,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 BABEL-2999
 BABEL-4606
 BABEL-4672
@@ -665,3 +665,4 @@ babel_string_to_money
 comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 BABEL-1664
+string_aggregate

--- a/test/JDBC/upgrade/17_7/schedule
+++ b/test/JDBC/upgrade/17_7/schedule
@@ -521,7 +521,7 @@ BABEL-4484
 pivot
 #AUTO_ANALYZE #uncomment this test when preparing for new minor version
 cast_eliminate
-TestDatatypeAggSort
+TestDatatypeAggSort-before-16_12-or-17_8
 BABEL-2999
 BABEL-4606
 BABEL-4672
@@ -667,3 +667,4 @@ BABEL-4271
 comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 BABEL-1664
+string_aggregate

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -673,3 +673,4 @@ Test-Polygon
 BABEL-5788
 BABEL-1664
 sys-fn_varbintohexstr
+string_aggregate


### PR DESCRIPTION
### Description

Earlier in Babelfish, we were losing out on typmod information in case of MIN/MAX() function having CHAR/NCHAR as argument, which was leading to error and requiring explicit casting to Varchar/Nvarchar.

With this commit, we are using `pltsql_post_transform_expr_recurse` function to detect MIN/MAX aggregates on CHAR/NCHAR types and preserve the original column's typmod by adding a relabel node with the correct type modifier.

Cherry-pick from PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4372
Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)


### Issues Resolved

BABEL-5688

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -** Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** Yes


* **Major version upgrade tests -** Yes


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).