### PR TITLE
Added tests for the fix of crash when dropping a temp table from nested QueryEnv

### DIFF
--- a/.github/scripts/scan-warnings.sh
+++ b/.github/scripts/scan-warnings.sh
@@ -49,8 +49,8 @@ if [[ "$SNAPSHOT_ACTIVE_COUNT" -ne 44 ]]; then
     ERROR_FOUND=true
 fi
 
-if [[ "$LEAK_COUNT" -ne 370 ]]; then
-    echo "Error: Expected 370 leak warnings, but found $LEAK_COUNT"
+if [[ "$LEAK_COUNT" -ne 410 ]]; then
+    echo "Error: Expected 410 leak warnings, but found $LEAK_COUNT"
     ERROR_FOUND=true
 fi
 

--- a/test/JDBC/expected/parallel_query/table-variable-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/table-variable-vu-verify.out
@@ -281,3 +281,283 @@ int
 
 ~~ERROR (Message: relation "@t" does not exist)~~
 
+
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv Table Variable Tests - Nested Query Environment (BABEL-6268)
+---------------------------------------------------------------------------
+-- Basic table variable operations in procedure
+EXEC p_tv_basic
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated
+~~END~~
+
+
+-- Table variable with DELETE operations
+EXEC p_tv_delete
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int
+2#!#inactive#!#200
+1#!#processed#!#100
+4#!#new#!#150
+~~END~~
+
+
+-- Nested procedures with table variables
+EXEC p_tv_nested_outer
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inner procedure:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#from inner proc
+2#!#inner data
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Outer procedure:
+~~END~~
+
+~~START~~
+int#!#varchar
+10#!#updated in outer
+20#!#outer data
+~~END~~
+
+
+-- Table variable with transaction operations
+EXEC p_tv_transaction
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inside transaction:
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+~~START~~
+varchar
+After rollback (TV unaffected):
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+
+--  Multiple table variables with cross-operations
+EXEC p_tv_multiple
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Table Variable 1:
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated first
+~~END~~
+
+~~START~~
+varchar
+Table Variable 2:
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#1#!#ref to first
+~~END~~
+
+
+-- Table variable with error handling
+EXEC p_tv_error_handling
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error caught: duplicate key value violates unique constraint "@tv_1_pkey"
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#valid insert
+1#!#updated
+3#!#error handled
+~~END~~
+
+
+-- Table variable with conditional operations
+EXEC p_tv_conditional
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int
+1#!#active#!#50
+3#!#pending#!#75
+2#!#high_value#!#150
+4#!#new_high#!#200
+~~END~~
+
+
+-- Mixed table variable and temp table operations
+EXEC p_tv_mixed_with_temp
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Table Variable:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#updated TV
+2#!#TV second
+~~END~~
+
+~~START~~
+varchar
+Temp Table:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#updated temp
+2#!#temp second
+~~END~~
+
+
+-- Table variable scope across nested calls
+EXEC p_tv_scope_outer
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Outer scope TV before inner call:
+~~END~~
+
+~~START~~
+int#!#varchar
+100#!#outer scope
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inner scope TV:
+~~END~~
+
+~~START~~
+int#!#varchar
+200#!#inner scope
+201#!#inner scope 2
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Outer scope TV after inner call:
+~~END~~
+
+~~START~~
+int#!#varchar
+100#!#outer scope
+101#!#after inner call
+~~END~~
+

--- a/test/JDBC/expected/table-variable-vu-cleanup.out
+++ b/test/JDBC/expected/table-variable-vu-cleanup.out
@@ -69,3 +69,36 @@ GO
 
 DROP TYPE tv_nested_type
 GO
+
+DROP PROC p_tv_basic
+GO
+
+DROP PROC p_tv_delete
+GO
+
+DROP PROC p_tv_nested_outer
+GO
+
+DROP PROC p_tv_nested_inner
+GO
+
+DROP PROC p_tv_transaction
+GO
+
+DROP PROC p_tv_multiple
+GO
+
+DROP PROC p_tv_error_handling
+GO
+
+DROP PROC p_tv_conditional
+GO
+
+DROP PROC p_tv_mixed_with_temp
+GO
+
+DROP PROC p_tv_scope_outer
+GO
+
+DROP PROC p_tv_scope_inner
+GO

--- a/test/JDBC/expected/table-variable-vu-prepare.out
+++ b/test/JDBC/expected/table-variable-vu-prepare.out
@@ -247,3 +247,188 @@ CREATE FUNCTION tv_nested_func1 (@t tv_nested_type readonly) RETURNS @a TABLE (y
 GO
 CREATE FUNCTION tv_nested_func2 (@t tv_nested_type readonly) RETURNS @a TABLE (x INT) AS BEGIN; INSERT INTO @a SELECT y FROM tv_nested_func1(@t); RETURN; END;
 GO
+
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_tv_basic AS
+BEGIN
+    DECLARE @tv TABLE (id int, name varchar(30))
+    INSERT INTO @tv VALUES (1, 'first')
+    INSERT INTO @tv VALUES (2, 'second')
+    UPDATE @tv SET name = 'updated' WHERE id = 1
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_delete AS
+BEGIN
+    DECLARE @tv TABLE (id int, status varchar(20), value int)
+    INSERT INTO @tv VALUES (1, 'active', 100)
+    INSERT INTO @tv VALUES (2, 'inactive', 200)
+    INSERT INTO @tv VALUES (3, 'pending', 300)
+    
+    DELETE FROM @tv WHERE value > 250
+    UPDATE @tv SET status = 'processed' WHERE id = 1
+    INSERT INTO @tv VALUES (4, 'new', 150)
+    
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_nested_inner AS
+BEGIN
+    DECLARE @inner_tv TABLE (id int, data varchar(50))
+    INSERT INTO @inner_tv VALUES (1, 'from inner proc')
+    INSERT INTO @inner_tv VALUES (2, 'inner data')
+    SELECT 'Inner procedure:' as label
+    SELECT * FROM @inner_tv
+END
+GO
+
+CREATE PROC p_tv_nested_outer AS
+BEGIN
+    DECLARE @outer_tv TABLE (id int, info varchar(50))
+    INSERT INTO @outer_tv VALUES (10, 'from outer proc')
+    
+    EXEC p_tv_nested_inner
+    
+    UPDATE @outer_tv SET info = 'updated in outer' WHERE id = 10
+    INSERT INTO @outer_tv VALUES (20, 'outer data')
+    
+    SELECT 'Outer procedure:' as label
+    SELECT * FROM @outer_tv
+END
+GO
+
+CREATE PROC p_tv_transaction AS
+BEGIN
+    DECLARE @tv TABLE (id int, amount decimal(10,2))
+    INSERT INTO @tv VALUES (1, 100.00)
+    INSERT INTO @tv VALUES (2, 200.00)
+    
+    BEGIN TRAN
+        UPDATE @tv SET amount = amount * 2
+        INSERT INTO @tv VALUES (3, 300.00)
+        DELETE FROM @tv WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM @tv
+    ROLLBACK
+    
+    -- Table variables are not affected by rollback
+    SELECT 'After rollback (TV unaffected):' as label
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_multiple AS
+BEGIN
+    DECLARE @tv1 TABLE (id int, name varchar(20))
+    DECLARE @tv2 TABLE (id int, ref_id int, value varchar(30))
+    
+    INSERT INTO @tv1 VALUES (1, 'first')
+    INSERT INTO @tv1 VALUES (2, 'second')
+    
+    INSERT INTO @tv2 VALUES (10, 1, 'ref to first')
+    INSERT INTO @tv2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE @tv1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM @tv2 WHERE ref_id = 2
+    
+    SELECT 'Table Variable 1:' as label
+    SELECT * FROM @tv1
+    SELECT 'Table Variable 2:' as label
+    SELECT * FROM @tv2
+END
+GO
+
+CREATE PROC p_tv_error_handling AS
+BEGIN
+    DECLARE @tv TABLE (id int primary key, data varchar(20))
+    INSERT INTO @tv VALUES (1, 'original')
+    INSERT INTO @tv VALUES (2, 'valid insert')
+    
+    UPDATE @tv SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO @tv VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO @tv VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+    
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_conditional AS
+BEGIN
+    DECLARE @tv TABLE (id int, status varchar(10), value int)
+    INSERT INTO @tv VALUES (1, 'active', 50)
+    INSERT INTO @tv VALUES (2, 'inactive', 150)
+    INSERT INTO @tv VALUES (3, 'pending', 75)
+    
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM @tv WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE @tv SET status = 'high_value' WHERE value > 100
+        INSERT INTO @tv VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM @tv WHERE value < 60
+    END
+    
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_mixed_with_temp AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(20))
+    CREATE TABLE #temp_mixed (id int, temp_data varchar(20))
+    
+    INSERT INTO @tv VALUES (1, 'table variable')
+    INSERT INTO #temp_mixed VALUES (1, 'temp table')
+    
+    UPDATE @tv SET tv_data = 'updated TV' WHERE id = 1
+    UPDATE #temp_mixed SET temp_data = 'updated temp' WHERE id = 1
+    
+    INSERT INTO @tv VALUES (2, 'TV second')
+    INSERT INTO #temp_mixed VALUES (2, 'temp second')
+    
+    SELECT 'Table Variable:' as label
+    SELECT * FROM @tv
+    SELECT 'Temp Table:' as label
+    SELECT * FROM #temp_mixed
+    
+    DROP TABLE #temp_mixed
+END
+GO
+
+CREATE PROC p_tv_scope_inner (@param int) AS
+BEGIN
+    DECLARE @inner_tv TABLE (id int, scope_info varchar(30))
+    INSERT INTO @inner_tv VALUES (@param, 'inner scope')
+    INSERT INTO @inner_tv VALUES (@param + 1, 'inner scope 2')
+    SELECT 'Inner scope TV:' as label
+    SELECT * FROM @inner_tv
+END
+GO
+
+CREATE PROC p_tv_scope_outer AS
+BEGIN
+    DECLARE @outer_tv TABLE (id int, scope_info varchar(30))
+    INSERT INTO @outer_tv VALUES (100, 'outer scope')
+    
+    SELECT 'Outer scope TV before inner call:' as label
+    SELECT * FROM @outer_tv
+    
+    EXEC p_tv_scope_inner 200
+    
+    INSERT INTO @outer_tv VALUES (101, 'after inner call')
+    SELECT 'Outer scope TV after inner call:' as label
+    SELECT * FROM @outer_tv
+END
+GO

--- a/test/JDBC/expected/table-variable-vu-verify.out
+++ b/test/JDBC/expected/table-variable-vu-verify.out
@@ -278,3 +278,283 @@ int
 
 ~~ERROR (Message: relation "@t" does not exist)~~
 
+
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv Table Variable Tests - Nested Query Environment (BABEL-6268)
+---------------------------------------------------------------------------
+-- Basic table variable operations in procedure
+EXEC p_tv_basic
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated
+~~END~~
+
+
+-- Table variable with DELETE operations
+EXEC p_tv_delete
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int
+2#!#inactive#!#200
+1#!#processed#!#100
+4#!#new#!#150
+~~END~~
+
+
+-- Nested procedures with table variables
+EXEC p_tv_nested_outer
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inner procedure:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#from inner proc
+2#!#inner data
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Outer procedure:
+~~END~~
+
+~~START~~
+int#!#varchar
+10#!#updated in outer
+20#!#outer data
+~~END~~
+
+
+-- Table variable with transaction operations
+EXEC p_tv_transaction
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inside transaction:
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+~~START~~
+varchar
+After rollback (TV unaffected):
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+
+--  Multiple table variables with cross-operations
+EXEC p_tv_multiple
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Table Variable 1:
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated first
+~~END~~
+
+~~START~~
+varchar
+Table Variable 2:
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#1#!#ref to first
+~~END~~
+
+
+-- Table variable with error handling
+EXEC p_tv_error_handling
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error caught: duplicate key value violates unique constraint "@tv_1_pkey"
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#valid insert
+1#!#updated
+3#!#error handled
+~~END~~
+
+
+-- Table variable with conditional operations
+EXEC p_tv_conditional
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int
+1#!#active#!#50
+3#!#pending#!#75
+2#!#high_value#!#150
+4#!#new_high#!#200
+~~END~~
+
+
+-- Mixed table variable and temp table operations
+EXEC p_tv_mixed_with_temp
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Table Variable:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#updated TV
+2#!#TV second
+~~END~~
+
+~~START~~
+varchar
+Temp Table:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#updated temp
+2#!#temp second
+~~END~~
+
+
+-- Table variable scope across nested calls
+EXEC p_tv_scope_outer
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Outer scope TV before inner call:
+~~END~~
+
+~~START~~
+int#!#varchar
+100#!#outer scope
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inner scope TV:
+~~END~~
+
+~~START~~
+int#!#varchar
+200#!#inner scope
+201#!#inner scope 2
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Outer scope TV after inner call:
+~~END~~
+
+~~START~~
+int#!#varchar
+100#!#outer scope
+101#!#after inner call
+~~END~~
+

--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -36,3 +36,73 @@ GO
 
 DROP PROCEDURE test_alter_index_truncate_cache_fix
 GO
+
+
+DROP PROC p_drop
+GO
+
+DROP PROC p_drop_multi
+GO
+
+DROP PROC p_outer
+GO
+
+DROP PROC p_inner
+GO
+
+DROP PROC p_trans_drop
+GO
+
+DROP PROC p_create_insert
+GO
+
+DROP PROC p_update_delete
+GO
+
+DROP PROC p_nested_inner
+GO
+
+DROP PROC p_nested_outer
+GO
+
+DROP PROC p_rollback_ops
+GO
+
+DROP PROC p_multi_temp_ops
+GO
+
+DROP PROC p_error_ops
+GO
+
+DROP PROC p_truncate_ops
+GO
+
+DROP PROC p_conditional_ops
+GO
+
+DROP PROC p_insert_exec_basic
+GO
+
+DROP PROC p_insert_exec_nested_inner
+GO
+
+DROP PROC p_insert_exec_nested_outer
+GO
+
+DROP PROC p_insert_exec_temp_ops
+GO
+
+DROP PROC p_insert_exec_transaction
+GO
+
+DROP PROC p_insert_exec_multi_results
+GO
+
+DROP PROC p_insert_exec_error_handling
+GO
+
+DROP PROC p_insert_exec_table_var
+GO
+
+DROP PROC p_insert_exec_drop_table
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -171,3 +171,237 @@ BEGIN
     SET XACT_ABORT OFF
 END
 GO
+
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_drop AS DROP TABLE #test
+GO
+
+CREATE PROC p_drop_multi AS 
+BEGIN 
+    DROP TABLE #temp_proc_test 
+END 
+GO
+
+CREATE PROC p_inner AS DROP TABLE #nested_test
+GO
+
+CREATE PROC p_outer AS EXEC p_inner
+GO
+
+CREATE PROC p_trans_drop AS 
+BEGIN 
+    BEGIN TRAN 
+        INSERT INTO #trans_test VALUES (2, 'during') 
+        DROP TABLE #trans_test 
+    COMMIT 
+END 
+GO
+
+CREATE PROC p_create_insert AS
+BEGIN
+    CREATE TABLE #proc_create(id int, name varchar(30))
+    INSERT INTO #proc_create VALUES (1, 'first')
+    INSERT INTO #proc_create VALUES (2, 'second')
+    SELECT * FROM #proc_create
+    DROP TABLE #proc_create
+END
+GO
+
+CREATE PROC p_update_delete AS
+BEGIN
+    UPDATE #update_delete_test SET status = 'processed' WHERE id = 1
+    DELETE FROM #update_delete_test WHERE value > 250
+    INSERT INTO #update_delete_test VALUES (4, 'new', 150)
+END
+GO
+
+CREATE PROC p_nested_inner AS
+BEGIN
+    INSERT INTO #nested_ops_test VALUES (2, 'from inner')
+    UPDATE #nested_ops_test SET data = 'updated by inner' WHERE id = 1
+END
+GO
+
+CREATE PROC p_nested_outer AS
+BEGIN
+    EXEC p_nested_inner
+    DELETE FROM #nested_ops_test WHERE id = 2
+    INSERT INTO #nested_ops_test VALUES (3, 'from outer')
+END
+GO
+
+CREATE PROC p_rollback_ops AS
+BEGIN
+    INSERT INTO #rollback_ops_test VALUES (2, 200.00)
+    BEGIN TRAN
+        UPDATE #rollback_ops_test SET amount = amount * 2
+        INSERT INTO #rollback_ops_test VALUES (3, 300.00)
+        DELETE FROM #rollback_ops_test WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM #rollback_ops_test
+    ROLLBACK
+    SELECT 'After rollback:' as label
+END
+GO
+
+CREATE PROC p_multi_temp_ops AS
+BEGIN
+    CREATE TABLE #temp1(id int, name varchar(20))
+    CREATE TABLE #temp2(id int, ref_id int, value varchar(30))
+    
+    INSERT INTO #temp1 VALUES (1, 'first')
+    INSERT INTO #temp1 VALUES (2, 'second')
+    
+    INSERT INTO #temp2 VALUES (10, 1, 'ref to first')
+    INSERT INTO #temp2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE #temp1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM #temp2 WHERE ref_id = 2
+    
+    SELECT 'Temp1:' as label
+    SELECT * FROM #temp1
+    SELECT 'Temp2:' as label
+    SELECT * FROM #temp2
+    
+    DROP TABLE #temp1
+    DROP TABLE #temp2
+END
+GO
+
+CREATE PROC p_error_ops AS
+BEGIN
+    INSERT INTO #error_ops_test VALUES (2, 'valid insert')
+    UPDATE #error_ops_test SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO #error_ops_test VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #error_ops_test VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+END
+GO
+
+CREATE PROC p_truncate_ops AS
+BEGIN
+    SELECT 'Before truncate:' as label
+    SELECT * FROM #truncate_test
+    
+    TRUNCATE TABLE #truncate_test
+    
+    INSERT INTO #truncate_test VALUES ('after truncate')
+    SELECT 'After truncate:' as label
+END
+GO
+
+CREATE PROC p_conditional_ops AS
+BEGIN
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM #conditional_test WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE #conditional_test SET status = 'high_value' WHERE value > 100
+        INSERT INTO #conditional_test VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM #conditional_test WHERE value < 60
+    END
+END
+GO
+
+-- INSERT INTO EXEC procedures
+CREATE PROC p_insert_exec_basic AS 
+BEGIN 
+    SELECT 1 as id, 'first' as name 
+    UNION ALL 
+    SELECT 2, 'second' 
+END
+GO
+
+CREATE PROC p_insert_exec_nested_inner AS
+BEGIN
+    SELECT 10 as id, 'inner data' as data
+END
+GO
+
+CREATE PROC p_insert_exec_nested_outer AS
+BEGIN
+    CREATE TABLE #temp_inner(id int, data varchar(50))
+    INSERT INTO #temp_inner EXEC p_insert_exec_nested_inner
+    INSERT INTO #temp_inner VALUES (20, 'outer data')
+    SELECT * FROM #temp_inner
+    DROP TABLE #temp_inner
+END
+GO
+
+CREATE PROC p_insert_exec_temp_ops AS
+BEGIN
+    CREATE TABLE #temp_ops(id int, status varchar(20), value int)
+    INSERT INTO #temp_ops VALUES (1, 'active', 100)
+    INSERT INTO #temp_ops VALUES (2, 'pending', 200)
+    UPDATE #temp_ops SET status = 'processed' WHERE id = 1
+    SELECT * FROM #temp_ops
+    DROP TABLE #temp_ops
+END
+GO
+
+CREATE PROC p_insert_exec_transaction AS
+BEGIN
+    CREATE TABLE #temp_trans(id int, amount decimal(10,2))
+    INSERT INTO #temp_trans VALUES (1, 100.00)
+    BEGIN TRAN
+        INSERT INTO #temp_trans VALUES (2, 200.00)
+        UPDATE #temp_trans SET amount = amount * 2
+    ROLLBACK
+    SELECT * FROM #temp_trans
+    DROP TABLE #temp_trans
+END
+GO
+
+CREATE PROC p_insert_exec_multi_results AS
+BEGIN
+    SELECT 1 as id, 'first result' as info
+    SELECT 2 as id, 'second result' as info
+    SELECT 3 as id, 'third result' as info
+END
+GO
+
+CREATE PROC p_insert_exec_error_handling AS
+BEGIN
+    CREATE TABLE #temp_error(id int primary key, data varchar(20))
+    INSERT INTO #temp_error VALUES (1, 'original')
+    BEGIN TRY
+        INSERT INTO #temp_error VALUES (1, 'duplicate')
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #temp_error VALUES (2, 'error handled')
+    END CATCH
+    SELECT * FROM #temp_error
+    DROP TABLE #temp_error
+END
+GO
+
+CREATE PROC p_insert_exec_table_var AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(30))
+    INSERT INTO @tv VALUES (1, 'from table var')
+    INSERT INTO @tv VALUES (2, 'tv data')
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_insert_exec_drop_table AS
+BEGIN
+    -- Return some data first
+    SELECT 100 as id, 'before drop' as data
+    
+    -- Drop the target table
+    DROP TABLE #insert_exec_drop_target
+    
+    -- Try to return more data (but table is already dropped)
+    SELECT 200 as id, 'after drop' as data
+END
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -3513,3 +3513,549 @@ text
 #t2
 ~~END~~
 
+
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv ENR Tests - Procedure Drop Table Fix (BABEL-6268)
+---------------------------------------------------------------------------
+-- Test 1: Basic procedure drop table scenario
+CREATE TABLE #test(a int) 
+GO
+
+EXEC p_drop
+GO
+
+CREATE TABLE #test(a int)         -- should not crash
+GO
+
+DROP TABLE #test
+GO
+
+-- Test 2: Multiple procedure calls with same temp table name
+CREATE TABLE #temp_proc_test(id int, name varchar(50)) 
+INSERT INTO #temp_proc_test VALUES (1, 'test1') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_drop_multi
+GO
+
+CREATE TABLE #temp_proc_test(id int, data varchar(100)) 
+INSERT INTO #temp_proc_test VALUES (2, 'test2') 
+SELECT * FROM #temp_proc_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#test2
+~~END~~
+
+
+DROP TABLE #temp_proc_test
+GO
+
+-- Test 3: Nested procedure calls
+CREATE TABLE #nested_test(val int)
+INSERT INTO #nested_test VALUES (100)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_outer
+GO
+
+CREATE TABLE #nested_test(val int, descr varchar(20)) 
+INSERT INTO #nested_test VALUES (200, 'after fix') 
+SELECT * FROM #nested_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+200#!#after fix
+~~END~~
+
+
+DROP TABLE #nested_test
+GO
+
+-- Test 4: Procedure with transaction and temp table drop
+CREATE TABLE #trans_test(a int, b varchar(10)) 
+INSERT INTO #trans_test VALUES (1, 'before') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_trans_drop
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE #trans_test(c int) 
+INSERT INTO #trans_test VALUES (999)  
+SELECT * FROM #trans_test  
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #trans_test
+GO
+
+-- Test 5: Execute CREATE and INSERT operations
+EXEC p_create_insert
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+-- Test 6: Execute UPDATE and DELETE operations
+CREATE TABLE #update_delete_test(id int, status varchar(20), value int)
+INSERT INTO #update_delete_test VALUES (1, 'active', 100)
+INSERT INTO #update_delete_test VALUES (2, 'inactive', 200)
+INSERT INTO #update_delete_test VALUES (3, 'pending', 300)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_update_delete
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #update_delete_test
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#inactive#!#200
+1#!#processed#!#100
+4#!#new#!#150
+~~END~~
+
+
+DROP TABLE #update_delete_test
+GO
+
+-- Test 7: Execute nested procedures with mixed operations
+CREATE TABLE #nested_ops_test(id int, data varchar(50))
+INSERT INTO #nested_ops_test VALUES (1, 'initial')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_nested_outer
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #nested_ops_test
+GO
+~~START~~
+int#!#varchar
+1#!#updated by inner
+3#!#from outer
+~~END~~
+
+
+DROP TABLE #nested_ops_test
+GO
+
+-- Test 8: Execute transaction rollback and operations
+CREATE TABLE #rollback_ops_test(id int, amount decimal(10,2))
+INSERT INTO #rollback_ops_test VALUES (1, 100.00)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_rollback_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inside transaction:
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+~~START~~
+varchar
+After rollback:
+~~END~~
+
+
+SELECT * FROM #rollback_ops_test
+GO
+~~START~~
+int#!#numeric
+1#!#100.00
+2#!#200.00
+~~END~~
+
+
+DROP TABLE #rollback_ops_test
+GO
+
+-- Test 9: Execute multiple temp tables with cross-operations
+EXEC p_multi_temp_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Temp1:
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated first
+~~END~~
+
+~~START~~
+varchar
+Temp2:
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#1#!#ref to first
+~~END~~
+
+
+-- Test 10: Execute error handling and operations
+CREATE TABLE #error_ops_test(id int primary key, data varchar(20))
+INSERT INTO #error_ops_test VALUES (1, 'original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_error_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error caught: duplicate key value violates unique constraint "#error_ops_test_pkey"
+~~END~~
+
+
+SELECT * FROM #error_ops_test
+GO
+~~START~~
+int#!#varchar
+2#!#valid insert
+1#!#updated
+3#!#error handled
+~~END~~
+
+
+DROP TABLE #error_ops_test
+GO
+
+-- Test 11: Execute TRUNCATE operation
+CREATE TABLE #truncate_test(id int identity(1,1), data varchar(20))
+INSERT INTO #truncate_test VALUES ('first')
+INSERT INTO #truncate_test VALUES ('second')
+INSERT INTO #truncate_test VALUES ('third')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_truncate_ops
+GO
+~~START~~
+varchar
+Before truncate:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+3#!#third
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+After truncate:
+~~END~~
+
+
+SELECT * FROM #truncate_test
+GO
+~~START~~
+int#!#varchar
+1#!#after truncate
+~~END~~
+
+
+DROP TABLE #truncate_test
+GO
+
+-- Test 12: Execute conditional operations
+CREATE TABLE #conditional_test(id int, status varchar(10), value int)
+INSERT INTO #conditional_test VALUES (1, 'active', 50)
+INSERT INTO #conditional_test VALUES (2, 'inactive', 150)
+INSERT INTO #conditional_test VALUES (3, 'pending', 75)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_conditional_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #conditional_test
+GO
+~~START~~
+int#!#varchar#!#int
+1#!#active#!#50
+3#!#pending#!#75
+2#!#high_value#!#150
+4#!#new_high#!#200
+~~END~~
+
+
+DROP TABLE #conditional_test
+GO
+
+-- INSERT INTO EXEC Tests
+-- Test 13: Basic INSERT INTO EXEC with temp table
+CREATE TABLE #insert_exec_target(id int, name varchar(30))
+GO
+
+INSERT INTO #insert_exec_target EXEC p_insert_exec_basic
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_target
+GO
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+DROP TABLE #insert_exec_target
+GO
+
+-- Test 14: INSERT INTO EXEC with nested procedure calls
+CREATE TABLE #insert_exec_nested(id int, data varchar(50))
+GO
+
+INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+SELECT * FROM #insert_exec_nested
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+DROP TABLE #insert_exec_nested
+GO
+
+-- Test 15: INSERT INTO EXEC with temp table operations inside procedure
+CREATE TABLE #insert_exec_ops(id int, status varchar(20), value int)
+GO
+
+INSERT INTO #insert_exec_ops EXEC p_insert_exec_temp_ops
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_ops
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#pending#!#200
+1#!#processed#!#100
+~~END~~
+
+
+DROP TABLE #insert_exec_ops
+GO
+
+-- Test 16: INSERT INTO EXEC with transaction and rollback
+CREATE TABLE #insert_exec_trans(id int, amount decimal(10,2))
+GO
+
+INSERT INTO #insert_exec_trans EXEC p_insert_exec_transaction
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the ROLLBACK statement within an INSERT-EXEC statement.)~~
+
+
+SELECT * FROM #insert_exec_trans
+GO
+~~START~~
+int#!#numeric
+~~END~~
+
+
+DROP TABLE #insert_exec_trans
+GO
+
+-- Test 17: INSERT INTO EXEC with multiple result sets (only first is inserted)
+CREATE TABLE #insert_exec_multi(id int, info varchar(30))
+GO
+
+INSERT INTO #insert_exec_multi EXEC p_insert_exec_multi_results
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT * FROM #insert_exec_multi
+GO
+~~START~~
+int#!#varchar
+1#!#first result
+2#!#second result
+3#!#third result
+~~END~~
+
+
+DROP TABLE #insert_exec_multi
+GO
+
+-- Test 18: INSERT INTO EXEC with error handling
+CREATE TABLE #insert_exec_error(id int, data varchar(20))
+GO
+
+INSERT INTO #insert_exec_error EXEC p_insert_exec_error_handling
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_error
+GO
+~~START~~
+int#!#varchar
+1#!#original
+2#!#error handled
+~~END~~
+
+
+DROP TABLE #insert_exec_error
+GO
+
+-- Test 19: INSERT INTO EXEC with table variable in procedure
+CREATE TABLE #insert_exec_tv(id int, tv_data varchar(30))
+GO
+
+INSERT INTO #insert_exec_tv EXEC p_insert_exec_table_var
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_tv
+GO
+~~START~~
+int#!#varchar
+1#!#from table var
+2#!#tv data
+~~END~~
+
+
+DROP TABLE #insert_exec_tv
+GO
+
+-- Test 20: INSERT INTO EXEC where procedure attempts to drop the target table
+CREATE TABLE #insert_exec_drop_target(id int, data varchar(30))
+INSERT INTO #insert_exec_drop_target VALUES (1, 'initial data')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Should fail
+INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
+GO
+~~ERROR (Code: 556)~~
+
+~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+
+
+-- Table should still exist with original data since DROP failed
+SELECT * FROM #insert_exec_drop_target
+GO
+~~START~~
+int#!#varchar
+1#!#initial data
+~~END~~
+
+
+DROP TABLE #insert_exec_drop_target
+GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -174,6 +174,240 @@ BEGIN
 END
 GO
 
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_drop AS DROP TABLE #test
+GO
+
+CREATE PROC p_drop_multi AS 
+BEGIN 
+    DROP TABLE #temp_proc_test 
+END 
+GO
+
+CREATE PROC p_inner AS DROP TABLE #nested_test
+GO
+
+CREATE PROC p_outer AS EXEC p_inner
+GO
+
+CREATE PROC p_trans_drop AS 
+BEGIN 
+    BEGIN TRAN 
+        INSERT INTO #trans_test VALUES (2, 'during') 
+        DROP TABLE #trans_test 
+    COMMIT 
+END 
+GO
+
+CREATE PROC p_create_insert AS
+BEGIN
+    CREATE TABLE #proc_create(id int, name varchar(30))
+    INSERT INTO #proc_create VALUES (1, 'first')
+    INSERT INTO #proc_create VALUES (2, 'second')
+    SELECT * FROM #proc_create
+    DROP TABLE #proc_create
+END
+GO
+
+CREATE PROC p_update_delete AS
+BEGIN
+    UPDATE #update_delete_test SET status = 'processed' WHERE id = 1
+    DELETE FROM #update_delete_test WHERE value > 250
+    INSERT INTO #update_delete_test VALUES (4, 'new', 150)
+END
+GO
+
+CREATE PROC p_nested_inner AS
+BEGIN
+    INSERT INTO #nested_ops_test VALUES (2, 'from inner')
+    UPDATE #nested_ops_test SET data = 'updated by inner' WHERE id = 1
+END
+GO
+
+CREATE PROC p_nested_outer AS
+BEGIN
+    EXEC p_nested_inner
+    DELETE FROM #nested_ops_test WHERE id = 2
+    INSERT INTO #nested_ops_test VALUES (3, 'from outer')
+END
+GO
+
+CREATE PROC p_rollback_ops AS
+BEGIN
+    INSERT INTO #rollback_ops_test VALUES (2, 200.00)
+    BEGIN TRAN
+        UPDATE #rollback_ops_test SET amount = amount * 2
+        INSERT INTO #rollback_ops_test VALUES (3, 300.00)
+        DELETE FROM #rollback_ops_test WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM #rollback_ops_test
+    ROLLBACK
+    SELECT 'After rollback:' as label
+END
+GO
+
+CREATE PROC p_multi_temp_ops AS
+BEGIN
+    CREATE TABLE #temp1(id int, name varchar(20))
+    CREATE TABLE #temp2(id int, ref_id int, value varchar(30))
+    
+    INSERT INTO #temp1 VALUES (1, 'first')
+    INSERT INTO #temp1 VALUES (2, 'second')
+    
+    INSERT INTO #temp2 VALUES (10, 1, 'ref to first')
+    INSERT INTO #temp2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE #temp1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM #temp2 WHERE ref_id = 2
+    
+    SELECT 'Temp1:' as label
+    SELECT * FROM #temp1
+    SELECT 'Temp2:' as label
+    SELECT * FROM #temp2
+    
+    DROP TABLE #temp1
+    DROP TABLE #temp2
+END
+GO
+
+CREATE PROC p_error_ops AS
+BEGIN
+    INSERT INTO #error_ops_test VALUES (2, 'valid insert')
+    UPDATE #error_ops_test SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO #error_ops_test VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #error_ops_test VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+END
+GO
+
+CREATE PROC p_truncate_ops AS
+BEGIN
+    SELECT 'Before truncate:' as label
+    SELECT * FROM #truncate_test
+    
+    TRUNCATE TABLE #truncate_test
+    
+    INSERT INTO #truncate_test VALUES ('after truncate')
+    SELECT 'After truncate:' as label
+END
+GO
+
+CREATE PROC p_conditional_ops AS
+BEGIN
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM #conditional_test WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE #conditional_test SET status = 'high_value' WHERE value > 100
+        INSERT INTO #conditional_test VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM #conditional_test WHERE value < 60
+    END
+END
+GO
+
+-- INSERT INTO EXEC procedures
+CREATE PROC p_insert_exec_basic AS 
+BEGIN 
+    SELECT 1 as id, 'first' as name 
+    UNION ALL 
+    SELECT 2, 'second' 
+END
+GO
+
+CREATE PROC p_insert_exec_nested_inner AS
+BEGIN
+    SELECT 10 as id, 'inner data' as data
+END
+GO
+
+CREATE PROC p_insert_exec_nested_outer AS
+BEGIN
+    CREATE TABLE #temp_inner(id int, data varchar(50))
+    INSERT INTO #temp_inner EXEC p_insert_exec_nested_inner
+    INSERT INTO #temp_inner VALUES (20, 'outer data')
+    SELECT * FROM #temp_inner
+    DROP TABLE #temp_inner
+END
+GO
+
+CREATE PROC p_insert_exec_temp_ops AS
+BEGIN
+    CREATE TABLE #temp_ops(id int, status varchar(20), value int)
+    INSERT INTO #temp_ops VALUES (1, 'active', 100)
+    INSERT INTO #temp_ops VALUES (2, 'pending', 200)
+    UPDATE #temp_ops SET status = 'processed' WHERE id = 1
+    SELECT * FROM #temp_ops
+    DROP TABLE #temp_ops
+END
+GO
+
+CREATE PROC p_insert_exec_transaction AS
+BEGIN
+    CREATE TABLE #temp_trans(id int, amount decimal(10,2))
+    INSERT INTO #temp_trans VALUES (1, 100.00)
+    BEGIN TRAN
+        INSERT INTO #temp_trans VALUES (2, 200.00)
+        UPDATE #temp_trans SET amount = amount * 2
+    ROLLBACK
+    SELECT * FROM #temp_trans
+    DROP TABLE #temp_trans
+END
+GO
+
+CREATE PROC p_insert_exec_multi_results AS
+BEGIN
+    SELECT 1 as id, 'first result' as info
+    SELECT 2 as id, 'second result' as info
+    SELECT 3 as id, 'third result' as info
+END
+GO
+
+CREATE PROC p_insert_exec_error_handling AS
+BEGIN
+    CREATE TABLE #temp_error(id int primary key, data varchar(20))
+    INSERT INTO #temp_error VALUES (1, 'original')
+    BEGIN TRY
+        INSERT INTO #temp_error VALUES (1, 'duplicate')
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #temp_error VALUES (2, 'error handled')
+    END CATCH
+    SELECT * FROM #temp_error
+    DROP TABLE #temp_error
+END
+GO
+
+CREATE PROC p_insert_exec_table_var AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(30))
+    INSERT INTO @tv VALUES (1, 'from table var')
+    INSERT INTO @tv VALUES (2, 'tv data')
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_insert_exec_drop_table AS
+BEGIN
+    -- Return some data first
+    SELECT 100 as id, 'before drop' as data
+    
+    -- Drop the target table
+    DROP TABLE #insert_exec_drop_target
+    
+    -- Try to return more data (but table is already dropped)
+    SELECT 200 as id, 'after drop' as data
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -3688,6 +3922,552 @@ text
 #t2
 ~~END~~
 
+
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv ENR Tests - Procedure Drop Table Fix (BABEL-6268)
+---------------------------------------------------------------------------
+-- Test 1: Basic procedure drop table scenario
+CREATE TABLE #test(a int) 
+GO
+
+EXEC p_drop
+GO
+
+CREATE TABLE #test(a int)         -- should not crash
+GO
+
+DROP TABLE #test
+GO
+
+-- Test 2: Multiple procedure calls with same temp table name
+CREATE TABLE #temp_proc_test(id int, name varchar(50)) 
+INSERT INTO #temp_proc_test VALUES (1, 'test1') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_drop_multi
+GO
+
+CREATE TABLE #temp_proc_test(id int, data varchar(100)) 
+INSERT INTO #temp_proc_test VALUES (2, 'test2') 
+SELECT * FROM #temp_proc_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#test2
+~~END~~
+
+
+DROP TABLE #temp_proc_test
+GO
+
+-- Test 3: Nested procedure calls
+CREATE TABLE #nested_test(val int)
+INSERT INTO #nested_test VALUES (100)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_outer
+GO
+
+CREATE TABLE #nested_test(val int, descr varchar(20)) 
+INSERT INTO #nested_test VALUES (200, 'after fix') 
+SELECT * FROM #nested_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+200#!#after fix
+~~END~~
+
+
+DROP TABLE #nested_test
+GO
+
+-- Test 4: Procedure with transaction and temp table drop
+CREATE TABLE #trans_test(a int, b varchar(10)) 
+INSERT INTO #trans_test VALUES (1, 'before') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_trans_drop
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE #trans_test(c int) 
+INSERT INTO #trans_test VALUES (999)  
+SELECT * FROM #trans_test  
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #trans_test
+GO
+
+-- Test 5: Execute CREATE and INSERT operations
+EXEC p_create_insert
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+-- Test 6: Execute UPDATE and DELETE operations
+CREATE TABLE #update_delete_test(id int, status varchar(20), value int)
+INSERT INTO #update_delete_test VALUES (1, 'active', 100)
+INSERT INTO #update_delete_test VALUES (2, 'inactive', 200)
+INSERT INTO #update_delete_test VALUES (3, 'pending', 300)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_update_delete
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #update_delete_test
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#inactive#!#200
+1#!#processed#!#100
+4#!#new#!#150
+~~END~~
+
+
+DROP TABLE #update_delete_test
+GO
+
+-- Test 7: Execute nested procedures with mixed operations
+CREATE TABLE #nested_ops_test(id int, data varchar(50))
+INSERT INTO #nested_ops_test VALUES (1, 'initial')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_nested_outer
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #nested_ops_test
+GO
+~~START~~
+int#!#varchar
+1#!#updated by inner
+3#!#from outer
+~~END~~
+
+
+DROP TABLE #nested_ops_test
+GO
+
+-- Test 8: Execute transaction rollback and operations
+CREATE TABLE #rollback_ops_test(id int, amount decimal(10,2))
+INSERT INTO #rollback_ops_test VALUES (1, 100.00)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_rollback_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inside transaction:
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+~~START~~
+varchar
+After rollback:
+~~END~~
+
+
+SELECT * FROM #rollback_ops_test
+GO
+~~START~~
+int#!#numeric
+1#!#100.00
+2#!#200.00
+~~END~~
+
+
+DROP TABLE #rollback_ops_test
+GO
+
+-- Test 9: Execute multiple temp tables with cross-operations
+EXEC p_multi_temp_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Temp1:
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated first
+~~END~~
+
+~~START~~
+varchar
+Temp2:
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#1#!#ref to first
+~~END~~
+
+
+-- Test 10: Execute error handling and operations
+CREATE TABLE #error_ops_test(id int primary key, data varchar(20))
+INSERT INTO #error_ops_test VALUES (1, 'original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_error_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error caught: duplicate key value violates unique constraint "#error_ops_test_pkey"
+~~END~~
+
+
+SELECT * FROM #error_ops_test
+GO
+~~START~~
+int#!#varchar
+2#!#valid insert
+1#!#updated
+3#!#error handled
+~~END~~
+
+
+DROP TABLE #error_ops_test
+GO
+
+-- Test 11: Execute TRUNCATE operation
+CREATE TABLE #truncate_test(id int identity(1,1), data varchar(20))
+INSERT INTO #truncate_test VALUES ('first')
+INSERT INTO #truncate_test VALUES ('second')
+INSERT INTO #truncate_test VALUES ('third')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_truncate_ops
+GO
+~~START~~
+varchar
+Before truncate:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+3#!#third
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+After truncate:
+~~END~~
+
+
+SELECT * FROM #truncate_test
+GO
+~~START~~
+int#!#varchar
+1#!#after truncate
+~~END~~
+
+
+DROP TABLE #truncate_test
+GO
+
+-- Test 12: Execute conditional operations
+CREATE TABLE #conditional_test(id int, status varchar(10), value int)
+INSERT INTO #conditional_test VALUES (1, 'active', 50)
+INSERT INTO #conditional_test VALUES (2, 'inactive', 150)
+INSERT INTO #conditional_test VALUES (3, 'pending', 75)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_conditional_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #conditional_test
+GO
+~~START~~
+int#!#varchar#!#int
+1#!#active#!#50
+3#!#pending#!#75
+2#!#high_value#!#150
+4#!#new_high#!#200
+~~END~~
+
+
+DROP TABLE #conditional_test
+GO
+
+-- INSERT INTO EXEC Tests
+-- Test 13: Basic INSERT INTO EXEC with temp table
+CREATE TABLE #insert_exec_target(id int, name varchar(30))
+GO
+
+INSERT INTO #insert_exec_target EXEC p_insert_exec_basic
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_target
+GO
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+DROP TABLE #insert_exec_target
+GO
+
+-- Test 14: INSERT INTO EXEC with nested procedure calls
+CREATE TABLE #insert_exec_nested(id int, data varchar(50))
+GO
+
+INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+SELECT * FROM #insert_exec_nested
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+DROP TABLE #insert_exec_nested
+GO
+
+-- Test 15: INSERT INTO EXEC with temp table operations inside procedure
+CREATE TABLE #insert_exec_ops(id int, status varchar(20), value int)
+GO
+
+INSERT INTO #insert_exec_ops EXEC p_insert_exec_temp_ops
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_ops
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#pending#!#200
+1#!#processed#!#100
+~~END~~
+
+
+DROP TABLE #insert_exec_ops
+GO
+
+-- Test 16: INSERT INTO EXEC with transaction and rollback
+CREATE TABLE #insert_exec_trans(id int, amount decimal(10,2))
+GO
+
+INSERT INTO #insert_exec_trans EXEC p_insert_exec_transaction
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the ROLLBACK statement within an INSERT-EXEC statement.)~~
+
+
+SELECT * FROM #insert_exec_trans
+GO
+~~START~~
+int#!#numeric
+~~END~~
+
+
+DROP TABLE #insert_exec_trans
+GO
+
+-- Test 17: INSERT INTO EXEC with multiple result sets (only first is inserted)
+CREATE TABLE #insert_exec_multi(id int, info varchar(30))
+GO
+
+INSERT INTO #insert_exec_multi EXEC p_insert_exec_multi_results
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT * FROM #insert_exec_multi
+GO
+~~START~~
+int#!#varchar
+1#!#first result
+2#!#second result
+3#!#third result
+~~END~~
+
+
+DROP TABLE #insert_exec_multi
+GO
+
+-- Test 18: INSERT INTO EXEC with error handling
+CREATE TABLE #insert_exec_error(id int, data varchar(20))
+GO
+
+INSERT INTO #insert_exec_error EXEC p_insert_exec_error_handling
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_error
+GO
+~~START~~
+int#!#varchar
+1#!#original
+2#!#error handled
+~~END~~
+
+
+DROP TABLE #insert_exec_error
+GO
+
+-- Test 19: INSERT INTO EXEC with table variable in procedure
+CREATE TABLE #insert_exec_tv(id int, tv_data varchar(30))
+GO
+
+INSERT INTO #insert_exec_tv EXEC p_insert_exec_table_var
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_tv
+GO
+~~START~~
+int#!#varchar
+1#!#from table var
+2#!#tv data
+~~END~~
+
+
+DROP TABLE #insert_exec_tv
+GO
+
+-- Test 20: INSERT INTO EXEC where procedure attempts to drop the target table
+CREATE TABLE #insert_exec_drop_target(id int, data varchar(30))
+INSERT INTO #insert_exec_drop_target VALUES (1, 'initial data')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Should fail
+INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
+GO
+~~ERROR (Code: 556)~~
+
+~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+
+
+-- Table should still exist with original data since DROP failed
+SELECT * FROM #insert_exec_drop_target
+GO
+~~START~~
+int#!#varchar
+1#!#initial data
+~~END~~
+
+
+DROP TABLE #insert_exec_drop_target
+GO
 DROP VIEW enr_view
 GO
 
@@ -3725,4 +4505,74 @@ DROP PROCEDURE test_temp_table_drop_intermediate_idx
 GO
 
 DROP PROCEDURE test_alter_index_truncate_cache_fix
+GO
+
+
+DROP PROC p_drop
+GO
+
+DROP PROC p_drop_multi
+GO
+
+DROP PROC p_outer
+GO
+
+DROP PROC p_inner
+GO
+
+DROP PROC p_trans_drop
+GO
+
+DROP PROC p_create_insert
+GO
+
+DROP PROC p_update_delete
+GO
+
+DROP PROC p_nested_inner
+GO
+
+DROP PROC p_nested_outer
+GO
+
+DROP PROC p_rollback_ops
+GO
+
+DROP PROC p_multi_temp_ops
+GO
+
+DROP PROC p_error_ops
+GO
+
+DROP PROC p_truncate_ops
+GO
+
+DROP PROC p_conditional_ops
+GO
+
+DROP PROC p_insert_exec_basic
+GO
+
+DROP PROC p_insert_exec_nested_inner
+GO
+
+DROP PROC p_insert_exec_nested_outer
+GO
+
+DROP PROC p_insert_exec_temp_ops
+GO
+
+DROP PROC p_insert_exec_transaction
+GO
+
+DROP PROC p_insert_exec_multi_results
+GO
+
+DROP PROC p_insert_exec_error_handling
+GO
+
+DROP PROC p_insert_exec_table_var
+GO
+
+DROP PROC p_insert_exec_drop_table
 GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -174,6 +174,240 @@ BEGIN
 END
 GO
 
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_drop AS DROP TABLE #test
+GO
+
+CREATE PROC p_drop_multi AS 
+BEGIN 
+    DROP TABLE #temp_proc_test 
+END 
+GO
+
+CREATE PROC p_inner AS DROP TABLE #nested_test
+GO
+
+CREATE PROC p_outer AS EXEC p_inner
+GO
+
+CREATE PROC p_trans_drop AS 
+BEGIN 
+    BEGIN TRAN 
+        INSERT INTO #trans_test VALUES (2, 'during') 
+        DROP TABLE #trans_test 
+    COMMIT 
+END 
+GO
+
+CREATE PROC p_create_insert AS
+BEGIN
+    CREATE TABLE #proc_create(id int, name varchar(30))
+    INSERT INTO #proc_create VALUES (1, 'first')
+    INSERT INTO #proc_create VALUES (2, 'second')
+    SELECT * FROM #proc_create
+    DROP TABLE #proc_create
+END
+GO
+
+CREATE PROC p_update_delete AS
+BEGIN
+    UPDATE #update_delete_test SET status = 'processed' WHERE id = 1
+    DELETE FROM #update_delete_test WHERE value > 250
+    INSERT INTO #update_delete_test VALUES (4, 'new', 150)
+END
+GO
+
+CREATE PROC p_nested_inner AS
+BEGIN
+    INSERT INTO #nested_ops_test VALUES (2, 'from inner')
+    UPDATE #nested_ops_test SET data = 'updated by inner' WHERE id = 1
+END
+GO
+
+CREATE PROC p_nested_outer AS
+BEGIN
+    EXEC p_nested_inner
+    DELETE FROM #nested_ops_test WHERE id = 2
+    INSERT INTO #nested_ops_test VALUES (3, 'from outer')
+END
+GO
+
+CREATE PROC p_rollback_ops AS
+BEGIN
+    INSERT INTO #rollback_ops_test VALUES (2, 200.00)
+    BEGIN TRAN
+        UPDATE #rollback_ops_test SET amount = amount * 2
+        INSERT INTO #rollback_ops_test VALUES (3, 300.00)
+        DELETE FROM #rollback_ops_test WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM #rollback_ops_test
+    ROLLBACK
+    SELECT 'After rollback:' as label
+END
+GO
+
+CREATE PROC p_multi_temp_ops AS
+BEGIN
+    CREATE TABLE #temp1(id int, name varchar(20))
+    CREATE TABLE #temp2(id int, ref_id int, value varchar(30))
+    
+    INSERT INTO #temp1 VALUES (1, 'first')
+    INSERT INTO #temp1 VALUES (2, 'second')
+    
+    INSERT INTO #temp2 VALUES (10, 1, 'ref to first')
+    INSERT INTO #temp2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE #temp1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM #temp2 WHERE ref_id = 2
+    
+    SELECT 'Temp1:' as label
+    SELECT * FROM #temp1
+    SELECT 'Temp2:' as label
+    SELECT * FROM #temp2
+    
+    DROP TABLE #temp1
+    DROP TABLE #temp2
+END
+GO
+
+CREATE PROC p_error_ops AS
+BEGIN
+    INSERT INTO #error_ops_test VALUES (2, 'valid insert')
+    UPDATE #error_ops_test SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO #error_ops_test VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #error_ops_test VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+END
+GO
+
+CREATE PROC p_truncate_ops AS
+BEGIN
+    SELECT 'Before truncate:' as label
+    SELECT * FROM #truncate_test
+    
+    TRUNCATE TABLE #truncate_test
+    
+    INSERT INTO #truncate_test VALUES ('after truncate')
+    SELECT 'After truncate:' as label
+END
+GO
+
+CREATE PROC p_conditional_ops AS
+BEGIN
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM #conditional_test WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE #conditional_test SET status = 'high_value' WHERE value > 100
+        INSERT INTO #conditional_test VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM #conditional_test WHERE value < 60
+    END
+END
+GO
+
+-- INSERT INTO EXEC procedures
+CREATE PROC p_insert_exec_basic AS 
+BEGIN 
+    SELECT 1 as id, 'first' as name 
+    UNION ALL 
+    SELECT 2, 'second' 
+END
+GO
+
+CREATE PROC p_insert_exec_nested_inner AS
+BEGIN
+    SELECT 10 as id, 'inner data' as data
+END
+GO
+
+CREATE PROC p_insert_exec_nested_outer AS
+BEGIN
+    CREATE TABLE #temp_inner(id int, data varchar(50))
+    INSERT INTO #temp_inner EXEC p_insert_exec_nested_inner
+    INSERT INTO #temp_inner VALUES (20, 'outer data')
+    SELECT * FROM #temp_inner
+    DROP TABLE #temp_inner
+END
+GO
+
+CREATE PROC p_insert_exec_temp_ops AS
+BEGIN
+    CREATE TABLE #temp_ops(id int, status varchar(20), value int)
+    INSERT INTO #temp_ops VALUES (1, 'active', 100)
+    INSERT INTO #temp_ops VALUES (2, 'pending', 200)
+    UPDATE #temp_ops SET status = 'processed' WHERE id = 1
+    SELECT * FROM #temp_ops
+    DROP TABLE #temp_ops
+END
+GO
+
+CREATE PROC p_insert_exec_transaction AS
+BEGIN
+    CREATE TABLE #temp_trans(id int, amount decimal(10,2))
+    INSERT INTO #temp_trans VALUES (1, 100.00)
+    BEGIN TRAN
+        INSERT INTO #temp_trans VALUES (2, 200.00)
+        UPDATE #temp_trans SET amount = amount * 2
+    ROLLBACK
+    SELECT * FROM #temp_trans
+    DROP TABLE #temp_trans
+END
+GO
+
+CREATE PROC p_insert_exec_multi_results AS
+BEGIN
+    SELECT 1 as id, 'first result' as info
+    SELECT 2 as id, 'second result' as info
+    SELECT 3 as id, 'third result' as info
+END
+GO
+
+CREATE PROC p_insert_exec_error_handling AS
+BEGIN
+    CREATE TABLE #temp_error(id int primary key, data varchar(20))
+    INSERT INTO #temp_error VALUES (1, 'original')
+    BEGIN TRY
+        INSERT INTO #temp_error VALUES (1, 'duplicate')
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #temp_error VALUES (2, 'error handled')
+    END CATCH
+    SELECT * FROM #temp_error
+    DROP TABLE #temp_error
+END
+GO
+
+CREATE PROC p_insert_exec_table_var AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(30))
+    INSERT INTO @tv VALUES (1, 'from table var')
+    INSERT INTO @tv VALUES (2, 'tv data')
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_insert_exec_drop_table AS
+BEGIN
+    -- Return some data first
+    SELECT 100 as id, 'before drop' as data
+    
+    -- Drop the target table
+    DROP TABLE #insert_exec_drop_target
+    
+    -- Try to return more data (but table is already dropped)
+    SELECT 200 as id, 'after drop' as data
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -3688,6 +3922,552 @@ text
 #t2
 ~~END~~
 
+
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv ENR Tests - Procedure Drop Table Fix (BABEL-6268)
+---------------------------------------------------------------------------
+-- Test 1: Basic procedure drop table scenario
+CREATE TABLE #test(a int) 
+GO
+
+EXEC p_drop
+GO
+
+CREATE TABLE #test(a int)         -- should not crash
+GO
+
+DROP TABLE #test
+GO
+
+-- Test 2: Multiple procedure calls with same temp table name
+CREATE TABLE #temp_proc_test(id int, name varchar(50)) 
+INSERT INTO #temp_proc_test VALUES (1, 'test1') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_drop_multi
+GO
+
+CREATE TABLE #temp_proc_test(id int, data varchar(100)) 
+INSERT INTO #temp_proc_test VALUES (2, 'test2') 
+SELECT * FROM #temp_proc_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#test2
+~~END~~
+
+
+DROP TABLE #temp_proc_test
+GO
+
+-- Test 3: Nested procedure calls
+CREATE TABLE #nested_test(val int)
+INSERT INTO #nested_test VALUES (100)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_outer
+GO
+
+CREATE TABLE #nested_test(val int, descr varchar(20)) 
+INSERT INTO #nested_test VALUES (200, 'after fix') 
+SELECT * FROM #nested_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+200#!#after fix
+~~END~~
+
+
+DROP TABLE #nested_test
+GO
+
+-- Test 4: Procedure with transaction and temp table drop
+CREATE TABLE #trans_test(a int, b varchar(10)) 
+INSERT INTO #trans_test VALUES (1, 'before') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_trans_drop
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE #trans_test(c int) 
+INSERT INTO #trans_test VALUES (999)  
+SELECT * FROM #trans_test  
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #trans_test
+GO
+
+-- Test 5: Execute CREATE and INSERT operations
+EXEC p_create_insert
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+-- Test 6: Execute UPDATE and DELETE operations
+CREATE TABLE #update_delete_test(id int, status varchar(20), value int)
+INSERT INTO #update_delete_test VALUES (1, 'active', 100)
+INSERT INTO #update_delete_test VALUES (2, 'inactive', 200)
+INSERT INTO #update_delete_test VALUES (3, 'pending', 300)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_update_delete
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #update_delete_test
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#inactive#!#200
+1#!#processed#!#100
+4#!#new#!#150
+~~END~~
+
+
+DROP TABLE #update_delete_test
+GO
+
+-- Test 7: Execute nested procedures with mixed operations
+CREATE TABLE #nested_ops_test(id int, data varchar(50))
+INSERT INTO #nested_ops_test VALUES (1, 'initial')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_nested_outer
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #nested_ops_test
+GO
+~~START~~
+int#!#varchar
+1#!#updated by inner
+3#!#from outer
+~~END~~
+
+
+DROP TABLE #nested_ops_test
+GO
+
+-- Test 8: Execute transaction rollback and operations
+CREATE TABLE #rollback_ops_test(id int, amount decimal(10,2))
+INSERT INTO #rollback_ops_test VALUES (1, 100.00)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_rollback_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inside transaction:
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+~~START~~
+varchar
+After rollback:
+~~END~~
+
+
+SELECT * FROM #rollback_ops_test
+GO
+~~START~~
+int#!#numeric
+1#!#100.00
+2#!#200.00
+~~END~~
+
+
+DROP TABLE #rollback_ops_test
+GO
+
+-- Test 9: Execute multiple temp tables with cross-operations
+EXEC p_multi_temp_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Temp1:
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated first
+~~END~~
+
+~~START~~
+varchar
+Temp2:
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#1#!#ref to first
+~~END~~
+
+
+-- Test 10: Execute error handling and operations
+CREATE TABLE #error_ops_test(id int primary key, data varchar(20))
+INSERT INTO #error_ops_test VALUES (1, 'original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_error_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error caught: duplicate key value violates unique constraint "#error_ops_test_pkey"
+~~END~~
+
+
+SELECT * FROM #error_ops_test
+GO
+~~START~~
+int#!#varchar
+2#!#valid insert
+1#!#updated
+3#!#error handled
+~~END~~
+
+
+DROP TABLE #error_ops_test
+GO
+
+-- Test 11: Execute TRUNCATE operation
+CREATE TABLE #truncate_test(id int identity(1,1), data varchar(20))
+INSERT INTO #truncate_test VALUES ('first')
+INSERT INTO #truncate_test VALUES ('second')
+INSERT INTO #truncate_test VALUES ('third')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_truncate_ops
+GO
+~~START~~
+varchar
+Before truncate:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+3#!#third
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+After truncate:
+~~END~~
+
+
+SELECT * FROM #truncate_test
+GO
+~~START~~
+int#!#varchar
+1#!#after truncate
+~~END~~
+
+
+DROP TABLE #truncate_test
+GO
+
+-- Test 12: Execute conditional operations
+CREATE TABLE #conditional_test(id int, status varchar(10), value int)
+INSERT INTO #conditional_test VALUES (1, 'active', 50)
+INSERT INTO #conditional_test VALUES (2, 'inactive', 150)
+INSERT INTO #conditional_test VALUES (3, 'pending', 75)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_conditional_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #conditional_test
+GO
+~~START~~
+int#!#varchar#!#int
+1#!#active#!#50
+3#!#pending#!#75
+2#!#high_value#!#150
+4#!#new_high#!#200
+~~END~~
+
+
+DROP TABLE #conditional_test
+GO
+
+-- INSERT INTO EXEC Tests
+-- Test 13: Basic INSERT INTO EXEC with temp table
+CREATE TABLE #insert_exec_target(id int, name varchar(30))
+GO
+
+INSERT INTO #insert_exec_target EXEC p_insert_exec_basic
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_target
+GO
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+DROP TABLE #insert_exec_target
+GO
+
+-- Test 14: INSERT INTO EXEC with nested procedure calls
+CREATE TABLE #insert_exec_nested(id int, data varchar(50))
+GO
+
+INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+SELECT * FROM #insert_exec_nested
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+DROP TABLE #insert_exec_nested
+GO
+
+-- Test 15: INSERT INTO EXEC with temp table operations inside procedure
+CREATE TABLE #insert_exec_ops(id int, status varchar(20), value int)
+GO
+
+INSERT INTO #insert_exec_ops EXEC p_insert_exec_temp_ops
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_ops
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#pending#!#200
+1#!#processed#!#100
+~~END~~
+
+
+DROP TABLE #insert_exec_ops
+GO
+
+-- Test 16: INSERT INTO EXEC with transaction and rollback
+CREATE TABLE #insert_exec_trans(id int, amount decimal(10,2))
+GO
+
+INSERT INTO #insert_exec_trans EXEC p_insert_exec_transaction
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the ROLLBACK statement within an INSERT-EXEC statement.)~~
+
+
+SELECT * FROM #insert_exec_trans
+GO
+~~START~~
+int#!#numeric
+~~END~~
+
+
+DROP TABLE #insert_exec_trans
+GO
+
+-- Test 17: INSERT INTO EXEC with multiple result sets (only first is inserted)
+CREATE TABLE #insert_exec_multi(id int, info varchar(30))
+GO
+
+INSERT INTO #insert_exec_multi EXEC p_insert_exec_multi_results
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT * FROM #insert_exec_multi
+GO
+~~START~~
+int#!#varchar
+1#!#first result
+2#!#second result
+3#!#third result
+~~END~~
+
+
+DROP TABLE #insert_exec_multi
+GO
+
+-- Test 18: INSERT INTO EXEC with error handling
+CREATE TABLE #insert_exec_error(id int, data varchar(20))
+GO
+
+INSERT INTO #insert_exec_error EXEC p_insert_exec_error_handling
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_error
+GO
+~~START~~
+int#!#varchar
+1#!#original
+2#!#error handled
+~~END~~
+
+
+DROP TABLE #insert_exec_error
+GO
+
+-- Test 19: INSERT INTO EXEC with table variable in procedure
+CREATE TABLE #insert_exec_tv(id int, tv_data varchar(30))
+GO
+
+INSERT INTO #insert_exec_tv EXEC p_insert_exec_table_var
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_tv
+GO
+~~START~~
+int#!#varchar
+1#!#from table var
+2#!#tv data
+~~END~~
+
+
+DROP TABLE #insert_exec_tv
+GO
+
+-- Test 20: INSERT INTO EXEC where procedure attempts to drop the target table
+CREATE TABLE #insert_exec_drop_target(id int, data varchar(30))
+INSERT INTO #insert_exec_drop_target VALUES (1, 'initial data')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Should fail
+INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
+GO
+~~ERROR (Code: 556)~~
+
+~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+
+
+-- Table should still exist with original data since DROP failed
+SELECT * FROM #insert_exec_drop_target
+GO
+~~START~~
+int#!#varchar
+1#!#initial data
+~~END~~
+
+
+DROP TABLE #insert_exec_drop_target
+GO
 DROP VIEW enr_view
 GO
 
@@ -3725,4 +4505,74 @@ DROP PROCEDURE test_temp_table_drop_intermediate_idx
 GO
 
 DROP PROCEDURE test_alter_index_truncate_cache_fix
+GO
+
+
+DROP PROC p_drop
+GO
+
+DROP PROC p_drop_multi
+GO
+
+DROP PROC p_outer
+GO
+
+DROP PROC p_inner
+GO
+
+DROP PROC p_trans_drop
+GO
+
+DROP PROC p_create_insert
+GO
+
+DROP PROC p_update_delete
+GO
+
+DROP PROC p_nested_inner
+GO
+
+DROP PROC p_nested_outer
+GO
+
+DROP PROC p_rollback_ops
+GO
+
+DROP PROC p_multi_temp_ops
+GO
+
+DROP PROC p_error_ops
+GO
+
+DROP PROC p_truncate_ops
+GO
+
+DROP PROC p_conditional_ops
+GO
+
+DROP PROC p_insert_exec_basic
+GO
+
+DROP PROC p_insert_exec_nested_inner
+GO
+
+DROP PROC p_insert_exec_nested_outer
+GO
+
+DROP PROC p_insert_exec_temp_ops
+GO
+
+DROP PROC p_insert_exec_transaction
+GO
+
+DROP PROC p_insert_exec_multi_results
+GO
+
+DROP PROC p_insert_exec_error_handling
+GO
+
+DROP PROC p_insert_exec_table_var
+GO
+
+DROP PROC p_insert_exec_drop_table
 GO

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -174,6 +174,240 @@ BEGIN
 END
 GO
 
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_drop AS DROP TABLE #test
+GO
+
+CREATE PROC p_drop_multi AS 
+BEGIN 
+    DROP TABLE #temp_proc_test 
+END 
+GO
+
+CREATE PROC p_inner AS DROP TABLE #nested_test
+GO
+
+CREATE PROC p_outer AS EXEC p_inner
+GO
+
+CREATE PROC p_trans_drop AS 
+BEGIN 
+    BEGIN TRAN 
+        INSERT INTO #trans_test VALUES (2, 'during') 
+        DROP TABLE #trans_test 
+    COMMIT 
+END 
+GO
+
+CREATE PROC p_create_insert AS
+BEGIN
+    CREATE TABLE #proc_create(id int, name varchar(30))
+    INSERT INTO #proc_create VALUES (1, 'first')
+    INSERT INTO #proc_create VALUES (2, 'second')
+    SELECT * FROM #proc_create
+    DROP TABLE #proc_create
+END
+GO
+
+CREATE PROC p_update_delete AS
+BEGIN
+    UPDATE #update_delete_test SET status = 'processed' WHERE id = 1
+    DELETE FROM #update_delete_test WHERE value > 250
+    INSERT INTO #update_delete_test VALUES (4, 'new', 150)
+END
+GO
+
+CREATE PROC p_nested_inner AS
+BEGIN
+    INSERT INTO #nested_ops_test VALUES (2, 'from inner')
+    UPDATE #nested_ops_test SET data = 'updated by inner' WHERE id = 1
+END
+GO
+
+CREATE PROC p_nested_outer AS
+BEGIN
+    EXEC p_nested_inner
+    DELETE FROM #nested_ops_test WHERE id = 2
+    INSERT INTO #nested_ops_test VALUES (3, 'from outer')
+END
+GO
+
+CREATE PROC p_rollback_ops AS
+BEGIN
+    INSERT INTO #rollback_ops_test VALUES (2, 200.00)
+    BEGIN TRAN
+        UPDATE #rollback_ops_test SET amount = amount * 2
+        INSERT INTO #rollback_ops_test VALUES (3, 300.00)
+        DELETE FROM #rollback_ops_test WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM #rollback_ops_test
+    ROLLBACK
+    SELECT 'After rollback:' as label
+END
+GO
+
+CREATE PROC p_multi_temp_ops AS
+BEGIN
+    CREATE TABLE #temp1(id int, name varchar(20))
+    CREATE TABLE #temp2(id int, ref_id int, value varchar(30))
+    
+    INSERT INTO #temp1 VALUES (1, 'first')
+    INSERT INTO #temp1 VALUES (2, 'second')
+    
+    INSERT INTO #temp2 VALUES (10, 1, 'ref to first')
+    INSERT INTO #temp2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE #temp1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM #temp2 WHERE ref_id = 2
+    
+    SELECT 'Temp1:' as label
+    SELECT * FROM #temp1
+    SELECT 'Temp2:' as label
+    SELECT * FROM #temp2
+    
+    DROP TABLE #temp1
+    DROP TABLE #temp2
+END
+GO
+
+CREATE PROC p_error_ops AS
+BEGIN
+    INSERT INTO #error_ops_test VALUES (2, 'valid insert')
+    UPDATE #error_ops_test SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO #error_ops_test VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #error_ops_test VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+END
+GO
+
+CREATE PROC p_truncate_ops AS
+BEGIN
+    SELECT 'Before truncate:' as label
+    SELECT * FROM #truncate_test
+    
+    TRUNCATE TABLE #truncate_test
+    
+    INSERT INTO #truncate_test VALUES ('after truncate')
+    SELECT 'After truncate:' as label
+END
+GO
+
+CREATE PROC p_conditional_ops AS
+BEGIN
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM #conditional_test WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE #conditional_test SET status = 'high_value' WHERE value > 100
+        INSERT INTO #conditional_test VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM #conditional_test WHERE value < 60
+    END
+END
+GO
+
+-- INSERT INTO EXEC procedures
+CREATE PROC p_insert_exec_basic AS 
+BEGIN 
+    SELECT 1 as id, 'first' as name 
+    UNION ALL 
+    SELECT 2, 'second' 
+END
+GO
+
+CREATE PROC p_insert_exec_nested_inner AS
+BEGIN
+    SELECT 10 as id, 'inner data' as data
+END
+GO
+
+CREATE PROC p_insert_exec_nested_outer AS
+BEGIN
+    CREATE TABLE #temp_inner(id int, data varchar(50))
+    INSERT INTO #temp_inner EXEC p_insert_exec_nested_inner
+    INSERT INTO #temp_inner VALUES (20, 'outer data')
+    SELECT * FROM #temp_inner
+    DROP TABLE #temp_inner
+END
+GO
+
+CREATE PROC p_insert_exec_temp_ops AS
+BEGIN
+    CREATE TABLE #temp_ops(id int, status varchar(20), value int)
+    INSERT INTO #temp_ops VALUES (1, 'active', 100)
+    INSERT INTO #temp_ops VALUES (2, 'pending', 200)
+    UPDATE #temp_ops SET status = 'processed' WHERE id = 1
+    SELECT * FROM #temp_ops
+    DROP TABLE #temp_ops
+END
+GO
+
+CREATE PROC p_insert_exec_transaction AS
+BEGIN
+    CREATE TABLE #temp_trans(id int, amount decimal(10,2))
+    INSERT INTO #temp_trans VALUES (1, 100.00)
+    BEGIN TRAN
+        INSERT INTO #temp_trans VALUES (2, 200.00)
+        UPDATE #temp_trans SET amount = amount * 2
+    ROLLBACK
+    SELECT * FROM #temp_trans
+    DROP TABLE #temp_trans
+END
+GO
+
+CREATE PROC p_insert_exec_multi_results AS
+BEGIN
+    SELECT 1 as id, 'first result' as info
+    SELECT 2 as id, 'second result' as info
+    SELECT 3 as id, 'third result' as info
+END
+GO
+
+CREATE PROC p_insert_exec_error_handling AS
+BEGIN
+    CREATE TABLE #temp_error(id int primary key, data varchar(20))
+    INSERT INTO #temp_error VALUES (1, 'original')
+    BEGIN TRY
+        INSERT INTO #temp_error VALUES (1, 'duplicate')
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #temp_error VALUES (2, 'error handled')
+    END CATCH
+    SELECT * FROM #temp_error
+    DROP TABLE #temp_error
+END
+GO
+
+CREATE PROC p_insert_exec_table_var AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(30))
+    INSERT INTO @tv VALUES (1, 'from table var')
+    INSERT INTO @tv VALUES (2, 'tv data')
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_insert_exec_drop_table AS
+BEGIN
+    -- Return some data first
+    SELECT 100 as id, 'before drop' as data
+    
+    -- Drop the target table
+    DROP TABLE #insert_exec_drop_target
+    
+    -- Try to return more data (but table is already dropped)
+    SELECT 200 as id, 'after drop' as data
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -3689,6 +3923,552 @@ text
 #t2
 ~~END~~
 
+
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv ENR Tests - Procedure Drop Table Fix (BABEL-6268)
+---------------------------------------------------------------------------
+-- Test 1: Basic procedure drop table scenario
+CREATE TABLE #test(a int) 
+GO
+
+EXEC p_drop
+GO
+
+CREATE TABLE #test(a int)         -- should not crash
+GO
+
+DROP TABLE #test
+GO
+
+-- Test 2: Multiple procedure calls with same temp table name
+CREATE TABLE #temp_proc_test(id int, name varchar(50)) 
+INSERT INTO #temp_proc_test VALUES (1, 'test1') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_drop_multi
+GO
+
+CREATE TABLE #temp_proc_test(id int, data varchar(100)) 
+INSERT INTO #temp_proc_test VALUES (2, 'test2') 
+SELECT * FROM #temp_proc_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#test2
+~~END~~
+
+
+DROP TABLE #temp_proc_test
+GO
+
+-- Test 3: Nested procedure calls
+CREATE TABLE #nested_test(val int)
+INSERT INTO #nested_test VALUES (100)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_outer
+GO
+
+CREATE TABLE #nested_test(val int, descr varchar(20)) 
+INSERT INTO #nested_test VALUES (200, 'after fix') 
+SELECT * FROM #nested_test 
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+200#!#after fix
+~~END~~
+
+
+DROP TABLE #nested_test
+GO
+
+-- Test 4: Procedure with transaction and temp table drop
+CREATE TABLE #trans_test(a int, b varchar(10)) 
+INSERT INTO #trans_test VALUES (1, 'before') 
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_trans_drop
+GO
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE #trans_test(c int) 
+INSERT INTO #trans_test VALUES (999)  
+SELECT * FROM #trans_test  
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #trans_test
+GO
+
+-- Test 5: Execute CREATE and INSERT operations
+EXEC p_create_insert
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+-- Test 6: Execute UPDATE and DELETE operations
+CREATE TABLE #update_delete_test(id int, status varchar(20), value int)
+INSERT INTO #update_delete_test VALUES (1, 'active', 100)
+INSERT INTO #update_delete_test VALUES (2, 'inactive', 200)
+INSERT INTO #update_delete_test VALUES (3, 'pending', 300)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_update_delete
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #update_delete_test
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#inactive#!#200
+1#!#processed#!#100
+4#!#new#!#150
+~~END~~
+
+
+DROP TABLE #update_delete_test
+GO
+
+-- Test 7: Execute nested procedures with mixed operations
+CREATE TABLE #nested_ops_test(id int, data varchar(50))
+INSERT INTO #nested_ops_test VALUES (1, 'initial')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_nested_outer
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #nested_ops_test
+GO
+~~START~~
+int#!#varchar
+1#!#updated by inner
+3#!#from outer
+~~END~~
+
+
+DROP TABLE #nested_ops_test
+GO
+
+-- Test 8: Execute transaction rollback and operations
+CREATE TABLE #rollback_ops_test(id int, amount decimal(10,2))
+INSERT INTO #rollback_ops_test VALUES (1, 100.00)
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_rollback_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Inside transaction:
+~~END~~
+
+~~START~~
+int#!#numeric
+2#!#400.00
+3#!#300.00
+~~END~~
+
+~~START~~
+varchar
+After rollback:
+~~END~~
+
+
+SELECT * FROM #rollback_ops_test
+GO
+~~START~~
+int#!#numeric
+1#!#100.00
+2#!#200.00
+~~END~~
+
+
+DROP TABLE #rollback_ops_test
+GO
+
+-- Test 9: Execute multiple temp tables with cross-operations
+EXEC p_multi_temp_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+Temp1:
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+1#!#updated first
+~~END~~
+
+~~START~~
+varchar
+Temp2:
+~~END~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#1#!#ref to first
+~~END~~
+
+
+-- Test 10: Execute error handling and operations
+CREATE TABLE #error_ops_test(id int primary key, data varchar(20))
+INSERT INTO #error_ops_test VALUES (1, 'original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_error_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error caught: duplicate key value violates unique constraint "#error_ops_test_pkey"
+~~END~~
+
+
+SELECT * FROM #error_ops_test
+GO
+~~START~~
+int#!#varchar
+2#!#valid insert
+1#!#updated
+3#!#error handled
+~~END~~
+
+
+DROP TABLE #error_ops_test
+GO
+
+-- Test 11: Execute TRUNCATE operation
+CREATE TABLE #truncate_test(id int identity(1,1), data varchar(20))
+INSERT INTO #truncate_test VALUES ('first')
+INSERT INTO #truncate_test VALUES ('second')
+INSERT INTO #truncate_test VALUES ('third')
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_truncate_ops
+GO
+~~START~~
+varchar
+Before truncate:
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+3#!#third
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+varchar
+After truncate:
+~~END~~
+
+
+SELECT * FROM #truncate_test
+GO
+~~START~~
+int#!#varchar
+1#!#after truncate
+~~END~~
+
+
+DROP TABLE #truncate_test
+GO
+
+-- Test 12: Execute conditional operations
+CREATE TABLE #conditional_test(id int, status varchar(10), value int)
+INSERT INTO #conditional_test VALUES (1, 'active', 50)
+INSERT INTO #conditional_test VALUES (2, 'inactive', 150)
+INSERT INTO #conditional_test VALUES (3, 'pending', 75)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC p_conditional_ops
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT * FROM #conditional_test
+GO
+~~START~~
+int#!#varchar#!#int
+1#!#active#!#50
+3#!#pending#!#75
+2#!#high_value#!#150
+4#!#new_high#!#200
+~~END~~
+
+
+DROP TABLE #conditional_test
+GO
+
+-- INSERT INTO EXEC Tests
+-- Test 13: Basic INSERT INTO EXEC with temp table
+CREATE TABLE #insert_exec_target(id int, name varchar(30))
+GO
+
+INSERT INTO #insert_exec_target EXEC p_insert_exec_basic
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_target
+GO
+~~START~~
+int#!#varchar
+1#!#first
+2#!#second
+~~END~~
+
+
+DROP TABLE #insert_exec_target
+GO
+
+-- Test 14: INSERT INTO EXEC with nested procedure calls
+CREATE TABLE #insert_exec_nested(id int, data varchar(50))
+GO
+
+INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
+
+
+SELECT * FROM #insert_exec_nested
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+
+DROP TABLE #insert_exec_nested
+GO
+
+-- Test 15: INSERT INTO EXEC with temp table operations inside procedure
+CREATE TABLE #insert_exec_ops(id int, status varchar(20), value int)
+GO
+
+INSERT INTO #insert_exec_ops EXEC p_insert_exec_temp_ops
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_ops
+GO
+~~START~~
+int#!#varchar#!#int
+2#!#pending#!#200
+1#!#processed#!#100
+~~END~~
+
+
+DROP TABLE #insert_exec_ops
+GO
+
+-- Test 16: INSERT INTO EXEC with transaction and rollback
+CREATE TABLE #insert_exec_trans(id int, amount decimal(10,2))
+GO
+
+INSERT INTO #insert_exec_trans EXEC p_insert_exec_transaction
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Cannot use the ROLLBACK statement within an INSERT-EXEC statement.)~~
+
+
+SELECT * FROM #insert_exec_trans
+GO
+~~START~~
+int#!#numeric
+~~END~~
+
+
+DROP TABLE #insert_exec_trans
+GO
+
+-- Test 17: INSERT INTO EXEC with multiple result sets (only first is inserted)
+CREATE TABLE #insert_exec_multi(id int, info varchar(30))
+GO
+
+INSERT INTO #insert_exec_multi EXEC p_insert_exec_multi_results
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT * FROM #insert_exec_multi
+GO
+~~START~~
+int#!#varchar
+1#!#first result
+2#!#second result
+3#!#third result
+~~END~~
+
+
+DROP TABLE #insert_exec_multi
+GO
+
+-- Test 18: INSERT INTO EXEC with error handling
+CREATE TABLE #insert_exec_error(id int, data varchar(20))
+GO
+
+INSERT INTO #insert_exec_error EXEC p_insert_exec_error_handling
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_error
+GO
+~~START~~
+int#!#varchar
+1#!#original
+2#!#error handled
+~~END~~
+
+
+DROP TABLE #insert_exec_error
+GO
+
+-- Test 19: INSERT INTO EXEC with table variable in procedure
+CREATE TABLE #insert_exec_tv(id int, tv_data varchar(30))
+GO
+
+INSERT INTO #insert_exec_tv EXEC p_insert_exec_table_var
+GO
+~~ROW COUNT: 2~~
+
+
+SELECT * FROM #insert_exec_tv
+GO
+~~START~~
+int#!#varchar
+1#!#from table var
+2#!#tv data
+~~END~~
+
+
+DROP TABLE #insert_exec_tv
+GO
+
+-- Test 20: INSERT INTO EXEC where procedure attempts to drop the target table
+CREATE TABLE #insert_exec_drop_target(id int, data varchar(30))
+INSERT INTO #insert_exec_drop_target VALUES (1, 'initial data')
+GO
+~~ROW COUNT: 1~~
+
+
+-- Should fail
+INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
+GO
+~~ERROR (Code: 556)~~
+
+~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+
+
+-- Table should still exist with original data since DROP failed
+SELECT * FROM #insert_exec_drop_target
+GO
+~~START~~
+int#!#varchar
+1#!#initial data
+~~END~~
+
+
+DROP TABLE #insert_exec_drop_target
+GO
 DROP VIEW enr_view
 GO
 
@@ -3726,4 +4506,74 @@ DROP PROCEDURE test_temp_table_drop_intermediate_idx
 GO
 
 DROP PROCEDURE test_alter_index_truncate_cache_fix
+GO
+
+
+DROP PROC p_drop
+GO
+
+DROP PROC p_drop_multi
+GO
+
+DROP PROC p_outer
+GO
+
+DROP PROC p_inner
+GO
+
+DROP PROC p_trans_drop
+GO
+
+DROP PROC p_create_insert
+GO
+
+DROP PROC p_update_delete
+GO
+
+DROP PROC p_nested_inner
+GO
+
+DROP PROC p_nested_outer
+GO
+
+DROP PROC p_rollback_ops
+GO
+
+DROP PROC p_multi_temp_ops
+GO
+
+DROP PROC p_error_ops
+GO
+
+DROP PROC p_truncate_ops
+GO
+
+DROP PROC p_conditional_ops
+GO
+
+DROP PROC p_insert_exec_basic
+GO
+
+DROP PROC p_insert_exec_nested_inner
+GO
+
+DROP PROC p_insert_exec_nested_outer
+GO
+
+DROP PROC p_insert_exec_temp_ops
+GO
+
+DROP PROC p_insert_exec_transaction
+GO
+
+DROP PROC p_insert_exec_multi_results
+GO
+
+DROP PROC p_insert_exec_error_handling
+GO
+
+DROP PROC p_insert_exec_table_var
+GO
+
+DROP PROC p_insert_exec_drop_table
 GO

--- a/test/JDBC/input/table_variables/table-variable-vu-cleanup.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-cleanup.sql
@@ -69,3 +69,36 @@ GO
 
 DROP TYPE tv_nested_type
 GO
+
+DROP PROC p_tv_basic
+GO
+
+DROP PROC p_tv_delete
+GO
+
+DROP PROC p_tv_nested_outer
+GO
+
+DROP PROC p_tv_nested_inner
+GO
+
+DROP PROC p_tv_transaction
+GO
+
+DROP PROC p_tv_multiple
+GO
+
+DROP PROC p_tv_error_handling
+GO
+
+DROP PROC p_tv_conditional
+GO
+
+DROP PROC p_tv_mixed_with_temp
+GO
+
+DROP PROC p_tv_scope_outer
+GO
+
+DROP PROC p_tv_scope_inner
+GO

--- a/test/JDBC/input/table_variables/table-variable-vu-prepare.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-prepare.sql
@@ -233,3 +233,188 @@ CREATE FUNCTION tv_nested_func1 (@t tv_nested_type readonly) RETURNS @a TABLE (y
 GO
 CREATE FUNCTION tv_nested_func2 (@t tv_nested_type readonly) RETURNS @a TABLE (x INT) AS BEGIN; INSERT INTO @a SELECT y FROM tv_nested_func1(@t); RETURN; END;
 GO
+
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_tv_basic AS
+BEGIN
+    DECLARE @tv TABLE (id int, name varchar(30))
+    INSERT INTO @tv VALUES (1, 'first')
+    INSERT INTO @tv VALUES (2, 'second')
+    UPDATE @tv SET name = 'updated' WHERE id = 1
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_delete AS
+BEGIN
+    DECLARE @tv TABLE (id int, status varchar(20), value int)
+    INSERT INTO @tv VALUES (1, 'active', 100)
+    INSERT INTO @tv VALUES (2, 'inactive', 200)
+    INSERT INTO @tv VALUES (3, 'pending', 300)
+    
+    DELETE FROM @tv WHERE value > 250
+    UPDATE @tv SET status = 'processed' WHERE id = 1
+    INSERT INTO @tv VALUES (4, 'new', 150)
+    
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_nested_inner AS
+BEGIN
+    DECLARE @inner_tv TABLE (id int, data varchar(50))
+    INSERT INTO @inner_tv VALUES (1, 'from inner proc')
+    INSERT INTO @inner_tv VALUES (2, 'inner data')
+    SELECT 'Inner procedure:' as label
+    SELECT * FROM @inner_tv
+END
+GO
+
+CREATE PROC p_tv_nested_outer AS
+BEGIN
+    DECLARE @outer_tv TABLE (id int, info varchar(50))
+    INSERT INTO @outer_tv VALUES (10, 'from outer proc')
+    
+    EXEC p_tv_nested_inner
+    
+    UPDATE @outer_tv SET info = 'updated in outer' WHERE id = 10
+    INSERT INTO @outer_tv VALUES (20, 'outer data')
+    
+    SELECT 'Outer procedure:' as label
+    SELECT * FROM @outer_tv
+END
+GO
+
+CREATE PROC p_tv_transaction AS
+BEGIN
+    DECLARE @tv TABLE (id int, amount decimal(10,2))
+    INSERT INTO @tv VALUES (1, 100.00)
+    INSERT INTO @tv VALUES (2, 200.00)
+    
+    BEGIN TRAN
+        UPDATE @tv SET amount = amount * 2
+        INSERT INTO @tv VALUES (3, 300.00)
+        DELETE FROM @tv WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM @tv
+    ROLLBACK
+    
+    -- Table variables are not affected by rollback
+    SELECT 'After rollback (TV unaffected):' as label
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_multiple AS
+BEGIN
+    DECLARE @tv1 TABLE (id int, name varchar(20))
+    DECLARE @tv2 TABLE (id int, ref_id int, value varchar(30))
+    
+    INSERT INTO @tv1 VALUES (1, 'first')
+    INSERT INTO @tv1 VALUES (2, 'second')
+    
+    INSERT INTO @tv2 VALUES (10, 1, 'ref to first')
+    INSERT INTO @tv2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE @tv1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM @tv2 WHERE ref_id = 2
+    
+    SELECT 'Table Variable 1:' as label
+    SELECT * FROM @tv1
+    SELECT 'Table Variable 2:' as label
+    SELECT * FROM @tv2
+END
+GO
+
+CREATE PROC p_tv_error_handling AS
+BEGIN
+    DECLARE @tv TABLE (id int primary key, data varchar(20))
+    INSERT INTO @tv VALUES (1, 'original')
+    INSERT INTO @tv VALUES (2, 'valid insert')
+    
+    UPDATE @tv SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO @tv VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO @tv VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+    
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_conditional AS
+BEGIN
+    DECLARE @tv TABLE (id int, status varchar(10), value int)
+    INSERT INTO @tv VALUES (1, 'active', 50)
+    INSERT INTO @tv VALUES (2, 'inactive', 150)
+    INSERT INTO @tv VALUES (3, 'pending', 75)
+    
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM @tv WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE @tv SET status = 'high_value' WHERE value > 100
+        INSERT INTO @tv VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM @tv WHERE value < 60
+    END
+    
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_tv_mixed_with_temp AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(20))
+    CREATE TABLE #temp_mixed (id int, temp_data varchar(20))
+    
+    INSERT INTO @tv VALUES (1, 'table variable')
+    INSERT INTO #temp_mixed VALUES (1, 'temp table')
+    
+    UPDATE @tv SET tv_data = 'updated TV' WHERE id = 1
+    UPDATE #temp_mixed SET temp_data = 'updated temp' WHERE id = 1
+    
+    INSERT INTO @tv VALUES (2, 'TV second')
+    INSERT INTO #temp_mixed VALUES (2, 'temp second')
+    
+    SELECT 'Table Variable:' as label
+    SELECT * FROM @tv
+    SELECT 'Temp Table:' as label
+    SELECT * FROM #temp_mixed
+    
+    DROP TABLE #temp_mixed
+END
+GO
+
+CREATE PROC p_tv_scope_inner (@param int) AS
+BEGIN
+    DECLARE @inner_tv TABLE (id int, scope_info varchar(30))
+    INSERT INTO @inner_tv VALUES (@param, 'inner scope')
+    INSERT INTO @inner_tv VALUES (@param + 1, 'inner scope 2')
+    SELECT 'Inner scope TV:' as label
+    SELECT * FROM @inner_tv
+END
+GO
+
+CREATE PROC p_tv_scope_outer AS
+BEGIN
+    DECLARE @outer_tv TABLE (id int, scope_info varchar(30))
+    INSERT INTO @outer_tv VALUES (100, 'outer scope')
+    
+    SELECT 'Outer scope TV before inner call:' as label
+    SELECT * FROM @outer_tv
+    
+    EXEC p_tv_scope_inner 200
+    
+    INSERT INTO @outer_tv VALUES (101, 'after inner call')
+    SELECT 'Outer scope TV after inner call:' as label
+    SELECT * FROM @outer_tv
+END
+GO

--- a/test/JDBC/input/table_variables/table-variable-vu-verify.sql
+++ b/test/JDBC/input/table_variables/table-variable-vu-verify.sql
@@ -103,3 +103,43 @@ go
 -- BABEL-4337 - check nested TV for null; should not crash but throw an error
 SELECT * FROM tv_nested_func2(NULL)
 go
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv Table Variable Tests - Nested Query Environment (BABEL-6268)
+---------------------------------------------------------------------------
+
+-- Basic table variable operations in procedure
+EXEC p_tv_basic
+GO
+
+-- Table variable with DELETE operations
+EXEC p_tv_delete
+GO
+
+-- Nested procedures with table variables
+EXEC p_tv_nested_outer
+GO
+
+-- Table variable with transaction operations
+EXEC p_tv_transaction
+GO
+
+--  Multiple table variables with cross-operations
+EXEC p_tv_multiple
+GO
+
+-- Table variable with error handling
+EXEC p_tv_error_handling
+GO
+
+-- Table variable with conditional operations
+EXEC p_tv_conditional
+GO
+
+-- Mixed table variable and temp table operations
+EXEC p_tv_mixed_with_temp
+GO
+
+-- Table variable scope across nested calls
+EXEC p_tv_scope_outer
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -36,3 +36,73 @@ GO
 
 DROP PROCEDURE test_alter_index_truncate_cache_fix
 GO
+
+
+DROP PROC p_drop
+GO
+
+DROP PROC p_drop_multi
+GO
+
+DROP PROC p_outer
+GO
+
+DROP PROC p_inner
+GO
+
+DROP PROC p_trans_drop
+GO
+
+DROP PROC p_create_insert
+GO
+
+DROP PROC p_update_delete
+GO
+
+DROP PROC p_nested_inner
+GO
+
+DROP PROC p_nested_outer
+GO
+
+DROP PROC p_rollback_ops
+GO
+
+DROP PROC p_multi_temp_ops
+GO
+
+DROP PROC p_error_ops
+GO
+
+DROP PROC p_truncate_ops
+GO
+
+DROP PROC p_conditional_ops
+GO
+
+DROP PROC p_insert_exec_basic
+GO
+
+DROP PROC p_insert_exec_nested_inner
+GO
+
+DROP PROC p_insert_exec_nested_outer
+GO
+
+DROP PROC p_insert_exec_temp_ops
+GO
+
+DROP PROC p_insert_exec_transaction
+GO
+
+DROP PROC p_insert_exec_multi_results
+GO
+
+DROP PROC p_insert_exec_error_handling
+GO
+
+DROP PROC p_insert_exec_table_var
+GO
+
+DROP PROC p_insert_exec_drop_table
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -171,3 +171,237 @@ BEGIN
     SET XACT_ABORT OFF
 END
 GO
+
+-- Cross Query Env Tests (BABEL-6268)
+CREATE PROC p_drop AS DROP TABLE #test
+GO
+
+CREATE PROC p_drop_multi AS 
+BEGIN 
+    DROP TABLE #temp_proc_test 
+END 
+GO
+
+CREATE PROC p_inner AS DROP TABLE #nested_test
+GO
+
+CREATE PROC p_outer AS EXEC p_inner
+GO
+
+CREATE PROC p_trans_drop AS 
+BEGIN 
+    BEGIN TRAN 
+        INSERT INTO #trans_test VALUES (2, 'during') 
+        DROP TABLE #trans_test 
+    COMMIT 
+END 
+GO
+
+CREATE PROC p_create_insert AS
+BEGIN
+    CREATE TABLE #proc_create(id int, name varchar(30))
+    INSERT INTO #proc_create VALUES (1, 'first')
+    INSERT INTO #proc_create VALUES (2, 'second')
+    SELECT * FROM #proc_create
+    DROP TABLE #proc_create
+END
+GO
+
+CREATE PROC p_update_delete AS
+BEGIN
+    UPDATE #update_delete_test SET status = 'processed' WHERE id = 1
+    DELETE FROM #update_delete_test WHERE value > 250
+    INSERT INTO #update_delete_test VALUES (4, 'new', 150)
+END
+GO
+
+CREATE PROC p_nested_inner AS
+BEGIN
+    INSERT INTO #nested_ops_test VALUES (2, 'from inner')
+    UPDATE #nested_ops_test SET data = 'updated by inner' WHERE id = 1
+END
+GO
+
+CREATE PROC p_nested_outer AS
+BEGIN
+    EXEC p_nested_inner
+    DELETE FROM #nested_ops_test WHERE id = 2
+    INSERT INTO #nested_ops_test VALUES (3, 'from outer')
+END
+GO
+
+CREATE PROC p_rollback_ops AS
+BEGIN
+    INSERT INTO #rollback_ops_test VALUES (2, 200.00)
+    BEGIN TRAN
+        UPDATE #rollback_ops_test SET amount = amount * 2
+        INSERT INTO #rollback_ops_test VALUES (3, 300.00)
+        DELETE FROM #rollback_ops_test WHERE id = 1
+        SELECT 'Inside transaction:' as label
+        SELECT * FROM #rollback_ops_test
+    ROLLBACK
+    SELECT 'After rollback:' as label
+END
+GO
+
+CREATE PROC p_multi_temp_ops AS
+BEGIN
+    CREATE TABLE #temp1(id int, name varchar(20))
+    CREATE TABLE #temp2(id int, ref_id int, value varchar(30))
+    
+    INSERT INTO #temp1 VALUES (1, 'first')
+    INSERT INTO #temp1 VALUES (2, 'second')
+    
+    INSERT INTO #temp2 VALUES (10, 1, 'ref to first')
+    INSERT INTO #temp2 VALUES (20, 2, 'ref to second')
+    
+    UPDATE #temp1 SET name = 'updated first' WHERE id = 1
+    DELETE FROM #temp2 WHERE ref_id = 2
+    
+    SELECT 'Temp1:' as label
+    SELECT * FROM #temp1
+    SELECT 'Temp2:' as label
+    SELECT * FROM #temp2
+    
+    DROP TABLE #temp1
+    DROP TABLE #temp2
+END
+GO
+
+CREATE PROC p_error_ops AS
+BEGIN
+    INSERT INTO #error_ops_test VALUES (2, 'valid insert')
+    UPDATE #error_ops_test SET data = 'updated' WHERE id = 1
+    
+    BEGIN TRY
+        INSERT INTO #error_ops_test VALUES (1, 'duplicate key') -- Should fail
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #error_ops_test VALUES (3, 'error handled')
+        SELECT 'Error caught: ' + ERROR_MESSAGE() as error_info
+    END CATCH
+END
+GO
+
+CREATE PROC p_truncate_ops AS
+BEGIN
+    SELECT 'Before truncate:' as label
+    SELECT * FROM #truncate_test
+    
+    TRUNCATE TABLE #truncate_test
+    
+    INSERT INTO #truncate_test VALUES ('after truncate')
+    SELECT 'After truncate:' as label
+END
+GO
+
+CREATE PROC p_conditional_ops AS
+BEGIN
+    DECLARE @count int
+    SELECT @count = COUNT(*) FROM #conditional_test WHERE value > 100
+    
+    IF @count > 0
+    BEGIN
+        UPDATE #conditional_test SET status = 'high_value' WHERE value > 100
+        INSERT INTO #conditional_test VALUES (4, 'new_high', 200)
+    END
+    ELSE
+    BEGIN
+        DELETE FROM #conditional_test WHERE value < 60
+    END
+END
+GO
+
+-- INSERT INTO EXEC procedures
+CREATE PROC p_insert_exec_basic AS 
+BEGIN 
+    SELECT 1 as id, 'first' as name 
+    UNION ALL 
+    SELECT 2, 'second' 
+END
+GO
+
+CREATE PROC p_insert_exec_nested_inner AS
+BEGIN
+    SELECT 10 as id, 'inner data' as data
+END
+GO
+
+CREATE PROC p_insert_exec_nested_outer AS
+BEGIN
+    CREATE TABLE #temp_inner(id int, data varchar(50))
+    INSERT INTO #temp_inner EXEC p_insert_exec_nested_inner
+    INSERT INTO #temp_inner VALUES (20, 'outer data')
+    SELECT * FROM #temp_inner
+    DROP TABLE #temp_inner
+END
+GO
+
+CREATE PROC p_insert_exec_temp_ops AS
+BEGIN
+    CREATE TABLE #temp_ops(id int, status varchar(20), value int)
+    INSERT INTO #temp_ops VALUES (1, 'active', 100)
+    INSERT INTO #temp_ops VALUES (2, 'pending', 200)
+    UPDATE #temp_ops SET status = 'processed' WHERE id = 1
+    SELECT * FROM #temp_ops
+    DROP TABLE #temp_ops
+END
+GO
+
+CREATE PROC p_insert_exec_transaction AS
+BEGIN
+    CREATE TABLE #temp_trans(id int, amount decimal(10,2))
+    INSERT INTO #temp_trans VALUES (1, 100.00)
+    BEGIN TRAN
+        INSERT INTO #temp_trans VALUES (2, 200.00)
+        UPDATE #temp_trans SET amount = amount * 2
+    ROLLBACK
+    SELECT * FROM #temp_trans
+    DROP TABLE #temp_trans
+END
+GO
+
+CREATE PROC p_insert_exec_multi_results AS
+BEGIN
+    SELECT 1 as id, 'first result' as info
+    SELECT 2 as id, 'second result' as info
+    SELECT 3 as id, 'third result' as info
+END
+GO
+
+CREATE PROC p_insert_exec_error_handling AS
+BEGIN
+    CREATE TABLE #temp_error(id int primary key, data varchar(20))
+    INSERT INTO #temp_error VALUES (1, 'original')
+    BEGIN TRY
+        INSERT INTO #temp_error VALUES (1, 'duplicate')
+    END TRY
+    BEGIN CATCH
+        INSERT INTO #temp_error VALUES (2, 'error handled')
+    END CATCH
+    SELECT * FROM #temp_error
+    DROP TABLE #temp_error
+END
+GO
+
+CREATE PROC p_insert_exec_table_var AS
+BEGIN
+    DECLARE @tv TABLE (id int, tv_data varchar(30))
+    INSERT INTO @tv VALUES (1, 'from table var')
+    INSERT INTO @tv VALUES (2, 'tv data')
+    SELECT * FROM @tv
+END
+GO
+
+CREATE PROC p_insert_exec_drop_table AS
+BEGIN
+    -- Return some data first
+    SELECT 100 as id, 'before drop' as data
+    
+    -- Drop the target table
+    DROP TABLE #insert_exec_drop_target
+    
+    -- Try to return more data (but table is already dropped)
+    SELECT 200 as id, 'after drop' as data
+END
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -1711,3 +1711,274 @@ GO
 
 SELECT * FROM enr_view ORDER BY relname
 GO
+
+---------------------------------------------------------------------------
+-- Cross-QueryEnv ENR Tests - Procedure Drop Table Fix (BABEL-6268)
+---------------------------------------------------------------------------
+
+-- Test 1: Basic procedure drop table scenario
+CREATE TABLE #test(a int) 
+GO
+
+EXEC p_drop
+GO
+
+CREATE TABLE #test(a int)         -- should not crash
+GO
+
+DROP TABLE #test
+GO
+
+-- Test 2: Multiple procedure calls with same temp table name
+CREATE TABLE #temp_proc_test(id int, name varchar(50)) 
+INSERT INTO #temp_proc_test VALUES (1, 'test1') 
+GO
+
+EXEC p_drop_multi
+GO
+
+CREATE TABLE #temp_proc_test(id int, data varchar(100)) 
+INSERT INTO #temp_proc_test VALUES (2, 'test2') 
+SELECT * FROM #temp_proc_test 
+GO
+
+DROP TABLE #temp_proc_test
+GO
+
+-- Test 3: Nested procedure calls
+CREATE TABLE #nested_test(val int)
+INSERT INTO #nested_test VALUES (100)
+GO
+
+EXEC p_outer
+GO
+
+CREATE TABLE #nested_test(val int, descr varchar(20)) 
+INSERT INTO #nested_test VALUES (200, 'after fix') 
+SELECT * FROM #nested_test 
+GO
+
+DROP TABLE #nested_test
+GO
+
+-- Test 4: Procedure with transaction and temp table drop
+CREATE TABLE #trans_test(a int, b varchar(10)) 
+INSERT INTO #trans_test VALUES (1, 'before') 
+GO
+
+EXEC p_trans_drop
+GO
+
+CREATE TABLE #trans_test(c int) 
+INSERT INTO #trans_test VALUES (999)  
+SELECT * FROM #trans_test  
+GO
+
+DROP TABLE #trans_test
+GO
+
+-- Test 5: Execute CREATE and INSERT operations
+EXEC p_create_insert
+GO
+
+-- Test 6: Execute UPDATE and DELETE operations
+CREATE TABLE #update_delete_test(id int, status varchar(20), value int)
+INSERT INTO #update_delete_test VALUES (1, 'active', 100)
+INSERT INTO #update_delete_test VALUES (2, 'inactive', 200)
+INSERT INTO #update_delete_test VALUES (3, 'pending', 300)
+GO
+
+EXEC p_update_delete
+GO
+
+SELECT * FROM #update_delete_test
+GO
+
+DROP TABLE #update_delete_test
+GO
+
+-- Test 7: Execute nested procedures with mixed operations
+CREATE TABLE #nested_ops_test(id int, data varchar(50))
+INSERT INTO #nested_ops_test VALUES (1, 'initial')
+GO
+
+EXEC p_nested_outer
+GO
+
+SELECT * FROM #nested_ops_test
+GO
+
+DROP TABLE #nested_ops_test
+GO
+
+-- Test 8: Execute transaction rollback and operations
+CREATE TABLE #rollback_ops_test(id int, amount decimal(10,2))
+INSERT INTO #rollback_ops_test VALUES (1, 100.00)
+GO
+
+EXEC p_rollback_ops
+GO
+
+SELECT * FROM #rollback_ops_test
+GO
+
+DROP TABLE #rollback_ops_test
+GO
+
+-- Test 9: Execute multiple temp tables with cross-operations
+EXEC p_multi_temp_ops
+GO
+
+-- Test 10: Execute error handling and operations
+CREATE TABLE #error_ops_test(id int primary key, data varchar(20))
+INSERT INTO #error_ops_test VALUES (1, 'original')
+GO
+
+EXEC p_error_ops
+GO
+
+SELECT * FROM #error_ops_test
+GO
+
+DROP TABLE #error_ops_test
+GO
+
+-- Test 11: Execute TRUNCATE operation
+CREATE TABLE #truncate_test(id int identity(1,1), data varchar(20))
+INSERT INTO #truncate_test VALUES ('first')
+INSERT INTO #truncate_test VALUES ('second')
+INSERT INTO #truncate_test VALUES ('third')
+GO
+
+EXEC p_truncate_ops
+GO
+
+SELECT * FROM #truncate_test
+GO
+
+DROP TABLE #truncate_test
+GO
+
+-- Test 12: Execute conditional operations
+CREATE TABLE #conditional_test(id int, status varchar(10), value int)
+INSERT INTO #conditional_test VALUES (1, 'active', 50)
+INSERT INTO #conditional_test VALUES (2, 'inactive', 150)
+INSERT INTO #conditional_test VALUES (3, 'pending', 75)
+GO
+
+EXEC p_conditional_ops
+GO
+
+SELECT * FROM #conditional_test
+GO
+
+DROP TABLE #conditional_test
+GO
+
+-- INSERT INTO EXEC Tests
+-- Test 13: Basic INSERT INTO EXEC with temp table
+CREATE TABLE #insert_exec_target(id int, name varchar(30))
+GO
+
+INSERT INTO #insert_exec_target EXEC p_insert_exec_basic
+GO
+
+SELECT * FROM #insert_exec_target
+GO
+
+DROP TABLE #insert_exec_target
+GO
+
+-- Test 14: INSERT INTO EXEC with nested procedure calls
+CREATE TABLE #insert_exec_nested(id int, data varchar(50))
+GO
+
+INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
+GO
+
+SELECT * FROM #insert_exec_nested
+GO
+
+DROP TABLE #insert_exec_nested
+GO
+
+-- Test 15: INSERT INTO EXEC with temp table operations inside procedure
+CREATE TABLE #insert_exec_ops(id int, status varchar(20), value int)
+GO
+
+INSERT INTO #insert_exec_ops EXEC p_insert_exec_temp_ops
+GO
+
+SELECT * FROM #insert_exec_ops
+GO
+
+DROP TABLE #insert_exec_ops
+GO
+
+-- Test 16: INSERT INTO EXEC with transaction and rollback
+CREATE TABLE #insert_exec_trans(id int, amount decimal(10,2))
+GO
+
+INSERT INTO #insert_exec_trans EXEC p_insert_exec_transaction
+GO
+
+SELECT * FROM #insert_exec_trans
+GO
+
+DROP TABLE #insert_exec_trans
+GO
+
+-- Test 17: INSERT INTO EXEC with multiple result sets (only first is inserted)
+CREATE TABLE #insert_exec_multi(id int, info varchar(30))
+GO
+
+INSERT INTO #insert_exec_multi EXEC p_insert_exec_multi_results
+GO
+
+SELECT * FROM #insert_exec_multi
+GO
+
+DROP TABLE #insert_exec_multi
+GO
+
+-- Test 18: INSERT INTO EXEC with error handling
+CREATE TABLE #insert_exec_error(id int, data varchar(20))
+GO
+
+INSERT INTO #insert_exec_error EXEC p_insert_exec_error_handling
+GO
+
+SELECT * FROM #insert_exec_error
+GO
+
+DROP TABLE #insert_exec_error
+GO
+
+-- Test 19: INSERT INTO EXEC with table variable in procedure
+CREATE TABLE #insert_exec_tv(id int, tv_data varchar(30))
+GO
+
+INSERT INTO #insert_exec_tv EXEC p_insert_exec_table_var
+GO
+
+SELECT * FROM #insert_exec_tv
+GO
+
+DROP TABLE #insert_exec_tv
+GO
+
+-- Test 20: INSERT INTO EXEC where procedure attempts to drop the target table
+CREATE TABLE #insert_exec_drop_target(id int, data varchar(30))
+INSERT INTO #insert_exec_drop_target VALUES (1, 'initial data')
+GO
+
+-- Should fail
+INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
+GO
+
+-- Table should still exist with original data since DROP failed
+SELECT * FROM #insert_exec_drop_target
+GO
+
+DROP TABLE #insert_exec_drop_target
+GO


### PR DESCRIPTION
### Description

Added tests for the fix of crash when dropping a temp table from nested QueryEnv.

Cherry-pick of : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4550
Corresponding Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/715

Authored by: harshdu@amazon.com
Signed-off by: harshdu@amazon.com

### Issues Resolved

[BABEL-6268]



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).