### PR TITLE
Fix typmod for multiple concat of binaries

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -8478,8 +8478,8 @@ tsql_set_typmod_op_expr(ParseState *pstate, Node *OpExp, Node *lexpr, Node* rexp
 		lopr = exprType(lexpr);
 		ropr = exprType(rexpr);
 		if (strncmp(opname, "+", 1) == 0 &&
-			(*common_utility_plugin_ptr->is_tsql_sys_binary_datatype) (lopr) &&
-			(*common_utility_plugin_ptr->is_tsql_sys_binary_datatype) (ropr))
+			(*common_utility_plugin_ptr->is_tsql_binary_datatype) (getBaseType(lopr)) &&
+			(*common_utility_plugin_ptr->is_tsql_binary_datatype) (getBaseType(ropr)))
 		{
 			int32	typmod1 = exprTypmod(lexpr),
 					typmod2 = exprTypmod(rexpr),
@@ -8538,10 +8538,10 @@ pltsql_post_transform_expr_recurse(ParseState *pstate, Node *expr)
 				 * RelabelType with typmod = -1, so we need to look through to the underlying
 				 * expression to get the actual typmod value.
 				 */
-				while (lexpr && IsA(lexpr, RelabelType))
+				while (lexpr && IsA(lexpr, RelabelType) && exprTypmod(lexpr) == -1)
 					lexpr = (Node *) ((RelabelType *) lexpr)->arg;
 
-				while (rexpr && IsA(rexpr, RelabelType))
+				while (rexpr && IsA(rexpr, RelabelType) && exprTypmod(rexpr) == -1)
 					rexpr = (Node *) ((RelabelType *) rexpr)->arg;
 
 				expr = tsql_set_typmod_op_expr(pstate, expr, lexpr, rexpr);

--- a/test/JDBC/expected/babel_binary-before-17_5-or-16_9-vu-verify.out
+++ b/test/JDBC/expected/babel_binary-before-17_5-or-16_9-vu-verify.out
@@ -1413,3 +1413,80 @@ int
 1
 ~~END~~
 
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+4142004344000045474800000000
+~~END~~
+
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+414200000043440000000000000045460000000000000000000047
+~~END~~
+
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+~~START~~
+binary
+00000000000000000000000000000000000000000000
+~~END~~
+
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+~~ROW COUNT: 4~~
+
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+~~START~~
+binary#!#int#!#binary
+41424344454647484950000000#!#13#!#414243444546474849500000009999
+61626364656667686970000000#!#13#!#616263646566676869700000009999
+00000000004142434445000000#!#13#!#000000000041424344450000009999
+~~END~~
+
+
+DROP table binary_test_table
+GO

--- a/test/JDBC/expected/babel_binary-before-17_7-or-16_11-vu-verify.out
+++ b/test/JDBC/expected/babel_binary-before-17_7-or-16_11-vu-verify.out
@@ -1413,3 +1413,80 @@ int
 1
 ~~END~~
 
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+4142004344000045474800000000
+~~END~~
+
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+414200000043440000000000000045460000000000000000000047
+~~END~~
+
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+~~START~~
+binary
+00000000000000000000000000000000000000000000
+~~END~~
+
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+~~ROW COUNT: 4~~
+
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+~~START~~
+binary#!#int#!#binary
+41424344454647484950000000#!#13#!#414243444546474849500000009999
+61626364656667686970000000#!#13#!#616263646566676869700000009999
+00000000004142434445000000#!#13#!#000000000041424344450000009999
+~~END~~
+
+
+DROP table binary_test_table
+GO

--- a/test/JDBC/expected/babel_binary-vu-verify.out
+++ b/test/JDBC/expected/babel_binary-vu-verify.out
@@ -1414,3 +1414,80 @@ int
 1
 ~~END~~
 
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+4142004344000045474800000000
+~~END~~
+
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+414200000043440000000000000045460000000000000000000047
+~~END~~
+
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+~~START~~
+binary
+00000000000000000000000000000000000000000000
+~~END~~
+
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+~~ROW COUNT: 4~~
+
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+~~START~~
+binary#!#int#!#binary
+41424344454647484950000000#!#13#!#414243444546474849500000009999
+61626364656667686970000000#!#13#!#616263646566676869700000009999
+00000000004142434445000000#!#13#!#000000000041424344450000009999
+~~END~~
+
+
+DROP table binary_test_table
+GO

--- a/test/JDBC/expected/parallel_query/babel_binary-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/babel_binary-vu-verify.out
@@ -1432,3 +1432,80 @@ int
 1
 ~~END~~
 
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+4142004344000045474800000000
+~~END~~
+
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+~~START~~
+binary
+414200000043440000000000000045460000000000000000000047
+~~END~~
+
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+~~START~~
+binary
+00000000000000000000000000000000000000000000
+~~END~~
+
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+~~ROW COUNT: 4~~
+
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+~~START~~
+binary#!#int#!#binary
+41424344454647484950000000#!#13#!#414243444546474849500000009999
+61626364656667686970000000#!#13#!#616263646566676869700000009999
+00000000004142434445000000#!#13#!#000000000041424344450000009999
+~~END~~
+
+
+DROP table binary_test_table
+GO

--- a/test/JDBC/input/babel_binary-before-17_5-or-16_9-vu-verify.mix
+++ b/test/JDBC/input/babel_binary-before-17_5-or-16_9-vu-verify.mix
@@ -426,3 +426,56 @@ GO
 SELECT COUNT(*) FROM BABEL_5597_binary_test 
 WHERE binary_col > cast(cast(0x00000001 as binary(4)) + cast(0x00 as binary(1)) as binary(5));
 GO
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+
+DROP table binary_test_table
+GO

--- a/test/JDBC/input/babel_binary-before-17_7-or-16_11-vu-verify.mix
+++ b/test/JDBC/input/babel_binary-before-17_7-or-16_11-vu-verify.mix
@@ -426,3 +426,56 @@ GO
 SELECT COUNT(*) FROM BABEL_5597_binary_test 
 WHERE binary_col > cast(cast(0x00000001 as binary(4)) + cast(0x00 as binary(1)) as binary(5));
 GO
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+
+DROP table binary_test_table
+GO

--- a/test/JDBC/input/babel_binary-vu-verify.mix
+++ b/test/JDBC/input/babel_binary-vu-verify.mix
@@ -426,3 +426,56 @@ GO
 SELECT COUNT(*) FROM BABEL_5597_binary_test 
 WHERE binary_col > cast(cast(0x00000001 as binary(4)) + cast(0x00 as binary(1)) as binary(5));
 GO
+
+declare @bin1 binary(3) = 0x4142
+declare @bin2 binary(4) = 0x4344
+declare @bin3 binary(1) = 0x4546
+declare @bin4 binary(6) = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+
+declare @bin1 binary(5) = 0x4142
+declare @bin2 binary(9) = 0x4344
+declare @bin3 binary(12) = 0x4546
+declare @bin4 binary = 0x4748
+select (@bin1 + @bin2) + (@bin3 + @bin4) as NestedConcat
+GO
+
+declare @empty1 binary(15) = 0x00 
+declare @empty2 binary(1) = 0x00 
+declare @empty3 binary(6) = 0x00 
+select @empty1 + @empty2 + @empty3 as multiple_empty_concat 
+GO
+
+create table binary_test_table (
+    id int identity(1,1),
+    bin_col1 binary(5),
+    bin_col2 binary(8),
+    varbin_col1 varbinary(10),
+    varbin_col2 varbinary(6)
+)
+GO
+
+-- Insert test data
+insert into binary_test_table (bin_col1, bin_col2, varbin_col1, varbin_col2) values
+(0x4142434445, 0x4647484950, 0x5152535455, 0x5657585960),
+(0x6162636465, 0x6667686970, 0x7172737475, 0x7677787980),
+(0x, 0x4142434445, 0x, 0x4647484950),
+(NULL, 0x4142434445, NULL, 0x4647484950)
+GO
+
+with binary_cte as ( 
+    select id, 
+           bin_col1 + bin_col2 as concat_result, 
+           datalength(bin_col1 + bin_col2) as concat_len 
+    from binary_test_table 
+    where bin_col1 is not null and bin_col2 is not null 
+) 
+select concat_result, 
+       concat_len, 
+       concat_result + cast(0x9999 as binary(2)) as extended_concat 
+from binary_cte
+GO
+
+DROP table binary_test_table
+GO


### PR DESCRIPTION
### Description

This commit will fix the typmod for multiple concatenation of binaries for both base and domain binary types.


### Issues Resolved

Task: BABEL-6296

cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4429

Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).