### PR TITLE
Fix exact pattern matching for LIKE operator (#4473) (#4498)

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -485,6 +485,10 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 
 	Assert(ltypeId == rtypeId);
 
+	/* Always create a CollateExpr on top to match with op->inputcollid */
+	linitial(op->args) = (Node*) create_collate_expr(linitial(op->args), op->inputcollid);
+	lsecond(op->args) = (Node*) create_collate_expr(lsecond(op->args), op->inputcollid);
+
 	/*
 	 * If we found an exact-match pattern, generate an "=" indexqual.
 	 */
@@ -502,7 +506,7 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 									InvalidOid,
 									coll_info_of_inputcollid.oid,
 									oprfuncid(optup)));
-		
+		ret = make_and_qual(ret, node);
 		ReleaseSysCache(optup);
 	}
 	else
@@ -512,10 +516,6 @@ optimise_likenode(Node *node, OpExpr *op, like_ilike_info_t like_entry, coll_inf
 					*concat_expr;
 		Node	   *constant_suffix;
 		Const	   *highest_sort_key;
-
-		/* Always create a CollateExpr on top to match with op->inputcollid */
-		linitial(op->args) = (Node*) create_collate_expr(linitial(op->args), op->inputcollid);
-		lsecond(op->args) = (Node *) create_collate_expr(lsecond(op->args), op->inputcollid);
 
 		/* construct leftop >= pattern */
 		optup = compatible_oper(NULL, list_make1(makeString(">=")), ltypeId, rtypeId,

--- a/test/JDBC/expected/babel_collection.out
+++ b/test/JDBC/expected/babel_collection.out
@@ -183,15 +183,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
+Bitmap Heap Scan on testing4  (cost=4.17..11.29 rows=1 width=32)
   Recheck Cond: (c1 = 'jones'::"varchar")
+  Filter: ((c1)::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..4.17 rows=3 width=0)
         Index Cond: (c1 = 'jones'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 2.597 ms
+Babelfish T-SQL Batch Parsing Time: 2.891 ms
 ~~END~~
 
 
@@ -209,7 +210,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.096 ms
+Babelfish T-SQL Batch Parsing Time: 0.133 ms
 ~~END~~
 
 
@@ -227,7 +228,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.080 ms
+Babelfish T-SQL Batch Parsing Time: 0.133 ms
 ~~END~~
 
 
@@ -243,7 +244,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.075 ms
+Babelfish T-SQL Batch Parsing Time: 0.115 ms
 ~~END~~
 
 
@@ -259,7 +260,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.118 ms
 ~~END~~
 
 
@@ -278,7 +279,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.127 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -295,7 +296,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.079 ms
+Babelfish T-SQL Batch Parsing Time: 0.123 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -312,7 +313,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.081 ms
+Babelfish T-SQL Batch Parsing Time: 0.123 ms
 ~~END~~
 
 
@@ -322,14 +323,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
-  Filter: (c1 <> 'jones'::"varchar")
+Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
+  Filter: ((c1 <> 'jones'::"varchar") AND ((c1)::text !~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.452 ms
+Babelfish T-SQL Batch Parsing Time: 0.921 ms
 ~~END~~
 
 
@@ -345,7 +346,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.078 ms
+Babelfish T-SQL Batch Parsing Time: 0.092 ms
 ~~END~~
 
 
@@ -361,7 +362,7 @@ Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.081 ms
+Babelfish T-SQL Batch Parsing Time: 0.095 ms
 ~~END~~
 
 
@@ -381,7 +382,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.124 ms
 ~~END~~
 
 
@@ -399,7 +400,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.075 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -532,7 +533,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.074 ms
+Babelfish T-SQL Batch Parsing Time: 0.078 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -567,14 +568,14 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Seq Scan on testing5  (cost=0.00..27.00 rows=7 width=32)
+Seq Scan on testing5  (cost=0.00..30.40 rows=1 width=32)
   Disabled: true
-  Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.067 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -598,7 +599,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.069 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -626,7 +627,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.079 ms
+Babelfish T-SQL Batch Parsing Time: 0.091 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -653,7 +654,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.077 ms
+Babelfish T-SQL Batch Parsing Time: 0.112 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/babel_collection.out
+++ b/test/JDBC/expected/db_collation/babel_collection.out
@@ -183,14 +183,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=3 width=32)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar)
+Bitmap Heap Scan on testing4  (cost=11.40..34.40 rows=1 width=32)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.159 ms
+Babelfish T-SQL Batch Parsing Time: 2.845 ms
 ~~END~~
 
 
@@ -206,7 +206,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.109 ms
+Babelfish T-SQL Batch Parsing Time: 0.221 ms
 ~~END~~
 
 
@@ -222,7 +222,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.099 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -238,7 +238,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..31.15 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.096 ms
+Babelfish T-SQL Batch Parsing Time: 0.078 ms
 ~~END~~
 
 
@@ -254,7 +254,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..31.16 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -271,7 +271,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -286,7 +286,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.103 ms
+Babelfish T-SQL Batch Parsing Time: 0.198 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -301,7 +301,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.104 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -311,14 +311,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
-  Filter: (remove_accents_internal((c1)::text) <> 'jones'::nvarchar)
+Bitmap Heap Scan on testing4  (cost=11.56..34.56 rows=647 width=32)
+  Filter: ((remove_accents_internal((c1)::text) <> 'jones'::nvarchar) AND ((remove_accents_internal((c1)::text))::text !~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.109 ms
+Babelfish T-SQL Batch Parsing Time: 0.544 ms
 ~~END~~
 
 
@@ -334,7 +334,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..37.81 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.103 ms
+Babelfish T-SQL Batch Parsing Time: 0.208 ms
 ~~END~~
 
 
@@ -350,7 +350,7 @@ Bitmap Heap Scan on testing4  (cost=11.49..37.74 rows=361 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.104 ms
+Babelfish T-SQL Batch Parsing Time: 0.099 ms
 ~~END~~
 
 
@@ -368,7 +368,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.101 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -384,7 +384,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..37.65 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.078 ms
 ~~END~~
 
 
@@ -516,7 +516,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.093 ms
+Babelfish T-SQL Batch Parsing Time: 0.077 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -551,14 +551,14 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Seq Scan on testing5  (cost=0.00..27.00 rows=7 width=32)
+Seq Scan on testing5  (cost=0.00..30.40 rows=1 width=32)
   Disabled: true
-  Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.084 ms
+Babelfish T-SQL Batch Parsing Time: 0.073 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -582,7 +582,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.091 ms
+Babelfish T-SQL Batch Parsing Time: 0.074 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -610,7 +610,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -637,7 +637,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.097 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/db_collation/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/db_collation/test_constraint_like-vu-prepare.out
@@ -433,7 +433,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((sys.remove_accents_internal((status)::text))::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_like_for_AI-vu-verify.out
@@ -5471,13 +5471,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.325 ms
+Babelfish T-SQL Batch Parsing Time: 0.207 ms
 ~~END~~
 
 
@@ -5492,7 +5492,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.146 ms
+Babelfish T-SQL Batch Parsing Time: 0.101 ms
 ~~END~~
 
 
@@ -5507,7 +5507,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -5522,7 +5522,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -5537,7 +5537,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -5547,13 +5547,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.165 ms
+Babelfish T-SQL Batch Parsing Time: 0.100 ms
 ~~END~~
 
 
@@ -5568,7 +5568,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5583,7 +5583,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.138 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 
@@ -5598,7 +5598,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.081 ms
 ~~END~~
 
 
@@ -5613,7 +5613,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.133 ms
+Babelfish T-SQL Batch Parsing Time: 0.080 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/db_collation/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/db_collation/test_like_index-vu-verify.out
@@ -57,6 +57,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -104,6 +105,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -153,6 +155,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -201,6 +204,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -248,6 +252,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -297,6 +302,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -344,7 +350,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -370,6 +376,67 @@ Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -390,6 +457,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -406,6 +474,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -463,6 +532,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -478,7 +548,7 @@ FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -548,6 +618,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -595,6 +666,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -644,6 +716,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -692,6 +765,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -739,6 +813,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -788,6 +863,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -835,7 +911,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -861,6 +937,67 @@ Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -881,6 +1018,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -897,6 +1035,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -954,6 +1093,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -969,7 +1109,7 @@ FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -1039,6 +1179,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1085,6 +1226,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1134,6 +1276,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1180,6 +1323,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1226,6 +1370,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1275,6 +1420,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1320,7 +1466,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col
 FROM test_like_index_vu_prepare_v_csai 
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1346,6 +1492,67 @@ Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1366,6 +1573,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1382,6 +1590,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -1439,6 +1648,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1453,10 +1663,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1525,6 +1734,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1571,6 +1781,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1620,6 +1831,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1666,6 +1878,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1712,6 +1925,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1761,6 +1975,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1806,7 +2021,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1832,6 +2047,67 @@ Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1851,6 +2127,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1867,6 +2144,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1924,6 +2202,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1940,6 +2219,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -2014,6 +2294,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2059,6 +2340,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2105,6 +2387,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2153,6 +2436,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2198,6 +2482,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2244,6 +2529,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2291,7 +2577,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2317,6 +2603,125 @@ Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2337,6 +2742,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2353,6 +2759,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2408,6 +2815,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2423,7 +2831,7 @@ FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2491,6 +2899,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2536,6 +2945,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2582,6 +2992,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2630,6 +3041,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2675,6 +3087,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2721,6 +3134,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2768,7 +3182,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2794,6 +3208,125 @@ Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2814,6 +3347,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2830,6 +3364,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2885,6 +3420,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2900,7 +3436,7 @@ FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2968,6 +3504,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3011,6 +3548,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3057,6 +3595,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3103,6 +3642,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3146,6 +3686,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3192,6 +3733,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3237,7 +3779,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col
 FROM test_like_index_vu_prepare_c_csai 
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3263,6 +3805,125 @@ Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3283,6 +3944,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3299,6 +3961,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -3354,6 +4017,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3368,10 +4032,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3438,6 +4101,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3481,6 +4145,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3527,6 +4192,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3573,6 +4239,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3616,6 +4283,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3662,6 +4330,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3707,7 +4376,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3733,6 +4402,125 @@ Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3754,6 +4542,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3770,6 +4559,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3825,6 +4615,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3841,6 +4632,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3912,6 +4704,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -3959,6 +4752,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4008,6 +4802,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4056,6 +4851,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4103,6 +4899,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4152,6 +4949,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4199,7 +4997,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4225,6 +5023,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4245,6 +5104,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4261,6 +5121,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4318,6 +5179,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4333,7 +5195,7 @@ FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4404,6 +5266,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4451,6 +5314,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4500,6 +5364,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4548,6 +5413,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4595,6 +5461,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4644,6 +5511,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4691,7 +5559,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4717,6 +5585,67 @@ Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4737,6 +5666,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4753,6 +5683,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4810,6 +5741,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4825,7 +5757,7 @@ FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4895,6 +5827,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4941,6 +5874,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4990,6 +5924,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5036,6 +5971,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5082,6 +6018,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5131,6 +6068,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5176,7 +6114,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col
 FROM test_like_index_vu_prepare_nv_csai 
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5202,6 +6140,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5222,6 +6221,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5238,6 +6238,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -5295,6 +6296,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5309,10 +6311,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -5381,6 +6382,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5427,6 +6429,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5476,6 +6479,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5522,6 +6526,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5568,6 +6573,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5617,6 +6623,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5662,7 +6669,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5688,6 +6695,67 @@ Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5708,6 +6776,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5724,6 +6793,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5781,6 +6851,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5797,6 +6868,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5869,7 +6941,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -5914,7 +6987,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5960,7 +7034,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6008,7 +7083,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6053,7 +7129,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6099,7 +7176,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6147,7 +7225,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6173,6 +7251,66 @@ Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6192,7 +7330,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6209,6 +7348,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6263,7 +7403,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6279,7 +7420,7 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6347,6 +7488,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6392,6 +7534,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6438,6 +7581,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6486,6 +7630,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6531,6 +7676,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6577,6 +7723,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6624,7 +7771,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6650,6 +7797,66 @@ Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6670,6 +7877,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6686,6 +7894,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6741,6 +7950,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6756,7 +7966,7 @@ FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6824,6 +8034,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6870,6 +8081,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6919,6 +8131,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -6965,6 +8178,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7011,6 +8225,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7060,6 +8275,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7105,7 +8321,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col
 FROM test_like_index_vu_prepare_t_csai 
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7131,6 +8347,67 @@ Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7151,6 +8428,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7167,6 +8445,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -7224,6 +8503,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7238,10 +8518,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -7310,6 +8589,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7356,6 +8636,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7405,6 +8686,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7451,6 +8733,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7497,6 +8780,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7546,6 +8830,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7591,7 +8876,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7617,6 +8902,67 @@ Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7637,6 +8983,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7653,6 +9000,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 
@@ -7710,6 +9058,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7726,6 +9075,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_common_idx_ai on test_like_index_vu_prepare_t_common t2
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_collection.out
@@ -183,15 +183,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
+Bitmap Heap Scan on testing4  (cost=4.17..11.29 rows=1 width=32)
   Recheck Cond: (c1 = 'jones'::"varchar")
+  Filter: ((c1)::text ~~* 'jones'::text COLLATE chinese_prc_cs_as)
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..4.17 rows=3 width=0)
         Index Cond: (c1 = 'jones'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 2.856 ms
 ~~END~~
 
 
@@ -209,7 +210,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.092 ms
 ~~END~~
 
 
@@ -227,7 +228,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -243,7 +244,7 @@ Bitmap Heap Scan on testing4  (cost=11.40..29.53 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.090 ms
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
 ~~END~~
 
 
@@ -259,7 +260,7 @@ Bitmap Heap Scan on testing4  (cost=11.41..29.53 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.088 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -278,7 +279,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.094 ms
+Babelfish T-SQL Batch Parsing Time: 0.093 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -295,7 +296,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.096 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -312,7 +313,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.099 ms
+Babelfish T-SQL Batch Parsing Time: 0.088 ms
 ~~END~~
 
 
@@ -322,14 +323,14 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Bitmap Heap Scan on testing4  (cost=11.56..29.69 rows=647 width=32)
-  Filter: (c1 <> 'jones'::"varchar")
+Bitmap Heap Scan on testing4  (cost=11.56..31.31 rows=647 width=32)
+  Filter: ((c1 <> 'jones'::"varchar") AND ((c1)::text !~~* 'jones'::text COLLATE chinese_prc_cs_as))
   ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.101 ms
+Babelfish T-SQL Batch Parsing Time: 0.575 ms
 ~~END~~
 
 
@@ -345,7 +346,7 @@ Bitmap Heap Scan on testing4  (cost=11.56..32.94 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.094 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -361,7 +362,7 @@ Bitmap Heap Scan on testing4  (cost=11.55..32.92 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.086 ms
 ~~END~~
 
 
@@ -381,7 +382,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.143 ms
 ~~END~~
 
 
@@ -399,7 +400,7 @@ Bitmap Heap Scan on testing4  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.090 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -530,7 +531,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.090 ms
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -565,14 +566,14 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Seq Scan on testing5  (cost=0.00..27.00 rows=7 width=32)
+Seq Scan on testing5  (cost=0.00..30.40 rows=1 width=32)
   Disabled: true
-  Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.081 ms
+Babelfish T-SQL Batch Parsing Time: 0.076 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -596,7 +597,7 @@ Result  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.090 ms
+Babelfish T-SQL Batch Parsing Time: 0.078 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -624,7 +625,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.099 ms
+Babelfish T-SQL Batch Parsing Time: 0.094 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -651,7 +652,7 @@ Seq Scan on testing5  (cost=0.00..33.80 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.114 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_constraint_like-vu-verify.out
@@ -718,7 +718,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('inactive'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/test_like_index-vu-verify.out
@@ -57,6 +57,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -104,6 +105,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -153,6 +155,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -201,6 +204,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -248,6 +252,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -297,6 +302,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -344,7 +350,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -370,6 +376,67 @@ Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -390,6 +457,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -406,6 +474,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -463,6 +532,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -478,7 +548,7 @@ FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -548,6 +618,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -595,6 +666,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -644,6 +716,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -692,6 +765,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -739,6 +813,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -788,6 +863,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -835,7 +911,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -861,6 +937,67 @@ Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -881,6 +1018,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -897,6 +1035,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -954,6 +1093,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -969,7 +1109,7 @@ FROM test_like_index_vu_prepare_v_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -1039,6 +1179,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1085,6 +1226,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1134,6 +1276,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1180,6 +1323,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1226,6 +1370,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1275,6 +1420,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1320,7 +1466,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col
 FROM test_like_index_vu_prepare_v_csai 
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1346,6 +1492,67 @@ Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1366,6 +1573,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1382,6 +1590,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -1439,6 +1648,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1453,10 +1663,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1525,6 +1734,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1571,6 +1781,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1620,6 +1831,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1666,6 +1878,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1712,6 +1925,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1761,6 +1975,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1806,7 +2021,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1832,6 +2047,67 @@ Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1851,6 +2127,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1867,6 +2144,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1924,6 +2202,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1938,10 +2217,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -2012,6 +2290,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2057,6 +2336,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2103,6 +2383,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2151,6 +2432,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2196,6 +2478,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2242,6 +2525,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2289,7 +2573,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2315,6 +2599,125 @@ Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2335,6 +2738,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2351,6 +2755,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2406,6 +2811,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2421,7 +2827,7 @@ FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2489,6 +2895,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2534,6 +2941,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2580,6 +2988,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2628,6 +3037,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2673,6 +3083,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2719,6 +3130,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2766,7 +3178,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2792,6 +3204,125 @@ Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2812,6 +3343,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2828,6 +3360,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2883,6 +3416,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2898,7 +3432,7 @@ FROM test_like_index_vu_prepare_c_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2966,6 +3500,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3009,6 +3544,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3055,6 +3591,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3101,6 +3638,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3144,6 +3682,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3190,6 +3729,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3235,7 +3775,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col
 FROM test_like_index_vu_prepare_c_csai 
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3261,6 +3801,125 @@ Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3281,6 +3940,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3297,6 +3957,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -3352,6 +4013,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3366,10 +4028,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3436,6 +4097,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3479,6 +4141,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3525,6 +4188,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3571,6 +4235,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3614,6 +4279,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3660,6 +4326,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3705,7 +4372,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3731,6 +4398,125 @@ Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3752,6 +4538,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3768,6 +4555,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3823,6 +4611,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3837,10 +4626,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -3908,6 +4696,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -3955,6 +4744,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4004,6 +4794,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4052,6 +4843,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4099,6 +4891,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4148,6 +4941,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4195,7 +4989,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4221,6 +5015,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4241,6 +5096,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4257,6 +5113,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4314,6 +5171,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4329,7 +5187,7 @@ FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4400,6 +5258,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4447,6 +5306,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4496,6 +5356,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4544,6 +5405,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4591,6 +5453,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4640,6 +5503,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4687,7 +5551,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4713,6 +5577,67 @@ Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4733,6 +5658,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4749,6 +5675,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4806,6 +5733,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4821,7 +5749,7 @@ FROM test_like_index_vu_prepare_nv_cias t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4891,6 +5819,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4937,6 +5866,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4986,6 +5916,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5032,6 +5963,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5078,6 +6010,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5127,6 +6060,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5172,7 +6106,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col
 FROM test_like_index_vu_prepare_nv_csai 
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5198,6 +6132,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5218,6 +6213,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5234,6 +6230,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -5291,6 +6288,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5305,10 +6303,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -5377,6 +6374,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5423,6 +6421,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5472,6 +6471,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5518,6 +6518,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5564,6 +6565,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5613,6 +6615,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5658,7 +6661,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5684,6 +6687,67 @@ Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5704,6 +6768,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5720,6 +6785,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5777,6 +6843,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5791,10 +6858,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -5863,7 +6929,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -5908,7 +6975,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5954,7 +7022,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6002,7 +7071,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6047,7 +7117,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6093,7 +7164,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6141,7 +7213,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_ci_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6167,6 +7239,66 @@ Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6186,7 +7318,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6203,6 +7336,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6257,7 +7391,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6273,7 +7408,7 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6341,6 +7476,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6386,6 +7522,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6432,6 +7569,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6480,6 +7618,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6525,6 +7664,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6571,6 +7711,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6618,7 +7759,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6644,6 +7785,66 @@ Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text COLLATE bbf_unicode_cp1_ci_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6664,6 +7865,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6680,6 +7882,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6735,6 +7938,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_ci_as)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6750,7 +7954,7 @@ FROM test_like_index_vu_prepare_t_cias t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_ci_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6818,6 +8022,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6864,6 +8069,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6913,6 +8119,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -6959,6 +8166,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7005,6 +8213,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7054,6 +8263,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7099,7 +8309,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col
 FROM test_like_index_vu_prepare_t_csai 
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7125,6 +8335,67 @@ Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7145,6 +8416,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7161,6 +8433,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -7218,6 +8491,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7232,10 +8506,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -7304,6 +8577,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7350,6 +8624,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7399,6 +8674,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7445,6 +8721,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7491,6 +8768,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7540,6 +8818,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7585,7 +8864,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7611,6 +8890,67 @@ Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7631,6 +8971,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7647,6 +8988,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE chinese_prc_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 
@@ -7704,6 +9046,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7718,10 +9061,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/test_like_for_AI-vu-verify.out
@@ -5470,13 +5470,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.330 ms
+Babelfish T-SQL Batch Parsing Time: 0.326 ms
 ~~END~~
 
 
@@ -5491,7 +5491,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.140 ms
+Babelfish T-SQL Batch Parsing Time: 0.103 ms
 ~~END~~
 
 
@@ -5506,7 +5506,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.098 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5521,7 +5521,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5536,7 +5536,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.095 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5546,13 +5546,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.126 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5567,7 +5567,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.094 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5582,7 +5582,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.091 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5597,7 +5597,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.091 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5612,7 +5612,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.090 ms
+Babelfish T-SQL Batch Parsing Time: 0.083 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/babel_collection.out
+++ b/test/JDBC/expected/parallel_query/babel_collection.out
@@ -183,18 +183,19 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 LIKE 'jones'
-Gather  (cost=4.17..11.28 rows=3 width=32)
+Gather  (cost=4.17..11.29 rows=1 width=32)
   Workers Planned: 1
   Single Copy: true
-  ->  Bitmap Heap Scan on testing4  (cost=4.17..11.28 rows=3 width=32)
+  ->  Bitmap Heap Scan on testing4  (cost=4.17..11.29 rows=1 width=32)
         Recheck Cond: (c1 = 'jones'::"varchar")
+        Filter: ((c1)::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as)
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..4.17 rows=3 width=0)
               Index Cond: (c1 = 'jones'::"varchar")
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 2.736 ms
+Babelfish T-SQL Batch Parsing Time: 2.903 ms
 ~~END~~
 
 
@@ -215,7 +216,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.100 ms
+Babelfish T-SQL Batch Parsing Time: 0.222 ms
 ~~END~~
 
 
@@ -236,7 +237,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.088 ms
+Babelfish T-SQL Batch Parsing Time: 0.196 ms
 ~~END~~
 
 
@@ -254,7 +255,7 @@ Gather  (cost=11.40..24.02 rows=5 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.078 ms
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
 ~~END~~
 
 
@@ -272,7 +273,7 @@ Gather  (cost=11.41..24.03 rows=26 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.080 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 
@@ -294,7 +295,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.085 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äb%';
@@ -314,7 +315,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.080 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 select c1 from testing4 where c1 LIKE 'äḃĆ_';
@@ -334,7 +335,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.081 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -344,16 +345,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from testing4 where c1 NOT LIKE 'jones'
-Gather  (cost=11.56..24.18 rows=647 width=32)
+Gather  (cost=11.56..24.71 rows=647 width=32)
   Workers Planned: 3
-  ->  Parallel Bitmap Heap Scan on testing4  (cost=11.56..24.18 rows=209 width=32)
-        Filter: (c1 <> 'jones'::"varchar")
+  ->  Parallel Bitmap Heap Scan on testing4  (cost=11.56..24.71 rows=209 width=32)
+        Filter: ((c1 <> 'jones'::"varchar") AND ((c1)::text !~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as))
         ->  Bitmap Index Scan on c1_idxtesting49a168d73f3ba5aacdfd495b931b8d187  (cost=0.00..11.40 rows=650 width=0)
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.501 ms
+Babelfish T-SQL Batch Parsing Time: 0.711 ms
 ~~END~~
 
 
@@ -371,7 +372,7 @@ Gather  (cost=11.56..25.23 rows=648 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.081 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -389,7 +390,7 @@ Gather  (cost=11.55..25.22 rows=592 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -412,7 +413,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.082 ms
+Babelfish T-SQL Batch Parsing Time: 0.203 ms
 ~~END~~
 
 
@@ -433,7 +434,7 @@ Gather  (cost=4.18..11.30 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.077 ms
+Babelfish T-SQL Batch Parsing Time: 0.079 ms
 ~~END~~
 
 
@@ -568,7 +569,7 @@ Gather  (cost=0.00..17.68 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.166 ms
+Babelfish T-SQL Batch Parsing Time: 0.107 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -603,16 +604,16 @@ GO
 ~~START~~
 text
 Query Text: SELECT * from testing5 where c1 like ''
-Gather  (cost=0.00..15.48 rows=7 width=32)
+Gather  (cost=0.00..16.58 rows=1 width=32)
   Workers Planned: 3
-  ->  Parallel Seq Scan on testing5  (cost=0.00..15.48 rows=2 width=32)
+  ->  Parallel Seq Scan on testing5  (cost=0.00..16.58 rows=1 width=32)
         Disabled: true
-        Filter: (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((c1)::text ~~ ''::text COLLATE bbf_unicode_cp1_cs_as) AND (c1 = ''::"varchar" COLLATE bbf_unicode_cp1_cs_as))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.174 ms
+Babelfish T-SQL Batch Parsing Time: 0.108 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -639,7 +640,7 @@ Gather  (cost=0.00..0.00 rows=0 width=0)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.125 ms
+Babelfish T-SQL Batch Parsing Time: 0.090 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -669,7 +670,7 @@ Gather  (cost=0.00..17.68 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.168 ms
+Babelfish T-SQL Batch Parsing Time: 0.165 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;
@@ -698,7 +699,7 @@ Gather  (cost=0.00..17.68 rows=1 width=32)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.181 ms
+Babelfish T-SQL Batch Parsing Time: 0.140 ms
 ~~END~~
 
 SET babelfish_showplan_all OFF;

--- a/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_for_AI-vu-verify.out
@@ -5471,16 +5471,16 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Gather  (cost=0.13..12.23 rows=1 width=6)
+Gather  (cost=0.13..12.26 rows=1 width=6)
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  ->  Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+        Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.365 ms
+Babelfish T-SQL Batch Parsing Time: 0.332 ms
 ~~END~~
 
 
@@ -5498,7 +5498,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.148 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5516,7 +5516,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -5534,7 +5534,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.139 ms
+Babelfish T-SQL Batch Parsing Time: 0.105 ms
 ~~END~~
 
 
@@ -5552,7 +5552,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.137 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5562,16 +5562,16 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Gather  (cost=0.13..12.23 rows=1 width=6)
+Gather  (cost=0.13..12.26 rows=1 width=6)
   Workers Planned: 1
   Single Copy: true
-  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-        Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  ->  Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+        Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.164 ms
+Babelfish T-SQL Batch Parsing Time: 0.106 ms
 ~~END~~
 
 
@@ -5589,7 +5589,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.153 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5607,7 +5607,7 @@ Gather  (cost=0.13..12.28 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.096 ms
 ~~END~~
 
 
@@ -5625,7 +5625,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.143 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5643,7 +5643,7 @@ Gather  (cost=0.13..12.23 rows=1 width=6)
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/test_like_index-vu-verify.out
@@ -61,6 +61,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -115,6 +116,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -171,6 +173,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -227,6 +230,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -281,6 +285,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -337,6 +342,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -391,7 +397,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=0.33 loops=3)
-        Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar")
+        Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar"))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -420,6 +426,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -444,6 +520,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
                     Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+                    Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -463,6 +540,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -529,6 +607,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
                     Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+                    Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -545,7 +624,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csas t1
@@ -628,6 +707,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -682,6 +762,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -738,6 +819,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+        Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -794,6 +876,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -848,6 +931,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -904,6 +988,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+        Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -958,7 +1043,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=0.33 loops=3)
-        Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -987,6 +1072,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar"))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar"))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar"))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1011,6 +1166,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
                     Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1030,6 +1186,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1096,6 +1253,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
                     Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1115,6 +1273,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1196,6 +1355,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1249,6 +1409,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1305,6 +1466,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -1359,6 +1521,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1412,6 +1575,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1468,6 +1632,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -1520,7 +1685,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=0.33 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -1549,6 +1714,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1573,6 +1808,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1592,6 +1828,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1658,6 +1895,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -1673,12 +1911,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1758,6 +1995,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1811,6 +2049,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1867,6 +2106,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -1921,6 +2161,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -1974,6 +2215,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -2030,6 +2272,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -2082,7 +2325,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=0.33 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -2111,6 +2354,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2134,6 +2447,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2153,6 +2467,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2219,6 +2534,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2234,12 +2550,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_v_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -2321,6 +2636,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -2374,6 +2690,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -2428,6 +2745,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -2484,6 +2802,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -2537,6 +2856,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -2591,6 +2911,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -2645,7 +2966,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=0.20 loops=5)
-        Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar)
+        Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -2674,6 +2995,143 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2698,6 +3156,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
                     Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+                    Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2717,6 +3176,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2781,6 +3241,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
                     Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+                    Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -2797,7 +3258,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csas t1
@@ -2878,6 +3339,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -2931,6 +3393,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -2985,6 +3448,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+        Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -3041,6 +3505,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -3094,6 +3559,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -3148,6 +3614,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+        Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -3202,7 +3669,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=0.20 loops=5)
-        Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -3231,6 +3698,143 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3255,6 +3859,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
                     Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+                    Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3274,6 +3879,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3338,6 +3944,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
                     Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+                    Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3357,6 +3964,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3436,6 +4044,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -3487,6 +4096,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -3541,6 +4151,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -3595,6 +4206,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -3646,6 +4258,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -3700,6 +4313,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -3752,7 +4366,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=0.20 loops=5)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -3781,6 +4395,143 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3805,6 +4556,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3824,6 +4576,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3888,6 +4641,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -3902,13 +4656,12 @@ FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
   ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3986,6 +4739,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -4037,6 +4791,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -4091,6 +4846,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -4145,6 +4901,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -4196,6 +4953,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -4250,6 +5008,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -4302,7 +5061,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=0.20 loops=5)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 200
 ~~END~~
 
@@ -4331,6 +5090,143 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=0.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4356,6 +5252,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4375,6 +5272,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4439,6 +5337,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4453,13 +5352,12 @@ FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
   ->  Gather
+        Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
         Workers Planned: 4
         ->  Parallel Seq Scan on test_like_index_vu_prepare_c_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -4538,6 +5436,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -4592,6 +5491,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -4648,6 +5548,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -4704,6 +5605,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -4758,6 +5660,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -4814,6 +5717,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -4868,7 +5772,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=0.33 loops=3)
-        Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar)
+        Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -4897,6 +5801,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4921,6 +5895,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
                     Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+                    Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -4940,6 +5915,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5006,6 +5982,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
                     Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+                    Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5022,7 +5999,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csas t1
@@ -5106,6 +6083,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -5160,6 +6138,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -5216,6 +6195,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+        Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -5272,6 +6252,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -5326,6 +6307,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -5382,6 +6364,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+        Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -5436,7 +6419,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=0.33 loops=3)
-        Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -5465,6 +6448,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=0.50 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5489,6 +6542,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
                     Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+                    Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5508,6 +6562,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5574,6 +6629,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
                     Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+                    Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5593,6 +6649,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -5674,6 +6731,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -5727,6 +6785,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -5783,6 +6842,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -5837,6 +6897,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -5890,6 +6951,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -5946,6 +7008,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -5998,7 +7061,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=0.33 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -6027,6 +7090,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6051,6 +7184,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6070,6 +7204,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6136,6 +7271,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6151,12 +7287,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -6236,6 +7371,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -6289,6 +7425,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -6345,6 +7482,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -6399,6 +7537,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -6452,6 +7591,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -6508,6 +7648,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -6560,7 +7701,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=0.33 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -6589,6 +7730,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6613,6 +7824,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6632,6 +7844,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6698,6 +7911,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
                     Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -6713,12 +7927,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_nv_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -6798,7 +8011,8 @@ Gather (actual rows=1.00 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -6851,7 +8065,8 @@ Gather (actual rows=1.00 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -6905,7 +8120,8 @@ Gather (actual rows=1.00 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -6961,7 +8177,8 @@ Gather (actual rows=1.00 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -7014,7 +8231,8 @@ Gather (actual rows=1.00 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -7068,7 +8286,8 @@ Gather (actual rows=1.00 loops=1)
   Workers Launched: 1
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -7123,7 +8342,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=0.33 loops=3)
-        Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text)
+        Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -7152,6 +8371,75 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=0.25 loops=4)
+        Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=0.25 loops=4)
+        Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=0.25 loops=4)
+        Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7175,7 +8463,8 @@ Gather
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-                    Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+                    Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+                    Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7195,6 +8484,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7258,7 +8548,8 @@ Gather
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-                    Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+                    Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+                    Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7275,7 +8566,7 @@ Nested Loop
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+              Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Gather
         Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csas t1
@@ -7356,6 +8647,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -7409,6 +8701,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -7463,6 +8756,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+        Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -7519,6 +8813,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -7572,6 +8867,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -7626,6 +8922,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
         Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+        Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Heap Fetches: 1
         Index Searches: 1
 ~~END~~
@@ -7680,7 +8977,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=0.33 loops=3)
-        Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -7709,6 +9006,75 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=0.25 loops=4)
+        Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7733,6 +9099,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
                     Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+                    Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7752,6 +9119,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7816,6 +9184,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
                     Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+                    Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7835,6 +9204,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -7914,6 +9284,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -7967,6 +9338,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8023,6 +9395,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -8077,6 +9450,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8130,6 +9504,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8186,6 +9561,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -8238,7 +9614,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=0.33 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -8267,6 +9643,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -8291,6 +9737,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
                     Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8310,6 +9757,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8376,6 +9824,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
                     Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+                    Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8391,12 +9840,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -8476,6 +9924,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8529,6 +9978,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8585,6 +10035,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -8639,6 +10090,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8692,6 +10144,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
         Index Searches: 1
 ~~END~~
 
@@ -8748,6 +10201,7 @@ Gather (actual rows=1.00 loops=1)
   Single Copy: true
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
         Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
         Index Searches: 1
 ~~END~~
 
@@ -8800,7 +10254,7 @@ Gather (actual rows=1.00 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=0.33 loops=3)
-        Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
         Rows Removed by Filter: 333
 ~~END~~
 
@@ -8829,6 +10283,76 @@ Gather (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Gather (actual rows=2.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=0.50 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Gather (actual rows=1.00 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=0.25 loops=4)
+        Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+        Rows Removed by Filter: 0
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -8853,6 +10377,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
                     Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8872,6 +10397,7 @@ Gather
         ->  Materialize
               ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
                     Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+                    Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8938,6 +10464,7 @@ Gather
         ->  Materialize
               ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
                     Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+                    Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
 ~~END~~
 
 
@@ -8953,12 +10480,11 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Gather
         Workers Planned: 2
+        ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
+              Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  ->  Gather
+        Workers Planned: 2
         ->  Parallel Seq Scan on test_like_index_vu_prepare_t_ciai t1
-  ->  Materialize
-        ->  Gather
-              Workers Planned: 2
-              ->  Parallel Seq Scan on test_like_index_vu_prepare_t_common t2
-                    Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like-vu-prepare.out
@@ -433,7 +433,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like-vu-verify.out
@@ -718,7 +718,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 

--- a/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-cleanup.out
+++ b/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-cleanup.out
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-prepare.out
+++ b/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-prepare.out
@@ -263,7 +263,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('ABC'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -271,7 +271,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -297,7 +297,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -340,7 +340,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('abc'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -348,7 +348,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -424,7 +424,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
 ~~END~~
 
 
@@ -433,7 +433,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('inactive'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 
@@ -497,7 +497,7 @@ SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
 GO
 ~~START~~
 text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
 ~~END~~
 
 
@@ -515,6 +515,6 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.chinese_prc_cs_as) ~~* ('A%'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 

--- a/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-verify.out
+++ b/test/JDBC/expected/test_constraint_like_before_17_8-or-16_12-vu-verify.out
@@ -1,234 +1,519 @@
 -- tsql
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
-CREATE TABLE BABEL_5608_vu_prepare_t1(BABEL_5608_vu_prepare_t1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t1_c1 CHECK ('abc' LIKE 'A%' COLLATE Latin1_general_ci_as));
+INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t1;
+
+SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
 GO
+~~START~~
+varchar
+Abc
+~~END~~
+
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
-CREATE TABLE BABEL_5608_vu_prepare_t2(BABEL_5608_vu_prepare_t2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t2_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%'));
+INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t2;
+
+SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
 GO
+~~START~~
+varchar
+Abc
+~~END~~
+
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
-CREATE TABLE BABEL_5608_vu_prepare_t3(BABEL_5608_vu_prepare_t3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t3_c1 CHECK ('abc' COLLATE Latin1_general_ci_as LIKE 'A%' COLLATE Latin1_general_ci_as));
+INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t3;
+
+SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
 GO
+~~START~~
+varchar
+Abc
+~~END~~
+
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
-CREATE TABLE BABEL_5608_vu_prepare_t4_1(BABEL_5608_vu_prepare_t4_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_1_c1 CHECK (BABEL_5608_vu_prepare_t4_1_col1 LIKE 'ABC'));
+INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t4_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_1;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t4_2(BABEL_5608_vu_prepare_t4_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t4_2_c1 CHECK (BABEL_5608_vu_prepare_t4_2_col1 LIKE 'a%'));
+SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
 GO
+~~START~~
+varchar
+Abc
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t4_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t4_2;
+
+INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
 GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
-CREATE TABLE BABEL_5608_vu_prepare_t5_1(BABEL_5608_vu_prepare_t5_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_1_c1 CHECK (BABEL_5608_vu_prepare_t5_1_col1 LIKE 'ABC' COLLATE Latin1_General_CI_AI));
+INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t5_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_1;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t5_2(BABEL_5608_vu_prepare_t5_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t5_2_c1 CHECK (BABEL_5608_vu_prepare_t5_2_col1 LIKE 'a%' COLLATE Latin1_General_CI_AI));
+SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
 GO
+~~START~~
+varchar
+Abc
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t5_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t5_2;
+
+INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
 GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+~~START~~
+varchar
+Abc
+~~END~~
+
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
-CREATE TABLE BABEL_5608_vu_prepare_t6(BABEL_5608_vu_prepare_t6_col1 varchar(max), BABEL_5608_vu_prepare_t6_col2 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t6_c1 CHECK (BABEL_5608_vu_prepare_t6_col1 LIKE BABEL_5608_vu_prepare_t6_col2));
+INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t6;
+
+SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
 GO
+~~START~~
+varchar#!#varchar
+abc#!#ABC
+~~END~~
+
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
-CREATE TABLE BABEL_5608_vu_prepare_t7_1(BABEL_5608_vu_prepare_t7_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_1_c1 CHECK (BABEL_5608_vu_prepare_t7_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc'));
+INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t7_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_1;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t7_2(BABEL_5608_vu_prepare_t7_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t7_2_c1 CHECK (BABEL_5608_vu_prepare_t7_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%'));
+SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
 GO
+~~START~~
+varchar
+ABC
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t7_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t7_2;
+
+INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
 GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+~~START~~
+varchar
+ABC
+~~END~~
+
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
-CREATE TABLE BABEL_5608_vu_prepare_t8_1(BABEL_5608_vu_prepare_t8_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_1_c1 CHECK (BABEL_5608_vu_prepare_t8_1_col1 COLLATE Latin1_General_CI_AI LIKE 'abc' COLLATE Latin1_General_CI_AI));
+INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t8_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_1;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t8_2(BABEL_5608_vu_prepare_t8_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t8_2_c1 CHECK (BABEL_5608_vu_prepare_t8_2_col1 COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
 GO
+~~START~~
+varchar
+ABC
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t8_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t8_2;
-GO
 
--- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
-CREATE TABLE BABEL_5608_vu_prepare_t9_1(BABEL_5608_vu_prepare_t9_1_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_1_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_1_col1) LIKE 'abc'));
+INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_1;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_2(BABEL_5608_vu_prepare_t9_2_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_2_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_2_col1) LIKE 'a%'));
+SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
 GO
+~~START~~
+varchar
+ABC
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_2;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_3(BABEL_5608_vu_prepare_t9_3_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_3_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_3_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc'));
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_3;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_4(BABEL_5608_vu_prepare_t9_4_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_4_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_4_col1 COLLATE Latin1_General_CI_AI) LIKE 'a%'));
+SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
 GO
+~~START~~
+varchar
+abc
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_4;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_5(BABEL_5608_vu_prepare_t9_5_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_5_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_5_col1) COLLATE Latin1_General_CI_AI LIKE 'abc'));
+INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_5;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_6(BABEL_5608_vu_prepare_t9_6_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_6_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_6_col1) COLLATE Latin1_General_CI_AI LIKE 'a%'));
+SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
 GO
+~~START~~
+varchar
+abc
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_6_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_6;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_7(BABEL_5608_vu_prepare_t9_7_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_7_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_7_col1 COLLATE Latin1_General_CI_AI) LIKE 'abc' COLLATE Latin1_General_CI_AI));
+INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_7_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_7;
-GO
 
-CREATE TABLE BABEL_5608_vu_prepare_t9_8(BABEL_5608_vu_prepare_t9_8_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t9_8_c1 CHECK (LOWER(BABEL_5608_vu_prepare_t9_8_col1) COLLATE Latin1_General_CI_AI LIKE 'a%' COLLATE Latin1_General_CI_AI));
+SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
 GO
+~~START~~
+varchar
+abc
+~~END~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t9_8_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t9_8;
+
+INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
 GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
+
+INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+~~START~~
+varchar
+abc
+~~END~~
+
 
 -- CASE 10: ESCAPE WITH LIKE
-CREATE TABLE BABEL_5608_vu_prepare_t10(BABEL_5608_vu_prepare_t10_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t10_c1 CHECK (BABEL_5608_vu_prepare_t10_col1 COLLATE Latin1_General_CI_AS LIKE '15/% %' ESCAPE '/'));
+INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t10_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t10;
+
+SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
 GO
+~~START~~
+varchar
+15% off
+~~END~~
+
 
 -- CASE 11: T_CoerceViaIO
-CREATE TABLE BABEL_5608_vu_prepare_t11(BABEL_5608_vu_prepare_t11_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t11_c1 CHECK (N'123' collate Latin1_General_CI_AI LIKE CAST(123 as varchar(3))));
+INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t11_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t11;
+
+SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
 GO
+~~START~~
+varchar
+abc
+~~END~~
+
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
-CREATE TABLE BABEL_5608_vu_prepare_t12_1 (status varchar(10), CONSTRAINT chk_status CHECK (IIF(status LIKE 'act%', 1, 0) = 1 OR IIF(status = 'inactive', 1, 0) = 1));
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t12_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_1;
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
 GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
 
 -- CASE WHEN
-CREATE TABLE BABEL_5608_vu_prepare_t12_2 (status varchar(10),CONSTRAINT chk_status CHECK (
-        CASE 
-            WHEN status LIKE 'act%' THEN 1
-            WHEN status LIKE 'inactive' THEN 1
-            ELSE 0
-        END = 1
-    )
-);
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2;
+~~ROW COUNT: 1~~
+
+
+-- should fail
+INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
 GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+~~START~~
+varchar
+active
+inactive
+~~END~~
+
+
+-- IF EXISTS
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+Found matching records
+~~END~~
+
+
+IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
+BEGIN
+    SELECT 'Found matching records'
+END
+ELSE
+BEGIN
+    SELECT 'No matches found'
+END
+GO
+~~START~~
+varchar
+No matches found
+~~END~~
+
 
 
 
 
 -- COMPUTED COLUMNS (BABEL-5022)
--- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
 -- GO
--- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
+-- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
+-- GO
+-- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
 -- GO
 -- FUNCTION
-CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
-(
-    @pattern varchar(100)
-)
-RETURNS TABLE
-AS
-RETURN
-(
-    SELECT * FROM BABEL_5608_vu_prepare_t12_2
-    WHERE status LIKE @pattern
-);
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
 GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
+GO
+~~START~~
+varchar
+~~END~~
+
+
 
 -- PROCEDURE
-CREATE PROCEDURE BABEL_5608_vu_prepare_t12_proc1
-    @pattern varchar(100)
-AS
-BEGIN
-    SET NOCOUNT ON;
-    
-    SELECT * FROM BABEL_5608_vu_prepare_t12_2
-    WHERE status LIKE @pattern
-END;
+EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
 GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
+GO
+~~START~~
+varchar
+inactive
+~~END~~
+
+
+EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
+GO
+~~START~~
+varchar
+~~END~~
 
 
 -- CASE 13: VIEW WITH LIKE
-CREATE VIEW BABEL_5608_13_1_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%';
+SELECT * FROM BABEL_5608_13_1_VIEW;
 GO
+~~START~~
+varchar
+active
+~~END~~
 
-CREATE VIEW BABEL_5608_13_2_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status COLLATE estonian_ci_ai LIKE 'ac%';
-GO
 
-CREATE VIEW BABEL_5608_13_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'ac%' COLLATE estonian_ci_ai;
+SELECT * FROM BABEL_5608_13_2_VIEW;
 GO
+~~START~~
+varchar
+active
+~~END~~
 
-CREATE VIEW BABEL_5608_13_4_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) LIKE 'ac%';
-GO
 
-CREATE VIEW BABEL_5608_13_5_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_2 WHERE UPPER(status) COLLATE DATABASE_DEFAULT LIKE 'ac%';
+SELECT * FROM BABEL_5608_13_3_VIEW;
 GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_4_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
+
+SELECT * FROM BABEL_5608_13_5_VIEW;
+GO
+~~START~~
+varchar
+active
+~~END~~
+
 
 -- CASE 14: PostFix Pattern match
-CREATE TABLE BABEL_5608_vu_prepare_t14(BABEL_5608_vu_prepare_t14_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t14_c1 CHECK (BABEL_5608_vu_prepare_t14_col1 COLLATE Latin1_General_CI_AI LIKE '%abc'));
+INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t14_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t14;
+
+SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
 GO
+~~START~~
+varchar
+abc
+~~END~~
 
 
 -- CASE 15: T_Const LIKE T_Const
-CREATE TABLE BABEL_5608_vu_prepare_t15(BABEL_5608_vu_prepare_t15_col1 varchar(max), CONSTRAINT BABEL_5608_vu_prepare_t15_c1 CHECK ('abc' LIKE 'A%'));
+INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
 GO
+~~ROW COUNT: 1~~
 
-CREATE VIEW BABEL_5608_vu_prepare_t15_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t15;
+
+SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
 GO
+~~START~~
+varchar
+abc
+~~END~~
+
 
 -- psql
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
@@ -263,7 +548,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('ABC'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -271,7 +556,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -297,7 +582,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -340,7 +625,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('abc'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -348,7 +633,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 
 
@@ -424,7 +709,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
+CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
 ~~END~~
 
 
@@ -433,7 +718,7 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('inactive'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
+CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN ((status)::text ~~* 'inactive'::text) THEN 1<newline>    ELSE 0<newline>END = 1))
 ~~END~~
 
 
@@ -457,7 +742,6 @@ GO
 text
 CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
 ~~END~~
-
 
 
 -- CASE 13: VIEW WITH LIKE
@@ -497,7 +781,7 @@ SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
 GO
 ~~START~~
 text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
+ SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_as) ~~ 'ac%'::text;
 ~~END~~
 
 
@@ -515,6 +799,6 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo
 GO
 ~~START~~
 text
-CHECK ((('abc'::text COLLATE sys.chinese_prc_cs_as) ~~* ('A%'::text COLLATE sys.chinese_prc_cs_as)))
+CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
 ~~END~~
 

--- a/test/JDBC/expected/test_like_for_AI-vu-verify.out
+++ b/test/JDBC/expected/test_like_for_AI-vu-verify.out
@@ -5471,13 +5471,13 @@ GO
 ~~START~~
 text
 Query Text: select c1 from test_like_for_AI_prepare_index where c1 LIKE 'jones'
-Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a9184c6b2 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c1)::text))::text ~~* 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c1)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.318 ms
+Babelfish T-SQL Batch Parsing Time: 0.310 ms
 ~~END~~
 
 
@@ -5492,7 +5492,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.146 ms
+Babelfish T-SQL Batch Parsing Time: 0.102 ms
 ~~END~~
 
 
@@ -5507,7 +5507,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.136 ms
+Babelfish T-SQL Batch Parsing Time: 0.089 ms
 ~~END~~
 
 
@@ -5522,7 +5522,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.085 ms
 ~~END~~
 
 
@@ -5537,7 +5537,7 @@ Index Only Scan using c1_idxtest_like_for_ai_prepare_38f8448780355a5f23c35e9a918
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.116 ms
 ~~END~~
 
 
@@ -5547,13 +5547,13 @@ GO
 ~~START~~
 text
 Query Text: select c2 from test_like_for_AI_prepare_index where c2 LIKE 'jones'
-Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.23 rows=1 width=6)
-  Filter: (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e8139ccc9 on test_like_for_ai_prepare_index  (cost=0.13..12.26 rows=1 width=6)
+  Filter: (((remove_accents_internal((c2)::text))::text ~~ 'jones'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((c2)::text) = 'jones'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
 ~~END~~
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.162 ms
+Babelfish T-SQL Batch Parsing Time: 0.110 ms
 ~~END~~
 
 
@@ -5568,7 +5568,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.135 ms
+Babelfish T-SQL Batch Parsing Time: 0.087 ms
 ~~END~~
 
 
@@ -5583,7 +5583,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.084 ms
 ~~END~~
 
 
@@ -5598,7 +5598,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 
@@ -5613,7 +5613,7 @@ Index Only Scan using c2_idxtest_like_for_ai_prepare_bf9020e1683683184624689e813
 
 ~~START~~
 text
-Babelfish T-SQL Batch Parsing Time: 0.134 ms
+Babelfish T-SQL Batch Parsing Time: 0.082 ms
 ~~END~~
 
 

--- a/test/JDBC/expected/test_like_index-vu-cleanup.out
+++ b/test/JDBC/expected/test_like_index-vu-cleanup.out
@@ -10,6 +10,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_v_cias_idx ON test_like_index_vu_prepare_v_cias;
 GO
@@ -18,6 +21,9 @@ DROP INDEX test_like_index_vu_prepare_v_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_v_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_cias;
 GO
 
 -- psql
@@ -32,6 +38,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_v_ciai_idx;
@@ -42,6 +51,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_v_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_ciai;
 GO
 
 -- CHAR
@@ -55,6 +67,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csas;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_c_cias_idx ON test_like_index_vu_prepare_c_cias;
 GO
@@ -63,6 +81,12 @@ DROP INDEX test_like_index_vu_prepare_c_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_cias;
 GO
 
 -- psql
@@ -77,6 +101,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_c_ciai_idx;
@@ -87,6 +117,12 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_ciai;
 GO
 
 -- NVARCHAR
@@ -100,6 +136,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_nv_cias_idx ON test_like_index_vu_prepare_nv_cias;
 GO
@@ -108,6 +147,9 @@ DROP INDEX test_like_index_vu_prepare_nv_cias_idx_composite ON test_like_index_v
 GO
 
 DROP TABLE test_like_index_vu_prepare_nv_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_cias;
 GO
 
 -- psql
@@ -122,6 +164,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_nv_ciai_idx;
@@ -132,6 +177,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_nv_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_ciai;
 GO
 
 -- TEXT
@@ -145,6 +193,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_t_cias_idx ON test_like_index_vu_prepare_t_cias;
 GO
@@ -153,6 +204,9 @@ DROP INDEX test_like_index_vu_prepare_t_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_t_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_cias;
 GO
 
 -- psql
@@ -167,6 +221,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csai;
+GO
+
 -- psql
 -- CI_AI
 DROP INDEX master_dbo.test_like_index_vu_prepare_t_ciai_idx;
@@ -177,6 +234,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_t_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_ciai;
 GO
 
 -- COMMON TABLE FOR JOIN

--- a/test/JDBC/expected/test_like_index-vu-prepare.out
+++ b/test/JDBC/expected/test_like_index-vu-prepare.out
@@ -20,6 +20,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csas(new_test_like_index_vu_prepare_v_csas_col varchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_v_cias(
     test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as,
@@ -38,6 +56,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_v_cias(new_test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -62,6 +98,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csai(new_test_like_index_vu_prepare_v_csai_col varchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_v_ciai(
     test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai,
@@ -82,6 +136,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_v_ciai(new_test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CHAR
@@ -105,6 +177,33 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csas(new_test_like_index_vu_prepare_c_csas_col char(1000) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csas (new_test_like_index_vu_prepare_c_fixed_csas_col char(4) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_c_cias(
     test_like_index_vu_prepare_c_cias_col char(8000) collate latin1_general_ci_as,
@@ -123,6 +222,33 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_c_cias(new_test_like_index_vu_prepare_c_cias_col char(1000) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_cias (new_test_like_index_vu_prepare_c_fixed_cias_col char(4) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -147,6 +273,33 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csai(new_test_like_index_vu_prepare_c_csai_col char(1000) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csai (new_test_like_index_vu_prepare_c_fixed_csai_col char(4) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_c_ciai(
     test_like_index_vu_prepare_c_ciai_col char(8000) collate latin1_general_ci_ai,
@@ -167,6 +320,33 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_c_ciai(new_test_like_index_vu_prepare_c_ciai_col char(1000) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_ciai (new_test_like_index_vu_prepare_c_fixed_ciai_col char(4) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 -- NVARCHAR
@@ -190,6 +370,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csas(new_test_like_index_vu_prepare_nv_csas_col nvarchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_nv_cias(
     test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as,
@@ -208,6 +406,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_cias(new_test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -232,6 +448,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csai(new_test_like_index_vu_prepare_nv_csai_col nvarchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_nv_ciai(
     test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai,
@@ -252,6 +486,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_ciai(new_test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 -- TEXT Tables
@@ -275,6 +527,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csas(new_test_like_index_vu_prepare_t_csas_col TEXT collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES(' csas');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_t_cias(
     test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as,
@@ -293,6 +563,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_t_cias(new_test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES(' cias');
+GO
+~~ROW COUNT: 1~~
 
 
 -- CS_AI
@@ -317,6 +605,24 @@ GO
 ~~ROW COUNT: 1000~~
 
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csai(new_test_like_index_vu_prepare_t_csai_col TEXT collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES(' csai');
+GO
+~~ROW COUNT: 1~~
+
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_t_ciai(
     test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai,
@@ -337,6 +643,24 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
 GO
 ~~ROW COUNT: 1000~~
+
+
+CREATE TABLE new_test_like_index_vu_prepare_t_ciai(new_test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai ');
+GO
+~~ROW COUNT: 1~~
+
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES(' ciai');
+GO
+~~ROW COUNT: 1~~
 
 
 

--- a/test/JDBC/expected/test_like_index-vu-verify.out
+++ b/test/JDBC/expected/test_like_index-vu-verify.out
@@ -57,6 +57,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -104,6 +105,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -153,6 +155,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -201,6 +204,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -248,6 +252,7 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -297,6 +302,7 @@ WHERE test_like_index_vu_prepare_v_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_v_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_v_cs1be7daa864eef6c8c3e0c3048d8f7fef on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_csas_col2 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col3 = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_v_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -344,7 +350,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csas_col
 FROM test_like_index_vu_prepare_v_csas 
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar")
+  Filter: (((test_like_index_vu_prepare_v_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar"))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -370,6 +376,67 @@ Seq Scan on test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+varchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+varchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = 'csas '::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+varchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_v_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_csas_col = ' csas'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -390,6 +457,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -406,6 +474,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -463,6 +532,7 @@ ON t1.test_like_index_vu_prepare_v_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_cs84732f1ac470066fb5b0b1aa0dc83304 on test_like_index_vu_prepare_v_csas t1
         Index Cond: (test_like_index_vu_prepare_v_csas_col = 'cs1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_v_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -478,7 +548,7 @@ FROM test_like_index_vu_prepare_v_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_v_csas t1
 ~~END~~
 
@@ -548,6 +618,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -595,6 +666,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -644,6 +716,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -692,6 +765,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -739,6 +813,7 @@ FROM test_like_index_vu_prepare_v_cias
 WHERE test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+  Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -788,6 +863,7 @@ WHERE test_like_index_vu_prepare_v_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_v_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_v_ci06c213505bb54e5b30098481866856c0 on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_v_cias_col2 = 'ci1'::"varchar") AND (test_like_index_vu_prepare_v_cias_col3 = 'ci1'::"varchar"))
+  Filter: (((test_like_index_vu_prepare_v_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_v_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -835,7 +911,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_cias_col
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_v_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -861,6 +937,67 @@ Seq Scan on test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+varchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias'::"varchar"))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+varchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = 'cias '::"varchar"))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+varchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_v_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_v_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_v_cias_col = ' cias'::"varchar"))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -881,6 +1018,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -897,6 +1035,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -954,6 +1093,7 @@ ON t1.test_like_index_vu_prepare_v_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_v_ci2d75c4ad76ed9b58a88ba0a93bab0133 on test_like_index_vu_prepare_v_cias t1
         Index Cond: (test_like_index_vu_prepare_v_cias_col = 'ci1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_v_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -970,6 +1110,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_cias t1
 ~~END~~
 
@@ -1042,6 +1183,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1088,6 +1230,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1137,6 +1280,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1183,6 +1327,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1229,6 +1374,7 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1278,6 +1424,7 @@ WHERE test_like_index_vu_prepare_v_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_v_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_v_csai_idx_composite on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1323,7 +1470,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col
 FROM test_like_index_vu_prepare_v_csai 
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1349,6 +1496,67 @@ Seq Scan on test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+varchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+varchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+varchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_v_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1369,6 +1577,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1385,6 +1594,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
 ~~END~~
 
@@ -1442,6 +1652,7 @@ ON t1.test_like_index_vu_prepare_v_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_csai_idx on test_like_index_vu_prepare_v_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1456,10 +1667,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -1528,6 +1738,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1574,6 +1785,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1623,6 +1835,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1669,6 +1882,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1715,6 +1929,7 @@ FROM test_like_index_vu_prepare_v_ciai
 WHERE test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -1764,6 +1979,7 @@ WHERE test_like_index_vu_prepare_v_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_v_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_v_ciai_idx_composite on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -1809,7 +2025,7 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -1835,6 +2051,67 @@ Seq Scan on test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+varchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+varchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+varchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_v_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_v_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1854,6 +2131,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1870,6 +2148,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
 ~~END~~
 
@@ -1927,6 +2206,7 @@ ON t1.test_like_index_vu_prepare_v_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_v_ciai_idx on test_like_index_vu_prepare_v_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_v_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -1941,10 +2221,9 @@ Query Text: SELECT test_like_index_vu_prepare_v_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_v_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_v_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -2015,6 +2294,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2060,6 +2340,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2106,6 +2387,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2154,6 +2436,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2199,6 +2482,7 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2245,6 +2529,7 @@ WHERE test_like_index_vu_prepare_c_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_c_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_c_cs791a5fc798e23d1a51f5f87124680363 on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_csas_col2 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col3 = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_c_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2292,7 +2577,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csas_col
 FROM test_like_index_vu_prepare_c_csas 
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar)
+  Filter: (((test_like_index_vu_prepare_c_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2318,6 +2603,125 @@ Seq Scan on test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+ csas                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+char
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = 'csas '::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csas (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_csas_col = ' csas'::bpchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2338,6 +2742,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2354,6 +2759,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2409,6 +2815,7 @@ ON t1.test_like_index_vu_prepare_c_csas_col LIKE 'cs1' COLLATE latin1_general_cs
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_csc57b567326112a54a52b273738c78881 on test_like_index_vu_prepare_c_csas t1
         Index Cond: (test_like_index_vu_prepare_c_csas_col = 'cs1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_c_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2424,7 +2831,7 @@ FROM test_like_index_vu_prepare_c_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_c_csas t1
 ~~END~~
 
@@ -2492,6 +2899,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2537,6 +2945,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2583,6 +2992,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2631,6 +3041,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2676,6 +3087,7 @@ FROM test_like_index_vu_prepare_c_cias
 WHERE test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+  Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -2722,6 +3134,7 @@ WHERE test_like_index_vu_prepare_c_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_c_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_c_ci31b79f3450a4c7378407c1b6e6ccd10e on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_c_cias_col2 = 'ci1'::bpchar) AND (test_like_index_vu_prepare_c_cias_col3 = 'ci1'::bpchar))
+  Filter: (((test_like_index_vu_prepare_c_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_c_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -2769,7 +3182,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_cias_col
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_c_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -2795,6 +3208,125 @@ Seq Scan on test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias'::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = 'cias '::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+ cias                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_cias_col = ' cias'::bpchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+char
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias'::bpchar))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = 'cias '::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_cias (actual rows=0.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_c_fixed_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_c_fixed_cias_col = ' cias'::bpchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2815,6 +3347,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2831,6 +3364,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2886,6 +3420,7 @@ ON t1.test_like_index_vu_prepare_c_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_c_ci217f3585158e2dbe6ae3ecd7b6c05ffa on test_like_index_vu_prepare_c_cias t1
         Index Cond: (test_like_index_vu_prepare_c_cias_col = 'ci1'::bpchar)
+        Filter: ((test_like_index_vu_prepare_c_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -2902,6 +3437,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_cias t1
 ~~END~~
 
@@ -2972,6 +3508,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3015,6 +3552,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3061,6 +3599,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3107,6 +3646,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3150,6 +3690,7 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3196,6 +3737,7 @@ WHERE test_like_index_vu_prepare_c_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_c_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_c_csai_idx_composite on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3241,7 +3783,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col
 FROM test_like_index_vu_prepare_c_csai 
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3267,6 +3809,125 @@ Seq Scan on test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+ csai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+char
+csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_csai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3287,6 +3948,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3303,6 +3965,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
 ~~END~~
 
@@ -3358,6 +4021,7 @@ ON t1.test_like_index_vu_prepare_c_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_csai_idx on test_like_index_vu_prepare_c_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3372,10 +4036,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -3442,6 +4105,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3485,6 +4149,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3531,6 +4196,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3577,6 +4243,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3620,6 +4287,7 @@ FROM test_like_index_vu_prepare_c_ciai
 WHERE test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -3666,6 +4334,7 @@ WHERE test_like_index_vu_prepare_c_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_c_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_c_ciai_idx_composite on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -3711,7 +4380,7 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -3737,6 +4406,125 @@ Seq Scan on test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+ ciai                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+char
+ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+char
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_c_fixed_ciai (actual rows=0.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_c_fixed_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -3758,6 +4546,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3774,6 +4563,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
 ~~END~~
 
@@ -3829,6 +4619,7 @@ ON t1.test_like_index_vu_prepare_c_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_c_ciai_idx on test_like_index_vu_prepare_c_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_c_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -3843,10 +4634,9 @@ Query Text: SELECT test_like_index_vu_prepare_c_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_c_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_c_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -3914,6 +4704,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -3961,6 +4752,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4010,6 +4802,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4058,6 +4851,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4105,6 +4899,7 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4154,6 +4949,7 @@ WHERE test_like_index_vu_prepare_nv_csas_col2 LIKE 'cs1'
 AND test_like_index_vu_prepare_nv_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_nv_c99e80581dc4bb40f645fc48f195d2c30 on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_csas_col2 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col3 = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (((test_like_index_vu_prepare_nv_csas_col2)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_csas_col3)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4201,7 +4997,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csas_col
 FROM test_like_index_vu_prepare_nv_csas 
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar)
+  Filter: (((test_like_index_vu_prepare_nv_csas_col)::text ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4227,6 +5023,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+nvarchar
+csas
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+nvarchar
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = 'csas '::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+nvarchar
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_nv_csas (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_csas_col)::text ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_csas_col = ' csas'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4247,6 +5104,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4263,6 +5121,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4320,6 +5179,7 @@ ON t1.test_like_index_vu_prepare_nv_csas_col LIKE 'cs1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_ca8b74d26b39141ade7d5b3aae3285f48 on test_like_index_vu_prepare_nv_csas t1
         Index Cond: (test_like_index_vu_prepare_nv_csas_col = 'cs1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+        Filter: ((test_like_index_vu_prepare_nv_csas_col)::text ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4335,7 +5195,7 @@ FROM test_like_index_vu_prepare_nv_csas t1 JOIN test_like_index_vu_prepare_t_com
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csas t1
 ~~END~~
 
@@ -4406,6 +5266,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4453,6 +5314,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4502,6 +5364,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4550,6 +5413,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4597,6 +5461,7 @@ FROM test_like_index_vu_prepare_nv_cias
 WHERE test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+  Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4646,6 +5511,7 @@ WHERE test_like_index_vu_prepare_nv_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_nv_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_nv_c0e22aed5922b7184785c4615b7989383 on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_nv_cias_col2 = 'ci1'::nvarchar) AND (test_like_index_vu_prepare_nv_cias_col3 = 'ci1'::nvarchar))
+  Filter: (((test_like_index_vu_prepare_nv_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_nv_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -4693,7 +5559,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_cias_col
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_nv_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -4719,6 +5585,67 @@ Seq Scan on test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+nvarchar
+cias
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=2.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias'::nvarchar))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+nvarchar
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = 'cias '::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+nvarchar
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_nv_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_nv_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_nv_cias_col = ' cias'::nvarchar))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -4739,6 +5666,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4755,6 +5683,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4812,6 +5741,7 @@ ON t1.test_like_index_vu_prepare_nv_cias_col LIKE 'ci1' COLLATE latin1_general_c
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_nv_cbf6b47879b13fa596ab94667e81ae9c9 on test_like_index_vu_prepare_nv_cias t1
         Index Cond: (test_like_index_vu_prepare_nv_cias_col = 'ci1'::nvarchar)
+        Filter: ((test_like_index_vu_prepare_nv_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -4828,6 +5758,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_cias t1
 ~~END~~
 
@@ -4900,6 +5831,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4946,6 +5878,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -4995,6 +5928,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5041,6 +5975,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5087,6 +6022,7 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5136,6 +6072,7 @@ WHERE test_like_index_vu_prepare_nv_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_nv_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_nv_csai_idx_composite on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col2)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col3)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5181,7 +6118,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col
 FROM test_like_index_vu_prepare_nv_csai 
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5207,6 +6144,67 @@ Seq Scan on test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+nvarchar
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+nvarchar
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+nvarchar
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_nv_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_csai_col)::text) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5227,6 +6225,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5243,6 +6242,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
 ~~END~~
 
@@ -5300,6 +6300,7 @@ ON t1.test_like_index_vu_prepare_nv_csai_col LIKE 'csai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_csai_idx on test_like_index_vu_prepare_nv_csai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_csai_col)::text))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5314,10 +6315,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_csai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -5386,6 +6386,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5432,6 +6433,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5481,6 +6483,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5527,6 +6530,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5573,6 +6577,7 @@ FROM test_like_index_vu_prepare_nv_ciai
 WHERE test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5622,6 +6627,7 @@ WHERE test_like_index_vu_prepare_nv_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_nv_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_nv_ciai_idx_composite on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col2)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col3)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -5667,7 +6673,7 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -5693,6 +6699,67 @@ Seq Scan on test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+nvarchar
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+nvarchar
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+nvarchar
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_nv_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((new_test_like_index_vu_prepare_nv_ciai_col)::text) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -5713,6 +6780,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5729,6 +6797,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
 ~~END~~
 
@@ -5786,6 +6855,7 @@ ON t1.test_like_index_vu_prepare_nv_ciai_col LIKE 'ciai1' COLLATE latin1_general
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_nv_ciai_idx on test_like_index_vu_prepare_nv_ciai t1
         Index Cond: (remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal((test_like_index_vu_prepare_nv_ciai_col)::text))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -5800,10 +6870,9 @@ Query Text: SELECT test_like_index_vu_prepare_nv_ciai_col, test_like_index_vu_pr
 FROM test_like_index_vu_prepare_nv_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_nv_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 
@@ -5872,7 +6941,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -5917,7 +6987,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -5963,7 +7034,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1'
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6011,7 +7083,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6056,7 +7129,8 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col_no_idx
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6102,7 +7176,8 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col2 LIKE 'cs1' 
 AND test_like_index_vu_prepare_t_csas_col3 LIKE 'cs1' COLLATE latin1_general_cs_as
 Index Only Scan using test_like_index_vu_prepare_t_csce712f1af9d7f9e1f899be47087d5a6f on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Index Cond: ((test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col2 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col3 = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+  Filter: ((test_like_index_vu_prepare_t_csas_col2 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col3 ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6150,7 +7225,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csas_col
 FROM test_like_index_vu_prepare_t_csas 
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs1'
 Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text)
+  Filter: ((test_like_index_vu_prepare_t_csas_col ~~* 'cs1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6176,6 +7251,66 @@ Seq Scan on test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+~~START~~
+text
+csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+~~START~~
+text
+csas 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas '
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ 'csas '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = 'csas '::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+~~START~~
+text
+ csas
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas'
+Seq Scan on new_test_like_index_vu_prepare_t_csas (actual rows=1.00 loops=1)
+  Filter: ((new_test_like_index_vu_prepare_t_csas_col ~~ ' csas'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_csas_col = ' csas'::text COLLATE bbf_unicode_cp1_cs_as))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6195,7 +7330,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6212,6 +7348,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6266,7 +7403,8 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t1.test_like_index_vu_prepare_t_csas_col LIKE 'cs1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_cs4eed40d3bd890c30153d1932e03e043b on test_like_index_vu_prepare_t_csas t1
-        Index Cond: (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
+        Index Cond: ((test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE "default") AND (test_like_index_vu_prepare_t_csas_col = 'cs1'::text COLLATE bbf_unicode_cp1_cs_as))
+        Filter: (test_like_index_vu_prepare_t_csas_col ~~ 'cs1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6282,7 +7420,7 @@ FROM test_like_index_vu_prepare_t_csas t1 JOIN test_like_index_vu_prepare_t_comm
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_as
 Nested Loop
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-        Filter: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as)
+        Filter: (((test_like_index_vu_prepare_t_common_col)::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar" COLLATE bbf_unicode_cp1_cs_as))
   ->  Seq Scan on test_like_index_vu_prepare_t_csas t1
 ~~END~~
 
@@ -6350,6 +7488,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6395,6 +7534,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6441,6 +7581,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1'
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6489,6 +7630,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6534,6 +7676,7 @@ FROM test_like_index_vu_prepare_t_cias
 WHERE test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+  Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6580,6 +7723,7 @@ WHERE test_like_index_vu_prepare_t_cias_col2 LIKE 'ci1'
 AND test_like_index_vu_prepare_t_cias_col3 LIKE 'ci1' COLLATE latin1_general_ci_as
 Index Only Scan using test_like_index_vu_prepare_t_ciaf182c036c48c240a6285e2fb3b90309 on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
   Index Cond: ((test_like_index_vu_prepare_t_cias_col2 = 'ci1'::text) AND (test_like_index_vu_prepare_t_cias_col3 = 'ci1'::text))
+  Filter: (((test_like_index_vu_prepare_t_cias_col2)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((test_like_index_vu_prepare_t_cias_col3)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Heap Fetches: 1
   Index Searches: 1
 ~~END~~
@@ -6627,7 +7771,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_cias_col
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci1'
 Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
-  Filter: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
+  Filter: (((test_like_index_vu_prepare_t_cias_col)::text ~~ 'ci1'::text COLLATE bbf_unicode_cp1_cs_as) AND (test_like_index_vu_prepare_t_cias_col = 'ci1'::text COLLATE bbf_unicode_cp1_cs_as))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -6653,6 +7797,66 @@ Seq Scan on test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+~~START~~
+text
+cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias'::text))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+~~START~~
+text
+cias 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias '
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* 'cias '::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = 'cias '::text))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+~~START~~
+text
+ cias
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias'
+Seq Scan on new_test_like_index_vu_prepare_t_cias (actual rows=1.00 loops=1)
+  Filter: (((new_test_like_index_vu_prepare_t_cias_col)::text ~~* ' cias'::text COLLATE bbf_unicode_cp1_cs_as) AND (new_test_like_index_vu_prepare_t_cias_col = ' cias'::text))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -6673,6 +7877,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6689,6 +7894,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6744,6 +7950,7 @@ ON t1.test_like_index_vu_prepare_t_cias_col LIKE 'ci1' COLLATE latin1_general_ci
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_ci4396880db55c57e891a5445ee6b9f8f9 on test_like_index_vu_prepare_t_cias t1
         Index Cond: (test_like_index_vu_prepare_t_cias_col = 'ci1'::text)
+        Filter: ((test_like_index_vu_prepare_t_cias_col)::text ~~* 'ci1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -6760,6 +7967,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_gene
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_cias t1
 ~~END~~
 
@@ -6830,6 +8038,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6876,6 +8085,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -6925,6 +8135,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1'
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -6971,6 +8182,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7017,6 +8229,7 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7066,6 +8279,7 @@ WHERE test_like_index_vu_prepare_t_csai_col2 LIKE 'csai1'
 AND test_like_index_vu_prepare_t_csai_col3 LIKE 'csai1' COLLATE latin1_general_cs_ai
 Index Scan using test_like_index_vu_prepare_t_csai_idx_composite on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_csai_col3) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_csai_col2))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col3))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7111,7 +8325,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col
 FROM test_like_index_vu_prepare_t_csai 
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai1'
 Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text))::text ~~* 'csai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_csai_col)::text) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7137,6 +8351,67 @@ Seq Scan on test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+~~START~~
+text
+csai
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+~~START~~
+text
+csai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai '
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = 'csai '::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+~~START~~
+text
+ csai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai'
+Seq Scan on new_test_like_index_vu_prepare_t_csai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col))::text ~~ ' csai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_csai_col) = ' csai'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7157,6 +8432,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7173,6 +8449,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
 ~~END~~
 
@@ -7230,6 +8507,7 @@ ON t1.test_like_index_vu_prepare_t_csai_col LIKE 'csai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_csai_idx on test_like_index_vu_prepare_t_csai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_csai_col) = 'csai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_csai_col))::text ~~ 'csai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7244,10 +8522,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_csai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_csai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_cs_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~ 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_csai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
 ~~END~~
 
 
@@ -7316,6 +8593,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7362,6 +8640,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7411,6 +8690,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1'
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7457,6 +8737,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7503,6 +8784,7 @@ FROM test_like_index_vu_prepare_t_ciai
 WHERE test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+  Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   Index Searches: 1
 ~~END~~
 
@@ -7552,6 +8834,7 @@ WHERE test_like_index_vu_prepare_t_ciai_col2 LIKE 'ciai1'
 AND test_like_index_vu_prepare_t_ciai_col3 LIKE 'ciai1' COLLATE latin1_general_ci_ai
 Index Scan using test_like_index_vu_prepare_t_ciai_idx_composite on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
   Index Cond: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai) AND (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Filter: (((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col2))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col3))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as))
   Index Searches: 1
 ~~END~~
 
@@ -7597,7 +8880,7 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai1'
 Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
-  Filter: (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai)
+  Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text))::text ~~ 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_ciai_col)::text) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_cs_ai))
   Rows Removed by Filter: 999
 ~~END~~
 
@@ -7623,6 +8906,67 @@ Seq Scan on test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
 ~~END~~
 
 
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+~~START~~
+text
+ciai
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=2.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 1
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+~~START~~
+text
+ciai 
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai '
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai '::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = 'ciai '::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+~~START~~
+text
+ ciai
+~~END~~
+
+~~START~~
+text
+Query Text: SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai'
+Seq Scan on new_test_like_index_vu_prepare_t_ciai (actual rows=1.00 loops=1)
+  Filter: (((remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col))::text ~~* ' ciai'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal(new_test_like_index_vu_prepare_t_ciai_col) = ' ciai'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
+  Rows Removed by Filter: 2
+~~END~~
+
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -7643,6 +8987,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1'
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7659,6 +9004,7 @@ ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1'
 Nested Loop
   ->  Index Only Scan using test_like_index_vu_prepare_t_co6aff0678de8b489ba66e2cc9af2b6c77 on test_like_index_vu_prepare_t_common t2
         Index Cond: (test_like_index_vu_prepare_t_common_col = 'common1'::"varchar")
+        Filter: ((test_like_index_vu_prepare_t_common_col)::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
 ~~END~~
 
@@ -7716,6 +9062,7 @@ ON t1.test_like_index_vu_prepare_t_ciai_col LIKE 'ciai1' COLLATE latin1_general_
 Nested Loop
   ->  Index Scan using test_like_index_vu_prepare_t_ciai_idx on test_like_index_vu_prepare_t_ciai t1
         Index Cond: (remove_accents_internal(test_like_index_vu_prepare_t_ciai_col) = 'ciai1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
+        Filter: ((remove_accents_internal(test_like_index_vu_prepare_t_ciai_col))::text ~~* 'ciai1'::text COLLATE bbf_unicode_cp1_cs_as)
   ->  Seq Scan on test_like_index_vu_prepare_t_common t2
 ~~END~~
 
@@ -7730,10 +9077,9 @@ Query Text: SELECT test_like_index_vu_prepare_t_ciai_col, test_like_index_vu_pre
 FROM test_like_index_vu_prepare_t_ciai t1 JOIN test_like_index_vu_prepare_t_common t2
 ON t2.test_like_index_vu_prepare_t_common_col LIKE 'common1' COLLATE latin1_general_ci_ai
 Nested Loop
+  ->  Seq Scan on test_like_index_vu_prepare_t_common t2
+        Filter: (((remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text))::text ~~* 'common1'::text COLLATE bbf_unicode_cp1_cs_as) AND (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai))
   ->  Seq Scan on test_like_index_vu_prepare_t_ciai t1
-  ->  Materialize
-        ->  Seq Scan on test_like_index_vu_prepare_t_common t2
-              Filter: (remove_accents_internal((test_like_index_vu_prepare_t_common_col)::text) = 'common1'::nvarchar COLLATE bbf_unicode_cp1_ci_ai)
 ~~END~~
 
 

--- a/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-cleanup.sql
+++ b/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-cleanup.sql
@@ -1,0 +1,202 @@
+-- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t1;
+GO
+
+-- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t2;
+GO
+
+-- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t3;
+GO
+
+-- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t4_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t4_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t4_2;
+GO
+
+-- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t5_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t5_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t5_2;
+GO
+
+-- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
+DROP VIEW BABEL_5608_vu_prepare_t6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t6;
+GO
+
+-- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t7_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t7_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t7_2;
+GO
+
+-- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
+DROP VIEW BABEL_5608_vu_prepare_t8_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t8_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t8_2;
+GO
+
+-- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
+DROP VIEW BABEL_5608_vu_prepare_t9_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_1;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_2_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_2;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_3_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_3;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_4_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_4;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_5;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_6_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_6;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_7_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_7;
+GO
+
+DROP VIEW BABEL_5608_vu_prepare_t9_8_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t9_8;
+GO
+
+-- CASE 10: ESCAPE WITH LIKE
+DROP VIEW BABEL_5608_vu_prepare_t10_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t10;
+GO
+
+-- CASE 11: T_CoerceViaIO
+DROP VIEW BABEL_5608_vu_prepare_t11_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t11;
+GO
+
+-- CASE 12: CFL CONDITIONS AND MORE
+-- IF ELSE
+DROP VIEW BABEL_5608_vu_prepare_t12_1_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_1;
+GO
+
+-- CASE WHEN
+DROP VIEW BABEL_5608_vu_prepare_t12_2_VIEW;
+GO
+
+-- COMPUTED COLUMN (BABEL-5022)
+-- DROP VIEW BABEL_5608_vu_prepare_t12_3_VIEW;
+-- GO
+
+-- DROP TABLE BABEL_5608_vu_prepare_t12_3;
+-- GO
+
+-- FUNCTIONS
+DROP FUNCTION BABEL_5608_vu_prepare_t12_fun1;
+GO
+
+-- PROCEDURE
+DROP PROCEDURE BABEL_5608_vu_prepare_t12_proc1;
+GO
+
+-- CASE 13: VIEW WITH LIKE
+DROP VIEW BABEL_5608_13_1_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_2_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_3_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_4_VIEW;
+GO
+
+DROP VIEW BABEL_5608_13_5_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t12_2;
+GO
+
+-- CASE 14: PostFix Pattern match
+DROP VIEW BABEL_5608_vu_prepare_t14_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t14;
+GO
+
+-- CASE 15: T_Const LIKE T_Const
+DROP VIEW BABEL_5608_vu_prepare_t15_VIEW;
+GO
+
+DROP TABLE BABEL_5608_vu_prepare_t15;
+GO

--- a/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-prepare.mix
+++ b/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-prepare.mix
@@ -165,13 +165,13 @@ CREATE VIEW BABEL_5608_vu_prepare_t12_2_VIEW AS SELECT * FROM BABEL_5608_vu_prep
 GO
 
 
-
-
 -- COMPUTED COLUMNS (BABEL-5022)
 -- CREATE TABLE BABEL_5608_vu_prepare_t12_3 (name varchar(10), is_product AS CASE WHEN name LIKE 'PRD%' THEN 1 WHEN name LIKE 'DRP' THEN 2 ELSE 0 END PERSISTED);
 -- GO
+
 -- CREATE VIEW BABEL_5608_vu_prepare_t12_3_VIEW AS SELECT * FROM BABEL_5608_vu_prepare_t12_3;
 -- GO
+
 -- FUNCTION
 CREATE FUNCTION BABEL_5608_vu_prepare_t12_fun1
 (
@@ -234,287 +234,122 @@ GO
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t4_1_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('ABC'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t4_2_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t6_col1)::text COLLATE sys.chinese_prc_cs_as) ~~* ((babel_5608_vu_prepare_t6_col2)::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('abc'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text COLLATE sys.chinese_prc_cs_as) ~~* ('a%'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 10: ESCAPE WITH LIKE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 11: T_CoerceViaIO
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar")::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
 GO
-~~START~~
-text
-CHECK (((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar") THEN 1<newline>    ELSE 0<newline>END = 1)))
-~~END~~
-
 
 -- CASE WHEN
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((<newline>CASE<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('act%'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    WHEN (((status)::text COLLATE sys.chinese_prc_cs_as) ~~* ('inactive'::text COLLATE sys.chinese_prc_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
-~~END~~
-
-
 
 -- COMPUTED COLUMNS (BABEL-5022)
 -- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
 -- GO
+
 -- FUNCTION
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
-~~END~~
-
 
 -- PROCEDURE
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
-~~END~~
-
 
 
 -- CASE 13: VIEW WITH LIKE
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.chinese_prc_ci_as) ~~ 'ac%'::text;
-~~END~~
-
 
 -- CASE 14: PostFix Pattern match
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 15: T_Const LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.chinese_prc_cs_as) ~~* ('A%'::text COLLATE sys.chinese_prc_cs_as)))
-~~END~~
-

--- a/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-verify.mix
+++ b/test/JDBC/input/test_constraint_like_before_17_8-or-16_12-vu-verify.mix
@@ -2,344 +2,166 @@
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t1 VALUES('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t1_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t2 VALUES('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t2_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t3 VALUES('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t3_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t4_1 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t4_1_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t4_2 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t4_2_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t5_1 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t5_1_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t5_2 VALUES ('Abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t5_2_VIEW;
 GO
-~~START~~
-varchar
-Abc
-~~END~~
-
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
 INSERT INTO BABEL_5608_vu_prepare_t6 VALUES('abc', 'ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t6_VIEW;
 GO
-~~START~~
-varchar#!#varchar
-abc#!#ABC
-~~END~~
-
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t7_1 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t7_1_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t7_2 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t7_2_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
 INSERT INTO BABEL_5608_vu_prepare_t8_1 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t8_1_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t8_2 VALUES('ABC');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t8_2_VIEW;
 GO
-~~START~~
-varchar
-ABC
-~~END~~
-
 
 -- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINATIONS
 INSERT INTO BABEL_5608_vu_prepare_t9_1 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_1_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_2 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_2_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_3 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_3_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_4 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_4_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_5 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_5_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_6 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_6_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_7 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_7_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 INSERT INTO BABEL_5608_vu_prepare_t9_8 VALUES('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t9_8_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- CASE 10: ESCAPE WITH LIKE
 INSERT INTO BABEL_5608_vu_prepare_t10 values('15% off');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t10_VIEW;
 GO
-~~START~~
-varchar
-15% off
-~~END~~
-
 
 -- CASE 11: T_CoerceViaIO
 INSERT INTO BABEL_5608_vu_prepare_t11 values('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t11_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
 INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('active');
 INSERT INTO BABEL_5608_vu_prepare_t12_1 VALUES ('inactive');
 GO
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_1_VIEW;
 GO
-~~START~~
-varchar
-active
-inactive
-~~END~~
-
 
 -- CASE WHEN
 INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('active');
 INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('inactive');
 GO
-~~ROW COUNT: 1~~
-
-~~ROW COUNT: 1~~
-
 
 -- should fail
 INSERT INTO BABEL_5608_vu_prepare_t12_2 VALUES ('idle');
 GO
-~~ERROR (Code: 547)~~
-
-~~ERROR (Message: new row for relation "babel_5608_vu_prepare_t12_2" violates check constraint "chk_status")~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_2_VIEW;
 GO
-~~START~~
-varchar
-active
-inactive
-~~END~~
-
 
 -- IF EXISTS
 IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'act%'))
@@ -351,11 +173,6 @@ BEGIN
     SELECT 'No matches found'
 END
 GO
-~~START~~
-varchar
-Found matching records
-~~END~~
-
 
 IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'inactive'))
 BEGIN
@@ -366,11 +183,6 @@ BEGIN
     SELECT 'No matches found'
 END
 GO
-~~START~~
-varchar
-Found matching records
-~~END~~
-
 
 IF (EXISTS (SELECT 1 FROM BABEL_5608_vu_prepare_t12_2 WHERE status LIKE 'idle'))
 BEGIN
@@ -381,424 +193,187 @@ BEGIN
     SELECT 'No matches found'
 END
 GO
-~~START~~
-varchar
-No matches found
-~~END~~
-
-
-
-
 
 -- COMPUTED COLUMNS (BABEL-5022)
 -- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('prd'),('drp');
 -- GO
+
 -- INSERT INTO BABEL_5608_vu_prepare_t12_3(name) VALUES('r');
 -- GO
+
 -- SELECT * FROM BABEL_5608_vu_prepare_t12_3_VIEW;
 -- GO
+
 -- FUNCTION
 SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('act%');
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('inactive');
 GO
-~~START~~
-varchar
-inactive
-~~END~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t12_fun1('idle%');
 GO
-~~START~~
-varchar
-~~END~~
-
 
 
 -- PROCEDURE
 EXEC BABEL_5608_vu_prepare_t12_proc1 'act%';
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 EXEC BABEL_5608_vu_prepare_t12_proc1 'inactive';
 GO
-~~START~~
-varchar
-inactive
-~~END~~
-
 
 EXEC BABEL_5608_vu_prepare_t12_proc1 'idle';
 GO
-~~START~~
-varchar
-~~END~~
-
 
 -- CASE 13: VIEW WITH LIKE
 SELECT * FROM BABEL_5608_13_1_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_2_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_3_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_4_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 SELECT * FROM BABEL_5608_13_5_VIEW;
 GO
-~~START~~
-varchar
-active
-~~END~~
-
 
 -- CASE 14: PostFix Pattern match
 INSERT INTO BABEL_5608_vu_prepare_t14 VALUES ('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t14_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- CASE 15: T_Const LIKE T_Const
 INSERT INTO BABEL_5608_vu_prepare_t15 VALUES ('abc');
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT * FROM BABEL_5608_vu_prepare_t15_VIEW;
 GO
-~~START~~
-varchar
-abc
-~~END~~
-
 
 -- psql
 -- CASE 1: T_Const LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t1'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 2: T_CollateExpr(T_Const) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t2'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 3: T_CollateExpr(T_Const) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t3'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 4: T_ReLabelType (T_Var) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t4_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t4_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t4_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 5: T_ReLabelType(T_Var) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_1_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('ABC'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t5_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t5_2_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 6: T_ReLabelType(T_Var) LIKE T_ReLabelType(T_Var)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col1)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal((babel_5608_vu_prepare_t6_col2)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 7: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t7_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t7_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 8: T_CollateExpr(T_ReLabel(T_Var)) LIKE T_CollateExpr(T_Const)
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_1_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t8_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t8_2_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 9: T_FuncExpr LIKE T_CollateExpr(T_Const) AND COMBINTAIONS
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_1'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_1_col1))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower(babel_5608_vu_prepare_t9_2_col1))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_3'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_3_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_4'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_4_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_5'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_5_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_6'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_6_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_7'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal((sys.lower((babel_5608_vu_prepare_t9_7_col1 COLLATE sys.bbf_unicode_cp1_ci_ai)))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t9_8'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((sys.lower(babel_5608_vu_prepare_t9_8_col1))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('a%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 10: ESCAPE WITH LIKE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t10'::regclass;
 GO
-~~START~~
-text
-CHECK ((((babel_5608_vu_prepare_t10_col1)::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* (like_escape('15/% %'::text, '/'::text) COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 11: T_CoerceViaIO
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t11'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((('123'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai)::sys.nvarchar(3))::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ((sys.remove_accents_internal(((123)::sys."varchar"(3))::text))::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 12: CFL CONDITIONS AND MORE
 -- IF ELSE
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_1'::regclass;
 GO
-~~START~~
-text
-CHECK (((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1) OR (<newline>CASE<newline>    WHEN (status = 'inactive'::sys."varchar" COLLATE sys.bbf_unicode_cp1_ci_ai) THEN 1<newline>    ELSE 0<newline>END = 1)))
-~~END~~
-
 
 -- CASE WHEN
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_2'::regclass;
 GO
-~~START~~
-text
-CHECK ((<newline>CASE<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('act%'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    WHEN (((sys.remove_accents_internal((status)::text))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('inactive'::text COLLATE sys.bbf_unicode_cp1_cs_as)) THEN 1<newline>    ELSE 0<newline>END = 1))
-~~END~~
-
-
 
 -- COMPUTED COLUMNS (BABEL-5022)
 -- SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t12_3'::regclass;
 -- GO
+
 -- FUNCTION
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_fun1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE FUNCTION master_dbo.babel_5608_vu_prepare_t12_fun1("@pattern" sys."varchar")<newline> RETURNS TABLE(status sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100", "-1"], "original_probin": ""}', $function$RETURN<newline>(<newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>);$function$<newline>
-~~END~~
-
 
 -- PROCEDURE
 SELECT pg_get_functiondef(CAST('master_dbo.BABEL_5608_vu_prepare_t12_proc1' as regproc));
 GO
-~~START~~
-text
-CREATE OR REPLACE PROCEDURE master_dbo.babel_5608_vu_prepare_t12_proc1(IN "@pattern" sys."varchar")<newline> LANGUAGE pltsql<newline>AS '{"version_num": "1", "typmod_array": ["100"], "original_probin": ""}', $procedure$BEGIN<newline>    SET NOCOUNT ON;<newline>    <newline>    SELECT * FROM BABEL_5608_vu_prepare_t12_2<newline>    WHERE status LIKE @pattern<newline>END;$procedure$<newline>
-~~END~~
-
 
 -- CASE 13: VIEW WITH LIKE
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_1_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_2_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (status::text COLLATE sys.estonian_ci_ai) ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_3_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE status::text ~~ ('ac%'::text COLLATE sys.estonian_ci_ai);
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_4_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE sys.upper(status)::text ~~ 'ac%'::text;
-~~END~~
-
 
 SELECT pg_get_viewdef('master_dbo.BABEL_5608_13_5_VIEW', true);
 GO
-~~START~~
-text
- SELECT status<newline>   FROM master_dbo.babel_5608_vu_prepare_t12_2<newline>  WHERE (sys.upper(status)::text COLLATE sys.bbf_unicode_cp1_ci_ai) ~~ 'ac%'::text;
-~~END~~
-
 
 -- CASE 14: PostFix Pattern match
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t14'::regclass;
 GO
-~~START~~
-text
-CHECK ((((sys.remove_accents_internal(((babel_5608_vu_prepare_t14_col1)::text COLLATE sys.bbf_unicode_cp1_ci_ai)))::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('%abc'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-
 
 -- CASE 15: T_Const LIKE T_Const
 SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'master_dbo.BABEL_5608_vu_prepare_t15'::regclass;
 GO
-~~START~~
-text
-CHECK ((('abc'::text COLLATE sys.bbf_unicode_cp1_cs_as) ~~* ('A%'::text COLLATE sys.bbf_unicode_cp1_cs_as)))
-~~END~~
-

--- a/test/JDBC/input/test_like_index-vu-cleanup.mix
+++ b/test/JDBC/input/test_like_index-vu-cleanup.mix
@@ -10,6 +10,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_v_cias_idx ON test_like_index_vu_prepare_v_cias;
 GO
@@ -18,6 +21,9 @@ DROP INDEX test_like_index_vu_prepare_v_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_v_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_cias;
 GO
 
 -- CS_AI
@@ -32,6 +38,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_v_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_v_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_v_ciai_idx;
@@ -42,6 +51,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_v_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_v_ciai;
 GO
 
 -- CHAR
@@ -55,6 +67,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csas;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_c_cias_idx ON test_like_index_vu_prepare_c_cias;
 GO
@@ -63,6 +81,12 @@ DROP INDEX test_like_index_vu_prepare_c_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_cias;
 GO
 
 -- CS_AI
@@ -77,6 +101,12 @@ GO
 DROP TABLE test_like_index_vu_prepare_c_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_c_csai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_c_ciai_idx;
@@ -87,6 +117,12 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_c_fixed_ciai;
 GO
 
 -- NVARCHAR
@@ -100,6 +136,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_nv_cias_idx ON test_like_index_vu_prepare_nv_cias;
 GO
@@ -108,6 +147,9 @@ DROP INDEX test_like_index_vu_prepare_nv_cias_idx_composite ON test_like_index_v
 GO
 
 DROP TABLE test_like_index_vu_prepare_nv_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_cias;
 GO
 
 -- CS_AI
@@ -122,6 +164,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_nv_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_nv_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_nv_ciai_idx;
@@ -132,6 +177,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_nv_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_nv_ciai;
 GO
 
 -- TEXT
@@ -145,6 +193,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csas;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csas;
+GO
+
 -- CI_AS
 DROP INDEX test_like_index_vu_prepare_t_cias_idx ON test_like_index_vu_prepare_t_cias;
 GO
@@ -153,6 +204,9 @@ DROP INDEX test_like_index_vu_prepare_t_cias_idx_composite ON test_like_index_vu
 GO
 
 DROP TABLE test_like_index_vu_prepare_t_cias;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_cias;
 GO
 
 -- CS_AI
@@ -167,6 +221,9 @@ GO
 DROP TABLE test_like_index_vu_prepare_t_csai;
 GO
 
+DROP TABLE new_test_like_index_vu_prepare_t_csai;
+GO
+
 -- CI_AI
 -- psql
 DROP INDEX master_dbo.test_like_index_vu_prepare_t_ciai_idx;
@@ -177,6 +234,9 @@ GO
 
 -- tsql
 DROP TABLE test_like_index_vu_prepare_t_ciai;
+GO
+
+DROP TABLE new_test_like_index_vu_prepare_t_ciai;
 GO
 
 -- COMMON TABLE FOR JOIN

--- a/test/JDBC/input/test_like_index-vu-prepare.mix
+++ b/test/JDBC/input/test_like_index-vu-prepare.mix
@@ -18,6 +18,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csas(new_test_like_index_vu_prepare_v_csas_col varchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csas VALUES(' csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_v_cias(
     test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as,
@@ -34,6 +46,18 @@ CREATE INDEX test_like_index_vu_prepare_v_cias_idx_composite ON test_like_index_
 GO
 
 INSERT INTO test_like_index_vu_prepare_v_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_v_cias(new_test_like_index_vu_prepare_v_cias_col varchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_cias VALUES(' cias');
 GO
 
 -- CS_AI
@@ -56,6 +80,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_v_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_v_csai(new_test_like_index_vu_prepare_v_csai_col varchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_csai VALUES(' csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_v_ciai(
     test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai,
@@ -74,6 +110,18 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_v_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_v_ciai(new_test_like_index_vu_prepare_v_ciai_col varchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_v_ciai VALUES(' ciai');
 GO
 
 -- CHAR
@@ -95,6 +143,25 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csas(new_test_like_index_vu_prepare_c_csas_col char(1000) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csas VALUES(' csas');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csas (new_test_like_index_vu_prepare_c_fixed_csas_col char(4) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csas VALUES('csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_c_cias(
     test_like_index_vu_prepare_c_cias_col char(8000) collate latin1_general_ci_as,
@@ -111,6 +178,25 @@ CREATE INDEX test_like_index_vu_prepare_c_cias_idx_composite ON test_like_index_
 GO
 
 INSERT INTO test_like_index_vu_prepare_c_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_c_cias(new_test_like_index_vu_prepare_c_cias_col char(1000) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_cias VALUES(' cias');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_cias (new_test_like_index_vu_prepare_c_fixed_cias_col char(4) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_cias VALUES('cias');
 GO
 
 -- CS_AI
@@ -133,6 +219,25 @@ GO
 INSERT INTO test_like_index_vu_prepare_c_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_c_csai(new_test_like_index_vu_prepare_c_csai_col char(1000) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_csai VALUES(' csai');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_csai (new_test_like_index_vu_prepare_c_fixed_csai_col char(4) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_csai VALUES('csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_c_ciai(
     test_like_index_vu_prepare_c_ciai_col char(8000) collate latin1_general_ci_ai,
@@ -151,6 +256,25 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_c_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_c_ciai(new_test_like_index_vu_prepare_c_ciai_col char(1000) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_ciai VALUES(' ciai');
+GO
+
+-- new char table without padding
+CREATE TABLE new_test_like_index_vu_prepare_c_fixed_ciai (new_test_like_index_vu_prepare_c_fixed_ciai_col char(4) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_c_fixed_ciai VALUES('ciai');
 GO
 
 -- NVARCHAR
@@ -172,6 +296,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csas(new_test_like_index_vu_prepare_nv_csas_col nvarchar(max) collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csas VALUES(' csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_nv_cias(
     test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as,
@@ -188,6 +324,18 @@ CREATE INDEX test_like_index_vu_prepare_nv_cias_idx_composite ON test_like_index
 GO
 
 INSERT INTO test_like_index_vu_prepare_nv_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_cias(new_test_like_index_vu_prepare_nv_cias_col nvarchar(max) collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_cias VALUES(' cias');
 GO
 
 -- CS_AI
@@ -210,6 +358,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_nv_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_nv_csai(new_test_like_index_vu_prepare_nv_csai_col nvarchar(max) collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_csai VALUES(' csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_nv_ciai(
     test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai,
@@ -228,6 +388,18 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_nv_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_nv_ciai(new_test_like_index_vu_prepare_nv_ciai_col nvarchar(max) collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_nv_ciai VALUES(' ciai');
 GO
 
 -- TEXT Tables
@@ -249,6 +421,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_csas VALUES(CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)), CONCAT('cs', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csas(new_test_like_index_vu_prepare_t_csas_col TEXT collate latin1_general_cs_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES('csas ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csas VALUES(' csas');
+GO
+
 -- CI_AS
 CREATE TABLE test_like_index_vu_prepare_t_cias(
     test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as,
@@ -265,6 +449,18 @@ CREATE INDEX test_like_index_vu_prepare_t_cias_idx_composite ON test_like_index_
 GO
 
 INSERT INTO test_like_index_vu_prepare_t_cias VALUES(CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)), CONCAT('ci', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_t_cias(new_test_like_index_vu_prepare_t_cias_col TEXT collate latin1_general_ci_as);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES('cias ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_cias VALUES(' cias');
 GO
 
 -- CS_AI
@@ -287,6 +483,18 @@ GO
 INSERT INTO test_like_index_vu_prepare_t_csai VALUES(CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)), CONCAT('csai', generate_series(1,1000)));
 GO
 
+CREATE TABLE new_test_like_index_vu_prepare_t_csai(new_test_like_index_vu_prepare_t_csai_col TEXT collate latin1_general_cs_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES('csai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_csai VALUES(' csai');
+GO
+
 -- CI_AI
 CREATE TABLE test_like_index_vu_prepare_t_ciai(
     test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai,
@@ -305,6 +513,18 @@ GO
 
 -- tsql
 INSERT INTO test_like_index_vu_prepare_t_ciai VALUES(CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)), CONCAT('ciai', generate_series(1,1000)));
+GO
+
+CREATE TABLE new_test_like_index_vu_prepare_t_ciai(new_test_like_index_vu_prepare_t_ciai_col TEXT collate latin1_general_ci_ai);
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES('ciai ');
+GO
+
+INSERT INTO new_test_like_index_vu_prepare_t_ciai VALUES(' ciai');
 GO
 
 

--- a/test/JDBC/input/test_like_index-vu-verify.mix
+++ b/test/JDBC/input/test_like_index-vu-verify.mix
@@ -113,6 +113,21 @@ FROM test_like_index_vu_prepare_v_csas
 WHERE test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csas_col 
+FROM new_test_like_index_vu_prepare_v_csas 
+WHERE new_test_like_index_vu_prepare_v_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -267,6 +282,21 @@ GO
 SELECT test_like_index_vu_prepare_v_cias_col 
 FROM test_like_index_vu_prepare_v_cias 
 WHERE test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_cias_col 
+FROM new_test_like_index_vu_prepare_v_cias 
+WHERE new_test_like_index_vu_prepare_v_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -425,6 +455,21 @@ FROM test_like_index_vu_prepare_v_csai
 WHERE test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_csai_col 
+FROM new_test_like_index_vu_prepare_v_csai 
+WHERE new_test_like_index_vu_prepare_v_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -579,6 +624,21 @@ GO
 SELECT test_like_index_vu_prepare_v_ciai_col 
 FROM test_like_index_vu_prepare_v_ciai 
 WHERE test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_v_ciai_col 
+FROM new_test_like_index_vu_prepare_v_ciai 
+WHERE new_test_like_index_vu_prepare_v_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -738,6 +798,36 @@ FROM test_like_index_vu_prepare_c_csas
 WHERE test_like_index_vu_prepare_c_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csas_col 
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csas_col
+FROM new_test_like_index_vu_prepare_c_csas 
+WHERE new_test_like_index_vu_prepare_c_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csas_col
+FROM new_test_like_index_vu_prepare_c_fixed_csas 
+WHERE new_test_like_index_vu_prepare_c_fixed_csas_col  COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -892,6 +982,36 @@ GO
 SELECT test_like_index_vu_prepare_c_cias_col 
 FROM test_like_index_vu_prepare_c_cias 
 WHERE test_like_index_vu_prepare_c_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_cias_col 
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_cias_col
+FROM new_test_like_index_vu_prepare_c_cias 
+WHERE new_test_like_index_vu_prepare_c_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col 
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_cias_col
+FROM new_test_like_index_vu_prepare_c_fixed_cias 
+WHERE new_test_like_index_vu_prepare_c_fixed_cias_col  COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1050,6 +1170,36 @@ FROM test_like_index_vu_prepare_c_csai
 WHERE test_like_index_vu_prepare_c_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csai_col 
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_csai_col
+FROM new_test_like_index_vu_prepare_c_csai 
+WHERE new_test_like_index_vu_prepare_c_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_csai_col
+FROM new_test_like_index_vu_prepare_c_fixed_csai 
+WHERE new_test_like_index_vu_prepare_c_fixed_csai_col  COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1204,6 +1354,36 @@ GO
 SELECT test_like_index_vu_prepare_c_ciai_col 
 FROM test_like_index_vu_prepare_c_ciai 
 WHERE test_like_index_vu_prepare_c_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col 
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_ciai_col
+FROM new_test_like_index_vu_prepare_c_ciai 
+WHERE new_test_like_index_vu_prepare_c_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col 
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_c_fixed_ciai_col
+FROM new_test_like_index_vu_prepare_c_fixed_ciai 
+WHERE new_test_like_index_vu_prepare_c_fixed_ciai_col  COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1364,6 +1544,21 @@ FROM test_like_index_vu_prepare_nv_csas
 WHERE test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csas_col 
+FROM new_test_like_index_vu_prepare_nv_csas 
+WHERE new_test_like_index_vu_prepare_nv_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1519,6 +1714,21 @@ GO
 SELECT test_like_index_vu_prepare_nv_cias_col 
 FROM test_like_index_vu_prepare_nv_cias 
 WHERE test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_cias_col 
+FROM new_test_like_index_vu_prepare_nv_cias 
+WHERE new_test_like_index_vu_prepare_nv_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1677,6 +1887,21 @@ FROM test_like_index_vu_prepare_nv_csai
 WHERE test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_csai_col 
+FROM new_test_like_index_vu_prepare_nv_csai 
+WHERE new_test_like_index_vu_prepare_nv_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -1831,6 +2056,21 @@ GO
 SELECT test_like_index_vu_prepare_nv_ciai_col 
 FROM test_like_index_vu_prepare_nv_ciai 
 WHERE test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_nv_ciai_col 
+FROM new_test_like_index_vu_prepare_nv_ciai 
+WHERE new_test_like_index_vu_prepare_nv_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -1990,6 +2230,21 @@ FROM test_like_index_vu_prepare_t_csas
 WHERE test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_ci_as LIKE 'cs999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE 'csas ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csas_col 
+FROM new_test_like_index_vu_prepare_t_csas 
+WHERE new_test_like_index_vu_prepare_t_csas_col COLLATE latin1_general_cs_as LIKE ' csas';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2144,6 +2399,21 @@ GO
 SELECT test_like_index_vu_prepare_t_cias_col 
 FROM test_like_index_vu_prepare_t_cias 
 WHERE test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_cs_as LIKE 'ci999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE 'cias ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_cias_col 
+FROM new_test_like_index_vu_prepare_t_cias 
+WHERE new_test_like_index_vu_prepare_t_cias_col COLLATE latin1_general_ci_as LIKE ' cias';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;
@@ -2302,6 +2572,21 @@ FROM test_like_index_vu_prepare_t_csai
 WHERE test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_ci_ai LIKE 'csai999%';
 GO
 
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE 'csai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_csai_col 
+FROM new_test_like_index_vu_prepare_t_csai 
+WHERE new_test_like_index_vu_prepare_t_csai_col COLLATE latin1_general_cs_ai LIKE ' csai';
+GO
+
 SET BABELFISH_STATISTICS PROFILE OFF;
 GO
 
@@ -2456,6 +2741,21 @@ GO
 SELECT test_like_index_vu_prepare_t_ciai_col 
 FROM test_like_index_vu_prepare_t_ciai 
 WHERE test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_cs_ai LIKE 'ciai999%';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE 'ciai ';
+GO
+
+SELECT new_test_like_index_vu_prepare_t_ciai_col 
+FROM new_test_like_index_vu_prepare_t_ciai 
+WHERE new_test_like_index_vu_prepare_t_ciai_col COLLATE latin1_general_ci_ai LIKE ' ciai';
 GO
 
 SET BABELFISH_STATISTICS PROFILE OFF;

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -766,3 +766,6 @@ ignore#!#datetime_roundoff-before-17_8-or-16_12-vu-cleanup
 ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-prepare
 ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-verify
 ignore#!#TestDatatypeAggSort-before-16_12-or-17_8-vu-cleanup
+ignore#!#test_constraint_like_before_17_8-or-16_12-vu-prepare
+ignore#!#test_constraint_like_before_17_8-or-16_12-vu-verify
+ignore#!#test_constraint_like_before_17_8-or-16_12-vu-cleanup

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -611,7 +611,7 @@ BABEL-NUMERIC_EXPR
 test_conv_float_to_varchar_char
 BABEL-5467
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 round_return_type_test-before-16_11-or-17_7
 alter-view
 test_conv_int_to_varbinary_binary

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -611,7 +611,7 @@ BABEL-NUMERIC_EXPR
 test_conv_float_to_varchar_char
 BABEL-5467
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 round_return_type_test
 alter-view
 test_conv_int_to_varbinary_binary

--- a/test/JDBC/upgrade/17_6/schedule
+++ b/test/JDBC/upgrade/17_6/schedule
@@ -622,7 +622,7 @@ sys-login-property
 sys-fn-varbintohexsubstring
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 test_like_index
 unpivot
 forjson-escape

--- a/test/JDBC/upgrade/17_7/schedule
+++ b/test/JDBC/upgrade/17_7/schedule
@@ -622,7 +622,7 @@ sys-login-property
 sys-fn-varbintohexsubstring
 BABEL_OBJECT_RESOLUTION_IN_ROUTINES
 alter-mvu-test
-test_constraint_like
+test_constraint_like_before_17_8-or-16_12
 test_like_index
 unpivot
 forjson-escape


### PR DESCRIPTION
### Description


```
DROP TABLE IF EXISTS DummyTable
GO

CREATE TABLE [dbo].[DummyTable](
 [ViewDetailsID] [varchar](50) NULL
) 

 GO  

  SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS 
        WHERE TABLE_NAME = 'DummyTable' 
        AND COLUMN_NAME like 'ViewDetailsID ' 
```

16.11 returned 1, which is incorrect because it matches ViewDetailsID even though the pattern includes a trailing space. Now, we have fixed it to return no results, which is the expected behavior since the column name does not contain a trailing space. 

### Problem: 
Currently, when LIKE operator is transformed for exact match cases, it is completely converted to an = operator without retaining the LIKE filter. This causes incorrect behavior with sys.sysname (domain on sys.varchar(128)) and varchar datatypes where trailing spaces are ignored during comparison.

### Solution: 
Modify LIKE transformation logic: When transforming LIKE to = operator for exact match, retain the LIKE filter as well. This will ensure both operands are cast to TEXT and return expected results.


### Issues Resolved

BABEL-6223
cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4498

Signed-off by: Mohit Raj [mrxmohit@amazon.com](mailto:mrxmohit@amazon.com)

Authored by: Mohit Raj [mrxmohit@amazon.com](mailto:mrxmohit@amazon.com)


### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).