### PR TITLE
fix test file BABEL-3326-vu-verify

### DIFF
--- a/test/JDBC/expected/BABEL-3326-vu-verify.out
+++ b/test/JDBC/expected/BABEL-3326-vu-verify.out
@@ -741,9 +741,13 @@ GO
 -- psql
 -- Test cases if user tries to enable/disable trigger <schema-1>.<trigger-1> on table <schema-2>.<table-1> 
 -- if both schemas have tables with same name and each table have trigger with same trigger name
+SET babelfishpg_tsql.enable_alter_owner_from_pg = true;
+GO
 ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_babel_3326_u1;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_babel_3326_u1;
+GO
+SET babelfishpg_tsql.enable_alter_owner_from_pg = false;
 GO
 
 -- tsql user=babel_3326_u1 password=12345678
@@ -882,9 +886,13 @@ DISABLE TRIGGER [db].[TR_ins_안녕하세요_babel_3326_Employees] ON [db].[babe
 GO
 
 -- psql
+SET babelfishpg_tsql.enable_alter_owner_from_pg = true;
+GO
 ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_dbo;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_dbo;
+GO
+SET babelfishpg_tsql.enable_alter_owner_from_pg = false;
 GO
 
 -- tsql user=jdbc_user password=12345678

--- a/test/JDBC/input/BABEL-3326-vu-verify.mix
+++ b/test/JDBC/input/BABEL-3326-vu-verify.mix
@@ -385,9 +385,13 @@ GO
 -- if both schemas have tables with same name and each table have trigger with same trigger name
 
 -- psql
+SET babelfishpg_tsql.enable_alter_owner_from_pg = true;
+GO
 ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_babel_3326_u1;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_babel_3326_u1;
+GO
+SET babelfishpg_tsql.enable_alter_owner_from_pg = false;
 GO
 
 -- tsql user=babel_3326_u1 password=12345678
@@ -494,9 +498,13 @@ DISABLE TRIGGER [db].[TR_ins_안녕하세요_babel_3326_Employees] ON [db].[babe
 GO
 
 -- psql
+SET babelfishpg_tsql.enable_alter_owner_from_pg = true;
+GO
 ALTER TABLE master_dbo.babel_3326_Employees OWNER TO master_dbo;
 GO
 ALTER TABLE master_db.babel_3326_Employees OWNER TO master_dbo;
+GO
+SET babelfishpg_tsql.enable_alter_owner_from_pg = false;
 GO
 
 -- tsql user=jdbc_user password=12345678


### PR DESCRIPTION
### Description
Commit [f78c096](https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/f78c096a646288c52d50509277d633297351d477) blocked ALTER .. OWNER .. execution from psql for non-superusers. This can cause BABEL-3326-vu-verify test to fail when transferring table ownership to babel_3326_u1 for cross-schema trigger testing.

This test fix enables babelfishpg_tsql.enable_alter_owner_from_pg GUC to allow the ownership transfer, as the test validates trigger enable/disable behavior across schemas, not ownership restrictions.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).