### PR TITLE
Fixed DataAdapter.FillSchema() to retrieve primary key metadata 

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -1628,7 +1628,7 @@ PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *target
 				 * and we do not have to translate it to logical schema name.
 				 */
 				if (pltsql_plugin_handler_ptr &&
-					pltsql_plugin_handler_ptr->pltsql_get_logical_schema_name)
+					pltsql_plugin_handler_ptr->pltsql_get_logical_schema_name && physical_schema_name != NULL)
 					relMetaDataInfo->partName[1] = (char *) pltsql_plugin_handler_ptr->pltsql_get_logical_schema_name(physical_schema_name, true);
 
 				/*
@@ -1636,8 +1636,13 @@ PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *target
 				 * schema name only assuming its shared schema.
 				 */
 				if (relMetaDataInfo->partName[1] == NULL)
-					relMetaDataInfo->partName[1] = strdup(physical_schema_name);
-
+				{
+					if (physical_schema_name != NULL)
+						relMetaDataInfo->partName[1] = strdup(physical_schema_name);
+					else
+						relMetaDataInfo->partName[1] = NULL;
+				}
+				
 				if (physical_schema_name)
 					pfree(physical_schema_name);
 
@@ -2181,7 +2186,7 @@ TdsSendRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt,
 	Assert(typeinfo != NULL);
 
 	/* Prepare the column metadata first */
-	PrepareRowDescription(typeinfo, plannedstmt, targetlist, formats, false, false);
+	PrepareRowDescription(typeinfo, plannedstmt, targetlist, formats, true, true);
 
 	/*
 	 * If fNoMetadata flags is set in RPC header flag, the server doesn't need
@@ -2209,6 +2214,7 @@ TdsSendRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt,
 	}
 
 	SendColumnMetadataToken(typeinfo->natts, false);
+	SendColInfoToken(typeinfo->natts, false);
 }
 
 bool

--- a/test/JDBC/expected/primarykey_tests.out
+++ b/test/JDBC/expected/primarykey_tests.out
@@ -1,0 +1,532 @@
+#Test case 1: Composite Primary Key (Two columns)
+DROP TABLE IF EXISTS primarytest
+CREATE TABLE primarytest (col1 INT NOT NULL, col2 INT NOT NULL, data VARCHAR(50), PRIMARY KEY (col1, col2))
+fillschema_test#!#SELECT * FROM primarytest
+~~START~~
+Table Columns:
+Column: col1
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- col1
+- col2
+~~END~~
+
+DROP TABLE IF EXISTS primarytest
+
+#Test case 2: No Primary Key
+DROP TABLE IF EXISTS pk_none
+CREATE TABLE pk_none (col1 INT NOT NULL, col2 VARCHAR(50) NULL, col3 BIT NOT NULL)
+fillschema_test#!#SELECT * FROM pk_none
+~~START~~
+Table Columns:
+Column: col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col3
+  - Is Primary Key: False
+  - Data Type: System.Boolean
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS pk_none
+
+# Test case 3: PK in Middle Position
+DROP TABLE IF EXISTS pk_middle
+CREATE TABLE pk_middle (col1 VARCHAR(50), col2 VARCHAR(50), id INT PRIMARY KEY, col3 VARCHAR(50), col4 VARCHAR(50))
+fillschema_test#!#SELECT * FROM pk_middle
+~~START~~
+Table Columns:
+Column: col1
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: col3
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col4
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS pk_middle
+
+#Test case 4: Multi-Table LEFT JOIN (3 tables, no FK constraint)
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+CREATE TABLE customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100) NOT NULL, city VARCHAR(50))
+CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT NOT NULL, order_date DATETIME NOT NULL, status VARCHAR(20))
+CREATE TABLE order_items (item_id INT PRIMARY KEY, order_id INT NOT NULL, product_name VARCHAR(100), quantity INT)
+fillschema_test#!#SELECT * FROM customers c LEFT JOIN orders o ON c.customer_id = o.customer_id LEFT JOIN order_items oi ON o.order_id = oi.order_id
+~~START~~
+Table Columns:
+Column: customer_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: customer_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: city
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: order_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: customer_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: order_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+Column: status
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: item_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: order_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: product_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: quantity
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+
+Primary Key Columns:
+- customer_id
+~~END~~
+
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+
+#Test case 5: UNIQUE Nullable Column
+DROP TABLE IF EXISTS rule2b_unique_null
+CREATE TABLE rule2b_unique_null (id INT NULL UNIQUE, name VARCHAR(50) NULL)
+fillschema_test#!#SELECT * FROM rule2b_unique_null
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS rule2b_unique_null
+
+Test case 6: Primary key detection
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'case' at line 1 and character position 5)~~
+
+DROP TABLE IF EXISTS int_boundary
+CREATE TABLE int_boundary (id INT PRIMARY KEY, data VARCHAR(50))
+fillschema_test#!#SELECT * FROM int_boundary
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS int_boundary
+
+#Test case 7: PK with Multiple UNIQUE Constraints
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+CREATE TABLE rule3_pk_multi_unique (id INT PRIMARY KEY, email VARCHAR(100) NOT NULL UNIQUE, phone VARCHAR(20) NOT NULL UNIQUE, ssn VARCHAR(20) NULL UNIQUE, name VARCHAR(50))
+INSERT INTO rule3_pk_multi_unique VALUES (1, 'test@test.com', '555-1234', [REDACTED:SSN], 'test')
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "redacted:ssn" does not exist)~~
+
+fillschema_test#!#SELECT * FROM rule3_pk_multi_unique
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: email
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: phone
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: ssn
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+
+#Test case 8: Composite Foreign Key (2 columns)
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+CREATE TABLE fk_parent_composite (col1 INT NOT NULL, col2 INT NOT NULL, name VARCHAR(50), PRIMARY KEY (col1, col2))
+CREATE TABLE fk_child_composite (id INT PRIMARY KEY, ref_col1 INT NOT NULL, ref_col2 INT NOT NULL, data VARCHAR(50), FOREIGN KEY (ref_col1, ref_col2) REFERENCES fk_parent_composite(col1, col2))
+fillschema_test#!#SELECT * FROM fk_child_composite
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col2
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+fillschema_test#!#SELECT c.*, p.name FROM fk_child_composite c JOIN fk_parent_composite p ON c.ref_col1 = p.col1 AND c.ref_col2 = p.col2
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col2
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+
+#Test case 9: Primary Key detection in 3-level hierarchy with chained foreign keys
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+CREATE TABLE fk_chain_a (id INT PRIMARY KEY, name VARCHAR(50))
+CREATE TABLE fk_chain_b (id INT PRIMARY KEY, a_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (a_id) REFERENCES fk_chain_a(id))
+CREATE TABLE fk_chain_c (id INT PRIMARY KEY, b_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (b_id) REFERENCES fk_chain_b(id))
+fillschema_test#!#SELECT c.*, b.name as b_name, a.name as a_name FROM fk_chain_c c JOIN fk_chain_b b ON c.b_id = b.id JOIN fk_chain_a a ON b.a_id = a.id
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: b_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: b_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: a_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+
+#Test case 10: Testing with NO_BROWSETABLE_OFF
+DROP TABLE IF EXISTS dbo.cclass 
+CREATE TABLE dbo.cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL, room_number INT NULL )
+fillschema_test#!#SET NO_BROWSETABLE OFF; select * from dbo.cclass
+~~START~~
+Table Columns:
+Column: class_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: class_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: teacher_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: room_number
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+
+Primary Key Columns:
+- class_id
+~~END~~
+
+DROP TABLE IF EXISTS dbo.cclass
+
+#Test case 11: Testing with NO_BROWSETABLE_ON
+DROP TABLE IF EXISTS new_cclass
+CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )
+fillschema_test#!#SET NO_BROWSETABLE ON; select * from new_cclass
+~~START~~
+Table Columns:
+Column: class_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: class_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: teacher_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- class_id
+~~END~~
+
+DROP TABLE IF EXISTS new_cclass
+
+#Test case 12: Stored Procedures
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+CREATE TABLE sp_param_table (id INT NOT NULL PRIMARY KEY, names VARCHAR(50) NOT NULL, val DECIMAL(10,2) NULL)
+INSERT INTO sp_param_table VALUES (1, 'Item1', 100.50), (2, 'Item2', 200.75), (3, 'Item3', 300.00)
+~~ROW COUNT: 3~~
+
+CREATE PROCEDURE sp_get_by_id @id INT AS BEGIN SELECT * FROM sp_param_table WHERE id = @id END
+fillschema_test#!#EXEC sp_get_by_id @id = 1
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: names
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: val
+  - Is Primary Key: False
+  - Data Type: System.Decimal
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+
+#Test case 13: sp_prepexec
+DROP TABLE IF EXISTS prepexec_test
+CREATE TABLE prepexec_test (id INT PRIMARY KEY, name VARCHAR(50), value INT)
+INSERT INTO prepexec_test VALUES (1, 'Test1', 100), (2, 'Test2', 200)
+~~ROW COUNT: 2~~
+
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@id INT', N'SELECT * FROM prepexec_test WHERE id = @id', @id = 1
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: value
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS prepexec_test
+
+#Test case 14: sp_prepexec and sp_prepare
+DROP TABLE IF EXISTS prepare_exec_test
+CREATE TABLE prepare_exec_test (id INT PRIMARY KEY, data VARCHAR(100))
+INSERT INTO prepare_exec_test VALUES (1, 'Data1'), (2, 'Data2')
+~~ROW COUNT: 2~~
+
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepare @handle OUTPUT, N'@id INT', N'SELECT * FROM prepare_exec_test WHERE id = @id'; EXEC sp_execute @handle, 1; EXEC sp_unprepare @handle
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS prepare_exec_test
+
+#Test case 15: FMTONLY ON case
+DROP TABLE IF EXISTS fmtonly_test
+CREATE TABLE fmtonly_test (id INT PRIMARY KEY, name VARCHAR(50), created_date DATETIME)
+INSERT INTO fmtonly_test VALUES (1, 'Test', GETDATE())
+~~ROW COUNT: 1~~
+
+fillschema_test#!#SET FMTONLY ON; SELECT * FROM fmtonly_test
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: created_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS fmtonly_test
+
+#Test case 16: prepexec with join tables
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers
+CREATE TABLE prepexec_customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100))
+CREATE TABLE prepexec_orders (order_id INT PRIMARY KEY, customer_id INT, order_date DATE, amount DECIMAL(10,2))
+INSERT INTO prepexec_customers VALUES (1, 'Customer A'), (2, 'Customer B')
+~~ROW COUNT: 2~~
+
+INSERT INTO prepexec_orders VALUES (101, 1, '2024-01-01', 500.00), (102, 1, '2024-01-15', 750.00), (103, 2, '2024-02-01', 300.00)
+~~ROW COUNT: 3~~
+
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@custid INT', N'SELECT o.order_id, o.order_date, o.amount, c.customer_name FROM prepexec_orders o JOIN prepexec_customers c ON o.customer_id = c.customer_id WHERE c.customer_id = @custid', @custid = 1
+~~START~~
+Table Columns:
+Column: order_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: order_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+Column: amount
+  - Is Primary Key: False
+  - Data Type: System.Decimal
+  - Allow Null: True
+Column: customer_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- order_id
+~~END~~
+
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers

--- a/test/JDBC/input/primarykey/primarykey_tests.txt
+++ b/test/JDBC/input/primarykey/primarykey_tests.txt
@@ -1,0 +1,124 @@
+#Test case 1: Composite Primary Key (Two columns)
+DROP TABLE IF EXISTS primarytest
+CREATE TABLE primarytest (col1 INT NOT NULL, col2 INT NOT NULL, data VARCHAR(50), PRIMARY KEY (col1, col2))
+fillschema_test#!#SELECT * FROM primarytest
+DROP TABLE IF EXISTS primarytest
+
+#Test case 2: No Primary Key
+DROP TABLE IF EXISTS pk_none
+CREATE TABLE pk_none (col1 INT NOT NULL, col2 VARCHAR(50) NULL, col3 BIT NOT NULL)
+fillschema_test#!#SELECT * FROM pk_none
+DROP TABLE IF EXISTS pk_none
+
+# Test case 3: PK in Middle Position
+DROP TABLE IF EXISTS pk_middle
+CREATE TABLE pk_middle (col1 VARCHAR(50), col2 VARCHAR(50), id INT PRIMARY KEY, col3 VARCHAR(50), col4 VARCHAR(50))
+fillschema_test#!#SELECT * FROM pk_middle
+DROP TABLE IF EXISTS pk_middle
+
+#Test case 4: Multi-Table LEFT JOIN (3 tables, no FK constraint)
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+CREATE TABLE customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100) NOT NULL, city VARCHAR(50))
+CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT NOT NULL, order_date DATETIME NOT NULL, status VARCHAR(20))
+CREATE TABLE order_items (item_id INT PRIMARY KEY, order_id INT NOT NULL, product_name VARCHAR(100), quantity INT)
+fillschema_test#!#SELECT * FROM customers c LEFT JOIN orders o ON c.customer_id = o.customer_id LEFT JOIN order_items oi ON o.order_id = oi.order_id
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+
+#Test case 5: UNIQUE Nullable Column
+DROP TABLE IF EXISTS rule2b_unique_null
+CREATE TABLE rule2b_unique_null (id INT NULL UNIQUE, name VARCHAR(50) NULL)
+fillschema_test#!#SELECT * FROM rule2b_unique_null
+DROP TABLE IF EXISTS rule2b_unique_null
+
+Test case 6: Primary key detection
+DROP TABLE IF EXISTS int_boundary
+CREATE TABLE int_boundary (id INT PRIMARY KEY, data VARCHAR(50))
+fillschema_test#!#SELECT * FROM int_boundary
+DROP TABLE IF EXISTS int_boundary
+
+#Test case 7: PK with Multiple UNIQUE Constraints
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+CREATE TABLE rule3_pk_multi_unique (id INT PRIMARY KEY, email VARCHAR(100) NOT NULL UNIQUE, phone VARCHAR(20) NOT NULL UNIQUE, ssn VARCHAR(20) NULL UNIQUE, name VARCHAR(50))
+INSERT INTO rule3_pk_multi_unique VALUES (1, 'test@test.com', '555-1234', [REDACTED:SSN], 'test')
+fillschema_test#!#SELECT * FROM rule3_pk_multi_unique
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+
+#Test case 8: Composite Foreign Key (2 columns)
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+CREATE TABLE fk_parent_composite (col1 INT NOT NULL, col2 INT NOT NULL, name VARCHAR(50), PRIMARY KEY (col1, col2))
+CREATE TABLE fk_child_composite (id INT PRIMARY KEY, ref_col1 INT NOT NULL, ref_col2 INT NOT NULL, data VARCHAR(50), FOREIGN KEY (ref_col1, ref_col2) REFERENCES fk_parent_composite(col1, col2))
+fillschema_test#!#SELECT * FROM fk_child_composite
+fillschema_test#!#SELECT c.*, p.name FROM fk_child_composite c JOIN fk_parent_composite p ON c.ref_col1 = p.col1 AND c.ref_col2 = p.col2
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+
+#Test case 9: Primary Key detection in 3-level hierarchy with chained foreign keys
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+CREATE TABLE fk_chain_a (id INT PRIMARY KEY, name VARCHAR(50))
+CREATE TABLE fk_chain_b (id INT PRIMARY KEY, a_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (a_id) REFERENCES fk_chain_a(id))
+CREATE TABLE fk_chain_c (id INT PRIMARY KEY, b_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (b_id) REFERENCES fk_chain_b(id))
+fillschema_test#!#SELECT c.*, b.name as b_name, a.name as a_name FROM fk_chain_c c JOIN fk_chain_b b ON c.b_id = b.id JOIN fk_chain_a a ON b.a_id = a.id
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+
+#Test case 10: Testing with NO_BROWSETABLE_OFF
+DROP TABLE IF EXISTS dbo.cclass 
+CREATE TABLE dbo.cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL, room_number INT NULL )
+fillschema_test#!#SET NO_BROWSETABLE OFF; select * from dbo.cclass
+DROP TABLE IF EXISTS dbo.cclass
+
+#Test case 11: Testing with NO_BROWSETABLE_ON
+DROP TABLE IF EXISTS new_cclass
+CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )
+fillschema_test#!#SET NO_BROWSETABLE ON; select * from new_cclass
+DROP TABLE IF EXISTS new_cclass
+
+#Test case 12: Stored Procedures
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+CREATE TABLE sp_param_table (id INT NOT NULL PRIMARY KEY, names VARCHAR(50) NOT NULL, val DECIMAL(10,2) NULL)
+INSERT INTO sp_param_table VALUES (1, 'Item1', 100.50), (2, 'Item2', 200.75), (3, 'Item3', 300.00)
+CREATE PROCEDURE sp_get_by_id @id INT AS BEGIN SELECT * FROM sp_param_table WHERE id = @id END
+fillschema_test#!#EXEC sp_get_by_id @id = 1
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+
+#Test case 13: sp_prepexec
+DROP TABLE IF EXISTS prepexec_test
+CREATE TABLE prepexec_test (id INT PRIMARY KEY, name VARCHAR(50), value INT)
+INSERT INTO prepexec_test VALUES (1, 'Test1', 100), (2, 'Test2', 200)
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@id INT', N'SELECT * FROM prepexec_test WHERE id = @id', @id = 1
+DROP TABLE IF EXISTS prepexec_test
+
+#Test case 14: sp_prepexec and sp_prepare
+DROP TABLE IF EXISTS prepare_exec_test
+CREATE TABLE prepare_exec_test (id INT PRIMARY KEY, data VARCHAR(100))
+INSERT INTO prepare_exec_test VALUES (1, 'Data1'), (2, 'Data2')
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepare @handle OUTPUT, N'@id INT', N'SELECT * FROM prepare_exec_test WHERE id = @id'; EXEC sp_execute @handle, 1; EXEC sp_unprepare @handle
+DROP TABLE IF EXISTS prepare_exec_test
+
+#Test case 15: FMTONLY ON case
+DROP TABLE IF EXISTS fmtonly_test
+CREATE TABLE fmtonly_test (id INT PRIMARY KEY, name VARCHAR(50), created_date DATETIME)
+INSERT INTO fmtonly_test VALUES (1, 'Test', GETDATE())
+fillschema_test#!#SET FMTONLY ON; SELECT * FROM fmtonly_test
+DROP TABLE IF EXISTS fmtonly_test
+
+#Test case 16: prepexec with join tables
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers
+CREATE TABLE prepexec_customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100))
+CREATE TABLE prepexec_orders (order_id INT PRIMARY KEY, customer_id INT, order_date DATE, amount DECIMAL(10,2))
+INSERT INTO prepexec_customers VALUES (1, 'Customer A'), (2, 'Customer B')
+INSERT INTO prepexec_orders VALUES (101, 1, '2024-01-01', 500.00), (102, 1, '2024-01-15', 750.00), (103, 2, '2024-02-01', 300.00)
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@custid INT', N'SELECT o.order_id, o.order_date, o.amount, c.customer_name FROM prepexec_orders o JOIN prepexec_customers c ON o.customer_id = c.customer_id WHERE c.customer_id = @custid', @custid = 1
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers

--- a/test/JDBC/src/main/java/com/sqlsamples/JDBCFillSchema.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/JDBCFillSchema.java
@@ -1,0 +1,154 @@
+package com.sqlsamples;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.Logger;
+import static com.sqlsamples.HandleException.handleSQLExceptionWithFile;
+
+public class JDBCFillSchema {
+    
+    static void testFillSchema(BufferedWriter bw, Logger logger, Connection con_bbl, String query) throws IOException {
+        try {
+            bw.write("~~START~~");
+            bw.newLine();
+
+            Statement stmt = con_bbl.createStatement();
+            ResultSet rs = stmt.executeQuery(query);
+            ResultSetMetaData rsmd = rs.getMetaData();
+
+            String tableName = extractTableName(query);
+            List<String> primaryKeyColumns = new ArrayList<>();
+            
+            if (tableName != null && !tableName.isEmpty()) {
+                try {
+                    DatabaseMetaData dbmeta = con_bbl.getMetaData();
+                    ResultSet pkRs = dbmeta.getPrimaryKeys(null, null, tableName);
+                    while (pkRs.next()) {
+                        primaryKeyColumns.add(pkRs.getString("COLUMN_NAME"));
+                    }
+                    pkRs.close();
+                } catch (SQLException e) {
+                    logger.warn("Could not retrieve primary keys for table: " + tableName);
+                }
+            }
+            
+            bw.write("Table Columns:");
+            bw.newLine();
+            
+            int columnCount = rsmd.getColumnCount();
+            for (int i = 1; i <= columnCount; i++) {
+                String columnName = rsmd.getColumnName(i);
+                String columnClassName = rsmd.getColumnClassName(i);
+                int nullable = rsmd.isNullable(i);
+                boolean isPrimaryKey = primaryKeyColumns.contains(columnName);
+                
+                bw.write("Column: " + columnName);
+                bw.newLine();
+                bw.write("  - Is Primary Key: " + (isPrimaryKey ? "True" : "False"));
+                bw.newLine();
+                bw.write("  - Data Type: " + mapToNetType(columnClassName));
+                bw.newLine();
+                
+                String allowNull;
+                if (nullable == ResultSetMetaData.columnNoNulls) {
+                    allowNull = "False";
+                } else if (nullable == ResultSetMetaData.columnNullable) {
+                    allowNull = "True";
+                } else {
+                    allowNull = "Unknown";
+                }
+                bw.write("  - Allow Null: " + allowNull);
+                bw.newLine();
+            }
+            
+            bw.newLine();
+            bw.write("Primary Key Columns:");
+            bw.newLine();
+            if (!primaryKeyColumns.isEmpty()) {
+                for (String pkCol : primaryKeyColumns) {
+                    bw.write("- " + pkCol);
+                    bw.newLine();
+                }
+            } else {
+                bw.write("- None");
+                bw.newLine();
+            }
+            
+            rs.close();
+            stmt.close();
+            
+            bw.write("~~END~~");
+            bw.newLine();
+            bw.newLine();
+            
+            logger.info("FillSchema test completed for query: " + query);
+            
+        } catch (SQLException e) {
+            handleSQLExceptionWithFile(e, bw, logger);
+        }
+    }
+    
+    private static String mapToNetType(String javaClassName) {
+        if (javaClassName == null) return "System.Object";
+        
+        switch (javaClassName) {
+            case "java.lang.Integer":
+                return "System.Int32";
+            case "java.lang.Long":
+                return "System.Int64";
+            case "java.lang.Short":
+                return "System.Int16";
+            case "java.lang.Byte":
+                return "System.Byte";
+            case "java.lang.String":
+                return "System.String";
+            case "java.lang.Boolean":
+                return "System.Boolean";
+            case "java.lang.Double":
+                return "System.Double";
+            case "java.lang.Float":
+                return "System.Single";
+            case "java.math.BigDecimal":
+                return "System.Decimal";
+            case "java.sql.Date":
+            case "java.sql.Timestamp":
+            case "java.time.LocalDateTime":
+                return "System.DateTime";
+            case "java.sql.Time":
+                return "System.TimeSpan";
+            case "[B":  
+                return "System.Byte[]";
+            default:
+                return javaClassName;
+        }
+    }
+    
+    private static String extractTableName(String query) {
+        try {
+            Pattern pattern = Pattern.compile("\\bFROM\\s+([^\\s,;()]+)", Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(query);
+            if (matcher.find()) {
+                String tableName = matcher.group(1);
+                if (tableName.contains(".")) {
+                    tableName = tableName.substring(tableName.lastIndexOf(".") + 1);
+                }
+                tableName = tableName.replaceAll("[\\[\\]\"]", "");
+                return tableName;
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return null;
+    }
+}

--- a/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
+++ b/test/JDBC/src/main/java/com/sqlsamples/batch_run.java
@@ -242,6 +242,14 @@ public class batch_run {
                     String data = result.length >= 3 ? result[2] : "";
 
                     JDBCMetadata.testDatabaseMetadata(bw, logger, con_bbl, method, data);
+                } else if (strLine.startsWith("fillschema_test")) {
+                    bw.write(strLine);
+                    bw.newLine();
+                    
+                    String[] result = strLine.split("#!#");
+                    String query = result.length >= 2 ? result[1] : "";
+                    
+                    JDBCFillSchema.testFillSchema(bw, logger, con_bbl, query);
                 } else if (isCrossDialectFile && (  (tsqlDialect = strLine.toLowerCase().startsWith("-- tsql")) ||
                                                     (psqlDialect = strLine.toLowerCase().startsWith("-- psql")))) {
                     // Cross dialect testing

--- a/test/dotnet/ExpectedOutput/primarykey_tests.out
+++ b/test/dotnet/ExpectedOutput/primarykey_tests.out
@@ -1,0 +1,433 @@
+#Q#DROP TABLE IF EXISTS primarytest
+#Q#CREATE TABLE primarytest (col1 INT NOT NULL, col2 INT NOT NULL, data VARCHAR(50), PRIMARY KEY (col1, col2))
+#Q#SELECT * FROM primarytest
+
+Table Columns:
+Column: col1
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: col2
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- col1
+- col2
+#Q#DROP TABLE IF EXISTS primarytest
+#Q#DROP TABLE IF EXISTS pk_none
+#Q#CREATE TABLE pk_none (col1 INT NOT NULL, col2 VARCHAR(50) NULL, col3 BIT NOT NULL)
+#Q#SELECT * FROM pk_none
+
+Table Columns:
+Column: col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: col2
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col3
+  - Is Primary Key: False
+  - Data Type: System.Boolean
+  - Allow Null: False
+Primary Key Columns:
+- None
+#Q#DROP TABLE IF EXISTS pk_none
+#Q#DROP TABLE IF EXISTS pk_middle
+#Q#CREATE TABLE pk_middle (col1 VARCHAR(50), col2 VARCHAR(50), id INT PRIMARY KEY, col3 VARCHAR(50), col4 VARCHAR(50))
+#Q#SELECT * FROM pk_middle
+
+Table Columns:
+Column: col1
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: col3
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col4
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS pk_middle
+#Q#DROP TABLE IF EXISTS order_items
+#Q#DROP TABLE IF EXISTS orders
+#Q#DROP TABLE IF EXISTS customers
+#Q#CREATE TABLE customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100) NOT NULL, city VARCHAR(50))
+#Q#CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT NOT NULL, order_date DATETIME NOT NULL, status VARCHAR(20))
+#Q#CREATE TABLE order_items (item_id INT PRIMARY KEY, order_id INT NOT NULL, product_name VARCHAR(100), quantity INT)
+#Q#SELECT * FROM customers c LEFT JOIN orders o ON c.customer_id = o.customer_id LEFT JOIN order_items oi ON o.order_id = oi.order_id
+
+Table Columns:
+Column: customer_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: customer_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: city
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: order_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: customer_id1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: order_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: False
+Column: status
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: item_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: order_id1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: product_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: quantity
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Primary Key Columns:
+- customer_id
+- order_id
+- item_id
+#Q#DROP TABLE IF EXISTS order_items
+#Q#DROP TABLE IF EXISTS orders
+#Q#DROP TABLE IF EXISTS customers
+#Q#DROP TABLE IF EXISTS rule2b_unique_null
+#Q#CREATE TABLE rule2b_unique_null (id INT NULL UNIQUE, name VARCHAR(50) NULL)
+#Q#SELECT * FROM rule2b_unique_null
+
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- None
+#Q#DROP TABLE IF EXISTS rule2b_unique_null
+#Q#DROP TABLE IF EXISTS int_boundary
+#Q#CREATE TABLE int_boundary (id INT PRIMARY KEY, data VARCHAR(50))
+#Q#SELECT * FROM int_boundary
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS int_boundary
+#Q#DROP TABLE IF EXISTS rule3_pk_multi_unique
+#Q#CREATE TABLE rule3_pk_multi_unique (id INT PRIMARY KEY, email VARCHAR(100) NOT NULL UNIQUE, phone VARCHAR(20) NOT NULL UNIQUE, ssn VARCHAR(20) NULL UNIQUE, name VARCHAR(50))
+#Q#INSERT INTO rule3_pk_multi_unique VALUES (1, 'test@test.com', '555-1234', [REDACTED:SSN], 'test')
+#E#column "redacted:ssn" does not exist
+#Q#SELECT * FROM rule3_pk_multi_unique
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: email
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: phone
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: ssn
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS rule3_pk_multi_unique
+#Q#DROP TABLE IF EXISTS fk_child_composite
+#Q#DROP TABLE IF EXISTS fk_parent_composite
+#Q#CREATE TABLE fk_parent_composite (col1 INT NOT NULL, col2 INT NOT NULL, name VARCHAR(50), PRIMARY KEY (col1, col2))
+#Q#CREATE TABLE fk_child_composite (id INT PRIMARY KEY, ref_col1 INT NOT NULL, ref_col2 INT NOT NULL, data VARCHAR(50), FOREIGN KEY (ref_col1, ref_col2) REFERENCES fk_parent_composite(col1, col2))
+#Q#SELECT * FROM fk_child_composite
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: ref_col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: ref_col2
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#SELECT c.*, p.name FROM fk_child_composite c JOIN fk_parent_composite p ON c.ref_col1 = p.col1 AND c.ref_col2 = p.col2
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: ref_col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: ref_col2
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS fk_child_composite
+#Q#DROP TABLE IF EXISTS fk_parent_composite
+#Q#DROP TABLE IF EXISTS fk_chain_c
+#Q#DROP TABLE IF EXISTS fk_chain_b
+#Q#DROP TABLE IF EXISTS fk_chain_a
+#Q#CREATE TABLE fk_chain_a (id INT PRIMARY KEY, name VARCHAR(50))
+#Q#CREATE TABLE fk_chain_b (id INT PRIMARY KEY, a_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (a_id) REFERENCES fk_chain_a(id))
+#Q#CREATE TABLE fk_chain_c (id INT PRIMARY KEY, b_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (b_id) REFERENCES fk_chain_b(id))
+#Q#SELECT c.*, b.name as b_name, a.name as a_name FROM fk_chain_c c JOIN fk_chain_b b ON c.b_id = b.id JOIN fk_chain_a a ON b.a_id = a.id
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: b_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: b_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: a_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS fk_chain_c
+#Q#DROP TABLE IF EXISTS fk_chain_b
+#Q#DROP TABLE IF EXISTS fk_chain_a
+#Q#DROP TABLE IF EXISTS dbo.cclass 
+#Q#CREATE TABLE dbo.cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL, room_number INT NULL )
+#Q#SET NO_BROWSETABLE OFF; select * from dbo.cclass
+
+Table Columns:
+Column: class_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: class_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: teacher_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: room_number
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Primary Key Columns:
+- class_id
+#Q#DROP TABLE IF EXISTS dbo.cclass
+#Q#DROP TABLE IF EXISTS new_cclass
+#Q#CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )
+#Q#SET NO_BROWSETABLE ON; select * from new_cclass
+
+Table Columns:
+Column: class_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: class_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: teacher_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- class_id
+#Q#DROP TABLE IF EXISTS new_cclass
+#Q#DROP PROCEDURE IF EXISTS sp_get_by_id
+#Q#DROP TABLE IF EXISTS sp_param_table
+#Q#CREATE TABLE sp_param_table (id INT NOT NULL PRIMARY KEY, names VARCHAR(50) NOT NULL, val DECIMAL(10,2) NULL)
+#Q#INSERT INTO sp_param_table VALUES (1, 'Item1', 100.50), (2, 'Item2', 200.75), (3, 'Item3', 300.00)
+#Q#CREATE PROCEDURE sp_get_by_id @id INT AS BEGIN SELECT * FROM sp_param_table WHERE id = @id END
+#Q#EXEC sp_get_by_id @id = 1
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: names
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: val
+  - Is Primary Key: False
+  - Data Type: System.Decimal
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP PROCEDURE IF EXISTS sp_get_by_id
+#Q#DROP TABLE IF EXISTS sp_param_table
+#Q#DROP TABLE IF EXISTS prepexec_test
+#Q#CREATE TABLE prepexec_test (id INT PRIMARY KEY, name VARCHAR(50), value INT)
+#Q#INSERT INTO prepexec_test VALUES (1, 'Test1', 100), (2, 'Test2', 200)
+#Q#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@id INT', N'SELECT * FROM prepexec_test WHERE id = @id', @id = 1
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: value
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS prepexec_test
+#Q#DROP TABLE IF EXISTS prepare_exec_test
+#Q#CREATE TABLE prepare_exec_test (id INT PRIMARY KEY, data VARCHAR(100))
+#Q#INSERT INTO prepare_exec_test VALUES (1, 'Data1'), (2, 'Data2')
+#Q#DECLARE @handle INT; EXEC sp_prepare @handle OUTPUT, N'@id INT', N'SELECT * FROM prepare_exec_test WHERE id = @id'; EXEC sp_execute @handle, 1; EXEC sp_unprepare @handle
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS prepare_exec_test
+#Q#DROP TABLE IF EXISTS fmtonly_test
+#Q#CREATE TABLE fmtonly_test (id INT PRIMARY KEY, name VARCHAR(50), created_date DATETIME)
+#Q#INSERT INTO fmtonly_test VALUES (1, 'Test', GETDATE())
+#Q#SET FMTONLY ON; SELECT * FROM fmtonly_test
+
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: created_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+Primary Key Columns:
+- id
+#Q#DROP TABLE IF EXISTS fmtonly_test
+#Q#DROP TABLE IF EXISTS prepexec_orders
+#Q#DROP TABLE IF EXISTS prepexec_customers
+#Q#CREATE TABLE prepexec_customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100))
+#Q#CREATE TABLE prepexec_orders (order_id INT PRIMARY KEY, customer_id INT, order_date DATE, amount DECIMAL(10,2))
+#Q#INSERT INTO prepexec_customers VALUES (1, 'Customer A'), (2, 'Customer B')
+#Q#INSERT INTO prepexec_orders VALUES (101, 1, '2024-01-01', 500.00), (102, 1, '2024-01-15', 750.00), (103, 2, '2024-02-01', 300.00)
+#Q#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@custid INT', N'SELECT o.order_id, o.order_date, o.amount, c.customer_name FROM prepexec_orders o JOIN prepexec_customers c ON o.customer_id = c.customer_id WHERE c.customer_id = @custid', @custid = 1
+
+Table Columns:
+Column: order_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: order_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+Column: amount
+  - Is Primary Key: False
+  - Data Type: System.Decimal
+  - Allow Null: True
+Column: customer_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Primary Key Columns:
+- order_id
+#Q#DROP TABLE IF EXISTS prepexec_orders
+#Q#DROP TABLE IF EXISTS prepexec_customers

--- a/test/dotnet/input/primarykey_tests.txt
+++ b/test/dotnet/input/primarykey_tests.txt
@@ -1,0 +1,124 @@
+#Test case 1: Composite Primary Key (Two columns)
+DROP TABLE IF EXISTS primarytest
+CREATE TABLE primarytest (col1 INT NOT NULL, col2 INT NOT NULL, data VARCHAR(50), PRIMARY KEY (col1, col2))
+fillschema_test#!#SELECT * FROM primarytest
+DROP TABLE IF EXISTS primarytest
+
+#Test case 2: No Primary Key
+DROP TABLE IF EXISTS pk_none
+CREATE TABLE pk_none (col1 INT NOT NULL, col2 VARCHAR(50) NULL, col3 BIT NOT NULL)
+fillschema_test#!#SELECT * FROM pk_none
+DROP TABLE IF EXISTS pk_none
+
+# Test case 3: PK in Middle Position
+DROP TABLE IF EXISTS pk_middle
+CREATE TABLE pk_middle (col1 VARCHAR(50), col2 VARCHAR(50), id INT PRIMARY KEY, col3 VARCHAR(50), col4 VARCHAR(50))
+fillschema_test#!#SELECT * FROM pk_middle
+DROP TABLE IF EXISTS pk_middle
+
+#Test case 4: Multi-Table LEFT JOIN (3 tables, no FK constraint)
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+CREATE TABLE customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100) NOT NULL, city VARCHAR(50))
+CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT NOT NULL, order_date DATETIME NOT NULL, status VARCHAR(20))
+CREATE TABLE order_items (item_id INT PRIMARY KEY, order_id INT NOT NULL, product_name VARCHAR(100), quantity INT)
+fillschema_test#!#SELECT * FROM customers c LEFT JOIN orders o ON c.customer_id = o.customer_id LEFT JOIN order_items oi ON o.order_id = oi.order_id
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+
+#Test case 5: UNIQUE Nullable Column
+DROP TABLE IF EXISTS rule2b_unique_null
+CREATE TABLE rule2b_unique_null (id INT NULL UNIQUE, name VARCHAR(50) NULL)
+fillschema_test#!#SELECT * FROM rule2b_unique_null
+DROP TABLE IF EXISTS rule2b_unique_null
+
+Test case 6: Primary key detection
+DROP TABLE IF EXISTS int_boundary
+CREATE TABLE int_boundary (id INT PRIMARY KEY, data VARCHAR(50))
+fillschema_test#!#SELECT * FROM int_boundary
+DROP TABLE IF EXISTS int_boundary
+
+#Test case 7: PK with Multiple UNIQUE Constraints
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+CREATE TABLE rule3_pk_multi_unique (id INT PRIMARY KEY, email VARCHAR(100) NOT NULL UNIQUE, phone VARCHAR(20) NOT NULL UNIQUE, ssn VARCHAR(20) NULL UNIQUE, name VARCHAR(50))
+INSERT INTO rule3_pk_multi_unique VALUES (1, 'test@test.com', '555-1234', [REDACTED:SSN], 'test')
+fillschema_test#!#SELECT * FROM rule3_pk_multi_unique
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+
+#Test case 8: Composite Foreign Key (2 columns)
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+CREATE TABLE fk_parent_composite (col1 INT NOT NULL, col2 INT NOT NULL, name VARCHAR(50), PRIMARY KEY (col1, col2))
+CREATE TABLE fk_child_composite (id INT PRIMARY KEY, ref_col1 INT NOT NULL, ref_col2 INT NOT NULL, data VARCHAR(50), FOREIGN KEY (ref_col1, ref_col2) REFERENCES fk_parent_composite(col1, col2))
+fillschema_test#!#SELECT * FROM fk_child_composite
+fillschema_test#!#SELECT c.*, p.name FROM fk_child_composite c JOIN fk_parent_composite p ON c.ref_col1 = p.col1 AND c.ref_col2 = p.col2
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+
+#Test case 9: Primary Key detection in 3-level hierarchy with chained foreign keys
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+CREATE TABLE fk_chain_a (id INT PRIMARY KEY, name VARCHAR(50))
+CREATE TABLE fk_chain_b (id INT PRIMARY KEY, a_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (a_id) REFERENCES fk_chain_a(id))
+CREATE TABLE fk_chain_c (id INT PRIMARY KEY, b_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (b_id) REFERENCES fk_chain_b(id))
+fillschema_test#!#SELECT c.*, b.name as b_name, a.name as a_name FROM fk_chain_c c JOIN fk_chain_b b ON c.b_id = b.id JOIN fk_chain_a a ON b.a_id = a.id
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+
+#Test case 10: Testing with NO_BROWSETABLE_OFF
+DROP TABLE IF EXISTS dbo.cclass 
+CREATE TABLE dbo.cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL, room_number INT NULL )
+fillschema_test#!#SET NO_BROWSETABLE OFF; select * from dbo.cclass
+DROP TABLE IF EXISTS dbo.cclass
+
+#Test case 11: Testing with NO_BROWSETABLE_ON
+DROP TABLE IF EXISTS new_cclass
+CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )
+fillschema_test#!#SET NO_BROWSETABLE ON; select * from new_cclass
+DROP TABLE IF EXISTS new_cclass
+
+#Test case 12: Stored Procedures
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+CREATE TABLE sp_param_table (id INT NOT NULL PRIMARY KEY, names VARCHAR(50) NOT NULL, val DECIMAL(10,2) NULL)
+INSERT INTO sp_param_table VALUES (1, 'Item1', 100.50), (2, 'Item2', 200.75), (3, 'Item3', 300.00)
+CREATE PROCEDURE sp_get_by_id @id INT AS BEGIN SELECT * FROM sp_param_table WHERE id = @id END
+fillschema_test#!#EXEC sp_get_by_id @id = 1
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+
+#Test case 13: sp_prepexec
+DROP TABLE IF EXISTS prepexec_test
+CREATE TABLE prepexec_test (id INT PRIMARY KEY, name VARCHAR(50), value INT)
+INSERT INTO prepexec_test VALUES (1, 'Test1', 100), (2, 'Test2', 200)
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@id INT', N'SELECT * FROM prepexec_test WHERE id = @id', @id = 1
+DROP TABLE IF EXISTS prepexec_test
+
+#Test case 14: sp_prepexec and sp_prepare
+DROP TABLE IF EXISTS prepare_exec_test
+CREATE TABLE prepare_exec_test (id INT PRIMARY KEY, data VARCHAR(100))
+INSERT INTO prepare_exec_test VALUES (1, 'Data1'), (2, 'Data2')
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepare @handle OUTPUT, N'@id INT', N'SELECT * FROM prepare_exec_test WHERE id = @id'; EXEC sp_execute @handle, 1; EXEC sp_unprepare @handle
+DROP TABLE IF EXISTS prepare_exec_test
+
+#Test case 15: FMTONLY ON case
+DROP TABLE IF EXISTS fmtonly_test
+CREATE TABLE fmtonly_test (id INT PRIMARY KEY, name VARCHAR(50), created_date DATETIME)
+INSERT INTO fmtonly_test VALUES (1, 'Test', GETDATE())
+fillschema_test#!#SET FMTONLY ON; SELECT * FROM fmtonly_test
+DROP TABLE IF EXISTS fmtonly_test
+
+#Test case 16: prepexec with join tables
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers
+CREATE TABLE prepexec_customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100))
+CREATE TABLE prepexec_orders (order_id INT PRIMARY KEY, customer_id INT, order_date DATE, amount DECIMAL(10,2))
+INSERT INTO prepexec_customers VALUES (1, 'Customer A'), (2, 'Customer B')
+INSERT INTO prepexec_orders VALUES (101, 1, '2024-01-01', 500.00), (102, 1, '2024-01-15', 750.00), (103, 2, '2024-02-01', 300.00)
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@custid INT', N'SELECT o.order_id, o.order_date, o.amount, c.customer_name FROM prepexec_orders o JOIN prepexec_customers c ON o.customer_id = c.customer_id WHERE c.customer_id = @custid', @custid = 1
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers

--- a/test/dotnet/src/BatchRun.cs
+++ b/test/dotnet/src/BatchRun.cs
@@ -291,6 +291,28 @@ namespace BabelfishDotnetFramework
 							LoginDatabaseScripter.ScriptDatabase(strLine, testName, testUtils, logger);
 							LoginDatabaseScripter.ScriptLogins(testName, testUtils, logger);
 						}
+						else if (strLine.ToLowerInvariant().StartsWith("fillschema_test"))
+						{
+							testUtils.PrintToLogsOrConsole("######################################################################", logger, "information");
+							testUtils.PrintToLogsOrConsole("####################### FILLSCHEMA TEST ##############################", logger, "information");
+							testUtils.PrintToLogsOrConsole("######################################################################\n", logger, "information");
+							
+							var result = strLine.Split("#!#", StringSplitOptions.RemoveEmptyEntries);
+							
+							if (result.Length >= 2)
+							{
+								string tableOrQuery = result[1].Trim();
+								
+								testUtils.PrintToLogsOrConsole($"Query: {tableOrQuery}", logger, "information");
+								testUtils.FillSchemaTest(bblCnn, bblTransaction, tableOrQuery, testName, logger, ref stCount);
+							}
+							else
+							{
+								testUtils.PrintToLogsOrConsole("Invalid format. Use: fillschema_test#!#tablename OR fillschema_test#!#SELECT * FROM table", logger, "error");
+								stCount--;
+							}
+						}
+
 						else
 						{
 							/*

--- a/test/dotnet/utils/TestUtils.cs
+++ b/test/dotnet/utils/TestUtils.cs
@@ -648,5 +648,60 @@ namespace BabelfishDotnetFramework
 				return null;
 			}
 		}
+		public void FillSchemaTest(DbConnection conn, DbTransaction transaction, string query, 
+			string testName, Logger logger, ref int stCount)
+		{
+			using var myoutputfile = new StreamWriter(Path.Combine(ConfigSetup.OutputFolder, testName + ".out"), true);
+			myoutputfile.WriteLine($"#Q#{query}");
+			myoutputfile.WriteLine();
+			
+			try
+			{
+				using var cmd = new SqlCommand(query, (SqlConnection)conn);
+				if (transaction != null)
+				{
+					cmd.Transaction = (SqlTransaction)transaction;
+				}
+				
+				var da = new SqlDataAdapter(cmd);
+				da.MissingSchemaAction = MissingSchemaAction.AddWithKey;
+				var dt = new DataTable();
+				da.FillSchema(dt, SchemaType.Source);
+				
+				// Write all columns
+				myoutputfile.WriteLine("Table Columns:");
+				foreach (DataColumn column in dt.Columns)
+				{
+					bool isPrimaryKey = dt.PrimaryKey != null && Array.Exists(dt.PrimaryKey, pk => pk == column);
+					
+					myoutputfile.WriteLine($"Column: {column.ColumnName}");
+					myoutputfile.WriteLine($"  - Is Primary Key: {isPrimaryKey}");
+					myoutputfile.WriteLine($"  - Data Type: {column.DataType}");
+					myoutputfile.WriteLine($"  - Allow Null: {column.AllowDBNull}");
+				}
+				
+				// Write primary key columns summary
+				myoutputfile.WriteLine("Primary Key Columns:");
+				if (dt.PrimaryKey != null && dt.PrimaryKey.Length > 0)
+				{
+					foreach (DataColumn pkColumn in dt.PrimaryKey)
+					{
+						myoutputfile.WriteLine($"- {pkColumn.ColumnName}");
+					}
+				}
+				else
+				{
+					myoutputfile.WriteLine("- None");
+				}
+				
+				PrintToLogsOrConsole($"FillSchemaTest completed for: {query}", logger, "information");
+			}
+			catch (Exception ex)
+			{
+				myoutputfile.WriteLine($"#E#{ex.Message}");
+				PrintToLogsOrConsole($"Error in FillSchemaTest: {ex.Message}", logger, "error");
+				stCount--;
+			}
+		}
 	}
 }

--- a/test/python/batch_run.py
+++ b/test/python/batch_run.py
@@ -1,5 +1,5 @@
 from utils.config import config_dict as cfg
-from execute_query import  parse_prepared_statement, parse_stored_procedures, process_transaction_statement,process_statement_in_file_mode,process_statement_in_file_mode_ddl
+from execute_query import  parse_prepared_statement, parse_stored_procedures, process_transaction_statement,process_statement_in_file_mode,process_statement_in_file_mode_ddl, process_fillschema_in_file_mode
 from  python_authentication import py_authentication
 if cfg['runIsolationTests'] == 'true':
     from isolationtest.isolationTestHandler import isolationTestHandler
@@ -120,6 +120,12 @@ def batch_run(bbl_cnxn, file_handler, file, logger):
             elif line.startswith("cursor"):
                 flag = True
                 logger.info("Skipping statement " + line + " as cursor operations are not supported currently by pyodbc/pymssql")
+            
+            #run the fill schema tests
+            elif line.startswith("fillschema_test"):
+                result = line.split("#!#")
+                query = result[1] if len(result) > 1 else ""
+                flag = process_fillschema_in_file_mode(bbl_cnxn, file_handler, query, line, logger)
             
             # run as normal sql statement
             else:

--- a/test/python/execute_query.py
+++ b/test/python/execute_query.py
@@ -388,4 +388,98 @@ def process_stored_procedure_in_file_mode(bbl_cnxn, file_writer, query, stored_p
     
     return True 
 
-         
+#function to generate output files for fillschema method statements   
+def extract_table_name(query):
+    try:
+        match = re.search(r'\bFROM\s+([^\s,;()]+)', query, re.IGNORECASE)
+        if match:
+            table_name = match.group(1)
+            if '.' in table_name:
+                table_name = table_name.split('.')[-1]
+            table_name = table_name.strip('[]"')
+            return table_name
+    except Exception:
+        pass
+    return None
+
+def get_python_type_name(type_code):
+    type_mapping = {
+        int: "System.Int32",
+        str: "System.String", 
+        float: "System.Double",
+        Decimal: "System.Decimal",
+        datetime: "System.DateTime",
+        date: "System.DateTime",
+        time: "System.TimeSpan",
+        bool: "System.Boolean",
+        bytes: "System.Byte[]",
+    }
+    return type_mapping.get(type_code, str(type_code))
+
+def process_fillschema_in_file_mode(bbl_cnxn, file_writer, actual_query, original_line, logger):
+    try:
+        file_writer.write(original_line)
+        file_writer.write("\n")
+        
+        try:
+            bbl_cursor = bbl_cnxn.get_cursor()
+            
+            bbl_cursor.execute(actual_query)
+            
+            file_writer.write("~~START~~\n")
+            
+            if bbl_cursor.description:
+                table_name = extract_table_name(actual_query)
+                
+                pk_columns = []
+                if table_name and cfg["driver"] == "pyodbc":
+                    try:
+                        pk_cursor = bbl_cnxn.get_cursor()
+                        for row in pk_cursor.primaryKeys(table=table_name):
+                            pk_columns.append(row.column_name)
+                        pk_cursor.close()
+                    except Exception as e:
+                        logger.warning(f"Could not retrieve primary keys: {str(e)}")
+                
+                file_writer.write("Table Columns:\n")
+                for col in bbl_cursor.description:
+                    col_name = col[0]         
+                    type_code = col[1]       
+                    nullable = col[6]        
+                    is_pk = col_name in pk_columns
+                    
+                    if nullable is None:
+                        allow_null = "Unknown"
+                    elif nullable:
+                        allow_null = "True"
+                    else:
+                        allow_null = "False"
+                    
+                    file_writer.write(f"Column: {col_name}\n")
+                    file_writer.write(f"  - Is Primary Key: {is_pk}\n")
+                    file_writer.write(f"  - Data Type: {get_python_type_name(type_code)}\n")
+                    file_writer.write(f"  - Allow Null: {allow_null}\n")
+                
+                file_writer.write("\nPrimary Key Columns:\n")
+                if pk_columns:
+                    for pk_col in pk_columns:
+                        file_writer.write(f"- {pk_col}\n")
+                else:
+                    file_writer.write("- None\n")
+            else:
+                file_writer.write("No result set returned\n")
+                
+            file_writer.write("~~END~~\n\n")
+                
+        except Exception as e:
+            handle_exception_in_file(e, file_writer)
+        
+        try:
+            bbl_cursor.close()
+        except Exception as e:
+            logger.warning(f"Error closing cursor: {str(e)}")
+            
+    except Exception as e:
+        logger.error(f"Error in process_fillschema_in_file_mode: {str(e)}")
+    
+    return True

--- a/test/python/expected/pyodbc/primarykey_tests.out
+++ b/test/python/expected/pyodbc/primarykey_tests.out
@@ -1,0 +1,530 @@
+#Test case 1: Composite Primary Key (Two columns)
+DROP TABLE IF EXISTS primarytest
+CREATE TABLE primarytest (col1 INT NOT NULL, col2 INT NOT NULL, data VARCHAR(50), PRIMARY KEY (col1, col2))
+fillschema_test#!#SELECT * FROM primarytest
+~~START~~
+Table Columns:
+Column: col1
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- col1
+- col2
+~~END~~
+
+DROP TABLE IF EXISTS primarytest
+
+#Test case 2: No Primary Key
+DROP TABLE IF EXISTS pk_none
+CREATE TABLE pk_none (col1 INT NOT NULL, col2 VARCHAR(50) NULL, col3 BIT NOT NULL)
+fillschema_test#!#SELECT * FROM pk_none
+~~START~~
+Table Columns:
+Column: col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col3
+  - Is Primary Key: False
+  - Data Type: System.Boolean
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS pk_none
+
+# Test case 3: PK in Middle Position
+DROP TABLE IF EXISTS pk_middle
+CREATE TABLE pk_middle (col1 VARCHAR(50), col2 VARCHAR(50), id INT PRIMARY KEY, col3 VARCHAR(50), col4 VARCHAR(50))
+fillschema_test#!#SELECT * FROM pk_middle
+~~START~~
+Table Columns:
+Column: col1
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col2
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: col3
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: col4
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS pk_middle
+
+#Test case 4: Multi-Table LEFT JOIN (3 tables, no FK constraint)
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+CREATE TABLE customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100) NOT NULL, city VARCHAR(50))
+CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT NOT NULL, order_date DATETIME NOT NULL, status VARCHAR(20))
+CREATE TABLE order_items (item_id INT PRIMARY KEY, order_id INT NOT NULL, product_name VARCHAR(100), quantity INT)
+fillschema_test#!#SELECT * FROM customers c LEFT JOIN orders o ON c.customer_id = o.customer_id LEFT JOIN order_items oi ON o.order_id = oi.order_id
+~~START~~
+Table Columns:
+Column: customer_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: customer_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: city
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: order_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: customer_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: order_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+Column: status
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: item_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: order_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: product_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: quantity
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+
+Primary Key Columns:
+- customer_id
+~~END~~
+
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+
+#Test case 5: UNIQUE Nullable Column
+DROP TABLE IF EXISTS rule2b_unique_null
+CREATE TABLE rule2b_unique_null (id INT NULL UNIQUE, name VARCHAR(50) NULL)
+fillschema_test#!#SELECT * FROM rule2b_unique_null
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS rule2b_unique_null
+
+Test case 6: Primary key detection
+~~ERROR (Code: 33557097)~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]syntax error near 'case' at line 1 and character position 5 (33557097) (SQLExecDirectW))~~
+
+DROP TABLE IF EXISTS int_boundary
+CREATE TABLE int_boundary (id INT PRIMARY KEY, data VARCHAR(50))
+fillschema_test#!#SELECT * FROM int_boundary
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS int_boundary
+
+#Test case 7: PK with Multiple UNIQUE Constraints
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+CREATE TABLE rule3_pk_multi_unique (id INT PRIMARY KEY, email VARCHAR(100) NOT NULL UNIQUE, phone VARCHAR(20) NOT NULL UNIQUE, ssn VARCHAR(20) NULL UNIQUE, name VARCHAR(50))
+INSERT INTO rule3_pk_multi_unique VALUES (1, 'test@test.com', '555-1234', [REDACTED:SSN], 'test')
+~~ERROR (Code: 33557097)~~
+~~ERROR (Message: [42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]column "redacted:ssn" does not exist (33557097) (SQLExecDirectW))~~
+
+fillschema_test#!#SELECT * FROM rule3_pk_multi_unique
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: email
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: phone
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: ssn
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+
+#Test case 8: Composite Foreign Key (2 columns)
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+CREATE TABLE fk_parent_composite (col1 INT NOT NULL, col2 INT NOT NULL, name VARCHAR(50), PRIMARY KEY (col1, col2))
+CREATE TABLE fk_child_composite (id INT PRIMARY KEY, ref_col1 INT NOT NULL, ref_col2 INT NOT NULL, data VARCHAR(50), FOREIGN KEY (ref_col1, ref_col2) REFERENCES fk_parent_composite(col1, col2))
+fillschema_test#!#SELECT * FROM fk_child_composite
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col2
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+fillschema_test#!#SELECT c.*, p.name FROM fk_child_composite c JOIN fk_parent_composite p ON c.ref_col1 = p.col1 AND c.ref_col2 = p.col2
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col1
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: ref_col2
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+
+#Test case 9: Primary Key detection in 3-level hierarchy with chained foreign keys
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+CREATE TABLE fk_chain_a (id INT PRIMARY KEY, name VARCHAR(50))
+CREATE TABLE fk_chain_b (id INT PRIMARY KEY, a_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (a_id) REFERENCES fk_chain_a(id))
+CREATE TABLE fk_chain_c (id INT PRIMARY KEY, b_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (b_id) REFERENCES fk_chain_b(id))
+fillschema_test#!#SELECT c.*, b.name as b_name, a.name as a_name FROM fk_chain_c c JOIN fk_chain_b b ON c.b_id = b.id JOIN fk_chain_a a ON b.a_id = a.id
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: b_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: b_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: a_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+
+#Test case 10: Testing with NO_BROWSETABLE_OFF
+DROP TABLE IF EXISTS dbo.cclass 
+CREATE TABLE dbo.cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL, room_number INT NULL )
+fillschema_test#!#SET NO_BROWSETABLE OFF; select * from dbo.cclass
+~~START~~
+Table Columns:
+Column: class_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: class_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: teacher_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: room_number
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+
+Primary Key Columns:
+- class_id
+~~END~~
+
+DROP TABLE IF EXISTS dbo.cclass
+
+#Test case 11: Testing with NO_BROWSETABLE_ON
+DROP TABLE IF EXISTS new_cclass
+CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )
+fillschema_test#!#SET NO_BROWSETABLE ON; select * from new_cclass
+~~START~~
+Table Columns:
+Column: class_id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: class_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: teacher_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- class_id
+~~END~~
+
+DROP TABLE IF EXISTS new_cclass
+
+#Test case 12: Stored Procedures
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+CREATE TABLE sp_param_table (id INT NOT NULL PRIMARY KEY, names VARCHAR(50) NOT NULL, val DECIMAL(10,2) NULL)
+INSERT INTO sp_param_table VALUES (1, 'Item1', 100.50), (2, 'Item2', 200.75), (3, 'Item3', 300.00)
+~~ROW COUNT: 3~~
+
+CREATE PROCEDURE sp_get_by_id @id INT AS BEGIN SELECT * FROM sp_param_table WHERE id = @id END
+fillschema_test#!#EXEC sp_get_by_id @id = 1
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: names
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: val
+  - Is Primary Key: False
+  - Data Type: System.Decimal
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+
+#Test case 13: sp_prepexec
+DROP TABLE IF EXISTS prepexec_test
+CREATE TABLE prepexec_test (id INT PRIMARY KEY, name VARCHAR(50), value INT)
+INSERT INTO prepexec_test VALUES (1, 'Test1', 100), (2, 'Test2', 200)
+~~ROW COUNT: 2~~
+
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@id INT', N'SELECT * FROM prepexec_test WHERE id = @id', @id = 1
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: value
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS prepexec_test
+
+#Test case 14: sp_prepexec and sp_prepare
+DROP TABLE IF EXISTS prepare_exec_test
+CREATE TABLE prepare_exec_test (id INT PRIMARY KEY, data VARCHAR(100))
+INSERT INTO prepare_exec_test VALUES (1, 'Data1'), (2, 'Data2')
+~~ROW COUNT: 2~~
+
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepare @handle OUTPUT, N'@id INT', N'SELECT * FROM prepare_exec_test WHERE id = @id'; EXEC sp_execute @handle, 1; EXEC sp_unprepare @handle
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: True
+Column: data
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS prepare_exec_test
+
+#Test case 15: FMTONLY ON case
+DROP TABLE IF EXISTS fmtonly_test
+CREATE TABLE fmtonly_test (id INT PRIMARY KEY, name VARCHAR(50), created_date DATETIME)
+INSERT INTO fmtonly_test VALUES (1, 'Test', GETDATE())
+~~ROW COUNT: 1~~
+
+fillschema_test#!#SET FMTONLY ON; SELECT * FROM fmtonly_test
+~~START~~
+Table Columns:
+Column: id
+  - Is Primary Key: True
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+Column: created_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+
+Primary Key Columns:
+- id
+~~END~~
+
+DROP TABLE IF EXISTS fmtonly_test
+
+#Test case 16: prepexec with join tables
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers
+CREATE TABLE prepexec_customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100))
+CREATE TABLE prepexec_orders (order_id INT PRIMARY KEY, customer_id INT, order_date DATE, amount DECIMAL(10,2))
+INSERT INTO prepexec_customers VALUES (1, 'Customer A'), (2, 'Customer B')
+~~ROW COUNT: 2~~
+
+INSERT INTO prepexec_orders VALUES (101, 1, '2024-01-01', 500.00), (102, 1, '2024-01-15', 750.00), (103, 2, '2024-02-01', 300.00)
+~~ROW COUNT: 3~~
+
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@custid INT', N'SELECT o.order_id, o.order_date, o.amount, c.customer_name FROM prepexec_orders o JOIN prepexec_customers c ON o.customer_id = c.customer_id WHERE c.customer_id = @custid', @custid = 1
+~~START~~
+Table Columns:
+Column: order_id
+  - Is Primary Key: False
+  - Data Type: System.Int32
+  - Allow Null: False
+Column: order_date
+  - Is Primary Key: False
+  - Data Type: System.DateTime
+  - Allow Null: True
+Column: amount
+  - Is Primary Key: False
+  - Data Type: System.Decimal
+  - Allow Null: True
+Column: customer_name
+  - Is Primary Key: False
+  - Data Type: System.String
+  - Allow Null: True
+
+Primary Key Columns:
+- None
+~~END~~
+
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers

--- a/test/python/input/primarykey_tests.txt
+++ b/test/python/input/primarykey_tests.txt
@@ -1,0 +1,124 @@
+#Test case 1: Composite Primary Key (Two columns)
+DROP TABLE IF EXISTS primarytest
+CREATE TABLE primarytest (col1 INT NOT NULL, col2 INT NOT NULL, data VARCHAR(50), PRIMARY KEY (col1, col2))
+fillschema_test#!#SELECT * FROM primarytest
+DROP TABLE IF EXISTS primarytest
+
+#Test case 2: No Primary Key
+DROP TABLE IF EXISTS pk_none
+CREATE TABLE pk_none (col1 INT NOT NULL, col2 VARCHAR(50) NULL, col3 BIT NOT NULL)
+fillschema_test#!#SELECT * FROM pk_none
+DROP TABLE IF EXISTS pk_none
+
+# Test case 3: PK in Middle Position
+DROP TABLE IF EXISTS pk_middle
+CREATE TABLE pk_middle (col1 VARCHAR(50), col2 VARCHAR(50), id INT PRIMARY KEY, col3 VARCHAR(50), col4 VARCHAR(50))
+fillschema_test#!#SELECT * FROM pk_middle
+DROP TABLE IF EXISTS pk_middle
+
+#Test case 4: Multi-Table LEFT JOIN (3 tables, no FK constraint)
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+CREATE TABLE customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100) NOT NULL, city VARCHAR(50))
+CREATE TABLE orders (order_id INT PRIMARY KEY, customer_id INT NOT NULL, order_date DATETIME NOT NULL, status VARCHAR(20))
+CREATE TABLE order_items (item_id INT PRIMARY KEY, order_id INT NOT NULL, product_name VARCHAR(100), quantity INT)
+fillschema_test#!#SELECT * FROM customers c LEFT JOIN orders o ON c.customer_id = o.customer_id LEFT JOIN order_items oi ON o.order_id = oi.order_id
+DROP TABLE IF EXISTS order_items
+DROP TABLE IF EXISTS orders
+DROP TABLE IF EXISTS customers
+
+#Test case 5: UNIQUE Nullable Column
+DROP TABLE IF EXISTS rule2b_unique_null
+CREATE TABLE rule2b_unique_null (id INT NULL UNIQUE, name VARCHAR(50) NULL)
+fillschema_test#!#SELECT * FROM rule2b_unique_null
+DROP TABLE IF EXISTS rule2b_unique_null
+
+Test case 6: Primary key detection
+DROP TABLE IF EXISTS int_boundary
+CREATE TABLE int_boundary (id INT PRIMARY KEY, data VARCHAR(50))
+fillschema_test#!#SELECT * FROM int_boundary
+DROP TABLE IF EXISTS int_boundary
+
+#Test case 7: PK with Multiple UNIQUE Constraints
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+CREATE TABLE rule3_pk_multi_unique (id INT PRIMARY KEY, email VARCHAR(100) NOT NULL UNIQUE, phone VARCHAR(20) NOT NULL UNIQUE, ssn VARCHAR(20) NULL UNIQUE, name VARCHAR(50))
+INSERT INTO rule3_pk_multi_unique VALUES (1, 'test@test.com', '555-1234', [REDACTED:SSN], 'test')
+fillschema_test#!#SELECT * FROM rule3_pk_multi_unique
+DROP TABLE IF EXISTS rule3_pk_multi_unique
+
+#Test case 8: Composite Foreign Key (2 columns)
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+CREATE TABLE fk_parent_composite (col1 INT NOT NULL, col2 INT NOT NULL, name VARCHAR(50), PRIMARY KEY (col1, col2))
+CREATE TABLE fk_child_composite (id INT PRIMARY KEY, ref_col1 INT NOT NULL, ref_col2 INT NOT NULL, data VARCHAR(50), FOREIGN KEY (ref_col1, ref_col2) REFERENCES fk_parent_composite(col1, col2))
+fillschema_test#!#SELECT * FROM fk_child_composite
+fillschema_test#!#SELECT c.*, p.name FROM fk_child_composite c JOIN fk_parent_composite p ON c.ref_col1 = p.col1 AND c.ref_col2 = p.col2
+DROP TABLE IF EXISTS fk_child_composite
+DROP TABLE IF EXISTS fk_parent_composite
+
+#Test case 9: Primary Key detection in 3-level hierarchy with chained foreign keys
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+CREATE TABLE fk_chain_a (id INT PRIMARY KEY, name VARCHAR(50))
+CREATE TABLE fk_chain_b (id INT PRIMARY KEY, a_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (a_id) REFERENCES fk_chain_a(id))
+CREATE TABLE fk_chain_c (id INT PRIMARY KEY, b_id INT NOT NULL, name VARCHAR(50), FOREIGN KEY (b_id) REFERENCES fk_chain_b(id))
+fillschema_test#!#SELECT c.*, b.name as b_name, a.name as a_name FROM fk_chain_c c JOIN fk_chain_b b ON c.b_id = b.id JOIN fk_chain_a a ON b.a_id = a.id
+DROP TABLE IF EXISTS fk_chain_c
+DROP TABLE IF EXISTS fk_chain_b
+DROP TABLE IF EXISTS fk_chain_a
+
+#Test case 10: Testing with NO_BROWSETABLE_OFF
+DROP TABLE IF EXISTS dbo.cclass 
+CREATE TABLE dbo.cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL, room_number INT NULL )
+fillschema_test#!#SET NO_BROWSETABLE OFF; select * from dbo.cclass
+DROP TABLE IF EXISTS dbo.cclass
+
+#Test case 11: Testing with NO_BROWSETABLE_ON
+DROP TABLE IF EXISTS new_cclass
+CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )
+fillschema_test#!#SET NO_BROWSETABLE ON; select * from new_cclass
+DROP TABLE IF EXISTS new_cclass
+
+#Test case 12: Stored Procedures
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+CREATE TABLE sp_param_table (id INT NOT NULL PRIMARY KEY, names VARCHAR(50) NOT NULL, val DECIMAL(10,2) NULL)
+INSERT INTO sp_param_table VALUES (1, 'Item1', 100.50), (2, 'Item2', 200.75), (3, 'Item3', 300.00)
+CREATE PROCEDURE sp_get_by_id @id INT AS BEGIN SELECT * FROM sp_param_table WHERE id = @id END
+fillschema_test#!#EXEC sp_get_by_id @id = 1
+DROP PROCEDURE IF EXISTS sp_get_by_id
+DROP TABLE IF EXISTS sp_param_table
+
+#Test case 13: sp_prepexec
+DROP TABLE IF EXISTS prepexec_test
+CREATE TABLE prepexec_test (id INT PRIMARY KEY, name VARCHAR(50), value INT)
+INSERT INTO prepexec_test VALUES (1, 'Test1', 100), (2, 'Test2', 200)
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@id INT', N'SELECT * FROM prepexec_test WHERE id = @id', @id = 1
+DROP TABLE IF EXISTS prepexec_test
+
+#Test case 14: sp_prepexec and sp_prepare
+DROP TABLE IF EXISTS prepare_exec_test
+CREATE TABLE prepare_exec_test (id INT PRIMARY KEY, data VARCHAR(100))
+INSERT INTO prepare_exec_test VALUES (1, 'Data1'), (2, 'Data2')
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepare @handle OUTPUT, N'@id INT', N'SELECT * FROM prepare_exec_test WHERE id = @id'; EXEC sp_execute @handle, 1; EXEC sp_unprepare @handle
+DROP TABLE IF EXISTS prepare_exec_test
+
+#Test case 15: FMTONLY ON case
+DROP TABLE IF EXISTS fmtonly_test
+CREATE TABLE fmtonly_test (id INT PRIMARY KEY, name VARCHAR(50), created_date DATETIME)
+INSERT INTO fmtonly_test VALUES (1, 'Test', GETDATE())
+fillschema_test#!#SET FMTONLY ON; SELECT * FROM fmtonly_test
+DROP TABLE IF EXISTS fmtonly_test
+
+#Test case 16: prepexec with join tables
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers
+CREATE TABLE prepexec_customers (customer_id INT PRIMARY KEY, customer_name VARCHAR(100))
+CREATE TABLE prepexec_orders (order_id INT PRIMARY KEY, customer_id INT, order_date DATE, amount DECIMAL(10,2))
+INSERT INTO prepexec_customers VALUES (1, 'Customer A'), (2, 'Customer B')
+INSERT INTO prepexec_orders VALUES (101, 1, '2024-01-01', 500.00), (102, 1, '2024-01-15', 750.00), (103, 2, '2024-02-01', 300.00)
+fillschema_test#!#DECLARE @handle INT; EXEC sp_prepexec @handle OUTPUT, N'@custid INT', N'SELECT o.order_id, o.order_date, o.amount, c.customer_name FROM prepexec_orders o JOIN prepexec_customers c ON o.customer_id = c.customer_id WHERE c.customer_id = @custid', @custid = 1
+DROP TABLE IF EXISTS prepexec_orders
+DROP TABLE IF EXISTS prepexec_customers


### PR DESCRIPTION
### Description
SqlDataAdapter.FillSchema() does not return primary key or base table information in Babelfish, causing DataTable.PrimaryKey to be empty and SqlCommandBuilder methods to fail.

**Solution:**
Enabled primary key metadata retrieval by setting `fetchPkeys = True` and added SendColInfoToken() call to send the COLINFO token with key information required by ADO.NET's FillSchema.

Cherry-picked from: [#4350](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4350)

### Issues Resolved

BABEL-6207

### Test Scenarios Covered ###
* **Use case based -** Added .NET Test Cases


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).