### PR TITLE
[OSS-ONLY] Fixing BABEL-CASE_EXPR-before-16_6 test file 

### DIFF
--- a/test/JDBC/expected/BABEL-CASE_EXPR-before-16_6-vu-verify.out
+++ b/test/JDBC/expected/BABEL-CASE_EXPR-before-16_6-vu-verify.out
@@ -10067,9 +10067,10 @@ SELECT CASE 1
    WHEN 2 THEN 'بطاقة التسجيل - قياسية'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10077,9 +10078,10 @@ SELECT CASE 1
    WHEN 2 THEN 'abc'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10087,9 +10089,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 
@@ -10446,9 +10449,10 @@ SELECT CASE 1
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10469,9 +10473,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10480,9 +10485,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10514,9 +10520,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10537,9 +10544,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10548,9 +10556,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10600,9 +10609,10 @@ SELECT CASE 1
    WHEN 2 THEN 'بطاقة التسجيل - قياسية'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10610,9 +10620,10 @@ SELECT CASE 1
    WHEN 2 THEN 'abc'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10620,9 +10631,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10978,9 +10990,10 @@ SELECT CASE 1
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11001,9 +11014,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11012,9 +11026,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11046,9 +11061,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -11069,9 +11085,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -11080,9 +11097,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-CASE_EXPR-before-16_6-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-CASE_EXPR-before-16_6-vu-verify.out
@@ -10067,9 +10067,10 @@ SELECT CASE 1
    WHEN 2 THEN 'بطاقة التسجيل - قياسية'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10077,9 +10078,10 @@ SELECT CASE 1
    WHEN 2 THEN 'abc'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10087,9 +10089,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 
@@ -10446,9 +10449,10 @@ SELECT CASE 1
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10469,9 +10473,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10480,9 +10485,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10514,9 +10520,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10537,9 +10544,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10548,9 +10556,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10600,9 +10609,10 @@ SELECT CASE 1
    WHEN 2 THEN 'بطاقة التسجيل - قياسية'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10610,9 +10620,10 @@ SELECT CASE 1
    WHEN 2 THEN 'abc'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10620,9 +10631,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10978,9 +10990,10 @@ SELECT CASE 1
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11001,9 +11014,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11012,9 +11026,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11046,9 +11061,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -11069,9 +11085,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -11080,9 +11097,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -14365,9 +14383,6 @@ numeric
 ~~END~~
 
 
--- TODO FIX: While calculating for money and smallmoney
--- babelfish is calculating it same as numeric logic
--- which is different from TSQL.
 -- Test Case 81: UNION with MONEY type
 SELECT CAST(1.23 AS DECIMAL(10,2)) AS value
 UNION ALL
@@ -14378,9 +14393,9 @@ ORDER BY value;
 GO
 ~~START~~
 numeric
-1.23
-4.56
-7.89
+1.2300
+4.5600
+7.8900
 ~~END~~
 
 
@@ -14394,9 +14409,9 @@ ORDER BY value;
 GO
 ~~START~~
 numeric
-1.23
-4.56
-7.89
+1.2300
+4.5600
+7.8900
 ~~END~~
 
 

--- a/test/JDBC/expected/non_default_server_collation/japanese_ci_as/BABEL-CASE_EXPR-before-16_6-vu-verify.out
+++ b/test/JDBC/expected/non_default_server_collation/japanese_ci_as/BABEL-CASE_EXPR-before-16_6-vu-verify.out
@@ -10067,9 +10067,10 @@ SELECT CASE 1
    WHEN 2 THEN 'بطاقة التسجيل - قياسية'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10077,9 +10078,10 @@ SELECT CASE 1
    WHEN 2 THEN 'abc'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10087,9 +10089,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 
@@ -10446,9 +10449,10 @@ SELECT CASE 1
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10469,9 +10473,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10480,9 +10485,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -10514,9 +10520,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10537,9 +10544,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10548,9 +10556,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to binary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10600,9 +10609,10 @@ SELECT CASE 1
    WHEN 2 THEN 'بطاقة التسجيل - قياسية'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10610,9 +10620,10 @@ SELECT CASE 1
    WHEN 2 THEN 'abc'
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -10620,9 +10631,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 1
@@ -10978,9 +10990,10 @@ SELECT CASE 1
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11001,9 +11014,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11012,9 +11026,10 @@ SELECT CASE 1
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+abc
+~~END~~
 
 
 SELECT CASE 1
@@ -11046,9 +11061,10 @@ SELECT CASE 2
    WHEN 2 THEN CAST(0x123456 AS BABEL_CASE_EXPR_TEST_UDT)
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -11069,9 +11085,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS CHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -11080,9 +11097,10 @@ SELECT CASE 2
    WHEN 3 THEN CAST('char1' AS NCHAR(100))
 END AS RESULT
 GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: cannot coerce string literal to varbinary datatype)~~
+~~START~~
+varchar
+4V
+~~END~~
 
 
 SELECT CASE 2
@@ -14365,9 +14383,6 @@ numeric
 ~~END~~
 
 
--- TODO FIX: While calculating for money and smallmoney
--- babelfish is calculating it same as numeric logic
--- which is different from TSQL.
 -- Test Case 81: UNION with MONEY type
 SELECT CAST(1.23 AS DECIMAL(10,2)) AS value
 UNION ALL
@@ -14378,9 +14393,9 @@ ORDER BY value;
 GO
 ~~START~~
 numeric
-1.23
-4.56
-7.89
+1.2300
+4.5600
+7.8900
 ~~END~~
 
 
@@ -14394,9 +14409,9 @@ ORDER BY value;
 GO
 ~~START~~
 numeric
-1.23
-4.56
-7.89
+1.2300
+4.5600
+7.8900
 ~~END~~
 
 


### PR DESCRIPTION
### Description

This commit fixes the `BABEL-CASE_EXPR-before-16_6.verify` test file.

cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4507

Authored-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).