### PR TITLE
[OSS-ONLY] Disable test which drops temp table from a procedure (#4576)

### DIFF
--- a/test/JDBC/expected/temp_table_visibility-vu-verify.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-verify.out
@@ -131,11 +131,3 @@ idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 #temptable5605
 ~~END~~
 
-EXEC p_drop
-GO
-SELECT * FROM #temptable5605
-GO
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: relation "#temptable5605" does not exist)~~
-

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
@@ -29,7 +29,8 @@ EXEC p_nested_2
 GO
 EXEC p_index_create
 GO
-EXEC p_drop
-GO
-SELECT * FROM #temptable5605
-GO
+-- FIXME: BABEL-6268
+-- EXEC p_drop
+-- GO
+-- SELECT * FROM #temptable5605
+-- GO


### PR DESCRIPTION
### Description

Original PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4576

Currently, this test fail because of BABEL-6268 and will be fixed as part of that JIRA

Engine PR - babelfish-for-postgresql/postgresql_modified_for_babelfish#708

Authored-by: Ayush Shah <ayushdsh@amazon.com>
(cherry picked from commit c9832c41a0fbce7b1ef036dda19832f08030bbc5)



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).