### PR TITLE
Fix MVU failure for sys.fn_varbintohexsubstring

### DIFF
--- a/.github/configuration/upgrade-test-configuration.yml
+++ b/.github/configuration/upgrade-test-configuration.yml
@@ -292,5 +292,41 @@ upgrade-version: [{
       upgrade-type: major
     }
   ]
+},
+{
+  upgrade-path: [
+    {
+      version: 16.4,
+      upgrade-type: null
+    },
+    {
+      version: 16.10,
+      upgrade-type: minor
+    },
+    {
+      version: 17.6,
+      upgrade-type: major
+    },
+    { 
+      version: target.latest,
+      upgrade-type: minor
+    }
+  ]
+},
+{
+  upgrade-path: [
+    {
+      version: 16.10,
+      upgrade-type: null
+    },
+    {
+      version: '16.12',
+      upgrade-type: minor
+    },
+    { 
+      version: target.latest,
+      upgrade-type: major
+    }
+  ]
 }
 ]

--- a/.github/configuration/upgrade-test-configuration.yml
+++ b/.github/configuration/upgrade-test-configuration.yml
@@ -292,41 +292,5 @@ upgrade-version: [{
       upgrade-type: major
     }
   ]
-},
-{
-  upgrade-path: [
-    {
-      version: 16.4,
-      upgrade-type: null
-    },
-    {
-      version: 16.10,
-      upgrade-type: minor
-    },
-    {
-      version: 17.6,
-      upgrade-type: major
-    },
-    { 
-      version: target.latest,
-      upgrade-type: minor
-    }
-  ]
-},
-{
-  upgrade-path: [
-    {
-      version: 16.10,
-      upgrade-type: null
-    },
-    {
-      version: '16.12',
-      upgrade-type: minor
-    },
-    { 
-      version: target.latest,
-      upgrade-type: major
-    }
-  ]
 }
 ]

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--5.4.0--5.5.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--5.4.0--5.5.0.sql
@@ -1676,6 +1676,20 @@ END;
 $$ 
 LANGUAGE plpgsql IMMUTABLE STRICT;
 
+DO $$
+DECLARE
+    exception_message text;
+BEGIN
+    ALTER FUNCTION sys.fn_varbintohexsubstring(set_prefix INT, expression sys.varbinary(128), start_offset INT, length_to_return INT) RENAME TO fn_varbintohexsubstring_deprecated_in_5_5_0;
+EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+    exception_message = MESSAGE_TEXT;
+    RAISE WARNING '%', exception_message;
+END;
+$$;
+
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'fn_varbintohexsubstring_deprecated_in_5_5_0');
+
 -- Drops the temporary procedure used by the upgrade script.
 -- Please have this be one of the last statements executed in this upgrade script.
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -651,3 +651,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 BABEL-1664
 babel_convert_with_style
+sys-fn-varbintohexsubstring

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -648,3 +648,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-1664
 babel_convert_with_style
 babel_string_to_money_reg
+sys-fn-varbintohexsubstring

--- a/test/JDBC/upgrade/16_12/schedule
+++ b/test/JDBC/upgrade/16_12/schedule
@@ -648,3 +648,4 @@ sys-fn_varbintohexstr
 babel_binary
 babel_convert_with_style
 babel_string_to_money_reg
+sys-fn-varbintohexsubstring

--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -643,3 +643,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style
+sys-fn-varbintohexsubstring-before-16_10-or-17_6


### PR DESCRIPTION
### Description

After a major version upgrade (e.g., 16.11 Zebra → 17.8 Alpaca), sys.fn_varbintohexsubstring() returns NULL for valid inputs or raises uniqueness errors.

This commit deprecates the lingering dummy definition in babelfishpg_tsql--5.4.0--5.5.0.sql to clean up instances that have already been upgraded.

### Issues Resolved

BABEL-6363

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).