### PR TITLE
Replace direct USE DB execution with API invocation

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -2034,10 +2034,9 @@ TdsProcessLogin(Port *port, bool loadedSsl)
 void
 TdsSetDbContext()
 {
-	char *dbname				= NULL;
-	char *useDbCommand			= NULL;
-	char *user 					= NULL;
-	MemoryContext oldContext	= CurrentMemoryContext;
+	char	   *dbname = NULL;
+	char	   *user = NULL;
+	MemoryContext oldContext = CurrentMemoryContext;
 
 	PG_TRY();
 	{
@@ -2060,11 +2059,6 @@ TdsSetDbContext()
 						(errcode(ERRCODE_UNDEFINED_DATABASE),
 							errmsg("database \"%s\" does not exist", loginInfo->database)));
 
-			/*
-			 * Any delimitated/quoted db name identifier requested in login
-			 * must be already handled before this point.
-			 */
-			useDbCommand = psprintf("USE [%s]", loginInfo->database);
 			dbname = pstrdup(loginInfo->database);
 		}
 		else
@@ -2079,8 +2073,6 @@ TdsSetDbContext()
 				ereport(ERROR,
 						(errcode(ERRCODE_UNDEFINED_DATABASE),
 							errmsg("could not find default database for user \"%s\"", loginInfo->username)));
-
-			useDbCommand = psprintf("USE [%s]", temp);
 			dbname = pstrdup(temp);
 			CommitTransactionCommand();
 			MemoryContextSwitchTo(oldContext);
@@ -2097,10 +2089,9 @@ TdsSetDbContext()
 						errmsg("Cannot open database \"%s\" requested by the login. The login failed", dbname)));
 
 		/*
-		 * loginInfo has a database name provided, so we execute a "USE
-		 * [<db_name>]" through pltsql inline handler.
+		 * Direct API invokation for switching database context.
 		 */
-		ExecuteSQLBatch(useDbCommand);
+		pltsql_plugin_handler_ptr->switch_database_context(dbname);
 		CommitTransactionCommand();
 	}
 	PG_CATCH();
@@ -2137,8 +2128,6 @@ TdsSetDbContext()
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	if (useDbCommand)
-		pfree(useDbCommand);
 	if (dbname)
 		pfree(dbname);
 }

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6043,6 +6043,7 @@ _PG_init(void)
 		(*pltsql_protocol_plugin_ptr)->pltsql_get_logical_schema_name = &get_logical_schema_name;
 		(*pltsql_protocol_plugin_ptr)->pltsql_is_fmtonly_stmt = &pltsql_fmtonly;
 		(*pltsql_protocol_plugin_ptr)->pltsql_get_user_for_database = &get_user_for_database;
+		(*pltsql_protocol_plugin_ptr)->switch_database_context = &switch_database_context;
 		(*pltsql_protocol_plugin_ptr)->get_insert_bulk_rows_per_batch = &get_insert_bulk_rows_per_batch;
 		(*pltsql_protocol_plugin_ptr)->get_insert_bulk_kilobytes_per_batch = &get_insert_bulk_kilobytes_per_batch;
 		(*pltsql_protocol_plugin_ptr)->tsql_varchar_input = common_utility_plugin_ptr->tsql_varchar_input;

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1789,6 +1789,8 @@ typedef struct PLtsql_protocol_plugin
 
 	char	   *(*pltsql_get_user_for_database) (const char *db_name);
 
+	void		(*switch_database_context) (const char *dbname);
+
 	char	   *(*TsqlEncodingConversion) (const char *s, int len, int encoding, int *encodedByteLen);
 
 	int			(*TdsGetEncodingFromLcid) (int32_t lcid);

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -190,6 +190,38 @@ set_cur_user_db_and_path(const char *db_name, bool check_db_id)
 	set_db_collation_internal(db_name);
 }
 
+/*
+ * switch_database_context - Switching database context during login
+ *
+ * This function performs all necessary steps to securely switch database context:
+ * 1. Validates user has access to the database
+ * 2. Acquires session-level lock on the target database
+ * 3. Sets the database, user, and search path
+ *
+ */
+void
+switch_database_context(const char *dbname)
+{
+	int16		new_db_id;
+
+	/* Validate user has access to the database */
+	check_session_db_access(dbname);
+	
+	/* Get database ID for lock acquisition */
+	new_db_id = get_db_id(dbname);
+	
+	/* Acquire session-level lock on the new database */
+	if (!TryLockLogicalDatabaseForSession(new_db_id, ShareLock))
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+					errmsg("Cannot use database \"%s\", failed to obtain lock. "
+						   "\"%s\" is probably undergoing DDL statements in another session.",
+						   dbname, dbname)));
+	
+	/* Set database context, user, and search path */
+	set_cur_user_db_and_path(dbname, false);
+}
+
 static void
 set_search_path_for_user_schema(const char *db_name, const char *user)
 {

--- a/contrib/babelfishpg_tsql/src/session.h
+++ b/contrib/babelfishpg_tsql/src/session.h
@@ -15,6 +15,7 @@ extern void set_cur_user_db_and_path(const char *db_name, bool check_db_id);
 extern void restore_session_properties(void);
 extern void reset_session_properties(void);
 extern void set_cur_db_name_for_parallel_worker(const char* logical_db_name);
+extern void switch_database_context(const char *dbname);
 
 /* Hooks for parallel workers for babelfish fixed state */
 extern void babelfixedparallelstate_insert(ParallelContext *pcxt, bool estimate);


### PR DESCRIPTION
### Description
With this commit we replace direct USE DB execution with API invocation during login. Bolstering the login process.

Signed-off-by: Kushaal Shroff <kushaal@amazon.com>


### Issues Resolved
BABEL-6346

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).