### PR TITLE
[POC] cte based query rewriting for insert execute select queries

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2720,9 +2720,9 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 								 * or if the INSERT itself is an INSERT-EXEC
 								 * and it just returned error.
 								 */
-								row_count_valid = !estate->insert_exec &&
-									!(markErrorFlag &&
-									  ((PLtsql_stmt_execsql *) stmt)->insert_exec);
+								row_count_valid = (!estate->insert_exec || estate->eval_processed > 0) &&
+								!(markErrorFlag &&
+								((PLtsql_stmt_execsql *) stmt)->insert_exec);
 							}
 							else if (plansource->commandTag == CMDTAG_UPDATE)
 							{
@@ -2744,8 +2744,8 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 								command_type = TDS_CMD_SELECT;
 								row_count_valid = !estate->insert_exec;
 							}
-						}
-					}
+											}
+				}
 				}
 
 				/*
@@ -2757,7 +2757,7 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 					estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER &&
 					strcmp(estate->func->fn_signature, "inline_code_block") != 0)
 					skip_done = true;
-			}
+			
 			break;
 		case PLTSQL_STMT_EXEC:
 		case PLTSQL_STMT_EXEC_BATCH:
@@ -2770,6 +2770,7 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 		default:
 			break;
 	}
+}
 
 	/*
 	 * XXX: For SP_CUSTOMTYPE, if we're done executing the top level stored

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -72,6 +72,7 @@ char	   *pltsql_host_service_pack_level = NULL;
 
 bool		pltsql_enable_create_alter_view_from_pg = false;
 bool		pltsql_enable_alter_owner_from_pg = false;
+bool 		pltsql_enable_insert_exec_query_rewrite = true;
 
 static const struct config_enum_entry explain_format_options[] = {
 	{"text", EXPLAIN_FORMAT_TEXT, false},
@@ -1139,6 +1140,18 @@ define_custom_variables(void)
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);
+	
+	/*
+	* Enable query rewriting for INSERT-EXEC instead of tuple store handling
+	*/
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_insert_exec_query_rewrite",
+							gettext_noop("Enable query rewriting for INSERT-EXEC"),
+							NULL,
+							&pltsql_enable_insert_exec_query_rewrite,
+							true,
+							PGC_USERSET,
+							GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							NULL, NULL, NULL);
 
 	/* Dump and Restore */
 	DefineCustomBoolVariable("babelfishpg_tsql.dump_restore",

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -23,6 +23,7 @@ extern bool pltsql_enable_ownership_chaining;
 extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;
 extern bool pltsql_weak_view_binding;
+extern bool pltsql_enable_insert_exec_query_rewrite;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -75,6 +75,15 @@ int			saved_expr_kind = -1;
 /* Global variable to record the retval for insert exec */
 Datum execute_call_insert_exec_retval = (Datum) 0;
 
+/* Global variables to track INSERT-EXEC query rewriting context */
+static bool in_insert_exec_query_rewrite = false;
+static char *insert_exec_target_table = NULL;
+static char *insert_exec_target_schema = NULL;
+static char *insert_exec_column_list = NULL;
+
+/* Global variable to track row count for INSERT-EXEC query rewriting */
+uint64 insert_exec_rewrite_row_count = 0;
+
 typedef struct
 {
 	int			nargs;			/* number of arguments */
@@ -2378,7 +2387,7 @@ exec_stmt(PLtsql_execstate *estate, PLtsql_stmt *stmt)
 
 	/* Let the plugin know that we have finished executing this statement */
 	if (*pltsql_plugin_ptr && (*pltsql_plugin_ptr)->stmt_end)
-		((*pltsql_plugin_ptr)->stmt_end) (estate, stmt);
+    ((*pltsql_plugin_ptr)->stmt_end) (estate, stmt);
 
 	estate->err_stmt = save_estmt;
 
@@ -4820,6 +4829,9 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	bool		enable_txn_in_triggers = !pltsql_disable_txn_in_triggers;
 	bool		support_tsql_trans = pltsql_support_tsql_transactions();
 	StringInfoData query;
+	StringInfoData rewritten_query;
+	char *temp_rewritten_query;
+	uint64 insert_processed;
 	char	   *cur_dbname = get_cur_db_name();
 	bool		is_cross_db = stmt->is_cross_db && stmt->db_name && strcmp(cur_dbname, stmt->db_name) != 0;
 	bool		ro_func = (estate->func->fn_prokind == PROKIND_FUNCTION) &&
@@ -4841,8 +4853,144 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 
 	PG_TRY();
 	{
-		/* Handle naked SELECT stmt differently for INSERT ... EXECUTE */
-		if (stmt->need_to_push_result && estate->insert_exec)
+		/* 
+		 * INSERT EXEC Query Rewriting Approach:
+		 * Instead of using tuple store, rewrite SELECT/OUTPUT statements 
+		 * inside procedures to directly INSERT into target table
+		 */
+		if (stmt->insert_exec && stmt->insert_exec_target_table != NULL)  // Only store if not already stored
+    	{
+        	insert_exec_target_table = pstrdup(stmt->insert_exec_target_table);
+    		insert_exec_target_schema = stmt->insert_exec_target_schema ? 
+                               pstrdup(stmt->insert_exec_target_schema) : NULL;
+    		insert_exec_column_list = stmt->insert_exec_column_list;
+    	}
+
+		/* Set up INSERT EXEC query rewriting context using estate info */
+    	if (estate->insert_exec && 
+    		pltsql_enable_insert_exec_query_rewrite &&
+    		insert_exec_target_table != NULL)  // Use GLOBAL variable
+		{
+    		in_insert_exec_query_rewrite = true;
+    		// Globals are already set above
+    
+    		elog(NOTICE, "DEBUG: Context setup successful - using global table=%s", 
+         		insert_exec_target_table);
+		}
+
+		if (in_insert_exec_query_rewrite && 
+            	estate->func && 
+            	estate->func->fn_prokind == PROKIND_PROCEDURE &&
+            	stmt->sqlstmt && stmt->sqlstmt->query)
+		{
+			char *query = stmt->sqlstmt->query;
+				
+			/* Skip whitespace */
+			while (*query && isspace(*query))
+				query++;
+
+			elog(NOTICE, "DEBUG: Checking if SELECT - trimmed query: %s", query);
+
+			// here the query is insert into test_t1 exec proc_p1 : what you have to do is expan the procedure : 
+				
+			/* Check if this is a SELECT statement that should be rewritten */
+			if (strncasecmp(query, "select", 6) == 0)
+			{
+					
+				elog(LOG, "INSERT-EXEC: Rewriting SELECT query in procedure: %s", query);
+						
+				/* Build the CTE-based rewritten query */
+				initStringInfo(&rewritten_query);
+				
+				/* Build: WITH cte AS (original_query) INSERT INTO table SELECT * FROM cte */
+				if (insert_exec_target_schema && insert_exec_column_list)
+				{
+					appendStringInfo(&rewritten_query,
+						"WITH insert_exec_cte AS (%s) INSERT INTO %s.%s %s SELECT * FROM insert_exec_cte",
+						query,
+						insert_exec_target_schema,
+						insert_exec_target_table,
+						insert_exec_column_list);
+				}
+				else if (insert_exec_target_schema)
+				{
+					appendStringInfo(&rewritten_query,
+						"WITH insert_exec_cte AS (%s) INSERT INTO %s.%s SELECT * FROM insert_exec_cte",
+						query,
+						insert_exec_target_schema,
+						insert_exec_target_table);
+				}
+				else if (insert_exec_column_list)
+				{
+					appendStringInfo(&rewritten_query,
+						"WITH insert_exec_cte AS (%s) INSERT INTO %s %s SELECT * FROM insert_exec_cte",
+						query,
+						insert_exec_target_table,
+						insert_exec_column_list);
+				}
+				else
+				{
+					appendStringInfo(&rewritten_query,
+						"WITH insert_exec_cte AS (%s) INSERT INTO %s SELECT * FROM insert_exec_cte",
+						query,
+						insert_exec_target_table);
+				}
+			}
+					
+			elog(LOG, "INSERT-EXEC: Rewritten query: %s", rewritten_query.data);
+					
+			/* Replace the original query with the rewritten one */
+			// stmt->sqlstmt->query = pstrdup(rewritten_query.data);
+			temp_rewritten_query = pstrdup(rewritten_query.data);
+					
+			/* Clear the plan so it gets re-prepared with the new query */
+			if (expr->plan)
+			{
+				SPI_freeplan(expr->plan);
+				expr->plan = NULL;
+			}
+					
+			pfree(rewritten_query.data);
+
+			if (estate->insert_exec && temp_rewritten_query &&
+    			strncasecmp(temp_rewritten_query, "with insert_exec_cte", 20) == 0)
+			{
+    			elog(NOTICE, "INSERT-EXEC: Executing rewritten INSERT query directly to avoid cursor issue");
+    
+    			/* Execute the rewritten INSERT query directly using SPI_execute */
+    			rc = SPI_execute(temp_rewritten_query, estate->readonly_func, 0);
+    
+    			if (rc != SPI_OK_INSERT)
+    			{
+        			elog(ERROR, "INSERT-EXEC: Failed to execute rewritten INSERT query: %s",
+             		SPI_result_code_string(rc));
+    			}
+
+				/* Store the processed count for later use */
+				insert_processed = SPI_processed;
+				
+				/* Set the processed count */
+				estate->eval_processed = insert_processed;
+
+				elog(NOTICE, "INSERT-EXEC DEBUG: Stored row count in global: %lu", insert_exec_rewrite_row_count);
+
+				/* Store in global variable for outer INSERT-EXEC to pick up */
+				insert_exec_rewrite_row_count = insert_processed;
+
+				pfree(temp_rewritten_query);
+    
+    			/* Set the processed count and return success */
+    			exec_set_found(estate, (SPI_processed != 0));
+    			exec_set_rowcount(SPI_processed);
+
+    			exec_eval_cleanup(estate);
+    
+    			return PLTSQL_RC_OK;
+			}
+		}
+
+		/* Handle naked SELECT stmt differently for INSERT ... EXECUTE - FALLBACK to tuple store */
+		else if (stmt->need_to_push_result && estate->insert_exec)
 		{
 			int			ret = exec_stmt_insert_execute_select(estate, expr);
 
@@ -5032,9 +5180,26 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 				 stmt->txn_data->stmt_kind == TRANS_STMT_ROLLBACK_TO))
 				restore_session_properties();
 		}
-		else
+		else{
 			rc = SPI_execute_plan_with_paramlist(expr->plan, paramLI,
 												 estate->readonly_func, tcount);
+		}
+
+		/* After procedure execution, check if we need to propagate row count from query rewriting */
+		if (stmt->insert_exec && insert_exec_rewrite_row_count > 0)
+		{
+
+			/* Set the row count on the outer estate so TDS layer can report it */
+			estate->eval_processed = insert_exec_rewrite_row_count;
+			exec_set_found(estate, true);
+			exec_set_rowcount(insert_exec_rewrite_row_count);
+			
+			/* Use the row count from the rewritten INSERT query */
+			elog(NOTICE, "INSERT-EXEC: Propagating row count from procedure: %lu", insert_exec_rewrite_row_count);
+			
+			/* Reset the global variable */
+			insert_exec_rewrite_row_count = 0;
+		}
 
 		/*
 		 * Check for error, and set FOUND if appropriate (for historical
@@ -5140,8 +5305,12 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			/* already set in execute_plan_and_push_result */
 		{
 			/* All variants should save result info for GET DIAGNOSTICS */
-			estate->eval_processed = SPI_processed;
-			exec_set_rowcount(SPI_processed);
+			/* For INSERT-EXEC with query rewriting, we already set the correct row count earlier */
+			if (!stmt->insert_exec || estate->eval_processed == 0)
+			{
+				estate->eval_processed = SPI_processed;
+				exec_set_rowcount(SPI_processed);
+			}
 		}
 
 		/* Process INTO if present */
@@ -7550,6 +7719,12 @@ exec_run_select(PLtsql_execstate *estate,
 	ParamListInfo paramLI;
 	int			rc;
 
+	/* DEBUG: Add logging to understand what's happening */
+	elog(LOG, "INSERT-EXEC DEBUG: exec_run_select called - estate->insert_exec=%s, portalP=%s, expr->query=%s",
+		 estate->insert_exec ? "true" : "false",
+		 portalP ? "NOT NULL" : "NULL",
+		 expr->query ? expr->query : "NULL");
+
 	/*
 	 * On the first call for this expression generate the plan.
 	 *
@@ -7585,13 +7760,17 @@ exec_run_select(PLtsql_execstate *estate,
 	 */
 	if (portalP != NULL)
 	{
+		/* DEBUG: Add this logging */
+    elog(NOTICE, "INSERT-EXEC DEBUG: exec_run_select about to open cursor");
+    elog(NOTICE, "INSERT-EXEC DEBUG: estate->insert_exec=%s", estate->insert_exec ? "true" : "false");
+    elog(NOTICE, "INSERT-EXEC DEBUG: expr->query=%s", expr->query ? expr->query : "NULL");
 		*portalP = SPI_cursor_open_with_paramlist(NULL, expr->plan,
 												  paramLI,
 												  estate->readonly_func);
 		if (*portalP == NULL)
 			elog(ERROR, "could not open implicit cursor for query \"%s\": %s",
 				 expr->query, SPI_result_code_string(SPI_result));
-	
+
 		exec_eval_cleanup(estate);
 		return SPI_OK_CURSOR;
 	}
@@ -10519,6 +10698,15 @@ pltsql_exec_function_cleanup(PLtsql_execstate *estate, PLtsql_function *func, Er
 
 		/* Drop the tables linked to table variables */
 		pltsql_clean_table_variables(estate, func);
+
+		/* Clean up INSERT EXEC query rewriting context */
+		if (in_insert_exec_query_rewrite)
+		{
+			in_insert_exec_query_rewrite = false;
+			insert_exec_target_table = NULL;
+			insert_exec_target_schema = NULL;
+			insert_exec_column_list = NULL;
+		}
 	}
 	PG_FINALLY();
 	{

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4874,9 +4874,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		{
     		in_insert_exec_query_rewrite = true;
     		// Globals are already set above
-    
-    		elog(NOTICE, "DEBUG: Context setup successful - using global table=%s", 
-         		insert_exec_target_table);
 		}
 
 		if (in_insert_exec_query_rewrite && 
@@ -4895,65 +4892,86 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			// here the query is insert into test_t1 exec proc_p1 : what you have to do is expan the procedure : 
 				
 			/* Check if this is a SELECT statement that should be rewritten */
+
 			if (strncasecmp(query, "select", 6) == 0)
 			{
+				/* Check if query contains parameter references or table variables */
+				if (strstr(query, "@") != NULL)
+				{
+					elog(LOG, "INSERT-EXEC: Query contains parameters/variables (@), disabling rewrite for this query");
+					in_insert_exec_query_rewrite = false;  /* Disable rewrite for this specific query */
+				}
+				/* Check for transaction statements */
+				else if (strcasestr(query, "COMMIT") != NULL || 
+						strcasestr(query, "ROLLBACK") != NULL ||
+						strcasestr(query, "BEGIN TRAN") != NULL)
+				{
+					elog(LOG, "INSERT-EXEC: Query contains transaction statements, disabling rewrite");
+					in_insert_exec_query_rewrite = false;  /* Disable rewrite for this specific query */
+				}
+				else{
 					
-				elog(LOG, "INSERT-EXEC: Rewriting SELECT query in procedure: %s", query);
+					elog(LOG, "INSERT-EXEC: Rewriting SELECT query in procedure: %s", query);
+							
+					/* Build the CTE-based rewritten query */
+					initStringInfo(&rewritten_query);
+					
+					/* Build: WITH cte AS (original_query) INSERT INTO table SELECT * FROM cte */
+					if (insert_exec_target_schema && insert_exec_column_list)
+					{
+						appendStringInfo(&rewritten_query,
+							"WITH insert_exec_cte AS (%s) INSERT INTO %s.%s %s SELECT * FROM insert_exec_cte",
+							query,
+							insert_exec_target_schema,
+							insert_exec_target_table,
+							insert_exec_column_list);
+					}
+					else if (insert_exec_target_schema)
+					{
+						appendStringInfo(&rewritten_query,
+							"WITH insert_exec_cte AS (%s) INSERT INTO %s.%s SELECT * FROM insert_exec_cte",
+							query,
+							insert_exec_target_schema,
+							insert_exec_target_table);
+					}
+					else if (insert_exec_column_list)
+					{
+						appendStringInfo(&rewritten_query,
+							"WITH insert_exec_cte AS (%s) INSERT INTO %s %s SELECT * FROM insert_exec_cte",
+							query,
+							insert_exec_target_table,
+							insert_exec_column_list);
+					}
+					else
+					{
+						appendStringInfo(&rewritten_query,
+							"WITH insert_exec_cte AS (%s) INSERT INTO %s SELECT * FROM insert_exec_cte",
+							query,
+							insert_exec_target_table);
+					}
 						
-				/* Build the CTE-based rewritten query */
-				initStringInfo(&rewritten_query);
-				
-				/* Build: WITH cte AS (original_query) INSERT INTO table SELECT * FROM cte */
-				if (insert_exec_target_schema && insert_exec_column_list)
+				elog(LOG, "INSERT-EXEC: Rewritten query: %s", rewritten_query.data);
+						
+				/* Replace the original query with the rewritten one */
+				// stmt->sqlstmt->query = pstrdup(rewritten_query.data);
+				temp_rewritten_query = pstrdup(rewritten_query.data);
+						
+				/* Clear the plan so it gets re-prepared with the new query */
+				if (expr->plan)
 				{
-					appendStringInfo(&rewritten_query,
-						"WITH insert_exec_cte AS (%s) INSERT INTO %s.%s %s SELECT * FROM insert_exec_cte",
-						query,
-						insert_exec_target_schema,
-						insert_exec_target_table,
-						insert_exec_column_list);
+					SPI_freeplan(expr->plan);
+					expr->plan = NULL;
 				}
-				else if (insert_exec_target_schema)
-				{
-					appendStringInfo(&rewritten_query,
-						"WITH insert_exec_cte AS (%s) INSERT INTO %s.%s SELECT * FROM insert_exec_cte",
-						query,
-						insert_exec_target_schema,
-						insert_exec_target_table);
-				}
-				else if (insert_exec_column_list)
-				{
-					appendStringInfo(&rewritten_query,
-						"WITH insert_exec_cte AS (%s) INSERT INTO %s %s SELECT * FROM insert_exec_cte",
-						query,
-						insert_exec_target_table,
-						insert_exec_column_list);
-				}
-				else
-				{
-					appendStringInfo(&rewritten_query,
-						"WITH insert_exec_cte AS (%s) INSERT INTO %s SELECT * FROM insert_exec_cte",
-						query,
-						insert_exec_target_table);
-				}
-					
-			elog(LOG, "INSERT-EXEC: Rewritten query: %s", rewritten_query.data);
-					
-			/* Replace the original query with the rewritten one */
-			// stmt->sqlstmt->query = pstrdup(rewritten_query.data);
-			temp_rewritten_query = pstrdup(rewritten_query.data);
-					
-			/* Clear the plan so it gets re-prepared with the new query */
-			if (expr->plan)
-			{
-				SPI_freeplan(expr->plan);
-				expr->plan = NULL;
+						
+				pfree(rewritten_query.data);
 			}
-					
-			pfree(rewritten_query.data);
+		}
+		else{
+			elog(LOG, "INSERT-EXEC: Not a SELECT statement, disabling rewrite");
+        	in_insert_exec_query_rewrite = false;
 		}
 
-			if (estate->insert_exec && temp_rewritten_query &&
+			if (in_insert_exec_query_rewrite && temp_rewritten_query &&
     			strncasecmp(temp_rewritten_query, "with insert_exec_cte", 20) == 0)
 			{
     			elog(NOTICE, "INSERT-EXEC: Executing rewritten INSERT query directly to avoid cursor issue");

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4830,8 +4830,8 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	bool		support_tsql_trans = pltsql_support_tsql_transactions();
 	StringInfoData query;
 	StringInfoData rewritten_query;
-	char *temp_rewritten_query;
-	uint64 insert_processed;
+	char *temp_rewritten_query = NULL;
+	uint64 insert_processed = 0;
 	char	   *cur_dbname = get_cur_db_name();
 	bool		is_cross_db = stmt->is_cross_db && stmt->db_name && strcmp(cur_dbname, stmt->db_name) != 0;
 	bool		ro_func = (estate->func->fn_prokind == PROKIND_FUNCTION) &&
@@ -4863,7 +4863,8 @@ exec_stmt_execsql(PLtsql_execstate *estate,
         	insert_exec_target_table = pstrdup(stmt->insert_exec_target_table);
     		insert_exec_target_schema = stmt->insert_exec_target_schema ? 
                                pstrdup(stmt->insert_exec_target_schema) : NULL;
-    		insert_exec_column_list = stmt->insert_exec_column_list;
+    		insert_exec_column_list = stmt->insert_exec_column_list ? 
+                          pstrdup(stmt->insert_exec_column_list) : NULL;
     	}
 
 		/* Set up INSERT EXEC query rewriting context using estate info */
@@ -4935,7 +4936,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 						query,
 						insert_exec_target_table);
 				}
-			}
 					
 			elog(LOG, "INSERT-EXEC: Rewritten query: %s", rewritten_query.data);
 					
@@ -4951,6 +4951,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			}
 					
 			pfree(rewritten_query.data);
+		}
 
 			if (estate->insert_exec && temp_rewritten_query &&
     			strncasecmp(temp_rewritten_query, "with insert_exec_cte", 20) == 0)
@@ -4977,7 +4978,8 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 				/* Store in global variable for outer INSERT-EXEC to pick up */
 				insert_exec_rewrite_row_count = insert_processed;
 
-				pfree(temp_rewritten_query);
+				if (temp_rewritten_query)
+						pfree(temp_rewritten_query);
     
     			/* Set the processed count and return success */
     			exec_set_found(estate, (SPI_processed != 0));
@@ -10703,9 +10705,21 @@ pltsql_exec_function_cleanup(PLtsql_execstate *estate, PLtsql_function *func, Er
 		if (in_insert_exec_query_rewrite)
 		{
 			in_insert_exec_query_rewrite = false;
-			insert_exec_target_table = NULL;
-			insert_exec_target_schema = NULL;
-			insert_exec_column_list = NULL;
+			if (insert_exec_target_table)
+			{
+				pfree(insert_exec_target_table);
+				insert_exec_target_table = NULL;
+			}
+			if (insert_exec_target_schema)
+			{
+				pfree(insert_exec_target_schema);
+				insert_exec_target_schema = NULL;
+			}
+			if (insert_exec_column_list)
+			{
+				pfree(insert_exec_column_list);
+				insert_exec_column_list = NULL;
+			}
 		}
 	}
 	PG_FINALLY();

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1180,6 +1180,9 @@ typedef struct PLtsql_stmt_execsql
 	bool		is_set_tran_isolation; /* SET TRANSACTION ISOLATION? */
 	char	   *original_query; /* Only for batch level statement. */
 	bool        is_schemabinding; /* Is schema binding? */
+	char       *insert_exec_target_table;    /* Target table for INSERT-EXEC */
+    char       *insert_exec_target_schema;   /* Target schema for INSERT-EXEC */
+    char       *insert_exec_column_list;     /* Column list for INSERT-EXEC */
 } PLtsql_stmt_execsql;
 
 /*
@@ -1542,6 +1545,9 @@ typedef struct PLtsql_execstate
 	 * EXECUTE, and can behave differently.
 	 */
 	bool		insert_exec;
+	char	   *insert_exec_target_table;		/* target table name */
+	char	   *insert_exec_target_schema;		/* target schema name */
+	bool		insert_exec_has_output_params;	/* does EXEC have OUTPUT params? */
 
 	List	   *explain_infos;
 	instr_time	planning_start;
@@ -1983,6 +1989,10 @@ extern bool pltsql_disable_batch_auto_commit;
 extern bool pltsql_disable_internal_savepoint;
 extern bool pltsql_disable_txn_in_triggers;
 extern bool pltsql_recursive_triggers;
+extern bool pltsql_enable_insert_exec_query_rewrite;
+
+/* Global variable to track row count for INSERT-EXEC query rewriting */
+extern uint64 insert_exec_rewrite_row_count;
 
 extern int	text_size;
 extern int	pltsql_rowcount;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1972,6 +1972,42 @@ public:
 				if (ctx_name->schema)
 					schema_name = stripQuoteFromId(ctx_name->schema);
 			}
+
+			auto insert_ddl_object = ctx->insert_statement()->ddl_object();
+			if (insert_ddl_object)
+			{
+				std::string target_table = extractTableName(insert_ddl_object, nullptr);
+				std::string target_schema = extractSchemaName(insert_ddl_object, nullptr);
+				if (!target_table.empty())
+					stmt->insert_exec_target_table = pstrdup(downcase_truncate_identifier(target_table.c_str(), target_table.length(), true));
+				
+				/* Set schema - use extracted schema or NULL if not specified */
+				if (!target_schema.empty())
+					stmt->insert_exec_target_schema = pstrdup(downcase_truncate_identifier(target_schema.c_str(), target_schema.length(), true));
+				else
+					stmt->insert_exec_target_schema = NULL;
+			}
+			
+			/* Extract column list if present */
+			auto insert_column_name_list = ctx->insert_statement()->insert_column_name_list();
+			if (insert_column_name_list)
+			{
+				std::string column_list = "(";
+				bool first = true;
+				for (auto column : insert_column_name_list->col)
+				{
+					if (!first)
+						column_list += ", ";
+					column_list += ::getFullText(column);
+					first = false;
+				}
+				column_list += ")";
+				stmt->insert_exec_column_list = pstrdup(column_list.c_str());
+			}
+			else
+			{
+				stmt->insert_exec_column_list = NULL;
+			}
 		}
 
 		// record whether stmt is cross-db

--- a/test/JDBC/expected/BABEL_5522_insert_execute_query_rewriting_poc_basic.out
+++ b/test/JDBC/expected/BABEL_5522_insert_execute_query_rewriting_poc_basic.out
@@ -1,0 +1,65 @@
+-- Test 1: Single column table with SELECT 1
+DROP TABLE IF EXISTS t1
+GO
+
+DROP PROCEDURE IF EXISTS p1
+GO
+
+CREATE TABLE t1 (a INT)
+GO
+
+CREATE PROC p1 AS SELECT 1
+GO
+
+INSERT INTO t1 EXEC p1
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM t1
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- Cleanup
+DROP TABLE t1
+GO
+
+DROP PROCEDURE p1
+GO
+
+-- Test 2: Two column table with SELECT 1 (inserts into first column only)
+DROP TABLE IF EXISTS t2
+GO
+
+DROP PROCEDURE IF EXISTS p2
+GO
+
+CREATE TABLE t2 (a INT, b INT)
+GO
+
+CREATE PROC p2 AS SELECT 1
+GO
+
+INSERT INTO t2 (b) EXEC p2
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM t2
+GO
+~~START~~
+int#!#int
+<NULL>#!#1
+~~END~~
+
+
+-- Cleanup
+DROP TABLE t2
+GO
+
+DROP PROCEDURE p2
+GO

--- a/test/JDBC/input/BABEL_5522_insert_execute_query_rewriting_poc_basic.sql
+++ b/test/JDBC/input/BABEL_5522_insert_execute_query_rewriting_poc_basic.sql
@@ -1,0 +1,51 @@
+-- Test 1: Single column table with SELECT 1
+DROP TABLE IF EXISTS t1
+GO
+
+DROP PROCEDURE IF EXISTS p1
+GO
+
+CREATE TABLE t1 (a INT)
+GO
+
+CREATE PROC p1 AS SELECT 1
+GO
+
+INSERT INTO t1 EXEC p1
+GO
+
+SELECT * FROM t1
+GO
+
+-- Cleanup
+DROP TABLE t1
+GO
+
+DROP PROCEDURE p1
+GO
+
+-- Test 2: Two column table with SELECT 1 (inserts into first column only)
+DROP TABLE IF EXISTS t2
+GO
+
+DROP PROCEDURE IF EXISTS p2
+GO
+
+CREATE TABLE t2 (a INT, b INT)
+GO
+
+CREATE PROC p2 AS SELECT 1
+GO
+
+INSERT INTO t2 (b) EXEC p2
+GO
+
+SELECT * FROM t2
+GO
+
+-- Cleanup
+DROP TABLE t2
+GO
+
+DROP PROCEDURE p2
+GO


### PR DESCRIPTION
### Description

Modified `contrib/babelfishpg_tsql/pl_exec.c` Inside the called procedure, SELECT statements are detected and rewritten.
Modified `contrib/babelfishpg_tsql/tsqlIface.cpp` Target table information extraction.
Modified `contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c` The TDS layer is updated to report row counts for INSERT-EXEC.
Added test case.

Authored by Arvind Sharma arvshaa@amazon.com
Signed-off by Arvind Sharma arvshaa@amazon.com
### Issues Resolved
Epic - BABEL-5522

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).