### PR TITLE
Replaced redundant plan generation in execsql for pltsql statements (…

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1258,25 +1258,11 @@ pltsql_planner_node_transformer(PlannerInfo *root,
 								Node *expr,
 								int kind)
 {
-	/*
-	 * check if this is called to reset saved expression kind. Quickly return if so.
-	 */
-	if (kind == -1)
-	{
-		Assert(expr == NULL);
-		saved_expr_kind = -1;
-		return NULL;
-	}
-
-	/*
-	 * Fall out quickly if expression is empty.
-	 */
 	if (expr == NULL)
 		return NULL;
 
 	if (EXPRKIND_TARGET == kind)
 	{
-		saved_expr_kind = EXPRKIND_TARGET;
 		/*
 		 * If expr is NOT a Boolean expression then recurse through its
 		 * expresion tree

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -324,7 +324,7 @@ static int	exec_stmt_assert(PLtsql_execstate *estate,
 							 PLtsql_stmt_assert *stmt);
 static int	exec_stmt_execsql(PLtsql_execstate *estate,
 							  PLtsql_stmt_execsql *stmt);
-static void updateColumnUpdatedList(PLtsql_expr *expr, int i);
+static void updateColumnUpdatedList(Query *query);
 static int	exec_stmt_dynexecute(PLtsql_execstate *estate,
 								 PLtsql_stmt_dynexecute *stmt);
 static int	exec_stmt_dynfors(PLtsql_execstate *estate,
@@ -4596,6 +4596,31 @@ is_start_implicit_txn_utility_command(Node *parsetree)
 }
 
 static bool
+is_query_using_regular_relation_walker(Node *node, void *context)
+{
+    if (node == NULL)
+        return false;
+    
+    if (IsA(node, RangeTblEntry))
+    {
+        RangeTblEntry *rte = (RangeTblEntry *) node;
+		if (rte->rtekind == RTE_RELATION && rte->relkind == 'r')
+			return true;
+    }
+    
+    if (IsA(node, Query))
+        return query_tree_walker((Query *) node, is_query_using_regular_relation_walker, context, QTW_EXAMINE_RTES_AFTER);
+    
+    return expression_tree_walker(node, is_query_using_regular_relation_walker, context);
+}
+
+static bool
+is_query_using_regular_relation(Node *node)
+{
+	return is_query_using_regular_relation_walker(node, NULL);
+}
+
+static bool
 is_impl_txn_required_for_execsql(PLtsql_stmt_execsql *stmt)
 {
 	PLtsql_expr *expr = stmt->sqlstmt;
@@ -4620,32 +4645,14 @@ is_impl_txn_required_for_execsql(PLtsql_stmt_execsql *stmt)
 	{
 		ListCell   *lc;
 
-		if (cachedPlanSource->gplan)
+		foreach(lc, cachedPlanSource->query_list)
 		{
-			foreach(lc, cachedPlanSource->gplan->stmt_list)
-			{
-				PlannedStmt *ps = (PlannedStmt *) lfirst(lc);
+			Query *q = (Query *) lfirst(lc);
 
-				if (ps->commandType == CMD_SELECT)
-				{
-					ListCell   *rt;
-
-					foreach(rt, ps->rtable)
-					{
-						RangeTblEntry *rte = (RangeTblEntry *) lfirst(rt);
-
-						/*
-						 * If range table entry is of kind ordinary relation
-						 * and relation kind is a simple table, we require an
-						 * implicit transaction.
-						 */
-						if (rte->rtekind == RTE_RELATION && rte->relkind == 'r')
-							return true;
-					}
-				}
-			}
-			return false;
+			if (is_query_using_regular_relation((Node *) q))
+				return true;
 		}
+		return false;
 	}
 	return true;
 }
@@ -4805,9 +4812,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	PLtsql_expr *expr = stmt->sqlstmt;
 	Portal		portal = NULL;
 	ListCell   *lc;
-	CachedPlan *cp;
 	bool		is_returning = false;
-	bool		is_select = true;
 
 	/*
 	 * Temporarily disable FMTONLY as it is causing issues with Import-Export.
@@ -4863,10 +4868,9 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			/*
 			 * If the set_fmtonly guc is set, we need to rewrite any
 			 * statements as exec statements that invoke
-			 * sp_describe_first_result_set. For now, only transform SELECT
-			 * statements.
+			 * sp_describe_first_result_set.
 			 */
-			if (pltsql_fmtonly && is_select && !strcasestr(estate->func->fn_signature, "sp_describe_first_result_set") && fmtonly_enabled && strcasestr(stmt->sqlstmt->query, "SELECT *"))
+			if (pltsql_fmtonly && !strcasestr(estate->func->fn_signature, "sp_describe_first_result_set") && fmtonly_enabled && strcasestr(stmt->sqlstmt->query, "SELECT *"))
 			{
 				initStringInfo(&query);
 				appendStringInfo(&query, "SELECT TOP 0");
@@ -4908,40 +4912,18 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		/*
 		 * Check whether the statement is an INSERT/DELETE with RETURNING
 		 */
-		cp = SPI_plan_get_cached_plan(expr->plan);
-		if (cp)
+		foreach(lc, ((CachedPlanSource *) linitial(SPI_plan_get_plan_sources(expr->plan)))->query_list)
 		{
-			int			i;
+			Query *q = (Query *) lfirst(lc);
 
-			i = 0;
-			foreach(lc, cp->stmt_list)
+			if (q->returningList != NIL)
 			{
-				PlannedStmt *ps = (PlannedStmt *) lfirst(lc);
-
-				if (ps->hasReturning)
-				{
-					is_returning = true;
-					if (ps->commandType == CMD_INSERT)
-						cmd = CMD_INSERT;
-					else if (ps->commandType == CMD_DELETE)
-						cmd = CMD_DELETE;
-					else if (ps->commandType == CMD_UPDATE)
-						cmd = CMD_UPDATE;
-					break;
-				}
-				if (ps->commandType != CMD_SELECT)
-				{
-					is_select = false;
-				}
-				if (ps->commandType == CMD_UPDATE || ps->commandType == CMD_INSERT)
-				{
-					updateColumnUpdatedList(expr, i);
-				}
-				++i;
+				is_returning = true;
+				cmd = q->commandType;
+				break;
 			}
-			ReleaseCachedPlan(cp, CurrentResourceOwner);
+			updateColumnUpdatedList(q);
 		}
-
 
 		/*
 		 * If we have INTO, then we only need one row back ... but if we have
@@ -5290,7 +5272,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 }
 
 static void
-updateColumnUpdatedList(PLtsql_expr *expr, int i)
+updateColumnUpdatedList(Query *query)
 {
 	ListCell   *lcj;
 	List	   *curr_columns_list;
@@ -5300,18 +5282,19 @@ updateColumnUpdatedList(PLtsql_expr *expr, int i)
 	MemoryContext oldContext;
 	UpdatedColumn *updateColumn;
 	int			length;
-	Query	   *query;
 	List	   *targetList;
 
-	query = (Query *) list_nth(
-							   ((CachedPlanSource *) list_nth(expr->plan->plancache_list, 0))->query_list
-							   ,i);
+	if (!(query->commandType == CMD_UPDATE || query->commandType == CMD_INSERT))
+		return;
+
 	targetList =
 		query->targetList;
 	if (query->rtable == NULL || targetList == NULL)
 		return;
 	rel = RelationIdGetRelation(((RangeTblEntry *) list_nth(query->rtable, query->resultRelation - 1))->relid);
-	if (!rel || rel->rd_islocaltemp || !rel->rd_isvalid)
+	if (!rel)
+		return;
+	if (rel->rd_islocaltemp || !rel->rd_isvalid)
 	{
 		RelationClose(rel);
 		return;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -49,6 +49,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/pg_list.h"
+#include "optimizer/optimizer.h"
 #include "parser/analyze.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
@@ -196,6 +197,8 @@ static int isolation_to_int(char *isolation_level);
 static void bbf_set_tran_isolation(char *new_isolation_level_str);
 static void gen_command_grant_revoke_priv_to_role(StringInfo query, const char *rolename,
 							bool is_grant, Oid login_oid);
+
+static Node *pltsql_simplify_const_expression(PlannerInfo *root, Node *expr, int kind);
 
 typedef struct ColumnAclInfo
 {
@@ -6109,6 +6112,8 @@ _PG_init(void)
 	prev_planner_node_transformer_hook = planner_node_transformer_hook;
 	planner_node_transformer_hook = pltsql_planner_node_transformer;
 
+	eval_const_expressions_in_preprocess_hook = pltsql_simplify_const_expression;
+
 	prev_pltsql_nextval_hook = pltsql_nextval_hook;
 	pltsql_nextval_hook = pltsql_nextval_identity;
 
@@ -8191,4 +8196,31 @@ gen_command_grant_revoke_priv_to_role(StringInfo query, const char *rolename,
 				(revoke_createrole ? "nocreaterole" : ""), grant_createdb ? "createdb" : 
 					(revoke_createdb ? "nocreatedb" : ""));
 
+}
+
+Node *
+pltsql_simplify_const_expression(PlannerInfo *root,
+								Node *expr,
+								int kind)
+{
+	int		prev_expr_kind = saved_expr_kind;
+
+	if (expr == NULL)
+		return NULL;
+
+	PG_TRY();
+	{
+		if (kind == EXPRKIND_TARGET)
+		{
+			saved_expr_kind = EXPRKIND_TARGET;
+		}
+		expr = eval_const_expressions(root, expr);
+	}
+	PG_FINALLY();
+	{
+		saved_expr_kind = prev_expr_kind;
+	}
+	PG_END_TRY();
+
+	return expr;
 }


### PR DESCRIPTION
…#4425)

Currently, to determine the type of the statement and whether it has a RETURNING clause, a plan is generated by calling SPI_plan_get_cached_plan(). This leads to additional overhead. This commit removes the call, instead using the query list to determine the type.

There were multiple dependencies on the plan being generated early, these have been changed to instead walk through query trees.

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/702

Task: BABEL-3756

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4425

Authored by: Saurav Samantaray <sauravay@amazon.com>

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).