### PR TITLE
Add hook to detect ENR to sys object dependencies and refactor find_object_in_enr hook (#4577)

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -12,6 +12,8 @@
 #include "access/xact.h"
 #include "access/relation.h"
 #include "access/reloptions.h"
+#include "catalog/catalog.h"
+#include "catalog/dependency.h"
 #include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_aggregate.h"
@@ -297,7 +299,8 @@ static Oid 	pltsql_GetNewTempOidWithIndex(Relation relation, Oid indexId, AttrNu
 static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
 static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
 static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
-static EphemeralNamedRelation find_object_in_enr(Oid catalog_oid, Oid object_id);
+static EphemeralNamedRelation find_object_in_enr(Oid catalog_oid, Oid object_id, QueryEnvironment *qe);
+static bool is_enr_to_sys_object_dependency(const ObjectAddress *depender, const ObjectAddress *referenced);
 static bool verify_stmt_alterdatabaseset(Node* n, const char* dbname, const char* config);
 PG_FUNCTION_INFO_V1(persist_temp_oid_buffer_start_internal);
 
@@ -342,6 +345,7 @@ static GetNewTempOidWithIndex_hook_type prev_GetNewTempOidWithIndex_hook = NULL;
 static pltsql_is_local_only_inval_msg_hook_type prev_pltsql_is_local_only_inval_msg_hook = NULL;
 static pltsql_get_tsql_enr_from_oid_hook_type prev_pltsql_get_tsql_enr_from_oid_hook = NULL;
 static find_object_in_enr_hook_type prev_find_object_in_enr_hook = NULL;
+static is_enr_to_sys_object_dependency_hook_type prev_is_enr_to_sys_object_dependency_hook = NULL;
 static inherit_view_constraints_from_table_hook_type prev_inherit_view_constraints_from_table = NULL;
 static bbfViewHasInsteadofTrigger_hook_type prev_bbfViewHasInsteadofTrigger_hook = NULL;
 static adjust_numeric_result_hook_type prev_adjust_numeric_result_hook = NULL;
@@ -494,6 +498,9 @@ InstallExtendedHooks(void)
 
 	prev_find_object_in_enr_hook = find_object_in_enr_hook;
 	find_object_in_enr_hook = find_object_in_enr;
+
+	prev_is_enr_to_sys_object_dependency_hook = is_enr_to_sys_object_dependency_hook;
+	is_enr_to_sys_object_dependency_hook = is_enr_to_sys_object_dependency;
 
 	prev_inherit_view_constraints_from_table = inherit_view_constraints_from_table_hook;
 	inherit_view_constraints_from_table_hook = preserve_view_constraints_from_base_table;
@@ -698,6 +705,7 @@ UninstallExtendedHooks(void)
 	GetNewTempObjectId_hook = prev_GetNewTempObjectId_hook;
 	GetNewTempOidWithIndex_hook = prev_GetNewTempOidWithIndex_hook;
 	find_object_in_enr_hook = prev_find_object_in_enr_hook;
+	is_enr_to_sys_object_dependency_hook = prev_is_enr_to_sys_object_dependency_hook;
 	inherit_view_constraints_from_table_hook = prev_inherit_view_constraints_from_table;
 	bbfViewHasInsteadofTrigger_hook = prev_bbfViewHasInsteadofTrigger_hook;
 	adjust_numeric_result_hook = prev_adjust_numeric_result_hook;
@@ -8316,12 +8324,13 @@ find_all_view_references(Node *node, List **view_oids)
  * For find_object_in_enr_hook
  *
  * Returns the ENR in which the given object (denoted by its catalog oid and object id)
- * exists. Based on the catalog we are searching the object in, the search criteria changes.
+ * exists. If a queryEnv is given, only check ENRs within that queryEnv.
+ * Based on the catalog we are searching the object in, the search criteria changes.
  */
 static EphemeralNamedRelation
-find_object_in_enr(Oid catalog_oid, Oid object_id)
+find_object_in_enr(Oid catalog_oid, Oid object_id, QueryEnvironment *qe)
 {
-	QueryEnvironment 		*queryEnv = currentQueryEnv;
+	QueryEnvironment 		*queryEnv = (qe ? qe : currentQueryEnv);
 	ListCell         		*curlc;
 	EphemeralNamedRelation	enr;
 
@@ -8420,9 +8429,59 @@ find_object_in_enr(Oid catalog_oid, Oid object_id)
 			default:
 				break;
 		}
+		/*
+		 * skip iterating through parent queryEnvs if a queryEnv is passed explicitly 
+		 */
+		if (qe)
+			break;
 		queryEnv = queryEnv->parentEnv;
 	}
 	return NULL;
+}
+
+/*
+ * Checks if the given objid from the given catalog is a system object or not.
+ *
+ * Pinned objects i.e. objects Postgres requires and babelfish extension declared objects i.e.
+ * objects created by the babelfish extension are regarded as system objects.
+ */
+static bool
+is_sys_object(Oid catalogid, Oid objid)
+{
+	/*
+	 * If the object is owned by an extension, only babelfish extension created
+	 * objects will be regarded as system objects.
+	 */
+	Oid 	owningext = getExtensionOfObject(catalogid, objid);
+	char	*bbf_prefix_ext_name = "babelfishpg";
+	if (owningext != InvalidOid)
+	{
+		char *ext_name = get_extension_name(owningext);
+		if (ext_name != NULL && strncmp(ext_name, bbf_prefix_ext_name, strlen(bbf_prefix_ext_name)) == 0)
+			return true;
+		else
+			return false;
+	}
+
+	/*
+	 * If this is not an object owned by an extension and it cannot be a postgres
+	 * pinned object because we skip creating dependency on pinned object way ahead
+	 * of this. Hence, this is simply not a system object.
+	 */
+	Assert(!IsPinnedObject(catalogid, objid));
+	return false;
+}
+
+/*
+ * Checks if the depender object is an ENR and the referenced object is a system object which
+ * helps to determine if we want to record a dependency between the objects in the pg_depend catalog. 
+ * Since system objects cannot be altered, it is safe to skip creating this dependency.
+ */		
+static bool
+is_enr_to_sys_object_dependency(const ObjectAddress *depender, const ObjectAddress *referenced)
+{
+	return find_object_in_enr(depender->classId, depender->objectId, NULL) && 
+			is_sys_object(referenced->classId, referenced->objectId);
 }
 
 static Node*

--- a/test/JDBC/expected/temp_table_visibility-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-cleanup.out
@@ -39,3 +39,9 @@ go
 
 drop view enr_view
 go
+
+drop function custom_adder;
+GO
+
+drop procedure p_def_cons;
+GO

--- a/test/JDBC/expected/temp_table_visibility-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-prepare.out
@@ -100,3 +100,21 @@ BEGIN
 	SELECT * FROM enr_view;
 END;
 GO
+
+CREATE FUNCTION custom_adder(@a INT, @b INT)
+RETURNS INT
+BEGIN
+	RETURN @a + @b;
+END;
+GO
+
+CREATE PROCEDURE p_def_cons
+AS
+BEGIN
+	DECLARE @tv_def_con TABLE(id INT PRIMARY KEY, a INT IDENTITY, b CHAR(1) DEFAULT 'F' CHECK (b IN ('T', 'F')));
+	INSERT INTO @tv_def_con(id, b) VALUES (1, 'T');
+	INSERT INTO @tv_def_con(id) VALUES (2);
+	INSERT INTO @tv_def_con(id, b) VALUES (3, 'A');
+	SELECT * FROM @tv_def_con;
+END;
+GO

--- a/test/JDBC/expected/temp_table_visibility-vu-verify.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-verify.out
@@ -131,3 +131,639 @@ idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 #temptable5605
 ~~END~~
 
+
+-- FIXME: BABEL-6268
+-- EXEC p_drop
+-- GO
+-- SELECT * FROM #temptable5605
+-- GO
+-- Test 1: Comprehensive System Functions, Operators, and DML Operations
+CREATE TABLE #sys_comprehensive (
+	id INT PRIMARY KEY,
+	created_date DATETIME DEFAULT GETDATE(),
+	guid_col UNIQUEIDENTIFIER DEFAULT NEWID(),
+	age INT CHECK (age > 0 AND age < 200),
+	salary MONEY CHECK (salary >= 0),
+	discount DECIMAL(5,2) CHECK (discount <= 100.00),
+	quantity INT CHECK (quantity <> 0),
+	status CHAR(1) CHECK (status = 'A' OR status = 'I' OR status = 'P'),
+	score INT CHECK (score BETWEEN 0 AND 100),
+	start_date DATETIME,
+	end_date DATETIME,
+	price MONEY,
+	total AS (price * quantity),
+	CHECK (end_date > start_date),
+	CHECK (DATEDIFF(DAY, start_date, end_date) <= 365)
+)
+GO
+
+-- Verify in ENR
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#t4122
+#temptable5605
+#sys_comprehensive
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#sys_comprehensive_pkey
+~~END~~
+
+
+-- Insert test data with system function defaults
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (1, 30, 50000, 10.5, 5, 'A', 85, '2024-01-01', '2024-06-30', 100.00)
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (2, 45, 75000, 15.0, -3, 'I', 92, '2024-02-01', '2024-08-15', 250.50)
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (3, 28, 62000, 8.0, 10, 'P', 78, '2024-03-01', '2024-09-30', 75.25)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT id, age, status, score, quantity FROM #sys_comprehensive
+GO
+~~START~~
+int#!#int#!#char#!#int#!#int
+1#!#30#!#A#!#85#!#5
+2#!#45#!#I#!#92#!#-3
+3#!#28#!#P#!#78#!#10
+~~END~~
+
+
+-- Test UPDATE operations
+UPDATE #sys_comprehensive SET salary = salary * 1.1 WHERE id = 1
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE #sys_comprehensive SET status = 'I', score = 95 WHERE age < 30
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT id, age, salary, status, score FROM #sys_comprehensive ORDER BY id
+GO
+~~START~~
+int#!#int#!#money#!#char#!#int
+1#!#30#!#55000.0000#!#A#!#85
+2#!#45#!#75000.0000#!#I#!#92
+3#!#28#!#62000.0000#!#I#!#95
+~~END~~
+
+
+-- Test DELETE operation
+DELETE FROM #sys_comprehensive WHERE quantity < 0
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT COUNT(*) as record_count FROM #sys_comprehensive
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- ALTER TABLE: Add new column with default
+ALTER TABLE #sys_comprehensive ADD department VARCHAR(50) DEFAULT 'Unknown'
+GO
+
+SELECT id, department FROM #sys_comprehensive
+GO
+~~START~~
+int#!#varchar
+1#!#Unknown
+3#!#Unknown
+~~END~~
+
+
+-- ALTER TABLE: Add new column with CHECK constraint
+ALTER TABLE #sys_comprehensive ADD bonus MONEY CHECK (bonus >= 0 AND bonus <= 50000)
+GO
+
+-- Update new column
+UPDATE #sys_comprehensive SET bonus = salary * 0.1, department = 'Sales' WHERE id = 1
+UPDATE #sys_comprehensive SET bonus = salary * 0.15, department = 'Engineering' WHERE id = 3
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT id, department, bonus FROM #sys_comprehensive ORDER BY id
+GO
+~~START~~
+int#!#varchar#!#money
+1#!#Sales#!#5500.0000
+3#!#Engineering#!#9300.0000
+~~END~~
+
+
+-- ALTER TABLE: Add computed column
+ALTER TABLE #sys_comprehensive ADD bonus_tax AS (bonus * 0.25)
+GO
+
+SELECT id, bonus, bonus_tax FROM #sys_comprehensive WHERE bonus IS NOT NULL
+GO
+~~START~~
+int#!#money#!#numeric
+1#!#5500.0000#!#1375.000000
+3#!#9300.0000#!#2325.000000
+~~END~~
+
+
+-- ALTER TABLE: Add CHECK constraint to existing table
+ALTER TABLE #sys_comprehensive ADD CONSTRAINT chk_department CHECK (department IN ('Sales', 'Engineering', 'Marketing', 'Unknown'))
+GO
+
+-- Test constraint (should fail)
+UPDATE #sys_comprehensive SET department = 'InvalidDept' WHERE id = 1
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "#sys_comprehensive" violates check constraint "chk_department")~~
+
+
+SELECT id, department FROM #sys_comprehensive ORDER BY id
+GO
+~~START~~
+int#!#varchar
+1#!#Sales
+3#!#Engineering
+~~END~~
+
+
+-- Test CHECK constraint violations (should fail)
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (10, 0, 50000, 10.0, 1, 'A', 50, '2024-01-01', '2024-06-30', 100.00)
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "#sys_comprehensive" violates check constraint "#sys_comprehensive_age_check")~~
+
+
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (11, 30, -1000, 10.0, 1, 'A', 50, '2024-01-01', '2024-06-30', 100.00)
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "#sys_comprehensive" violates check constraint "#sys_comprehensive_salary_check")~~
+
+
+DROP TABLE #sys_comprehensive
+GO
+
+-- Test 2: Advanced Column Features with NULL Handling and Computed Columns
+CREATE TABLE #advanced_columns (
+	id INT PRIMARY KEY,
+	first_name VARCHAR(50),
+	last_name VARCHAR(50),
+	age INT,
+	balance BIGINT,
+	amount AS (balance * 1000 / NULLIF(age, 0)),
+	nullable_col INT,
+	default_col INT DEFAULT COALESCE(NULL, 100),
+	is_null_col AS (CASE WHEN nullable_col IS NULL THEN 1 ELSE 0 END),
+	created_date DATETIME DEFAULT GETDATE(),
+	year_created AS YEAR(created_date),
+	CHECK (ISNULL(nullable_col, 0) >= 0),
+	CHECK (age > 0)
+)
+GO
+
+-- Verify in ENR
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#t4122
+#temptable5605
+#advanced_columns
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#advanced_columns_pkey
+~~END~~
+
+
+-- Insert test data
+INSERT INTO #advanced_columns (id, first_name, last_name, age, balance, nullable_col) 
+VALUES (1, 'John', 'Doe', 24, 50000, NULL)
+INSERT INTO #advanced_columns (id, first_name, last_name, age, balance, nullable_col) 
+VALUES (2, 'Jane', 'Smith', 35, 104230, 50)
+INSERT INTO #advanced_columns (id, first_name, last_name, age, balance) 
+VALUES (3, 'Bob', 'Johnson', 42, 75000)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT id, amount, is_null_col, default_col FROM #advanced_columns
+GO
+~~START~~
+int#!#bigint#!#int#!#int
+1#!#2083333#!#1#!#100
+2#!#2978000#!#0#!#100
+3#!#1785714#!#1#!#100
+~~END~~
+
+
+-- Test UPDATE on base columns (computed columns auto-update)
+UPDATE #advanced_columns SET first_name = 'Johnny' WHERE id = 1
+GO
+~~ROW COUNT: 1~~
+
+
+UPDATE #advanced_columns SET balance = balance + 10000, age = age + 1 WHERE id = 2
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT id, age, balance, amount FROM #advanced_columns ORDER BY id
+GO
+~~START~~
+int#!#int#!#bigint#!#bigint
+1#!#24#!#50000#!#2083333
+2#!#36#!#114230#!#3173055
+3#!#42#!#75000#!#1785714
+~~END~~
+
+
+-- Update nullable columns
+UPDATE #advanced_columns SET nullable_col = 100 WHERE id = 1
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT id, nullable_col, is_null_col FROM #advanced_columns ORDER BY id
+GO
+~~START~~
+int#!#int#!#int
+1#!#100#!#0
+2#!#50#!#0
+3#!#<NULL>#!#1
+~~END~~
+
+
+-- ALTER TABLE: Add new computed column
+ALTER TABLE #advanced_columns ADD age_group AS (
+	CASE 
+		WHEN age < 30 THEN 'Young'
+		WHEN age BETWEEN 30 AND 50 THEN 'Middle'
+		ELSE 'Senior'
+	END
+)
+GO
+
+SELECT id, age, age_group FROM #advanced_columns
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#42#!#Middle
+2#!#36#!#Middle
+1#!#24#!#Young
+~~END~~
+
+
+-- ALTER TABLE: Add column with COALESCE default
+ALTER TABLE #advanced_columns ADD priority INT DEFAULT COALESCE(NULL, 5)
+GO
+
+SELECT id, priority FROM #advanced_columns
+GO
+~~START~~
+int#!#int
+3#!#5
+2#!#5
+1#!#5
+~~END~~
+
+
+-- Update priority
+UPDATE #advanced_columns SET priority = 10 WHERE age < 30
+UPDATE #advanced_columns SET priority = 20 WHERE age >= 40
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT id, age, priority FROM #advanced_columns ORDER BY id
+GO
+~~START~~
+int#!#int#!#int
+1#!#24#!#10
+2#!#36#!#5
+3#!#42#!#20
+~~END~~
+
+
+-- ALTER TABLE: Add new column and update based on computed values
+ALTER TABLE #advanced_columns ADD category VARCHAR(20)
+GO
+
+UPDATE #advanced_columns SET category = 
+	CASE 
+		WHEN amount > 2000000 THEN 'Premium'
+		WHEN amount > 1000000 THEN 'Gold'
+		ELSE 'Standard'
+	END
+WHERE amount IS NOT NULL
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT id, amount, category FROM #advanced_columns ORDER BY id
+GO
+~~START~~
+int#!#bigint#!#varchar
+1#!#2083333#!#Premium
+2#!#3173055#!#Premium
+3#!#1785714#!#Gold
+~~END~~
+
+
+DROP TABLE #advanced_columns
+GO
+
+-- Test 3: Indexes with DML Operations and ALTER TABLE
+CREATE TABLE #indexed_dml (
+	id INT PRIMARY KEY,
+	text_col VARCHAR(100),
+	int_col INT DEFAULT 0,
+	date_col DATETIME DEFAULT GETDATE(),
+	money_col MONEY DEFAULT 0,
+	description VARCHAR(200),
+	status CHAR(1) DEFAULT 'A'
+)
+GO
+
+-- Create indexes on various data types
+CREATE INDEX IX_text ON #indexed_dml(text_col)
+GO
+
+CREATE INDEX IX_int ON #indexed_dml(int_col)
+GO
+
+CREATE INDEX IX_date ON #indexed_dml(date_col)
+GO
+
+CREATE INDEX IX_money ON #indexed_dml(money_col)
+GO
+
+CREATE INDEX IX_composite ON #indexed_dml(status, int_col)
+GO
+
+-- Verify in ENR
+SELECT * FROM enr_view;
+GO
+~~START~~
+text
+#t4122
+#temptable5605
+#indexed_dml
+#pg_toast_#oid_masked#
+#pg_toast_#oid_masked#_index
+#indexed_dml_pkey
+ix_text#indexed_dml331193019682437d7418b66eb4c0d94e
+ix_int#indexed_dml035dab3da66aea81011a3eae459c604c
+ix_date#indexed_dmle2166a864eb6380802f1dd642a3fde15
+ix_money#indexed_dmlf15b16dc03c5e414c280565f841360cc
+ix_composite#indexed_dml607dc45075f81468865d4be46b38df3e
+~~END~~
+
+
+-- Insert test data
+INSERT INTO #indexed_dml VALUES (1, 'Test One', 100, GETDATE(), 1000.00, 'First record', 'A')
+INSERT INTO #indexed_dml VALUES (2, 'Test Two', 200, GETDATE(), 2000.00, 'Second record', 'A')
+INSERT INTO #indexed_dml VALUES (3, 'Test Three', 300, GETDATE(), 3000.00, 'Third record', 'I')
+INSERT INTO #indexed_dml VALUES (4, 'Sample Four', 150, GETDATE(), 1500.00, 'Fourth record', 'A')
+INSERT INTO #indexed_dml VALUES (5, 'Sample Five', 250, GETDATE(), 2500.00, 'Fifth record', 'P')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Query using indexes
+SELECT id, text_col FROM #indexed_dml WHERE text_col LIKE 'Test%'
+GO
+~~START~~
+int#!#varchar
+1#!#Test One
+2#!#Test Two
+3#!#Test Three
+~~END~~
+
+
+SELECT id, int_col FROM #indexed_dml WHERE int_col > 150
+GO
+~~START~~
+int#!#int
+2#!#200
+3#!#300
+5#!#250
+~~END~~
+
+
+SELECT id, money_col FROM #indexed_dml WHERE money_col BETWEEN 1500 AND 2500
+GO
+~~START~~
+int#!#money
+2#!#2000.0000
+4#!#1500.0000
+5#!#2500.0000
+~~END~~
+
+
+SELECT id, status, int_col FROM #indexed_dml WHERE status = 'A' AND int_col > 100
+GO
+~~START~~
+int#!#char#!#int
+4#!#A#!#150
+2#!#A#!#200
+~~END~~
+
+
+-- UPDATE operations on indexed columns
+UPDATE #indexed_dml SET int_col = int_col + 50 WHERE status = 'A'
+GO
+~~ROW COUNT: 3~~
+
+
+UPDATE #indexed_dml SET money_col = money_col * 1.1, description = 'Updated: ' + description WHERE int_col > 200
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT id, int_col, money_col, status FROM #indexed_dml ORDER BY id
+GO
+~~START~~
+int#!#int#!#money#!#char
+1#!#150#!#1000.0000#!#A
+2#!#250#!#2200.0000#!#A
+3#!#300#!#3300.0000#!#I
+4#!#200#!#1500.0000#!#A
+5#!#250#!#2750.0000#!#P
+~~END~~
+
+
+-- DELETE operation
+DELETE FROM #indexed_dml WHERE status = 'P'
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT COUNT(*) as remaining_records FROM #indexed_dml
+GO
+~~START~~
+int
+4
+~~END~~
+
+
+-- ALTER TABLE: Add new indexed column
+ALTER TABLE #indexed_dml ADD category VARCHAR(30)
+GO
+
+UPDATE #indexed_dml SET category = 
+	CASE 
+		WHEN money_col < 1500 THEN 'Budget'
+		WHEN money_col < 2500 THEN 'Standard'
+		ELSE 'Premium'
+	END
+GO
+~~ROW COUNT: 4~~
+
+
+-- Create index on new column
+CREATE INDEX IX_category ON #indexed_dml(category)
+GO
+
+SELECT id, category FROM #indexed_dml WHERE category = 'Standard'
+GO
+~~START~~
+int#!#varchar
+4#!#Standard
+2#!#Standard
+~~END~~
+
+
+-- Bulk UPDATE to test index maintenance
+UPDATE #indexed_dml SET text_col = 'Bulk Update ' + CAST(id AS VARCHAR(10))
+GO
+~~ROW COUNT: 4~~
+
+
+SELECT id, text_col FROM #indexed_dml ORDER BY id
+GO
+~~START~~
+int#!#varchar
+1#!#Bulk Update 1
+2#!#Bulk Update 2
+3#!#Bulk Update 3
+4#!#Bulk Update 4
+~~END~~
+
+
+-- ALTER TABLE: Add column with index in same operation
+ALTER TABLE #indexed_dml ADD sequence_num INT
+GO
+
+UPDATE #indexed_dml SET sequence_num = id * 10
+GO
+~~ROW COUNT: 4~~
+
+
+CREATE INDEX IX_sequence ON #indexed_dml(sequence_num)
+GO
+
+SELECT id, sequence_num FROM #indexed_dml WHERE sequence_num > 20
+GO
+~~START~~
+int#!#int
+4#!#40
+3#!#30
+~~END~~
+
+
+-- Test DELETE with indexes
+DELETE FROM #indexed_dml WHERE int_col < 150
+GO
+
+SELECT id, int_col, text_col FROM #indexed_dml ORDER BY id
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#150#!#Bulk Update 1
+2#!#250#!#Bulk Update 2
+3#!#300#!#Bulk Update 3
+4#!#200#!#Bulk Update 4
+~~END~~
+
+
+DROP TABLE #indexed_dml
+GO
+
+EXEC p_def_cons;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "@tv_def_con_1" violates check constraint "@tv_def_con_1_b_check")~~
+
+~~START~~
+int#!#int#!#char
+1#!#1#!#T
+2#!#2#!#F
+~~END~~
+
+
+-- Test 4: Trying to create a default with UDF which should throw an error
+CREATE TABLE #temp_table_with_computed_udf (
+	id INT PRIMARY KEY,
+	credit BIGINT,
+	debit BIGINT,
+	total as custom_adder(credit, debit)
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: generation expression is not immutable)~~
+
+
+CREATE TABLE #temp_table_with_default_udf (
+	num INT DEFAULT custom_adder(5,10)
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: User-defined functions, partition functions, and column references are not allowed in expressions in this context.)~~
+
+
+CREATE TABLE #temp_table_with_default_udf (
+	num INT CHECK(custom_adder(num,10) > 100)
+)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: temporary objects cannot reference permanent non-system objects)~~
+

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-cleanup.sql
@@ -39,3 +39,9 @@ go
 
 drop view enr_view
 go
+
+drop function custom_adder;
+GO
+
+drop procedure p_def_cons;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-prepare.sql
@@ -100,3 +100,21 @@ BEGIN
 	SELECT * FROM enr_view;
 END;
 GO
+
+CREATE FUNCTION custom_adder(@a INT, @b INT)
+RETURNS INT
+BEGIN
+	RETURN @a + @b;
+END;
+GO
+
+CREATE PROCEDURE p_def_cons
+AS
+BEGIN
+	DECLARE @tv_def_con TABLE(id INT PRIMARY KEY, a INT IDENTITY, b CHAR(1) DEFAULT 'F' CHECK (b IN ('T', 'F')));
+	INSERT INTO @tv_def_con(id, b) VALUES (1, 'T');
+	INSERT INTO @tv_def_con(id) VALUES (2);
+	INSERT INTO @tv_def_con(id, b) VALUES (3, 'A');
+	SELECT * FROM @tv_def_con;
+END;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
@@ -34,3 +34,344 @@ GO
 -- GO
 -- SELECT * FROM #temptable5605
 -- GO
+
+-- Test 1: Comprehensive System Functions, Operators, and DML Operations
+CREATE TABLE #sys_comprehensive (
+	id INT PRIMARY KEY,
+	created_date DATETIME DEFAULT GETDATE(),
+	guid_col UNIQUEIDENTIFIER DEFAULT NEWID(),
+	age INT CHECK (age > 0 AND age < 200),
+	salary MONEY CHECK (salary >= 0),
+	discount DECIMAL(5,2) CHECK (discount <= 100.00),
+	quantity INT CHECK (quantity <> 0),
+	status CHAR(1) CHECK (status = 'A' OR status = 'I' OR status = 'P'),
+	score INT CHECK (score BETWEEN 0 AND 100),
+	start_date DATETIME,
+	end_date DATETIME,
+	price MONEY,
+	total AS (price * quantity),
+	CHECK (end_date > start_date),
+	CHECK (DATEDIFF(DAY, start_date, end_date) <= 365)
+)
+GO
+
+-- Verify in ENR
+SELECT * FROM enr_view;
+GO
+
+-- Insert test data with system function defaults
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (1, 30, 50000, 10.5, 5, 'A', 85, '2024-01-01', '2024-06-30', 100.00)
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (2, 45, 75000, 15.0, -3, 'I', 92, '2024-02-01', '2024-08-15', 250.50)
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (3, 28, 62000, 8.0, 10, 'P', 78, '2024-03-01', '2024-09-30', 75.25)
+GO
+
+SELECT id, age, status, score, quantity FROM #sys_comprehensive
+GO
+
+-- Test UPDATE operations
+UPDATE #sys_comprehensive SET salary = salary * 1.1 WHERE id = 1
+GO
+
+UPDATE #sys_comprehensive SET status = 'I', score = 95 WHERE age < 30
+GO
+
+SELECT id, age, salary, status, score FROM #sys_comprehensive ORDER BY id
+GO
+
+-- Test DELETE operation
+DELETE FROM #sys_comprehensive WHERE quantity < 0
+GO
+
+SELECT COUNT(*) as record_count FROM #sys_comprehensive
+GO
+
+-- ALTER TABLE: Add new column with default
+ALTER TABLE #sys_comprehensive ADD department VARCHAR(50) DEFAULT 'Unknown'
+GO
+
+SELECT id, department FROM #sys_comprehensive
+GO
+
+-- ALTER TABLE: Add new column with CHECK constraint
+ALTER TABLE #sys_comprehensive ADD bonus MONEY CHECK (bonus >= 0 AND bonus <= 50000)
+GO
+
+-- Update new column
+UPDATE #sys_comprehensive SET bonus = salary * 0.1, department = 'Sales' WHERE id = 1
+UPDATE #sys_comprehensive SET bonus = salary * 0.15, department = 'Engineering' WHERE id = 3
+GO
+
+SELECT id, department, bonus FROM #sys_comprehensive ORDER BY id
+GO
+
+-- ALTER TABLE: Add computed column
+ALTER TABLE #sys_comprehensive ADD bonus_tax AS (bonus * 0.25)
+GO
+
+SELECT id, bonus, bonus_tax FROM #sys_comprehensive WHERE bonus IS NOT NULL
+GO
+
+-- ALTER TABLE: Add CHECK constraint to existing table
+ALTER TABLE #sys_comprehensive ADD CONSTRAINT chk_department CHECK (department IN ('Sales', 'Engineering', 'Marketing', 'Unknown'))
+GO
+
+-- Test constraint (should fail)
+UPDATE #sys_comprehensive SET department = 'InvalidDept' WHERE id = 1
+GO
+
+SELECT id, department FROM #sys_comprehensive ORDER BY id
+GO
+
+-- Test CHECK constraint violations (should fail)
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (10, 0, 50000, 10.0, 1, 'A', 50, '2024-01-01', '2024-06-30', 100.00)
+GO
+
+INSERT INTO #sys_comprehensive (id, age, salary, discount, quantity, status, score, start_date, end_date, price) 
+VALUES (11, 30, -1000, 10.0, 1, 'A', 50, '2024-01-01', '2024-06-30', 100.00)
+GO
+
+DROP TABLE #sys_comprehensive
+GO
+
+-- Test 2: Advanced Column Features with NULL Handling and Computed Columns
+CREATE TABLE #advanced_columns (
+	id INT PRIMARY KEY,
+	first_name VARCHAR(50),
+	last_name VARCHAR(50),
+	age INT,
+	balance BIGINT,
+	amount AS (balance * 1000 / NULLIF(age, 0)),
+	nullable_col INT,
+	default_col INT DEFAULT COALESCE(NULL, 100),
+	is_null_col AS (CASE WHEN nullable_col IS NULL THEN 1 ELSE 0 END),
+	created_date DATETIME DEFAULT GETDATE(),
+	year_created AS YEAR(created_date),
+	CHECK (ISNULL(nullable_col, 0) >= 0),
+	CHECK (age > 0)
+)
+GO
+
+-- Verify in ENR
+SELECT * FROM enr_view;
+GO
+
+-- Insert test data
+INSERT INTO #advanced_columns (id, first_name, last_name, age, balance, nullable_col) 
+VALUES (1, 'John', 'Doe', 24, 50000, NULL)
+INSERT INTO #advanced_columns (id, first_name, last_name, age, balance, nullable_col) 
+VALUES (2, 'Jane', 'Smith', 35, 104230, 50)
+INSERT INTO #advanced_columns (id, first_name, last_name, age, balance) 
+VALUES (3, 'Bob', 'Johnson', 42, 75000)
+GO
+
+SELECT id, amount, is_null_col, default_col FROM #advanced_columns
+GO
+
+-- Test UPDATE on base columns (computed columns auto-update)
+UPDATE #advanced_columns SET first_name = 'Johnny' WHERE id = 1
+GO
+
+UPDATE #advanced_columns SET balance = balance + 10000, age = age + 1 WHERE id = 2
+GO
+
+SELECT id, age, balance, amount FROM #advanced_columns ORDER BY id
+GO
+
+-- Update nullable columns
+UPDATE #advanced_columns SET nullable_col = 100 WHERE id = 1
+GO
+
+SELECT id, nullable_col, is_null_col FROM #advanced_columns ORDER BY id
+GO
+
+-- ALTER TABLE: Add new computed column
+ALTER TABLE #advanced_columns ADD age_group AS (
+	CASE 
+		WHEN age < 30 THEN 'Young'
+		WHEN age BETWEEN 30 AND 50 THEN 'Middle'
+		ELSE 'Senior'
+	END
+)
+GO
+
+SELECT id, age, age_group FROM #advanced_columns
+GO
+
+-- ALTER TABLE: Add column with COALESCE default
+ALTER TABLE #advanced_columns ADD priority INT DEFAULT COALESCE(NULL, 5)
+GO
+
+SELECT id, priority FROM #advanced_columns
+GO
+
+-- Update priority
+UPDATE #advanced_columns SET priority = 10 WHERE age < 30
+UPDATE #advanced_columns SET priority = 20 WHERE age >= 40
+GO
+
+SELECT id, age, priority FROM #advanced_columns ORDER BY id
+GO
+
+-- ALTER TABLE: Add new column and update based on computed values
+ALTER TABLE #advanced_columns ADD category VARCHAR(20)
+GO
+
+UPDATE #advanced_columns SET category = 
+	CASE 
+		WHEN amount > 2000000 THEN 'Premium'
+		WHEN amount > 1000000 THEN 'Gold'
+		ELSE 'Standard'
+	END
+WHERE amount IS NOT NULL
+GO
+
+SELECT id, amount, category FROM #advanced_columns ORDER BY id
+GO
+
+DROP TABLE #advanced_columns
+GO
+
+-- Test 3: Indexes with DML Operations and ALTER TABLE
+CREATE TABLE #indexed_dml (
+	id INT PRIMARY KEY,
+	text_col VARCHAR(100),
+	int_col INT DEFAULT 0,
+	date_col DATETIME DEFAULT GETDATE(),
+	money_col MONEY DEFAULT 0,
+	description VARCHAR(200),
+	status CHAR(1) DEFAULT 'A'
+)
+GO
+
+-- Create indexes on various data types
+CREATE INDEX IX_text ON #indexed_dml(text_col)
+GO
+
+CREATE INDEX IX_int ON #indexed_dml(int_col)
+GO
+
+CREATE INDEX IX_date ON #indexed_dml(date_col)
+GO
+
+CREATE INDEX IX_money ON #indexed_dml(money_col)
+GO
+
+CREATE INDEX IX_composite ON #indexed_dml(status, int_col)
+GO
+
+-- Verify in ENR
+SELECT * FROM enr_view;
+GO
+
+-- Insert test data
+INSERT INTO #indexed_dml VALUES (1, 'Test One', 100, GETDATE(), 1000.00, 'First record', 'A')
+INSERT INTO #indexed_dml VALUES (2, 'Test Two', 200, GETDATE(), 2000.00, 'Second record', 'A')
+INSERT INTO #indexed_dml VALUES (3, 'Test Three', 300, GETDATE(), 3000.00, 'Third record', 'I')
+INSERT INTO #indexed_dml VALUES (4, 'Sample Four', 150, GETDATE(), 1500.00, 'Fourth record', 'A')
+INSERT INTO #indexed_dml VALUES (5, 'Sample Five', 250, GETDATE(), 2500.00, 'Fifth record', 'P')
+GO
+
+-- Query using indexes
+SELECT id, text_col FROM #indexed_dml WHERE text_col LIKE 'Test%'
+GO
+
+SELECT id, int_col FROM #indexed_dml WHERE int_col > 150
+GO
+
+SELECT id, money_col FROM #indexed_dml WHERE money_col BETWEEN 1500 AND 2500
+GO
+
+SELECT id, status, int_col FROM #indexed_dml WHERE status = 'A' AND int_col > 100
+GO
+
+-- UPDATE operations on indexed columns
+UPDATE #indexed_dml SET int_col = int_col + 50 WHERE status = 'A'
+GO
+
+UPDATE #indexed_dml SET money_col = money_col * 1.1, description = 'Updated: ' + description WHERE int_col > 200
+GO
+
+SELECT id, int_col, money_col, status FROM #indexed_dml ORDER BY id
+GO
+
+-- DELETE operation
+DELETE FROM #indexed_dml WHERE status = 'P'
+GO
+
+SELECT COUNT(*) as remaining_records FROM #indexed_dml
+GO
+
+-- ALTER TABLE: Add new indexed column
+ALTER TABLE #indexed_dml ADD category VARCHAR(30)
+GO
+
+UPDATE #indexed_dml SET category = 
+	CASE 
+		WHEN money_col < 1500 THEN 'Budget'
+		WHEN money_col < 2500 THEN 'Standard'
+		ELSE 'Premium'
+	END
+GO
+
+-- Create index on new column
+CREATE INDEX IX_category ON #indexed_dml(category)
+GO
+
+SELECT id, category FROM #indexed_dml WHERE category = 'Standard'
+GO
+
+-- Bulk UPDATE to test index maintenance
+UPDATE #indexed_dml SET text_col = 'Bulk Update ' + CAST(id AS VARCHAR(10))
+GO
+
+SELECT id, text_col FROM #indexed_dml ORDER BY id
+GO
+
+-- ALTER TABLE: Add column with index in same operation
+ALTER TABLE #indexed_dml ADD sequence_num INT
+GO
+
+UPDATE #indexed_dml SET sequence_num = id * 10
+GO
+
+CREATE INDEX IX_sequence ON #indexed_dml(sequence_num)
+GO
+
+SELECT id, sequence_num FROM #indexed_dml WHERE sequence_num > 20
+GO
+
+-- Test DELETE with indexes
+DELETE FROM #indexed_dml WHERE int_col < 150
+GO
+
+SELECT id, int_col, text_col FROM #indexed_dml ORDER BY id
+GO
+
+DROP TABLE #indexed_dml
+GO
+
+EXEC p_def_cons;
+GO
+
+-- Test 4: Trying to create a default with UDF which should throw an error
+CREATE TABLE #temp_table_with_computed_udf (
+	id INT PRIMARY KEY,
+	credit BIGINT,
+	debit BIGINT,
+	total as custom_adder(credit, debit)
+)
+GO
+
+CREATE TABLE #temp_table_with_default_udf (
+	num INT DEFAULT custom_adder(5,10)
+)
+GO
+
+CREATE TABLE #temp_table_with_default_udf (
+	num INT CHECK(custom_adder(num,10) > 100)
+)
+GO


### PR DESCRIPTION
### Description


Original PR - #4577

Added a hook to detect if the dependency being created if from an ENR to a system object given the depender and referenced obejcts. Refactored the find_object_in_enr hook to also search in a given queryEnv apart from traversing all queryEnvs Added unit tests and sql tests for the ability to create ENR objects to non-ENR system objects dependencies

Engine PR - babelfish-for-postgresql/postgresql_modified_for_babelfish#709

Task: BABEL-6139


(cherry picked from commit f9b23ffd47102c2c6cf10be0d32cdaecdeffbd41)

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).