### PR TITLE
Making default locale as C to match the Github workflow

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -155,7 +155,7 @@ build_bbf() {
 init_db() {
     cd $1/postgres
     rm -rf data
-    bin/initdb -D data/
+    bin/initdb -D data/ --locale=C --encoding=UTF8
     PID=$(ps -ef | grep postgres/bin/postgres | grep -v grep | awk '{print $2}')
     if [ $PID ]
     then


### PR DESCRIPTION
### Description

The initdb command now explicitly sets `--locale=C --encoding=UTF8 `

Becasue there were differences in the order of output despite using `ORDER BY` clause 

`SELECT * FROM enr_view ORDER BY relname ` in the test files may behave differently for the local systems and the github CI, leading to ouputs with different sorted order. This is because of the locale difference. The local system may use en_US that can lead to a different order whereas the CI running on Ubuntu (for which the default locale is C) can have a different sorted order.

This fix ensures that the default locale is set to C which helps in maintaining consistency.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).