### PR TITLE
Information Schema Tables Perf Improvement 

### DIFF
--- a/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
+++ b/contrib/babelfishpg_tsql/sql/information_schema_tsql.sql
@@ -457,6 +457,9 @@ GRANT SELECT ON information_schema_tsql.domains TO PUBLIC;
  */
 
 CREATE VIEW information_schema_tsql.tables AS
+	WITH tt_internal AS MATERIALIZED (
+		SELECT * FROM sys.table_types_internal
+	)
 	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
 		   CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
 		   CAST(
@@ -478,7 +481,7 @@ CREATE VIEW information_schema_tsql.tables AS
 
 	FROM sys.pg_namespace_ext nc JOIN pg_class c ON (nc.oid = c.relnamespace)
 		   LEFT OUTER JOIN sys.babelfish_namespace_ext ext on nc.nspname = ext.nspname
-		   LEFT JOIN sys.table_types_internal tt on c.oid = tt.typrelid
+		   LEFT JOIN tt_internal tt ON c.oid = tt.typrelid
 
 	WHERE c.relkind IN ('r', 'v', 'p')
 		AND (NOT pg_is_other_temp_schema(nc.oid))

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.12.0--3.13.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--3.12.0--3.13.0.sql
@@ -11,6 +11,42 @@ SELECT set_config('search_path', 'sys, '||current_setting('search_path'), false)
  * final behaviour.
  */
 
+CREATE OR REPLACE VIEW information_schema_tsql.tables AS
+	WITH tt_internal AS MATERIALIZED (
+		SELECT * FROM sys.table_types_internal
+	)
+	SELECT CAST(nc.dbname AS sys.nvarchar(128)) AS "TABLE_CATALOG",
+		   CAST(ext.orig_name AS sys.nvarchar(128)) AS "TABLE_SCHEMA",
+		   CAST(
+				COALESCE(
+					(SELECT PG_CATALOG.string_agg(
+						CASE
+						WHEN option LIKE 'bbf_original_rel_name=%' THEN substring(option, 23)
+						ELSE NULL
+						END, ',')
+					FROM unnest(c.reloptions) AS option),
+				c.relname)
+			AS sys._ci_sysname) AS "TABLE_NAME",
+
+		   CAST(
+			 CASE WHEN c.relkind IN ('r', 'p') THEN 'BASE TABLE'
+				  WHEN c.relkind = 'v' THEN 'VIEW'
+				  ELSE null END
+			 AS sys.varchar(10)) COLLATE sys.database_default AS "TABLE_TYPE"
+
+	FROM sys.pg_namespace_ext nc JOIN pg_class c ON (nc.oid = c.relnamespace)
+		   LEFT OUTER JOIN sys.babelfish_namespace_ext ext on nc.nspname = ext.nspname
+		   LEFT JOIN tt_internal tt ON c.oid = tt.typrelid
+
+	WHERE c.relkind IN ('r', 'v', 'p')
+		AND c.relispartition = false
+		AND (NOT pg_is_other_temp_schema(nc.oid))
+		AND tt.typrelid IS NULL
+		AND (pg_has_role(c.relowner, 'USAGE')
+			OR has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+			OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES') )
+		AND ext.dbid = sys.db_id()
+		AND (NOT c.relname = 'sysdatabases');
 
 -- After upgrade, always run analyze for all babelfish catalogs.
 CALL sys.analyze_babelfish_catalogs();


### PR DESCRIPTION
### Description
Information Schema Tables Perf Improvement: table_types_internal view, although written efficiently might cause perfomance degradation when joined with other system objects. One should try to use them as part of a materialized CTE. We do the same for Information Schema Tables.

Note extensive upgrade tests exist in test/JDBC/expected/ISC-Tables-vu-<>.out files

Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4409

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).