### PR TITLE
Fixed test failure in binary-index-vu-verify file

### DIFF
--- a/test/JDBC/expected/binary-index-vu-verify.out
+++ b/test/JDBC/expected/binary-index-vu-verify.out
@@ -1,3 +1,4 @@
+-- tsql
 create index ix_tab_binary_b on tab_varbinary (a)
 GO
 
@@ -9,6 +10,13 @@ off
 ~~END~~
 
 
+-- psql
+ANALYZE master_dbo.tab_varbinary;
+GO
+ANALYZE master_dbo.tab_binary;
+GO
+
+-- tsql
 exec babel_3939_vu_prepare_p1;
 GO
 ~~START~~
@@ -89,7 +97,7 @@ Query Text: EXEC babel_3939_vu_prepare_p1
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.097 ms
+Babelfish T-SQL Batch Parsing Time: 0.051 ms
 ~~END~~
 
 
@@ -120,7 +128,7 @@ Query Text: EXEC babel_3939_vu_prepare_p2
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 14.261 ms
+Babelfish T-SQL Batch Parsing Time: 4.706 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/binary-index-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/binary-index-vu-verify.out
@@ -1,3 +1,4 @@
+-- tsql
 create index ix_tab_binary_b on tab_varbinary (a)
 GO
 
@@ -9,6 +10,13 @@ off
 ~~END~~
 
 
+-- psql
+ANALYZE master_dbo.tab_varbinary;
+GO
+ANALYZE master_dbo.tab_binary;
+GO
+
+-- tsql
 exec babel_3939_vu_prepare_p1;
 GO
 ~~START~~
@@ -62,19 +70,22 @@ text
 Query Text: EXEC babel_3939_vu_prepare_p1
   Query Text: select * from tab_binary where a = 0xBAADF00D
   ->  Gather
-        Workers Planned: 4
-        ->  Parallel Seq Scan on tab_binary
-              Filter: ((a)::bbf_binary = '0xbaadf00d'::bbf_varbinary)
+        Workers Planned: 1
+        Single Copy: true
+        ->  Index Scan using ix_tab_binary_atab_binary30474ea5eaee4ec0e0a5a86377abb1ac on tab_binary
+              Index Cond: ((a)::bbf_binary = '0xbaadf00d'::bbf_varbinary)
   Query Text: select * from tab_binary where a = cast (0xBAADF00D as  binary )
   ->  Gather
-        Workers Planned: 4
-        ->  Parallel Seq Scan on tab_binary
-              Filter: ((a)::bbf_binary = '0xbaadf00d0000000000000000000000000000000000000000000000000000'::bbf_binary)
+        Workers Planned: 1
+        Single Copy: true
+        ->  Index Scan using ix_tab_binary_atab_binary30474ea5eaee4ec0e0a5a86377abb1ac on tab_binary
+              Index Cond: ((a)::bbf_binary = '0xbaadf00d0000000000000000000000000000000000000000000000000000'::bbf_binary)
   Query Text: select * from tab_binary where a = 0xBAADF00D
   ->  Gather
-        Workers Planned: 4
-        ->  Parallel Seq Scan on tab_binary
-              Filter: ((a)::bbf_binary = '0xbaadf00d'::bbf_varbinary)
+        Workers Planned: 1
+        Single Copy: true
+        ->  Index Scan using ix_tab_binary_atab_binary30474ea5eaee4ec0e0a5a86377abb1ac on tab_binary
+              Index Cond: ((a)::bbf_binary = '0xbaadf00d'::bbf_varbinary)
   Query Text: select count(*) from tab_binary where a > 0xBAADF00D
   ->  Finalize Aggregate
         ->  Gather
@@ -118,14 +129,16 @@ text
 Query Text: EXEC babel_3939_vu_prepare_p2
   Query Text: select * from tab_varbinary where a = 0xBAADF00D
   ->  Gather
-        Workers Planned: 4
-        ->  Parallel Seq Scan on tab_varbinary
-              Filter: ((a)::bbf_varbinary = '0xbaadf00d'::bbf_varbinary)
+        Workers Planned: 1
+        Single Copy: true
+        ->  Index Scan using ix_tab_binary_btab_varbinary785ec2330c9a18520469e01cd1dc6f53 on tab_varbinary
+              Index Cond: ((a)::bbf_varbinary = '0xbaadf00d'::bbf_varbinary)
   Query Text: select * from tab_varbinary where a = cast(0xBAADF00D as  binary )
   ->  Gather
-        Workers Planned: 4
-        ->  Parallel Seq Scan on tab_varbinary
-              Filter: ((a)::bbf_varbinary = '0xbaadf00d0000000000000000000000000000000000000000000000000000'::bbf_binary)
+        Workers Planned: 1
+        Single Copy: true
+        ->  Index Scan using ix_tab_binary_btab_varbinary785ec2330c9a18520469e01cd1dc6f53 on tab_varbinary
+              Index Cond: ((a)::bbf_varbinary = '0xbaadf00d0000000000000000000000000000000000000000000000000000'::bbf_binary)
   Query Text: select * from tab_varbinary where a > cast(0xBAADF00D as  binary )
   ->  Gather
         Workers Planned: 4

--- a/test/JDBC/input/binary-index-vu-verify.mix
+++ b/test/JDBC/input/binary-index-vu-verify.mix
@@ -1,10 +1,18 @@
 -- parallel_query_expected
+-- tsql
 create index ix_tab_binary_b on tab_varbinary (a)
 GO
 
 select set_config('enable_bitmapscan', 'off', false);
 GO
 
+-- psql
+ANALYZE master_dbo.tab_varbinary;
+GO
+ANALYZE master_dbo.tab_binary;
+GO
+
+-- tsql
 exec babel_3939_vu_prepare_p1;
 GO
 


### PR DESCRIPTION
### Description

The binary-index-vu-verify test in parallel_query mode was producing inconsistent query plans. Autoanalyze runs at unpredictable times, causing varying table statistics which affects planner's worker count and plan choice.

Added explicit ANALYZE on both tables to ensure consistent statistics and deterministic plans. Updated expected output accordingly.

### Issues Resolved

No JIRA
Signed-off-by: Rucha Kulkarni <ruchask@amazon.com>

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).