### PR TITLE
Bind NVARCHAR in TVP

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdstypeio.c
@@ -2256,7 +2256,6 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 		Datum	   *values = palloc(nargs * sizeof(Datum));
 		char	   *nulls = palloc(nargs * sizeof(char));
 		Oid		   *argtypes = palloc(nargs * sizeof(Datum));
-		int			i = 0;
 
 		query = " ";
 
@@ -2275,76 +2274,67 @@ TdsRecvTypeTable(const char *message, const ParameterToken token)
 			{
 				temp = &(row->columnValues[currentColumn]);
 				tempFuncInfo = TdsLookupTypeFunctionsByTdsId(colMetaData[currentColumn].columnTdsType, colMetaData[currentColumn].maxLen);
-				GetPgOid(argtypes[i], tempFuncInfo);
+				GetPgOid(argtypes[currentColumn], tempFuncInfo);
 				if (row->isNull[currentColumn] == 'n')
-					nulls[i] = row->isNull[currentColumn];
+					nulls[currentColumn] = row->isNull[currentColumn];
 				else
 					switch (colMetaData[currentColumn].columnTdsType)
 					{
 						case TDS_TYPE_CHAR:
 						case TDS_TYPE_VARCHAR:
-							values[i] = TdsTypeVarcharToDatum(temp, colMetaData[currentColumn].encoding, colMetaData[currentColumn].columnTdsType);
+							values[currentColumn] = TdsTypeVarcharToDatum(temp, colMetaData[currentColumn].encoding, colMetaData[currentColumn].columnTdsType);
 							break;
 						case TDS_TYPE_NCHAR:
-							values[i] = TdsTypeNCharToDatum(temp);
-							break;
 						case TDS_TYPE_NVARCHAR:
-							if (!row->isNull[currentColumn])	/* NULL. */
-								currentQuery = psprintf("%s,\'NULL\'", currentQuery);
-							else
-								currentQuery = psprintf("%s,\'%s\'", currentQuery, temp->data);
-							nargs--;
+							values[currentColumn] = TdsTypeNCharToDatum(temp);
 							break;
 						case TDS_TYPE_INTEGER:
 						case TDS_TYPE_BIT:
-							values[i] = TdsTypeIntegerToDatum(temp, colMetaData[currentColumn].maxLen);
+							values[currentColumn] = TdsTypeIntegerToDatum(temp, colMetaData[currentColumn].maxLen);
 							break;
 						case TDS_TYPE_FLOAT:
-							values[i] = TdsTypeFloatToDatum(temp, colMetaData[currentColumn].maxLen);
+							values[currentColumn] = TdsTypeFloatToDatum(temp, colMetaData[currentColumn].maxLen);
 							break;
 						case TDS_TYPE_NUMERICN:
 						case TDS_TYPE_DECIMALN:
-							values[i] = TdsTypeNumericToDatum(temp, colMetaData[currentColumn].scale);
+							values[currentColumn] = TdsTypeNumericToDatum(temp, colMetaData[currentColumn].scale);
 							break;
 						case TDS_TYPE_VARBINARY:
 						case TDS_TYPE_BINARY:
-							values[i] = TdsTypeVarbinaryToDatum(temp);
-							argtypes[i] = tempFuncInfo->ttmtypeid;
+							values[currentColumn] = TdsTypeVarbinaryToDatum(temp);
+							argtypes[currentColumn] = tempFuncInfo->ttmtypeid;
 							break;
 						case TDS_TYPE_DATE:
-							values[i] = TdsTypeDateToDatum(temp);
+							values[currentColumn] = TdsTypeDateToDatum(temp);
 							break;
 						case TDS_TYPE_TIME:
-							values[i] = TdsTypeTimeToDatum(temp, colMetaData[currentColumn].scale, temp->len);
+							values[currentColumn] = TdsTypeTimeToDatum(temp, colMetaData[currentColumn].scale, temp->len);
 							break;
 						case TDS_TYPE_DATETIMEOFFSET:
-							values[i] = TdsTypeDatetimeoffsetToDatum(temp, colMetaData[currentColumn].scale, temp->len);
+							values[currentColumn] = TdsTypeDatetimeoffsetToDatum(temp, colMetaData[currentColumn].scale, temp->len);
 							break;
 						case TDS_TYPE_DATETIME2:
-							values[i] = TdsTypeDatetime2ToDatum(temp, colMetaData[currentColumn].scale, temp->len);
+							values[currentColumn] = TdsTypeDatetime2ToDatum(temp, colMetaData[currentColumn].scale, temp->len);
 							break;
 						case TDS_TYPE_DATETIMEN:
-							values[i] = TdsTypeDatetimeToDatum(temp);
+							values[currentColumn] = TdsTypeDatetimeToDatum(temp);
 							break;
 						case TDS_TYPE_MONEYN:
-							values[i] = TdsTypeMoneyToDatum(temp);
+							values[currentColumn] = TdsTypeMoneyToDatum(temp);
 							break;
 						case TDS_TYPE_XML:
-							values[i] = TdsTypeXMLToDatum(temp);
+							values[currentColumn] = TdsTypeXMLToDatum(temp);
 							break;
 						case TDS_TYPE_UNIQUEIDENTIFIER:
-							values[i] = TdsTypeUIDToDatum(temp);
+							values[currentColumn] = TdsTypeUIDToDatum(temp);
 							break;
 						case TDS_TYPE_SQLVARIANT:
-							values[i] = TdsTypeSqlVariantToDatum(temp);
+							values[currentColumn] = TdsTypeSqlVariantToDatum(temp);
 							break;
 					}
 				/* Build a string for bind parameters. */
-				if (colMetaData[currentColumn].columnTdsType != TDS_TYPE_NVARCHAR || row->isNull[currentColumn] == 'n')
-				{
-					currentQuery = psprintf("%s,$%d", currentQuery, i + 1);
-					i++;
-				}
+				currentQuery = psprintf("%s,$%d", currentQuery, currentColumn + 1);
+				nulls[currentColumn] = row->isNull[currentColumn];
 				currentColumn++;
 			}
 			row = row->nextRow;

--- a/contrib/babelfishpg_tds/src/include/tds_request.h
+++ b/contrib/babelfishpg_tds/src/include/tds_request.h
@@ -388,14 +388,6 @@ SetTvpRowData(ParameterToken temp, const StringInfo message, uint64_t *offset)
 								memcpy(value, &messageData[*offset], rowData->columnValues[i].len);
 								rowData->columnValues[i].data = value;
 								*offset += rowData->columnValues[i].len;
-								if (colmetadata[i].columnTdsType == TDS_TYPE_NVARCHAR)
-								{
-									StringInfo	tempStringInfo = palloc(sizeof(StringInfoData));
-
-									initStringInfo(tempStringInfo);
-									TdsUTF16toUTF8StringInfo(tempStringInfo, value, rowData->columnValues[i].len);
-									rowData->columnValues[i] = *tempStringInfo;
-								}
 							}
 							else
 							{
@@ -413,14 +405,6 @@ SetTvpRowData(ParameterToken temp, const StringInfo message, uint64_t *offset)
 								rowData->isNull[i] = 'n';
 							}
 							rowData->columnValues[i] = *(TdsGetPlpStringInfoBufferFromToken(messageData, temp));
-							if (colmetadata[i].columnTdsType == TDS_TYPE_NVARCHAR)
-							{
-								StringInfo	tempStringInfo = palloc(sizeof(StringInfoData));
-
-								initStringInfo(tempStringInfo);
-								TdsUTF16toUTF8StringInfo(tempStringInfo, rowData->columnValues[i].data, rowData->columnValues[i].len);
-								rowData->columnValues[i] = *tempStringInfo;
-							}
 							temp->isNull = false;
 						}
 					}


### PR DESCRIPTION
### Description

Bind NVARCHAR in TVP - earlier we were parsing nvarchar in tvp as simple strings due to internal errors, but with maturity we are able to bind this type as well.

Sign-off: Kushaal Shroff <kushaal@amazon.com>


### Issues Resolved
BABEL-6336

### Test Scenarios Covered ###
Existing tests pass, we will also focus on writing some more tests and add support in dotnet framework for the same.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).