### PR TITLE
[TEST-ONLY] Re-enable kerberos tap tests

### DIFF
--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -164,7 +164,7 @@ jobs:
           export installdir16=$HOME/${{env.INSTALL_DIR_16}}
 
           cd contrib/babelfishpg_tds
-          make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/003_bbfextnotloaded.pl t/004_bbfdumprestore.pl"
+          make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/002_tdskerberos.pl t/003_bbfextnotloaded.pl t/004_bbfdumprestore.pl"
 
       - name: Upload Logs
         if: always() && steps.tap.outcome == 'failure'

--- a/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
+++ b/contrib/babelfishpg_tds/test/t/002_tdskerberos.pl
@@ -191,6 +191,7 @@ krb_server_keyfile = '$keytab'
 log_connections = on
 shared_preload_libraries = 'babelfishpg_tds'
 lc_messages = 'C'
+log_min_messages = debug2
 });
 $node->start;
 


### PR DESCRIPTION
### Description

Tap test framework added debug log matching for connection establishment which requires log_min_messages set to debug2 in commit https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/cd8cef7a721b2e5d94561f88a882ce881accbbae, which was missing due to which kerberos tap tests were failing.

This commit fixes above issue by setting log_min_messages to debug2 before running the tests.

Task: BABEL-6281

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).