### PR TITLE
Fixing uninitialized read in PrepareRowDescription

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2014,7 +2014,7 @@ PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *target
 				TdsRelationMetaDataInfo relMetaDataInfo;
 				char	   *physical_schema_name;
 
-				relMetaDataInfo = (TdsRelationMetaDataInfo) palloc(sizeof(TdsRelationMetaDataInfoData));
+				relMetaDataInfo = (TdsRelationMetaDataInfo) palloc0(sizeof(TdsRelationMetaDataInfoData));
 				tableNum++;
 
 				relMetaDataInfo->relOid = col->relOid;


### PR DESCRIPTION
### Description

In valgrind enabled babelfish, we get following issue:

```
==00:01:25:44.546 29212== VALGRINDERROR-BEGIN
==00:01:25:44.546 29212== Conditional jump or move depends on uninitialised value(s)
==00:01:25:44.546 29212==    at 0x89CDC64: PrepareRowDescription (tdsresponse.c:1638)
==00:01:25:44.546 29212==    by 0x89CEE2B: TdsSendRowDescription (tdsresponse.c:2189)
==00:01:25:44.546 29212==    by 0x89BC3D0: TdsPrinttupStartup (tdsprinttup.c:87)
==00:01:25:44.546 29212==    by 0x760A3F: standard_ExecutorRun (execMain.c:359)
==00:01:25:44.546 29212==    by 0x8C0B21A: pgss_ExecutorRun (pg_stat_statements.c:1025)
==00:01:25:44.546 29212==    by 0x126AC39F: pltsql_ExecutorRun (hooks.c:1345)
==00:01:25:44.546 29212==    by 0x7608D8: ExecutorRun (execMain.c:309)
==00:01:25:44.546 29212==    by 0xA01E1A: PortalRunSelect (pquery.c:922)
==00:01:25:44.546 29212==    by 0xA01AE1: PortalRun (pquery.c:766)
==00:01:25:44.546 29212==    by 0x125CA971: execute_plan_and_push_result (pl_exec-2.c:3838)
==00:01:25:44.546 29212==    by 0x125D8F64: exec_stmt_execsql (pl_exec.c:5024)
==00:01:25:44.546 29212==    by 0x125CE76A: dispatch_stmt (iterative_exec.c:670)
==00:01:25:44.546 29212==    by 0x125CFE3A: dispatch_stmt_handle_error (iterative_exec.c:1305)
==00:01:25:44.546 29212==    by 0x125D0DDB: exec_stmt_iterative (iterative_exec.c:1638)
==00:01:25:44.546 29212==    by 0x125BDCAF: pltsql_exec_function (pl_exec.c:695)
==00:01:25:44.546 29212==    by 0x125B201B: pltsql_inline_handler (pl_handler.c:6696)
==00:01:25:44.546 29212==    by 0x89DDFA2: ExecuteSQLBatch (tdssqlbatch.c:94)
==00:01:25:44.546 29212==    by 0x89DE1B9: ProcessSQLBatchRequest (tdssqlbatch.c:142)
==00:01:25:44.546 29212==    by 0x89C94CE: ProcessTDSRequest (tdsprotocol.c:462)
==00:01:25:44.546 29212==    by 0x89C9FD6: TdsSocketBackend (tdsprotocol.c:706)
==00:01:25:44.546 29212==    by 0x89BDDD8: pe_process_command (tds_srv.c:560)
==00:01:25:44.546 29212==    by 0x9FFC11: PostgresMain (postgres.c:4795)
==00:01:25:44.546 29212==    by 0x89BDC79: pe_mainfunc (tds_srv.c:494)
==00:01:25:44.546 29212==    by 0x9F74F7: BackendMain (backend_startup.c:105)
==00:01:25:44.546 29212==    by 0x9217BC: postmaster_child_launch (launch_backend.c:277)
==00:01:25:44.546 29212==    by 0x9275DF: BackendStartup (postmaster.c:3772)
==00:01:25:44.546 29212==    by 0x924AFF: ServerLoop (postmaster.c:1852)
==00:01:25:44.546 29212==    by 0x924106: PostmasterMain (postmaster.c:1413)
==00:01:25:44.546 29212==    by 0x7E2E07: main (main.c:199)
==00:01:25:44.546 29212==  Uninitialised value was created by a heap allocation
==00:01:25:44.546 29212==    at 0xC17891: palloc (mcxt.c:1340)
==00:01:25:44.546 29212==    by 0x89CDB4F: PrepareRowDescription (tdsresponse.c:1601)
==00:01:25:44.546 29212==    by 0x89CEE2B: TdsSendRowDescription (tdsresponse.c:2189)
==00:01:25:44.546 29212==    by 0x89BC3D0: TdsPrinttupStartup (tdsprinttup.c:87)
==00:01:25:44.546 29212==    by 0x760A3F: standard_ExecutorRun (execMain.c:359)
==00:01:25:44.546 29212==    by 0x8C0B21A: pgss_ExecutorRun (pg_stat_statements.c:1025)
==00:01:25:44.546 29212==    by 0x126AC39F: pltsql_ExecutorRun (hooks.c:1345)
==00:01:25:44.546 29212==    by 0x7608D8: ExecutorRun (execMain.c:309)
==00:01:25:44.546 29212==    by 0xA01E1A: PortalRunSelect (pquery.c:922)
==00:01:25:44.546 29212==    by 0xA01AE1: PortalRun (pquery.c:766)
==00:01:25:44.546 29212==    by 0x125CA971: execute_plan_and_push_result (pl_exec-2.c:3838)
==00:01:25:44.546 29212==    by 0x125D8F64: exec_stmt_execsql (pl_exec.c:5024)
==00:01:25:44.546 29212==    by 0x125CE76A: dispatch_stmt (iterative_exec.c:670)
==00:01:25:44.546 29212==    by 0x125CFE3A: dispatch_stmt_handle_error (iterative_exec.c:1305) 
```

This occurs because in PrepareRowDescription function, memory is allocated using palloc() which does not initialize memory:

`relMetaDataInfo = (TdsRelationMetaDataInfo) palloc(sizeof(TdsRelationMetaDataInfoData)); `

### Issues Resolved

Task: BABEL-6332

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).