### PR TITLE
Fix Exact Pattern matching for LIKE operator

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -485,6 +485,10 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 
 	Assert(ltypeId == rtypeId);
 
+	/* Always create a CollateExpr on top to match with op->inputcollid */
+	linitial(op->args) = (Node*) create_collate_expr(linitial(op->args), op->inputcollid);
+	lsecond(op->args) = (Node*) create_collate_expr(lsecond(op->args), op->inputcollid);
+
 	/*
 	 * If we found an exact-match pattern, generate an "=" indexqual.
 	 */
@@ -502,6 +506,7 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 									InvalidOid,
 									coll_info_of_inputcollid.oid,
 									oprfuncid(optup)));
+		ret = make_and_qual(ret, node);
 		ReleaseSysCache(optup);
 	}
 	else
@@ -511,10 +516,6 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 					*concat_expr;
 		Node	   *constant_suffix;
 		Const	   *highest_sort_key;
-
-		/* Always create a CollateExpr on top to match with op->inputcollid */
-		linitial(op->args) = (Node*) create_collate_expr(linitial(op->args), op->inputcollid);
-		lsecond(op->args) = (Node *) create_collate_expr(lsecond(op->args), op->inputcollid);
 
 		/* construct leftop >= pattern */
 		optup = compatible_oper(NULL, list_make1(makeString(">=")), ltypeId, rtypeId,

--- a/test/JDBC/expected/babel_collection.out
+++ b/test/JDBC/expected/babel_collection.out
@@ -183,15 +183,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
+Bitmap Heap Scan on testing4  (cost=4.17..11.29 rows=1 width=32)
   Recheck Cond: (c1 = 'jones'::"varchar")
+  Filter: ((c1)::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..4.17 rows=3 width=0)
         Index Cond: (c1 = 'jones'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.154 ms
+Babelfish T-SQL Batch Parsing Time: 3.324 ms
 ~~END~~
 
 
@@ -209,7 +210,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -227,7 +228,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 
@@ -243,7 +244,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.132 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -259,7 +260,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.130 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -278,7 +279,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.088 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -295,7 +296,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -312,7 +313,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -322,14 +323,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
-  Filter: (c1 <> 'jones'::"varchar")
+Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
+  Filter: ((c1 <> 'jones'::"varchar") AND ((c1)::text !~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.548 ms
 ~~END~~
 
 
@@ -345,7 +346,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -361,7 +362,7 @@ Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -381,7 +382,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -399,7 +400,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
 ~~END~~
 
 
@@ -531,7 +532,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.122 ms
+Babelfish T-SQL Batch Parsing Time: 0.185 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -566,13 +567,13 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
-  Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+Seq Scan on testing5  (cost=10000000000.00..10000000030.40 rows=1 width=32)
+  Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.118 ms
+Babelfish T-SQL Batch Parsing Time: 0.072 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -596,7 +597,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.118 ms
+Babelfish T-SQL Batch Parsing Time: 0.184 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -623,7 +624,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.212 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -649,7 +650,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/babel_collection.out
+++ b/test/JDBC/expected/db_collation/babel_collection.out
@@ -183,14 +183,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=3 width=32)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar)
+Bitmap Heap Scan on testing4  (cost=11.40..34.40 rows=1 width=32)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.170 ms
+Babelfish T-SQL Batch Parsing Time: 2.798 ms
 ~~END~~
 
 
@@ -206,7 +206,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.147 ms
+Babelfish T-SQL Batch Parsing Time: 0.206 ms
 ~~END~~
 
 
@@ -222,7 +222,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.100 ms
 ~~END~~
 
 
@@ -238,7 +238,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.097 ms
 ~~END~~
 
 
@@ -254,7 +254,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..31.16 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.104 ms
 ~~END~~
 
 
@@ -271,7 +271,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.151 ms
+Babelfish T-SQL Batch Parsing Time: 0.109 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -286,7 +286,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.152 ms
+Babelfish T-SQL Batch Parsing Time: 0.100 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -301,7 +301,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.159 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -311,14 +311,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
-  Filter: (remove_accents_internal((c1)::text) <> 'jones'::nvarchar)
+Bitmap Heap Scan on testing4  (cost=11.56..34.56 rows=647 width=32)
+  Filter: ((remove_accents_internal((c1)::text) <> 'jones'::nvarchar) AND ((remove_accents_internal((c1)::text))::text !~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.152 ms
+Babelfish T-SQL Batch Parsing Time: 0.669 ms
 ~~END~~
 
 
@@ -334,7 +334,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..37.81 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.183 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -350,7 +350,7 @@ Bitmap Heap Scan on testing4  (cost=11.49..37.74 rows=361 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.151 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -368,7 +368,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -384,7 +384,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.131 ms
+Babelfish T-SQL Batch Parsing Time: 0.080 ms
 ~~END~~
 
 
@@ -515,7 +515,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.132 ms
+Babelfish T-SQL Batch Parsing Time: 0.077 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -550,13 +550,13 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
-  Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+Seq Scan on testing5  (cost=10000000000.00..10000000030.40 rows=1 width=32)
+  Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.128 ms
+Babelfish T-SQL Batch Parsing Time: 0.075 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -580,7 +580,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.129 ms
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -607,7 +607,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.145 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -633,7 +633,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.147 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_constraint_like-vu-verify.out
@@ -718,7 +718,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((sys.remove_accents_internal((status)::text))::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_like_for_AI-vu-verify.out
@@ -5471,13 +5471,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.325 ms
+Babelfish T-SQL Batch Parsing Time: 0.207 ms
 ~~END~~
 
 
@@ -5492,7 +5492,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.146 ms
+Babelfish T-SQL Batch Parsing Time: 0.101 ms
 ~~END~~
 
 
@@ -5507,7 +5507,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -5522,7 +5522,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -5537,7 +5537,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -5547,13 +5547,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.165 ms
+Babelfish T-SQL Batch Parsing Time: 0.100 ms
 ~~END~~
 
 
@@ -5568,7 +5568,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5583,7 +5583,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -5598,7 +5598,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 
@@ -5613,7 +5613,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.080 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_like_index-vu-verify.out
@@ -57,6 +57,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -102,6 +103,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -149,6 +151,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -195,6 +198,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -240,6 +244,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -287,6 +292,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -332,7 +338,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -358,6 +364,67 @@ Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -378,6 +445,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -394,6 +462,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -451,6 +520,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -466,7 +536,7 @@ FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -536,6 +606,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -581,6 +652,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -628,6 +700,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -674,6 +747,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -719,6 +793,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -766,6 +841,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -811,7 +887,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -837,6 +913,67 @@ Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -857,6 +994,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -873,6 +1011,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -930,6 +1069,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -945,7 +1085,7 @@ FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -1015,6 +1155,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1059,6 +1200,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1106,6 +1248,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1150,6 +1293,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1194,6 +1338,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1241,6 +1386,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1284,7 +1430,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col
 FROM test_like_index_vu_prepare_v_csai 
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1310,6 +1456,67 @@ Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1330,6 +1537,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1346,6 +1554,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -1403,6 +1612,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1417,10 +1627,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1489,6 +1698,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1533,6 +1743,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1580,6 +1791,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1624,6 +1836,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1668,6 +1881,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1715,6 +1929,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1758,7 +1973,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1784,6 +1999,67 @@ Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1803,6 +2079,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1819,6 +2096,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1876,6 +2154,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1892,6 +2171,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1966,6 +2246,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2009,6 +2290,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2053,6 +2335,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2099,6 +2382,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2142,6 +2426,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2186,6 +2471,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2231,7 +2517,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2257,6 +2543,125 @@ Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2277,6 +2682,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2293,6 +2699,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2348,6 +2755,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2363,7 +2771,7 @@ FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2431,6 +2839,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2474,6 +2883,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2518,6 +2928,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2564,6 +2975,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2607,6 +3019,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2651,6 +3064,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2696,7 +3110,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2722,6 +3136,125 @@ Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2742,6 +3275,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2758,6 +3292,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2813,6 +3348,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2828,7 +3364,7 @@ FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2896,6 +3432,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2937,6 +3474,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2981,6 +3519,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3025,6 +3564,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3066,6 +3606,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3110,6 +3651,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3153,7 +3695,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col
 FROM test_like_index_vu_prepare_c_csai 
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3179,6 +3721,125 @@ Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3199,6 +3860,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3215,6 +3877,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -3270,6 +3933,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3284,10 +3948,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3354,6 +4017,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3395,6 +4059,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3439,6 +4104,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3483,6 +4149,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3524,6 +4191,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3568,6 +4236,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3611,7 +4280,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3637,6 +4306,125 @@ Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3658,6 +4446,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3674,6 +4463,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3729,6 +4519,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3745,6 +4536,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3816,6 +4608,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -3861,6 +4654,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3908,6 +4702,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -3954,6 +4749,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -3999,6 +4795,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4046,6 +4843,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4091,7 +4889,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4117,6 +4915,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4137,6 +4996,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4153,6 +5013,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4210,6 +5071,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4225,7 +5087,7 @@ FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4296,6 +5158,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4341,6 +5204,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4388,6 +5252,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4434,6 +5299,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4479,6 +5345,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4526,6 +5393,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4571,7 +5439,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4597,6 +5465,67 @@ Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4617,6 +5546,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4633,6 +5563,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4690,6 +5621,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4705,7 +5637,7 @@ FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4775,6 +5707,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4819,6 +5752,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4866,6 +5800,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -4910,6 +5845,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4954,6 +5890,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5001,6 +5938,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5044,7 +5982,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col
 FROM test_like_index_vu_prepare_nv_csai 
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5070,6 +6008,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5090,6 +6089,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5106,6 +6106,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -5163,6 +6164,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5177,10 +6179,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -5249,6 +6250,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5293,6 +6295,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5340,6 +6343,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5384,6 +6388,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5428,6 +6433,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5475,6 +6481,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5518,7 +6525,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5544,6 +6551,67 @@ Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5564,6 +6632,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5580,6 +6649,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5637,6 +6707,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5653,6 +6724,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5725,7 +6797,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -5768,7 +6841,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5812,7 +6886,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -5858,7 +6933,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -5901,7 +6977,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5945,7 +7022,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -5991,7 +7069,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6017,6 +7095,66 @@ Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6036,7 +7174,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6053,6 +7192,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6107,7 +7247,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6123,7 +7264,7 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6191,6 +7332,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -6234,6 +7376,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6278,6 +7421,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -6324,6 +7468,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -6367,6 +7512,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6411,6 +7557,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -6455,9 +7602,10 @@ text
 Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-  Rows Removed by Filter: 999
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE "default")
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
 ~~END~~
 
 
@@ -6482,6 +7630,66 @@ Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6502,6 +7710,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6518,6 +7727,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6573,6 +7783,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6588,7 +7799,7 @@ FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6656,6 +7867,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6700,6 +7912,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6747,6 +7960,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6791,6 +8005,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6835,6 +8050,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6882,6 +8098,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6925,7 +8142,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col
 FROM test_like_index_vu_prepare_t_csai 
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6951,6 +8168,67 @@ Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6971,6 +8249,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6987,6 +8266,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -7044,6 +8324,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7058,10 +8339,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -7130,6 +8410,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7174,6 +8455,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7221,6 +8503,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7265,6 +8548,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7309,6 +8593,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7356,6 +8641,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7399,7 +8685,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7425,6 +8711,67 @@ Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7445,6 +8792,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7461,6 +8809,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 
@@ -7518,6 +8867,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7534,6 +8884,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
@@ -183,15 +183,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
+Bitmap Heap Scan on testing4  (cost=4.17..11.29 rows=1 width=32)
   Recheck Cond: (c1 = 'jones'::"varchar")
+  Filter: ((c1)::text ~~* 'jones'::text COLLATE chinese_prc_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..4.17 rows=3 width=0)
         Index Cond: (c1 = 'jones'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.170 ms
+Babelfish T-SQL Batch Parsing Time: 2.841 ms
 ~~END~~
 
 
@@ -209,7 +210,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.195 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -227,7 +228,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -243,7 +244,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 
@@ -259,7 +260,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.195 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -278,7 +279,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.090 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -295,7 +296,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -312,7 +313,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.145 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -322,14 +323,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
-  Filter: (c1 <> 'jones'::"varchar")
+Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
+  Filter: ((c1 <> 'jones'::"varchar") AND ((c1)::text !~~* 'jones'::text COLLATE chinese_prc_cs_as))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.543 ms
 ~~END~~
 
 
@@ -345,7 +346,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.196 ms
+Babelfish T-SQL Batch Parsing Time: 0.088 ms
 ~~END~~
 
 
@@ -361,7 +362,7 @@ Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -381,7 +382,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.088 ms
 ~~END~~
 
 
@@ -399,7 +400,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 
@@ -529,7 +530,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.121 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -564,13 +565,13 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
-  Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+Seq Scan on testing5  (cost=10000000000.00..10000000030.40 rows=1 width=32)
+  Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.091 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -594,7 +595,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.118 ms
+Babelfish T-SQL Batch Parsing Time: 0.078 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -621,7 +622,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -647,7 +648,7 @@ Seq Scan on testing5  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
@@ -414,7 +414,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.chinese_prc_ci_as)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -424,7 +424,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.chinese_prc_ci_as) THEN 1<newline>    ELSE 0<newline>END = 1)))
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-prepare.out
@@ -414,7 +414,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.chinese_prc_ci_as)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -424,7 +424,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.chinese_prc_ci_as) THEN 1<newline>    ELSE 0<newline>END = 1)))
 ~~END~~
 
 
@@ -433,7 +433,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('inactive'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
@@ -699,7 +699,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.chinese_prc_ci_as)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -709,7 +709,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.chinese_prc_ci_as) THEN 1<newline>    ELSE 0<newline>END = 1)))
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_like_index-vu-verify.out
@@ -57,6 +57,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -102,6 +103,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -149,6 +151,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -195,6 +198,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -240,6 +244,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -287,6 +292,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -332,7 +338,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -358,6 +364,67 @@ Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -378,6 +445,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -394,6 +462,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -451,6 +520,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -466,7 +536,7 @@ FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -536,6 +606,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -581,6 +652,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -628,6 +700,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -674,6 +747,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -719,6 +793,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -766,6 +841,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -811,7 +887,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -837,6 +913,67 @@ Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -857,6 +994,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -873,6 +1011,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -930,6 +1069,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -945,7 +1085,7 @@ FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -1015,6 +1155,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1059,6 +1200,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1106,6 +1248,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1150,6 +1293,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1194,6 +1338,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1241,6 +1386,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1284,7 +1430,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col
 FROM test_like_index_vu_prepare_v_csai 
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1310,6 +1456,67 @@ Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1330,6 +1537,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1346,6 +1554,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -1403,6 +1612,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1417,10 +1627,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1489,6 +1698,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1533,6 +1743,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1580,6 +1791,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1624,6 +1836,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1668,6 +1881,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1715,6 +1929,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1758,7 +1973,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1784,6 +1999,67 @@ Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1803,6 +2079,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1819,6 +2096,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1876,6 +2154,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1890,10 +2169,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -1964,6 +2242,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2007,6 +2286,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2051,6 +2331,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2097,6 +2378,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2140,6 +2422,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2184,6 +2467,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2229,7 +2513,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2255,6 +2539,125 @@ Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2275,6 +2678,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2291,6 +2695,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2346,6 +2751,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2361,7 +2767,7 @@ FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2429,6 +2835,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2472,6 +2879,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2516,6 +2924,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2562,6 +2971,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2605,6 +3015,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2649,6 +3060,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2694,7 +3106,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2720,6 +3132,125 @@ Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2740,6 +3271,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2756,6 +3288,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2811,6 +3344,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2826,7 +3360,7 @@ FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2894,6 +3428,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2935,6 +3470,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2979,6 +3515,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3023,6 +3560,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3064,6 +3602,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3108,6 +3647,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3151,7 +3691,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col
 FROM test_like_index_vu_prepare_c_csai 
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3177,6 +3717,125 @@ Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3197,6 +3856,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3213,6 +3873,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -3268,6 +3929,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3282,10 +3944,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3352,6 +4013,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3393,6 +4055,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3437,6 +4100,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3481,6 +4145,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3522,6 +4187,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3566,6 +4232,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3609,7 +4276,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3635,6 +4302,125 @@ Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3656,6 +4442,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3672,6 +4459,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3727,6 +4515,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3741,10 +4530,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -3812,6 +4600,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -3857,6 +4646,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3904,6 +4694,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -3950,6 +4741,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -3995,6 +4787,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4042,6 +4835,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4087,7 +4881,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4113,6 +4907,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4133,6 +4988,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4149,6 +5005,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4206,6 +5063,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4221,7 +5079,7 @@ FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4292,6 +5150,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4337,6 +5196,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4384,6 +5244,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4430,6 +5291,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4475,6 +5337,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4522,6 +5385,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4567,7 +5431,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4593,6 +5457,67 @@ Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4613,6 +5538,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4629,6 +5555,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4686,6 +5613,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4701,7 +5629,7 @@ FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4771,6 +5699,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4815,6 +5744,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4862,6 +5792,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -4906,6 +5837,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4950,6 +5882,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4997,6 +5930,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5040,7 +5974,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col
 FROM test_like_index_vu_prepare_nv_csai 
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5066,6 +6000,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5086,6 +6081,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5102,6 +6098,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -5159,6 +6156,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5173,10 +6171,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -5245,6 +6242,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5289,6 +6287,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5336,6 +6335,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5380,6 +6380,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5424,6 +6425,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5471,6 +6473,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5514,7 +6517,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5540,6 +6543,67 @@ Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5560,6 +6624,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5576,6 +6641,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5633,6 +6699,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5647,10 +6714,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -5719,7 +6785,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -5762,7 +6829,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5806,7 +6874,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -5852,7 +6921,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -5895,7 +6965,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5939,7 +7010,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -5985,7 +7057,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6011,6 +7083,66 @@ Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6030,7 +7162,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6047,6 +7180,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6101,7 +7235,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6117,7 +7252,7 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6185,6 +7320,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -6228,6 +7364,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6272,6 +7409,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -6318,6 +7456,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -6361,6 +7500,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6405,6 +7545,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -6449,9 +7590,10 @@ text
 Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-  Rows Removed by Filter: 999
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE "default")
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
 ~~END~~
 
 
@@ -6476,6 +7618,66 @@ Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6496,6 +7698,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6512,6 +7715,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6567,6 +7771,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6582,7 +7787,7 @@ FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6650,6 +7855,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6694,6 +7900,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6741,6 +7948,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6785,6 +7993,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6829,6 +8038,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6876,6 +8086,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6919,7 +8130,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col
 FROM test_like_index_vu_prepare_t_csai 
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6945,6 +8156,67 @@ Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6965,6 +8237,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6981,6 +8254,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -7038,6 +8312,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7052,10 +8327,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -7124,6 +8398,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7168,6 +8443,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7215,6 +8491,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7259,6 +8536,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7303,6 +8581,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7350,6 +8629,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7393,7 +8673,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7419,6 +8699,67 @@ Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7439,6 +8780,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7455,6 +8797,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 
@@ -7512,6 +8855,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7526,10 +8870,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
@@ -5470,13 +5470,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.330 ms
+Babelfish T-SQL Batch Parsing Time: 0.326 ms
 ~~END~~
 
 
@@ -5491,7 +5491,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.103 ms
 ~~END~~
 
 
@@ -5506,7 +5506,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5521,7 +5521,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5536,7 +5536,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5546,13 +5546,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.126 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5567,7 +5567,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.094 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5582,7 +5582,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.091 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5597,7 +5597,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.091 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5612,7 +5612,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.090 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/babel_collection.out
+++ b/test/JDBC/expected/parallel_query/babel_collection.out
@@ -183,18 +183,19 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Gather  (cost=4.17..11.28 rows=3 width=32)
+Gather  (cost=4.17..11.29 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
-  ->  Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
+  ->  Bitmap Heap Scan on testing4  (cost=4.17..11.29 rows=1 width=32)
         Recheck Cond: (c1 = 'jones'::"varchar")
+        Filter: ((c1)::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..4.17 rows=3 width=0)
               Index Cond: (c1 = 'jones'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.175 ms
+Babelfish T-SQL Batch Parsing Time: 3.486 ms
 ~~END~~
 
 
@@ -215,7 +216,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.208 ms
 ~~END~~
 
 
@@ -236,7 +237,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.132 ms
+Babelfish T-SQL Batch Parsing Time: 0.200 ms
 ~~END~~
 
 
@@ -254,7 +255,7 @@ Gather  (cost=11.40..24.02 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.142 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 
@@ -272,7 +273,7 @@ Gather  (cost=11.41..24.03 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.186 ms
+Babelfish T-SQL Batch Parsing Time: 0.094 ms
 ~~END~~
 
 
@@ -294,7 +295,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.141 ms
+Babelfish T-SQL Batch Parsing Time: 0.128 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -314,7 +315,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -344,16 +345,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Gather  (cost=11.56..24.18 rows=647 width=32)
+Gather  (cost=11.56..24.71 rows=647 width=32)
   Workers Planned: 3
-  ->  Parallel Bitmap Heap Scan on testing4  (cost=11.56..24.18 rows=209 width=32)
-        Filter: (c1 <> 'jones'::"varchar")
+  ->  Parallel Bitmap Heap Scan on testing4  (cost=11.56..24.71 rows=209 width=32)
+        Filter: ((c1 <> 'jones'::"varchar") AND ((c1)::text !~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.206 ms
+Babelfish T-SQL Batch Parsing Time: 0.902 ms
 ~~END~~
 
 
@@ -371,7 +372,7 @@ Gather  (cost=11.56..25.23 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.173 ms
+Babelfish T-SQL Batch Parsing Time: 0.088 ms
 ~~END~~
 
 
@@ -389,7 +390,7 @@ Gather  (cost=11.55..25.22 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.148 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -412,7 +413,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.144 ms
+Babelfish T-SQL Batch Parsing Time: 0.209 ms
 ~~END~~
 
 
@@ -433,7 +434,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.194 ms
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
 ~~END~~
 
 
@@ -568,7 +569,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.102 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -603,16 +604,16 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Gather  (cost=10000000000.00..10000000027.00 rows=7 width=32)
+Gather  (cost=10000000000.00..10000000030.40 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
-  ->  Seq Scan on testing5  (cost=10000000000.00..10000000027.00 rows=7 width=32)
-        Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  ->  Seq Scan on testing5  (cost=10000000000.00..10000000030.40 rows=1 width=32)
+        Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.124 ms
+Babelfish T-SQL Batch Parsing Time: 0.115 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -639,7 +640,7 @@ Gather  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.121 ms
+Babelfish T-SQL Batch Parsing Time: 0.103 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -669,7 +670,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.113 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -698,7 +699,7 @@ Gather  (cost=10000000000.00..10000000033.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.110 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -5471,16 +5471,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Gather  (cost=0.13..12.23 rows=1 width=6)
+Gather  (cost=0.13..12.26 rows=1 width=6)
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+        Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.365 ms
+Babelfish T-SQL Batch Parsing Time: 0.332 ms
 ~~END~~
 
 
@@ -5498,7 +5498,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.148 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5516,7 +5516,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -5534,7 +5534,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.105 ms
 ~~END~~
 
 
@@ -5552,7 +5552,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5562,16 +5562,16 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Gather  (cost=0.13..12.23 rows=1 width=6)
+Gather  (cost=0.13..12.26 rows=1 width=6)
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+        Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.164 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5589,7 +5589,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.153 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5607,7 +5607,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.096 ms
 ~~END~~
 
 
@@ -5625,7 +5625,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5643,7 +5643,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_index-vu-verify.out
@@ -61,6 +61,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -113,6 +114,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -167,6 +169,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -221,6 +224,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -273,6 +277,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -327,6 +332,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -379,7 +385,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=0 loops=3)
-        Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar")
+        Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar"))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -408,6 +414,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -428,6 +504,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -446,6 +523,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas t1
@@ -509,6 +587,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -528,7 +607,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas t1
@@ -610,6 +689,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -662,6 +742,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -716,6 +797,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+        Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -770,6 +852,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -822,6 +905,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -876,6 +960,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+        Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -928,7 +1013,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=0 loops=3)
-        Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -957,6 +1042,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar"))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar"))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar"))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -977,6 +1132,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -995,6 +1151,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias t1
@@ -1058,6 +1215,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -1076,6 +1234,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias t1
@@ -1158,6 +1317,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1209,6 +1369,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1263,6 +1424,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1315,6 +1477,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1366,6 +1529,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1420,6 +1584,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1470,7 +1635,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=0 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -1499,6 +1664,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1519,6 +1754,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -1537,6 +1773,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai t1
@@ -1600,6 +1837,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -1618,12 +1856,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1702,6 +1939,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1753,6 +1991,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1807,6 +2046,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1859,6 +2099,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1910,6 +2151,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1964,6 +2206,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -2014,7 +2257,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=0 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -2043,6 +2286,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2062,6 +2375,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -2080,6 +2394,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai t1
@@ -2143,6 +2458,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -2161,12 +2477,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -2247,6 +2562,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -2298,6 +2614,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2350,6 +2667,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -2404,6 +2722,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -2455,6 +2774,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2507,6 +2827,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -2559,7 +2880,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0 loops=5)
-        Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar)
+        Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -2588,6 +2909,143 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2608,6 +3066,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -2626,6 +3085,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas t1
@@ -2687,6 +3147,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -2706,7 +3167,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas t1
@@ -2786,6 +3247,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -2837,6 +3299,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2889,6 +3352,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+        Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -2943,6 +3407,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -2994,6 +3459,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3046,6 +3512,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+        Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -3098,7 +3565,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0 loops=5)
-        Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -3127,6 +3594,143 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3147,6 +3751,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -3165,6 +3770,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias t1
@@ -3226,6 +3832,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -3244,6 +3851,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias t1
@@ -3324,6 +3932,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3373,6 +3982,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3425,6 +4035,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3477,6 +4088,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3526,6 +4138,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3578,6 +4191,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3628,7 +4242,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=0 loops=5)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -3657,6 +4271,143 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3677,6 +4428,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -3695,6 +4447,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai t1
@@ -3756,6 +4509,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -3773,13 +4527,12 @@ FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
   ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3856,6 +4609,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3905,6 +4659,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3957,6 +4712,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -4009,6 +4765,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4058,6 +4815,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4110,6 +4868,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -4160,7 +4919,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=0 loops=5)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -4189,6 +4948,143 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=0 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4210,6 +5106,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -4228,6 +5125,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai t1
@@ -4289,6 +5187,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -4306,13 +5205,12 @@ FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
   ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -4390,6 +5288,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -4442,6 +5341,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4496,6 +5396,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -4550,6 +5451,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -4602,6 +5504,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4656,6 +5559,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -4708,7 +5612,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=0 loops=3)
-        Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar)
+        Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -4737,6 +5641,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4757,6 +5731,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -4775,6 +5750,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas t1
@@ -4838,6 +5814,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -4857,7 +5834,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas t1
@@ -4940,6 +5917,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -4992,6 +5970,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5046,6 +6025,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+        Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -5100,6 +6080,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -5152,6 +6133,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5206,6 +6188,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+        Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -5258,7 +6241,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=0 loops=3)
-        Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -5287,6 +6270,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5307,6 +6360,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -5325,6 +6379,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias t1
@@ -5388,6 +6443,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -5406,6 +6462,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias t1
@@ -5488,6 +6545,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5539,6 +6597,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5593,6 +6652,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5645,6 +6705,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5696,6 +6757,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5750,6 +6812,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5800,7 +6863,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=0 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -5829,6 +6892,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5849,6 +6982,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -5867,6 +7001,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai t1
@@ -5930,6 +7065,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -5948,12 +7084,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -6032,6 +7167,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6083,6 +7219,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6137,6 +7274,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6189,6 +7327,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6240,6 +7379,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6294,6 +7434,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6344,7 +7485,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=0 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -6373,6 +7514,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6393,6 +7604,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -6411,6 +7623,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai t1
@@ -6474,6 +7687,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -6492,12 +7706,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -6576,7 +7789,8 @@ Gather (actual rows=1 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -6627,7 +7841,8 @@ Gather (actual rows=1 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6679,7 +7894,8 @@ Gather (actual rows=1 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -6733,7 +7949,8 @@ Gather (actual rows=1 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -6784,7 +8001,8 @@ Gather (actual rows=1 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6836,7 +8054,8 @@ Gather (actual rows=1 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -6889,7 +8108,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=0 loops=3)
-        Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text)
+        Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -6918,6 +8137,75 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=0 loops=4)
+        Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=0 loops=4)
+        Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=0 loops=4)
+        Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6937,7 +8225,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -6956,6 +8245,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas t1
@@ -7016,7 +8306,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -7036,7 +8327,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas t1
@@ -7116,6 +8407,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -7167,6 +8459,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7219,6 +8512,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+        Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -7273,6 +8567,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
 ~~END~~
 
@@ -7324,6 +8619,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7376,6 +8672,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
         Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+        Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
 ~~END~~
 
@@ -7425,11 +8722,13 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Gather (actual rows=1 loops=1)
-  Workers Planned: 2
-  Workers Launched: 2
-  ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=0 loops=3)
-        Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-        Rows Removed by Filter: 333
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+        Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE "default")
+        Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Heap Fetches: 1
 ~~END~~
 
 
@@ -7457,6 +8756,75 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=0 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7477,6 +8845,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -7495,6 +8864,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias t1
@@ -7556,6 +8926,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -7574,6 +8945,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias t1
@@ -7654,6 +9026,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7705,6 +9078,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7759,6 +9133,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7811,6 +9186,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7862,6 +9238,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7916,6 +9293,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7966,7 +9344,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=0 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -7995,6 +9373,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -8015,6 +9463,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -8033,6 +9482,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai t1
@@ -8096,6 +9546,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -8114,12 +9565,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -8198,6 +9648,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8249,6 +9700,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8303,6 +9755,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -8355,6 +9808,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8406,6 +9860,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8460,6 +9915,7 @@ Gather (actual rows=1 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -8510,7 +9966,7 @@ Gather (actual rows=1 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=0 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -8539,6 +9995,76 @@ Gather (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=0 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -8559,6 +10085,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -8577,6 +10104,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai t1
@@ -8640,6 +10168,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
@@ -8658,12 +10187,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like-vu-prepare.out
@@ -433,7 +433,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like-vu-verify.out
@@ -718,7 +718,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-cleanup.out
+++ b/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-cleanup.out
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-prepare.out
@@ -1,0 +1,520 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
+GO
+
+CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
+        CASE 
+            WHEN status LIKE 'act%' THEN 1
+            WHEN status LIKE 'inactive' THEN 1
+            ELSE 0
+        END = 1
+    )
+);
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+GO
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- GO
+-- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTION
+CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
+(
+    @pattern varchar(100)
+)
+RETURNS TABLE
+AS
+RETURN
+(
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+);
+GO
+
+-- PROCEDURE
+CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
+    @pattern varchar(100)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT * FROM BABEL_5608_vu_prepare_t12_2
+    WHERE status LIKE @pattern
+END;
+GO
+
+
+-- CASE 13: VIEW WITH LIKE
+CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+GO
+
+CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
+GO
+
+CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+GO
+
+-- CASE 14: PostFix Pattern match
+CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+GO
+
+
+-- CASE 15: T_Const LIKE T_Const
+CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+GO
+
+CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+GO
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+

--- a/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-verify.out
@@ -1,0 +1,804 @@
+-- tsql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
+GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
+GO
+~~START~~
+varchar
+15% off
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- CASE WHEN
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
+
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
+-- GO
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- FUNCTION
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
+
+-- PROCEDURE
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT * FROM BABEL_5608_13_1_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_2_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_3_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+-- psql
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 10: ESCAPE WITH LIKE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
+GO
+~~START~~
+text
+CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 11: T_CoerceViaIO
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
+GO
+~~START~~
+text
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+~~END~~
+
+
+-- CASE WHEN
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
+GO
+~~START~~
+text
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+~~END~~
+
+
+
+-- COMPUTED COLUMNS (BABEL-5022)
+-- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
+-- GO
+-- FUNCTION
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
+~~END~~
+
+
+-- PROCEDURE
+SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
+GO
+~~START~~
+text
+CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
+~~END~~
+
+
+-- CASE 13: VIEW WITH LIKE
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
+~~END~~
+
+
+SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
+GO
+~~START~~
+text
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
+~~END~~
+
+
+-- CASE 14: PostFix Pattern match
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
+GO
+~~START~~
+text
+CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+
+
+-- CASE 15: T_Const LIKE T_Const
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
+GO
+~~START~~
+text
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
+~~END~~
+

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -5471,13 +5471,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.318 ms
+Babelfish T-SQL Batch Parsing Time: 0.310 ms
 ~~END~~
 
 
@@ -5492,7 +5492,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.146 ms
+Babelfish T-SQL Batch Parsing Time: 0.102 ms
 ~~END~~
 
 
@@ -5507,7 +5507,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -5522,7 +5522,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5537,7 +5537,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.116 ms
 ~~END~~
 
 
@@ -5547,13 +5547,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.110 ms
 ~~END~~
 
 
@@ -5568,7 +5568,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5583,7 +5583,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5598,7 +5598,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 
@@ -5613,7 +5613,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/test_like_index-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_index-vu-cleanup.out
@@ -10,6 +10,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_v_cias_idx ON test_like_index_vu_prepare_v_cias;
 GO
@@ -18,6 +21,9 @@ DROP INDEX test_like_index_vu_prepare_v_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_v_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_cias;
 GO
 
 -- psql
@@ -32,6 +38,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_v_ciai_idx;
@@ -42,6 +51,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_v_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_ciai;
 GO
 
 -- CHAR
@@ -55,6 +67,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csas;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_c_cias_idx ON test_like_index_vu_prepare_c_cias;
 GO
@@ -63,6 +81,12 @@ DROP INDEX test_like_index_vu_prepare_c_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_cias;
 GO
 
 -- psql
@@ -77,6 +101,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_c_ciai_idx;
@@ -87,6 +117,12 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_ciai;
 GO
 
 -- NVARCHAR
@@ -100,6 +136,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_nv_cias_idx ON test_like_index_vu_prepare_nv_cias;
 GO
@@ -108,6 +147,9 @@ DROP INDEX test_like_index_vu_prepare_nv_cias_idx_composite ON test_like_index_v
 GO
 
 DROP TABLE test_like_index_vu_prepare_nv_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_cias;
 GO
 
 -- psql
@@ -122,6 +164,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_nv_ciai_idx;
@@ -132,6 +177,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_nv_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_ciai;
 GO
 
 -- TEXT
@@ -145,6 +193,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_t_cias_idx ON test_like_index_vu_prepare_t_cias;
 GO
@@ -153,6 +204,9 @@ DROP INDEX test_like_index_vu_prepare_t_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_t_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_cias;
 GO
 
 -- psql
@@ -167,6 +221,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_t_ciai_idx;
@@ -177,6 +234,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_t_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_ciai;
 GO
 
 -- COMMON TABLE FOR JOIN

--- a/test/JDBC/expected/test_like_index-vu-prepare.out
+++ b/test/JDBC/expected/test_like_index-vu-prepare.out
@@ -20,6 +20,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csas(new_test_like_index_vu_prepare_v_csas_col varchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_v_cias(
     test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as,
@@ -38,6 +56,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_v_cias(new_test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -62,6 +98,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csai(new_test_like_index_vu_prepare_v_csai_col varchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_v_ciai(
     test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai,
@@ -82,6 +136,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_v_ciai(new_test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CHAR
@@ -105,6 +177,33 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csas(new_test_like_index_vu_prepare_c_csas_col char(1000) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csas (new_test_like_index_vu_prepare_c_fixed_csas_col char(4) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_c_cias(
     test_like_index_vu_prepare_c_cias_col char(8000) collate latin1_general_ci_as,
@@ -123,6 +222,33 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_c_cias(new_test_like_index_vu_prepare_c_cias_col char(1000) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_cias (new_test_like_index_vu_prepare_c_fixed_cias_col char(4) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -147,6 +273,33 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csai(new_test_like_index_vu_prepare_c_csai_col char(1000) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csai (new_test_like_index_vu_prepare_c_fixed_csai_col char(4) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_c_ciai(
     test_like_index_vu_prepare_c_ciai_col char(8000) collate latin1_general_ci_ai,
@@ -167,6 +320,33 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_c_ciai(new_test_like_index_vu_prepare_c_ciai_col char(1000) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_ciai (new_test_like_index_vu_prepare_c_fixed_ciai_col char(4) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 -- NVARCHAR
@@ -190,6 +370,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csas(new_test_like_index_vu_prepare_nv_csas_col nvarchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_nv_cias(
     test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as,
@@ -208,6 +406,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_cias(new_test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -232,6 +448,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csai(new_test_like_index_vu_prepare_nv_csai_col nvarchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_nv_ciai(
     test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai,
@@ -252,6 +486,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_ciai(new_test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 -- TEXT Tables
@@ -275,6 +527,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csas(new_test_like_index_vu_prepare_t_csas_col TEXT collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_t_cias(
     test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as,
@@ -293,6 +563,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_t_cias(new_test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -317,6 +605,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csai(new_test_like_index_vu_prepare_t_csai_col TEXT collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_t_ciai(
     test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai,
@@ -337,6 +643,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_t_ciai(new_test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 

--- a/test/JDBC/expected/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/test_like_index-vu-verify.out
@@ -57,6 +57,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -102,6 +103,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -149,6 +151,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -195,6 +198,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -240,6 +244,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -287,6 +292,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -332,7 +338,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar")
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar"))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -358,6 +364,67 @@ Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -378,6 +445,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -394,6 +462,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -451,6 +520,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -466,7 +536,7 @@ FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -536,6 +606,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -581,6 +652,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -628,6 +700,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -674,6 +747,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -719,6 +793,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -766,6 +841,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -811,7 +887,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -837,6 +913,67 @@ Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar"))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar"))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar"))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -857,6 +994,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -873,6 +1011,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -930,6 +1069,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -946,6 +1086,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -1018,6 +1159,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1062,6 +1204,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1109,6 +1252,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1153,6 +1297,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1197,6 +1342,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1244,6 +1390,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1287,7 +1434,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col
 FROM test_like_index_vu_prepare_v_csai 
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1313,6 +1460,67 @@ Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1333,6 +1541,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1349,6 +1558,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -1406,6 +1616,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1420,10 +1631,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1492,6 +1702,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1536,6 +1747,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1583,6 +1795,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1627,6 +1840,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1671,6 +1885,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1718,6 +1933,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -1761,7 +1977,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1787,6 +2003,67 @@ Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1806,6 +2083,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1822,6 +2100,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1879,6 +2158,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1893,10 +2173,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -1967,6 +2246,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2010,6 +2290,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2054,6 +2335,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2100,6 +2382,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2143,6 +2426,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2187,6 +2471,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2232,7 +2517,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar)
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2258,6 +2543,125 @@ Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2278,6 +2682,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2294,6 +2699,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2349,6 +2755,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2364,7 +2771,7 @@ FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2432,6 +2839,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2475,6 +2883,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2519,6 +2928,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2565,6 +2975,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -2608,6 +3019,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2652,6 +3064,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -2697,7 +3110,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2723,6 +3136,125 @@ Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2743,6 +3275,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2759,6 +3292,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2814,6 +3348,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2830,6 +3365,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2900,6 +3436,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2941,6 +3478,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2985,6 +3523,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3029,6 +3568,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3070,6 +3610,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3114,6 +3655,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3157,7 +3699,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col
 FROM test_like_index_vu_prepare_c_csai 
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3183,6 +3725,125 @@ Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3203,6 +3864,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3219,6 +3881,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -3274,6 +3937,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3288,10 +3952,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3358,6 +4021,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3399,6 +4063,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3443,6 +4108,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3487,6 +4153,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3528,6 +4195,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3572,6 +4240,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -3615,7 +4284,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3641,6 +4310,125 @@ Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3662,6 +4450,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3678,6 +4467,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3733,6 +4523,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3747,10 +4538,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -3818,6 +4608,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -3863,6 +4654,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3910,6 +4702,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -3956,6 +4749,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4001,6 +4795,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4048,6 +4843,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4093,7 +4889,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar)
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4119,6 +4915,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4139,6 +4996,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4155,6 +5013,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4212,6 +5071,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4227,7 +5087,7 @@ FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4298,6 +5158,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4343,6 +5204,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4390,6 +5252,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4436,6 +5299,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -4481,6 +5345,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4528,6 +5393,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -4573,7 +5439,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4599,6 +5465,67 @@ Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=2 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4619,6 +5546,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4635,6 +5563,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4692,6 +5621,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4708,6 +5638,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4780,6 +5711,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4824,6 +5756,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4871,6 +5804,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -4915,6 +5849,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4959,6 +5894,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5006,6 +5942,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5049,7 +5986,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col
 FROM test_like_index_vu_prepare_nv_csai 
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5075,6 +6012,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5095,6 +6093,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5111,6 +6110,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -5168,6 +6168,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5182,10 +6183,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -5254,6 +6254,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5298,6 +6299,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5345,6 +6347,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5389,6 +6392,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5433,6 +6437,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5480,6 +6485,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -5523,7 +6529,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5549,6 +6555,67 @@ Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5569,6 +6636,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5585,6 +6653,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5642,6 +6711,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5656,10 +6726,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -5728,7 +6797,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -5771,7 +6841,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5815,7 +6886,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -5861,7 +6933,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -5904,7 +6977,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5948,7 +7022,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -5994,7 +7069,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text)
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6020,6 +7095,66 @@ Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6039,7 +7174,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6056,6 +7192,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6110,7 +7247,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6126,7 +7264,7 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6194,6 +7332,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -6237,6 +7376,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6281,6 +7421,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -6327,6 +7468,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
 ~~END~~
 
@@ -6370,6 +7512,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6414,6 +7557,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
 ~~END~~
 
@@ -6458,9 +7602,10 @@ text
 Query Text: SELECT test_like_index_vu_prepare_t_cias_col 
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
-Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
-  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
-  Rows Removed by Filter: 999
+Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE "default")
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Heap Fetches: 1
 ~~END~~
 
 
@@ -6485,6 +7630,66 @@ Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6505,6 +7710,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6521,6 +7727,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6576,6 +7783,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6592,6 +7800,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6662,6 +7871,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6706,6 +7916,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6753,6 +7964,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6797,6 +8009,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6841,6 +8054,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6888,6 +8102,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -6931,7 +8146,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col
 FROM test_like_index_vu_prepare_t_csai 
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6957,6 +8172,67 @@ Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6977,6 +8253,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6993,6 +8270,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -7050,6 +8328,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7064,10 +8343,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -7136,6 +8414,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7180,6 +8459,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7227,6 +8507,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7271,6 +8552,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7315,6 +8597,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7362,6 +8645,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 
@@ -7405,7 +8689,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7431,6 +8715,67 @@ Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=2 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7451,6 +8796,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7467,6 +8813,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 
@@ -7524,6 +8871,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7538,10 +8886,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 

--- a/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-cleanup.sql
+++ b/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-cleanup.sql
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-prepare.mix
+++ b/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-prepare.mix
@@ -165,13 +165,13 @@ CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prep
 GO
 
 
-
-
 -- COMPUTED COLUMNS (BABEL-5022)
 -- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
 -- GO
+
 -- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
 -- GO
+
 -- FUNCTION
 CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
 (
@@ -234,287 +234,122 @@ GO
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t4_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col2)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 10: ESCAPE WITH LIKE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 11: T_CoerceViaIO
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
 GO
-~~START~~
-text
-CHECK (((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai) THEN 1<newline>    ELSE 0<newline>END = 1)))
-~~END~~
-
 
 -- CASE WHEN
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
-~~END~~
-
-
 
 -- COMPUTED COLUMNS (BABEL-5022)
 -- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
 -- GO
+
 -- FUNCTION
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
-~~END~~
-
 
 -- PROCEDURE
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
-~~END~~
-
 
 
 -- CASE 13: VIEW WITH LIKE
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_ai) ~~ 'ac%'::text;
-~~END~~
-
 
 -- CASE 14: PostFix Pattern match
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 15: T_Const LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-

--- a/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-verify.mix
+++ b/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-verify.mix
@@ -2,344 +2,166 @@
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
 INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
 GO
-~~START~~
-varchar#!#varchar
-abc#!#ABC
-~~END~~
-
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 -- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
 INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- CASE 10: ESCAPE WITH LIKE
 INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
 GO
-~~START~~
-varchar
-15% off
-~~END~~
-
 
 -- CASE 11: T_CoerceViaIO
 INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
 INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
 INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
 GO
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
 GO
-~~START~~
-varchar
-active
-inactive
-~~END~~
-
 
 -- CASE WHEN
 INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
 INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
 GO
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
 
 -- should fail
 INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
 GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
 GO
-~~START~~
-varchar
-active
-inactive
-~~END~~
-
 
 -- IF EXISTS
 IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
@@ -351,11 +173,6 @@ BEGIN
     SELECT 'No matches found'
 END
 GO
-~~START~~
-varchar
-Found matching records
-~~END~~
-
 
 IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
 BEGIN
@@ -366,11 +183,6 @@ BEGIN
     SELECT 'No matches found'
 END
 GO
-~~START~~
-varchar
-Found matching records
-~~END~~
-
 
 IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
 BEGIN
@@ -381,424 +193,187 @@ BEGIN
     SELECT 'No matches found'
 END
 GO
-~~START~~
-varchar
-No matches found
-~~END~~
-
-
-
-
 
 -- COMPUTED COLUMNS (BABEL-5022)
 -- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
 -- GO
+
 -- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
 -- GO
+
 -- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
 -- GO
+
 -- FUNCTION
 SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
 GO
-~~START~~
-varchar
-inactive
-~~END~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
 GO
-~~START~~
-varchar
-~~END~~
-
 
 
 -- PROCEDURE
 EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
 GO
-~~START~~
-varchar
-inactive
-~~END~~
-
 
 EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
 GO
-~~START~~
-varchar
-~~END~~
-
 
 -- CASE 13: VIEW WITH LIKE
 SELECT * FROM BABEL_5608_13_1_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_2_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_3_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_4_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_5_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 -- CASE 14: PostFix Pattern match
 INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- CASE 15: T_Const LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- psql
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('ABC'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('abc'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 10: ESCAPE WITH LIKE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 11: T_CoerceViaIO
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.chinese_prc_ci_as)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
 GO
-~~START~~
-text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.chinese_prc_ci_as) THEN 1<newline>    ELSE 0<newline>END = 1)))
-~~END~~
-
 
 -- CASE WHEN
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('inactive'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
-~~END~~
-
-
 
 -- COMPUTED COLUMNS (BABEL-5022)
 -- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
 -- GO
+
 -- FUNCTION
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
-~~END~~
-
 
 -- PROCEDURE
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
-~~END~~
-
 
 -- CASE 13: VIEW WITH LIKE
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
-~~END~~
-
 
 -- CASE 14: PostFix Pattern match
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 15: T_Const LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.chinese_prc_cs_as) ~~* ('A%'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-

--- a/test/JDBC/input/test_like_index-vu-cleanup.mix
+++ b/test/JDBC/input/test_like_index-vu-cleanup.mix
@@ -10,6 +10,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_v_cias_idx ON test_like_index_vu_prepare_v_cias;
 GO
@@ -18,6 +21,9 @@ DROP INDEX test_like_index_vu_prepare_v_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_v_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_cias;
 GO
 
 -- CS_AI
@@ -32,6 +38,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_v_ciai_idx;
@@ -42,6 +51,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_v_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_ciai;
 GO
 
 -- CHAR
@@ -55,6 +67,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csas;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_c_cias_idx ON test_like_index_vu_prepare_c_cias;
 GO
@@ -63,6 +81,12 @@ DROP INDEX test_like_index_vu_prepare_c_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_cias;
 GO
 
 -- CS_AI
@@ -77,6 +101,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_c_ciai_idx;
@@ -87,6 +117,12 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_ciai;
 GO
 
 -- NVARCHAR
@@ -100,6 +136,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_nv_cias_idx ON test_like_index_vu_prepare_nv_cias;
 GO
@@ -108,6 +147,9 @@ DROP INDEX test_like_index_vu_prepare_nv_cias_idx_composite ON test_like_index_v
 GO
 
 DROP TABLE test_like_index_vu_prepare_nv_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_cias;
 GO
 
 -- CS_AI
@@ -122,6 +164,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_nv_ciai_idx;
@@ -132,6 +177,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_nv_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_ciai;
 GO
 
 -- TEXT
@@ -145,6 +193,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_t_cias_idx ON test_like_index_vu_prepare_t_cias;
 GO
@@ -153,6 +204,9 @@ DROP INDEX test_like_index_vu_prepare_t_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_t_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_cias;
 GO
 
 -- CS_AI
@@ -167,6 +221,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_t_ciai_idx;
@@ -177,6 +234,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_t_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_ciai;
 GO
 
 -- COMMON TABLE FOR JOIN

--- a/test/JDBC/input/test_like_index-vu-prepare.mix
+++ b/test/JDBC/input/test_like_index-vu-prepare.mix
@@ -18,6 +18,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csas(new_test_like_index_vu_prepare_v_csas_col varchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES(' csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_v_cias(
     test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as,
@@ -34,6 +46,18 @@ CREATE INDEX test_like_index_vu_prepare_v_cias_idx_composite ON test_like_index_
 GO
 
 INSERT INTO test_like_index_vu_prepare_v_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_v_cias(new_test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES(' cias');
 GO
 
 -- CS_AI
@@ -56,6 +80,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csai(new_test_like_index_vu_prepare_v_csai_col varchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES(' csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_v_ciai(
     test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai,
@@ -74,6 +110,18 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_v_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_v_ciai(new_test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES(' ciai');
 GO
 
 -- CHAR
@@ -95,6 +143,25 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csas(new_test_like_index_vu_prepare_c_csas_col char(1000) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES(' csas');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csas (new_test_like_index_vu_prepare_c_fixed_csas_col char(4) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csas VALUES('csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_c_cias(
     test_like_index_vu_prepare_c_cias_col char(8000) collate latin1_general_ci_as,
@@ -111,6 +178,25 @@ CREATE INDEX test_like_index_vu_prepare_c_cias_idx_composite ON test_like_index_
 GO
 
 INSERT INTO test_like_index_vu_prepare_c_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_c_cias(new_test_like_index_vu_prepare_c_cias_col char(1000) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES(' cias');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_cias (new_test_like_index_vu_prepare_c_fixed_cias_col char(4) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_cias VALUES('cias');
 GO
 
 -- CS_AI
@@ -133,6 +219,25 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csai(new_test_like_index_vu_prepare_c_csai_col char(1000) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES(' csai');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csai (new_test_like_index_vu_prepare_c_fixed_csai_col char(4) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csai VALUES('csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_c_ciai(
     test_like_index_vu_prepare_c_ciai_col char(8000) collate latin1_general_ci_ai,
@@ -151,6 +256,25 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_c_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_c_ciai(new_test_like_index_vu_prepare_c_ciai_col char(1000) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES(' ciai');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_ciai (new_test_like_index_vu_prepare_c_fixed_ciai_col char(4) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_ciai VALUES('ciai');
 GO
 
 -- NVARCHAR
@@ -172,6 +296,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csas(new_test_like_index_vu_prepare_nv_csas_col nvarchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES(' csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_nv_cias(
     test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as,
@@ -188,6 +324,18 @@ CREATE INDEX test_like_index_vu_prepare_nv_cias_idx_composite ON test_like_index
 GO
 
 INSERT INTO test_like_index_vu_prepare_nv_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_cias(new_test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES(' cias');
 GO
 
 -- CS_AI
@@ -210,6 +358,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csai(new_test_like_index_vu_prepare_nv_csai_col nvarchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES(' csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_nv_ciai(
     test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai,
@@ -228,6 +388,18 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_nv_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_ciai(new_test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES(' ciai');
 GO
 
 -- TEXT Tables
@@ -249,6 +421,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csas(new_test_like_index_vu_prepare_t_csas_col TEXT collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES(' csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_t_cias(
     test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as,
@@ -265,6 +449,18 @@ CREATE INDEX test_like_index_vu_prepare_t_cias_idx_composite ON test_like_index_
 GO
 
 INSERT INTO test_like_index_vu_prepare_t_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_t_cias(new_test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES(' cias');
 GO
 
 -- CS_AI
@@ -287,6 +483,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csai(new_test_like_index_vu_prepare_t_csai_col TEXT collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES(' csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_t_ciai(
     test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai,
@@ -305,6 +513,18 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_t_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_t_ciai(new_test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES(' ciai');
 GO
 
 

--- a/test/JDBC/input/test_like_index-vu-verify.mix
+++ b/test/JDBC/input/test_like_index-vu-verify.mix
@@ -113,6 +113,21 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -267,6 +282,21 @@ GO
 SELECT test_like_index_vu_prepare_v_cias_col 
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -425,6 +455,21 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -579,6 +624,21 @@ GO
 SELECT test_like_index_vu_prepare_v_ciai_col 
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -738,6 +798,36 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -892,6 +982,36 @@ GO
 SELECT test_like_index_vu_prepare_c_cias_col 
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1050,6 +1170,36 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1204,6 +1354,36 @@ GO
 SELECT test_like_index_vu_prepare_c_ciai_col 
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1364,6 +1544,21 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1519,6 +1714,21 @@ GO
 SELECT test_like_index_vu_prepare_nv_cias_col 
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1677,6 +1887,21 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1831,6 +2056,21 @@ GO
 SELECT test_like_index_vu_prepare_nv_ciai_col 
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1990,6 +2230,21 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2144,6 +2399,21 @@ GO
 SELECT test_like_index_vu_prepare_t_cias_col 
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -2302,6 +2572,21 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2456,6 +2741,21 @@ GO
 SELECT test_like_index_vu_prepare_t_ciai_col 
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,16 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+test_like_index-vu-prepare
+test_like_index-vu-verify
+test_like_index-vu-cleanup
+test_constraint_like-vu-prepare
+test_constraint_like-vu-verify
+test_constraint_like-vu-cleanup
+test_like_for_AI-vu-prepare
+test_like_for_AI-vu-verify
+test_like_for_AI-vu-cleanup
+babel_collection
 
 # FIX ME: Crash in vector extension. Ignoring to Unblock Dev
 # branches. Will be fixed with jira: BABEL-6260
@@ -637,4 +646,7 @@ ignore#!#datetime_roundoff-before-17_8-or-16_12-vu-cleanup
 ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare
 ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-verify
 ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup
+ignore#!#test_constraint_like_before_17_8-or-16_12-vu-prepare
+ignore#!#test_constraint_like_before_17_8-or-16_12-vu-verify
+ignore#!#test_constraint_like_before_17_8-or-16_12-vu-cleanup
 

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,16 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-test_like_index-vu-prepare
-test_like_index-vu-verify
-test_like_index-vu-cleanup
-test_constraint_like-vu-prepare
-test_constraint_like-vu-verify
-test_constraint_like-vu-cleanup
-test_like_for_AI-vu-prepare
-test_like_for_AI-vu-verify
-test_like_for_AI-vu-cleanup
-babel_collection
+all
 
 # FIX ME: Crash in vector extension. Ignoring to Unblock Dev
 # branches. Will be fixed with jira: BABEL-6260

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -616,7 +616,7 @@ sys-login-property
 sys-fn-varbintohexsubstring
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 unpivot
 forjson-escape
 round_return_type_test-before-16_11-or-17_7

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -616,7 +616,7 @@ sys-login-property
 sys-fn-varbintohexsubstring
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 unpivot
 forjson-escape
 round_return_type_test

--- a/test/JDBC/upgrade/16_12/schedule
+++ b/test/JDBC/upgrade/16_12/schedule
@@ -616,7 +616,7 @@ sys-login-property
 sys-fn-varbintohexsubstring
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 unpivot
 forjson-escape
 round_return_type_test


### PR DESCRIPTION
### Description


```
DROP TABLE IF EXISTS DummyTable
GO

CREATE TABLE [dbo].[DummyTable](
 [ViewDetailsID] [varchar](50) NULL
) 

 GO  

  SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS 
        WHERE TABLE_NAME = 'DummyTable' 
        AND COLUMN_NAME like 'ViewDetailsID ' 
```

16.11 returned 1, which is incorrect because it matches ViewDetailsID even though the pattern includes a trailing space. Now, we have fixed it to return no results, which is the expected behavior since the column name does not contain a trailing space. 

### Problem: 
Currently, when LIKE operator is transformed for exact match cases, it is completely converted to an = operator without retaining the LIKE filter. This causes incorrect behavior with sys.sysname (domain on sys.varchar(128)) and varchar datatypes where trailing spaces are ignored during comparison.

### Solution: 
Modify LIKE transformation logic: When transforming LIKE to = operator for exact match, retain the LIKE filter as well. This will ensure both operands are cast to TEXT and return expected results.


### Issues Resolved

BABEL-6223

Signed-off by: Mohit Raj [mrxmohit@amazon.com](mailto:mrxmohit@amazon.com)

Authored by: Mohit Raj [mrxmohit@amazon.com](mailto:mrxmohit@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).