### PR TITLE
[OSS-ONLY] fix: Replace query parameters with constants in generic plan qual clause

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -1018,6 +1018,210 @@ pltsql_ExecFuncProc_AclCheck(Oid funcid)
 	return object_aclcheck(ProcedureRelationId, funcid, userid, ACL_EXECUTE);
 }
 
+typedef struct WalkSubplanContext
+{
+	bool (*plan_walker) ();
+	void *plan_context;
+	List *allplans;
+} WalkSubplanContext;
+
+static bool expr_walk_subplan(Node *node, void *context)
+{
+	struct WalkSubplanContext* sc = (struct WalkSubplanContext*)context;
+	if (node && IsA(node, SubPlan) &&
+		sc->plan_walker(list_nth(sc->allplans,
+			((SubPlan *) node)->plan_id - 1), sc->plan_context))
+	{
+		return true;
+	}
+	return expression_tree_walker(node, expr_walk_subplan, context);
+}
+
+static bool
+plan_walk_members(List *plans, bool (*walker) (), void *context)
+{
+	ListCell   *l;
+	foreach(l, plans)
+	{
+		if (walker((Plan *) lfirst(l), context))
+			return true;
+	}
+
+	return false;
+}
+
+static bool
+plan_walk_subplans(List *plans, List *allplans,
+						bool (*walker) (),
+						void *context)
+{
+	ListCell   *lc;
+
+	foreach(lc, plans)
+	{
+		SubPlan *sp = (SubPlan *) lfirst(lc);
+
+		Assert(IsA(sp, SubPlan));
+		if (walker(list_nth(allplans, sp->plan_id - 1),
+					context))
+			return true;
+	}
+
+	return false;
+}
+
+static bool
+plan_tree_walker(Plan *plan, List *allplans, bool (*walker) (), void *context)
+{
+	struct WalkSubplanContext sc = { walker, context, allplans };
+
+	/* lefttree and righttree are intentionally visited first here so that
+	 * join inners can be determined from a single flat plans array in the
+	 * outline. The inners will always be in the 2nd array element.
+	 */
+
+	/* lefttree */
+	if (plan->lefttree)
+	{
+		if (walker(plan->lefttree, context))
+			return true;
+	}
+
+	/* righttree */
+	if (plan->righttree)
+	{
+		if (walker(plan->righttree, context))
+			return true;
+	}
+
+	/* initPlan-s */
+	if (plan_walk_subplans(plan->initPlan, allplans, walker, context))
+		return true;
+
+	/* special child plans */
+	switch (nodeTag(plan))
+	{
+		case T_Append:
+			if (plan_walk_members(((Append *) plan)->appendplans,
+						walker, context))
+				return true;
+			break;
+		case T_MergeAppend:
+			if (plan_walk_members(((MergeAppend *) plan)->mergeplans,
+						walker, context))
+				return true;
+			break;
+		case T_BitmapAnd:
+			if (plan_walk_members(((BitmapAnd *) plan)->bitmapplans,
+						walker, context))
+				return true;
+			break;
+		case T_BitmapOr:
+			if (plan_walk_members(((BitmapOr *) plan)->bitmapplans,
+						walker, context))
+				return true;
+			break;
+		case T_SubqueryScan:
+			if (walker(((SubqueryScan *) plan)->subplan, context))
+				return true;
+			break;
+		case T_CustomScan:
+			if (plan_walk_members(((CustomScan *) plan)->custom_plans,
+						walker, context))
+				return true;
+			break;
+		case T_HashJoin:
+			if(expression_tree_walker((Node*)(((HashJoin*)plan)->hashclauses), expr_walk_subplan, &sc))
+				return true;
+			break;
+		case T_Result:
+			if(expression_tree_walker((Node*)(((Result*)plan)->resconstantqual), expr_walk_subplan, &sc))
+				return true;
+			break;
+		default:
+			break;
+	}
+
+	if(expression_tree_walker((Node*)(plan->qual), expr_walk_subplan, &sc))
+		return true;
+	if(expression_tree_walker((Node*)(plan->targetlist), expr_walk_subplan, &sc))
+		return true;
+
+	return false;
+}
+
+/* Context for param replacement in quals */
+typedef struct ParamReplaceContext
+{
+	bool		in_qual;		/* Are we currently in a qual? */
+	QueryDesc  *queryDesc;		/* Original QueryDesc */
+} ParamReplaceContext;
+
+/*
+ * Expression tree mutator that replaces Param nodes with Const nodes when in a qual.
+ */
+static Node *
+replace_params_mutator(Node *node, ParamReplaceContext *context)
+{
+	if (node == NULL)
+		return NULL;
+
+	/* Handle Param nodes when we're in a qual */
+	if (IsA(node, Param) && context->in_qual)
+	{
+		ParamListInfo	paramLI = context->queryDesc->params;
+		PlannerInfo		root;
+		Node		   *ret;
+
+		root.glob = makeNode(PlannerGlobal);
+		root.glob->boundParams = paramLI;
+
+		ret = eval_const_expressions(&root, node);
+
+		pfree(root.glob);
+		return ret;
+	}
+
+	/* Handle SubPlan - unset qual flag when entering subquery */
+	if (IsA(node, SubPlan))
+	{
+		SubPlan	   *newsubplan;
+		bool		save_in_qual = context->in_qual;
+		
+		context->in_qual = false;
+		
+		newsubplan = (SubPlan *) expression_tree_mutator(node, replace_params_mutator, context);
+		
+		context->in_qual = save_in_qual;
+		
+		return (Node *) newsubplan;
+	}
+
+	return expression_tree_mutator(node, replace_params_mutator, context);
+}
+
+/*
+ * Recursively walk the plan tree and replace params in quals.
+ */
+static bool
+replace_params_in_plan_tree(Plan *plan, ParamReplaceContext *context)
+{
+	if (plan == NULL)
+		return false;
+
+	if (plan->qual != NIL)
+	{
+		bool	save_in_qual = context->in_qual;
+		
+		context->in_qual = true;
+		plan->qual = (List *) replace_params_mutator((Node *) plan->qual, context);
+		context->in_qual = save_in_qual;
+	}
+
+	return plan_tree_walker(plan, context->queryDesc->plannedstmt->subplans,
+							replace_params_in_plan_tree, context);
+}
+
 static void
 pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
@@ -1094,6 +1298,22 @@ pltsql_ExecutorStart(QueryDesc *queryDesc, int eflags)
 				}
 			}
 		}
+	}
+
+	if (queryDesc->plannedstmt
+		&& queryDesc->plannedstmt->planTree
+		&& queryDesc->params
+		&& queryDesc->params->numParams > 0)
+	{
+		ParamReplaceContext context;
+
+		/* Copy the plannedstmt so that changing it won't affect the cached plan */
+		queryDesc->plannedstmt = copyObject(queryDesc->plannedstmt);
+		
+		context.in_qual = false;
+		context.queryDesc = queryDesc;
+
+		replace_params_in_plan_tree(queryDesc->plannedstmt->planTree, &context);
 	}
 
 	if (prev_ExecutorStart)

--- a/test/JDBC/expected/parallel_query/params_in_generic_plan.out
+++ b/test/JDBC/expected/parallel_query/params_in_generic_plan.out
@@ -1,0 +1,4799 @@
+SELECT set_config('plan_cache_mode', 'force_generic_plan', false);
+go
+~~START~~
+text
+force_generic_plan
+~~END~~
+
+
+-- test_dynamic_local_vars
+-- simple vars
+declare @i int
+declare @j int
+set @i = 10
+set @j = @i + 10
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+
+declare @i int
+declare @j int
+select @i = 10, @j = @i + 10
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+
+declare @i int
+declare @j int = 0;
+select @i = 10, @j = @i + @j * 2
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#10
+~~END~~
+
+
+declare @i int
+declare @j int
+select @i = 10, @j = @i + 10
+select @j += 10
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#30
+~~END~~
+
+
+-- should throw an error
+declare @i int 
+select @i = 0, @i += 2
+select @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Babelfish does not support assignment to the same variable in SELECT. variable name: "@i")~~
+
+
+declare @i int
+select @i = 10, @i += 10
+select @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Babelfish does not support assignment to the same variable in SELECT. variable name: "@i")~~
+
+
+-- sub-expr
+declare @i int
+set @i = 10
+select @i += (5 - 1)
+select @i
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+DECLARE @a int
+select @a = (select ~cast('1' as int))
+select @a
+go
+~~START~~
+int
+-2
+~~END~~
+
+
+
+DECLARE @Counter INT = 1;
+DECLARE @MaxValue INT = 10;
+WHILE @Counter <= @MaxValue
+BEGIN
+    DECLARE @IsEven BIT;
+    
+    IF @Counter % 2 = 0
+        SET @IsEven = 1;
+    ELSE
+        SET @IsEven = 0;
+    
+    IF @IsEven = 1
+        SELECT CAST(@Counter AS VARCHAR(2)) + ' is even';
+    ELSE
+        SELECT CAST(@Counter AS VARCHAR(2)) + ' is odd';
+    
+    SET @Counter = @Counter + 1;
+END;
+GO
+~~START~~
+varchar
+1 is odd
+~~END~~
+
+~~START~~
+varchar
+2 is even
+~~END~~
+
+~~START~~
+varchar
+3 is odd
+~~END~~
+
+~~START~~
+varchar
+4 is even
+~~END~~
+
+~~START~~
+varchar
+5 is odd
+~~END~~
+
+~~START~~
+varchar
+6 is even
+~~END~~
+
+~~START~~
+varchar
+7 is odd
+~~END~~
+
+~~START~~
+varchar
+8 is even
+~~END~~
+
+~~START~~
+varchar
+9 is odd
+~~END~~
+
+~~START~~
+varchar
+10 is even
+~~END~~
+
+
+declare @a numeric (10, 4);
+declare @b numeric (10, 4);
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+~~START~~
+numeric#!#numeric
+100.4100#!#200.8200
+~~END~~
+
+~~START~~
+numeric
+301.2300
+~~END~~
+
+
+declare @a numeric;
+declare @b numeric (10, 4);
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+~~START~~
+numeric#!#numeric
+100#!#200.8200
+~~END~~
+
+~~START~~
+numeric
+300.8200
+~~END~~
+
+
+declare @a varbinary
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+74
+~~END~~
+
+
+declare @a varbinary(max)
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+746573745F62696E
+~~END~~
+
+
+declare @a varbinary(10)
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+746573745F62696E
+~~END~~
+
+
+declare @a varbinary
+declare @b varbinary
+select @a = cast('test_bin' as varbinary), @b = @a
+select @a, @b
+GO
+~~START~~
+varbinary#!#varbinary
+74#!#74
+~~END~~
+
+
+declare @a varbinary(max)
+select @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+746573745F62696E
+~~END~~
+
+
+DECLARE @a varchar
+set @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @v varchar(20);
+SELECT @v = NULL;
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+0#!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @a varchar(max)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+-- collate can not be used with local variables
+DECLARE @v varchar(20) collate BBF_Unicode_CP1_CI_As = 'ci_as';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'collate' at line 2 and character position 23)~~
+
+
+declare @source int;
+declare @target sql_variant;
+select @source = 1.0
+select @target = cast(@source as varchar(10));
+SELECT sql_variant_property(@target, 'basetype');
+select @target
+GO
+~~START~~
+sql_variant
+varchar
+~~END~~
+
+~~START~~
+sql_variant
+1
+~~END~~
+
+
+declare @source int;
+declare @target varchar(10);
+select @source = 1.0
+select cast(@source as varchar(10))
+select @target = cast(@source as varchar(10));
+select @target
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @a pg_catalog.varchar
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DECLARE @a pg_catalog.varchar(100)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DECLARE @a pg_catalog.varchar(10)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+10#!#10
+~~END~~
+
+~~START~~
+varchar
+1234567890
+~~END~~
+
+
+DECLARE @a varchar
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @a varchar(100)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DECLARE @a varchar(10)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+10#!#10
+~~END~~
+
+~~START~~
+varchar
+1234567890
+~~END~~
+
+
+DECLARE @a int
+set @a = 0
+select @a ^= 1
+select @a
+go
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a int
+set @a = 0
+select @a += ~@a
+select @a
+go
+~~START~~
+int
+-1
+~~END~~
+
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- quoted identifiers
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += "a""b''c'd", @v2 += "x""y''z";
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCa"b''c'd#!#XYZx"y''z
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += "a""b''c'd", @v2 += @v + "x""y''z";
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCa"b''c'd#!#XYZABCa"b''c'dx"y''z
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += @v + "x""y''z";
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCd'c''b"a#!#XYZABCd'c''b"ax"y''z
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += @v + reverse("x""y''z");
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCd'c''b"a#!#XYZABCd'c''b"az''y"x
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += REVERSE( @v + reverse("x""y''z"));
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCd'c''b"a#!#XYZx"y''za"b''c'dCBA
+~~END~~
+
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+declare @v varchar(20) = 'ABC', @v2 varchar(20)='XYZ';
+select @v += 'abc', @v2 += 'xyz';
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCabc#!#XYZxyz
+~~END~~
+
+
+declare @a int = 1, @b int = 2;
+select @a = 2, @b = @a + 2
+select @a, @b
+GO
+~~START~~
+int#!#int
+2#!#4
+~~END~~
+
+
+declare @a int = 1, @b int = 2;
+select @a += 2, @b -= @a + 2
+select @a, @b
+GO
+~~START~~
+int#!#int
+3#!#-3
+~~END~~
+
+
+-- xml methods
+DECLARE @a bit = 1
+DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
+SELECT @a |= @xml.exist('/artists/artist/@name')
+select @a
+GO
+~~START~~
+bit
+1
+~~END~~
+
+
+DECLARE @a bit = 1
+DECLARE @xml XML;
+SELECT @xml  = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>', @a |= @xml.exist('/artists/artist/@name')
+select @a
+GO
+~~START~~
+bit
+1
+~~END~~
+
+
+-- test all kind of udts
+create type udt from NCHAR
+go
+
+declare @a udt
+select @a = 'anc'
+select @a
+GO
+~~START~~
+nchar
+a
+~~END~~
+
+
+DROP type udt 
+GO
+
+create type varchar_max from varchar(max)
+GO
+
+DECLARE @a varchar_max
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DROP type varchar_max
+GO
+
+create type num_def from numeric
+GO
+
+declare @a numeric;
+declare @b num_def;
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+~~START~~
+numeric#!#numeric
+100#!#201
+~~END~~
+
+~~START~~
+numeric
+301
+~~END~~
+
+
+drop type num_def
+GO
+
+/*
+ * select/update test
+ */
+create table local_var_tst (id int) 
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (6)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- txn does not affect local variables
+begin tran
+declare @i int 
+update local_var_tst set id = 5, @i = id * 5
+select @i
+ROLLBACK tran
+select @i
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+25
+~~END~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+1
+2
+6
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should return 4
+declare @i int 
+select @i = 1
+select @i = id * 2 from local_var_tst where id = @i
+select @i
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+declare @i int 
+select @i = 1
+select @i = @i + id * 2 from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+declare @i int 
+select @i = 1
+select @i = id * 2 + @i from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+declare @i int 
+select @i = 1
+select @i += id * 2 from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- 3 parts name 
+declare @i int 
+select @i = 1
+select @i += master.dbo.local_var_tst.id * 2 from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- local var name same as column
+declare @id int = 1
+select @id += master.dbo.local_var_tst.id * 2 from local_var_tst
+select @id
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- should throw an error
+declare @i int
+declare @j int
+set @i = 10
+set @j = 0;
+select @i += (select @j = @j + id from local_var_tst)
+select @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+DECLARE @ans INT
+SELECT @ans = AVG(id) FROM local_var_tst
+select @ans
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- local variable inside functions
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans = AVG(id) FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func();
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DROP FUNCTION var_inside_func();
+GO
+
+-- show throw an error
+CREATE FUNCTION var_inside_func()
+RETURNS @tab table (a int) as
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans += id from local_var_tst
+    select @ans
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SELECT statement returning result to a client cannot be used in a function)~~
+
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans += id FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func()
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func(@def int)
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT;
+    select @ans = @def;
+    SELECT @ans += id FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func(0)
+go
+~~START~~
+int
+3
+~~END~~
+
+
+declare @def int = 1;
+select var_inside_func(@def)
+go
+~~START~~
+int
+4
+~~END~~
+
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    select @ans = 0
+    SELECT @ans += id + @ans FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func()
+go
+~~START~~
+int
+4
+~~END~~
+
+
+drop function if exists var_inside_func
+go
+
+-- variable with procedure
+CREATE PROCEDURE var_with_procedure (@a numeric(10,4) OUTPUT) AS
+BEGIN
+  SET @a=100.41;
+  select @a as a;
+END;
+GO
+
+exec var_with_procedure 2.000;
+GO
+~~START~~
+numeric
+100.4100
+~~END~~
+
+
+-- value of @out should remain 2.000
+declare @out numeric(10,4);
+set @out = 2.000;
+exec var_with_procedure 2.000;
+select @out
+GO
+~~START~~
+numeric
+100.4100
+~~END~~
+
+~~START~~
+numeric
+2.0000
+~~END~~
+
+
+drop procedure var_with_procedure;
+GO
+
+CREATE PROCEDURE var_with_procedure_1 (@a numeric(10,4) OUTPUT, @b numeric(10,4) OUTPUT) AS
+BEGIN
+  SET @a=100.41;
+  SET @b=200.82;
+  select @a+@b as r;
+END;
+GO
+
+EXEC var_with_procedure_1 2.000, 3.000;
+GO
+~~START~~
+numeric
+301.2300
+~~END~~
+
+
+-- value of @a should be 100
+DECLARE @a INT;
+EXEC var_with_procedure_1 @a OUT, 3.000;
+SELECT @a;
+GO
+~~START~~
+numeric
+301.2300
+~~END~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+drop procedure var_with_procedure_1;
+GO
+
+CREATE PROCEDURE var_with_procedure_2
+AS
+BEGIN
+  declare @a int
+  declare @b int
+  set @a = 1
+  return
+  select @b=@a+1
+END
+GO
+
+exec var_with_procedure_2
+GO
+
+DROP PROCEDURE var_with_procedure_2
+GO
+
+-- insert testing with local variables
+truncate table dbo.local_var_tst
+go
+
+-- should throw an error
+declare @a int = 1
+insert into local_var_tst select @a = @a + 1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+-- syntax error
+declare @a int = 1
+insert into local_var_tst values (@a = @a + 1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '=' at line 3 and character position 37)~~
+
+
+declare @a int = 1
+insert into local_var_tst values (@a + 1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- output clause with insert
+declare @a int = 1
+declare @mytbl table(a int)
+insert local_var_tst output inserted.id into @mytbl values (@a + 1) 
+select * from @mytbl
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+-- output clause with delete
+declare @a int = 1
+declare @mytbl table(a int)
+delete local_var_tst output deleted.id into @mytbl where id = @a + 1
+select * from @mytbl
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+2
+~~END~~
+
+
+drop table dbo.local_var_tst
+go
+
+create table local_var_tst_1 (a int, b int)
+GO
+
+insert into local_var_tst_1 values (1,3), (2, 4)
+go
+~~ROW COUNT: 2~~
+
+
+
+-- select test with multi-variable assignment
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += b from local_var_tst_1
+select @a, @b
+go
+~~START~~
+int#!#int
+3#!#7
+~~END~~
+
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += @a + b from local_var_tst_1
+select @a, @b
+go
+~~START~~
+int#!#int
+3#!#11
+~~END~~
+
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += @a + ~b from local_var_tst_1
+select @a, @b
+go
+~~START~~
+int#!#int
+3#!#-5
+~~END~~
+
+
+drop table local_var_tst_1
+go
+
+create table local_var_str_tst (id varchar(100))
+GO
+
+insert into local_var_str_tst values ('abc'), (' '), ('def')
+GO
+~~ROW COUNT: 3~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i = @i + id from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+abc def
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i = id + @i from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+def abc
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i += id from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+abc def
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i = reverse(@i + 'id') from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+didiid
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i += reverse(id) from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+cba fed
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = 'abc'
+select @i = reverse(@i)
+select @i
+go
+~~START~~
+varchar
+cba
+~~END~~
+
+
+-- function call like trim, ltrim, etc will be rewritten by ANTLR
+declare @i varchar(1000)
+set @i = ' '
+select @i += id from local_var_str_tst
+select len(@i), @i
+select @i = trim(@i)
+select len(@i), @i
+go
+~~START~~
+int#!#varchar
+8#!# abc def
+~~END~~
+
+~~START~~
+int#!#varchar
+7#!#abc def
+~~END~~
+
+
+drop table local_var_str_tst;
+go
+
+-- $PARTITION is rewritten by ANTLR
+CREATE PARTITION FUNCTION RangePF1 ( INT )  
+AS RANGE RIGHT FOR VALUES (10, 100, 1000) ;  
+GO
+
+declare @res int = -1;
+SELECT @res = $PARTITION.RangePF1 (10);
+select @res
+select 1 where @res = $PARTITION.RangePF1 (10);
+SELECT @res = $PARTITION.RangePF1 (@res);
+select @res
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+DROP PARTITION FUNCTION RangePF1 
+GO
+
+CREATE SEQUENCE CountBy1  
+    START WITH 1  
+    INCREMENT BY 1 ;
+GO
+
+-- NEXT VALUE FOR gets re-written by ANTLR
+DECLARE @myvar1 BIGINT = NEXT VALUE FOR CountBy1 ;
+DECLARE @myvar2 BIGINT ;  
+DECLARE @myvar3 BIGINT ;  
+select @myvar2 = NEXT VALUE FOR CountBy1 ;  
+SELECT @myvar3 = NEXT VALUE FOR CountBy1 ;  
+SELECT @myvar1 AS myvar1, @myvar2 AS myvar2, @myvar3 AS myvar3 ;  
+GO
+~~START~~
+bigint#!#bigint#!#bigint
+1#!#2#!#3
+~~END~~
+
+
+DROP SEQUENCE CountBy1
+GO
+
+-- any @@ is also re-written by ANTLR
+declare @pid int = 0
+select @pid += @@spid
+select 1 where @pid = @@spid
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- float point notation also gets rewritten by ANTLR e.g., 2.1E, -.2e+, -2.e-
+declare @a float = 0
+select @a = 2.1E
+select @a
+select @a = -.2e+
+select @a 
+select @a = -2.e-
+select @a
+go
+~~START~~
+float
+2.1
+~~END~~
+
+~~START~~
+float
+-0.2
+~~END~~
+
+~~START~~
+float
+-2.0
+~~END~~
+
+
+-- variables only in select target list shows dynamic behavior
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1
+declare @j int = 0
+select @j += id, @i = id + 1  from local_var_tst where id = @i
+select @i, @j
+go
+~~START~~
+int#!#int
+2#!#2
+~~END~~
+
+
+declare @i int = 1
+select @i = id * 2 from local_var_tst where id = @i
+select @i
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_statistics profile On;
+GO
+
+declare @i int = 1
+declare @j int = 0
+select @j += id, @i = id + 1  from local_var_tst where id = @i
+select @i, @j
+go
+~~START~~
+text
+Query Text: select       sys.pltsql_assign_var(3, @j + cast((id) as int)),      sys.pltsql_assign_var(2, cast((id + 1) as int))  from local_var_tst where id = "@i"
+Seq Scan on local_var_tst  (cost=0.00..42.01 rows=13 width=8) (actual rows=2 loops=1)
+  Filter: (id = 1)
+  Rows Removed by Filter: 1
+~~END~~
+
+~~START~~
+int#!#int
+2#!#2
+~~END~~
+
+~~START~~
+text
+Query Text: select "@i", "@j"
+Gather  (cost=0.00..0.01 rows=1 width=8) (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Result  (cost=0.00..0.01 rows=1 width=8) (actual rows=1 loops=1)
+~~END~~
+
+
+declare @i int = 1
+select @i = @i * 2 from local_var_tst where id = @i
+select @i
+GO
+~~START~~
+text
+Query Text: select      sys.pltsql_assign_var(2, cast((@i * 2) as int)) from local_var_tst where id = "@i"
+Seq Scan on local_var_tst  (cost=0.00..41.94 rows=13 width=4) (actual rows=2 loops=1)
+  Filter: (id = 1)
+  Rows Removed by Filter: 1
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+text
+Query Text: select "@i"
+Gather  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
+  Workers Planned: 1
+  Workers Launched: 1
+  Single Copy: true
+  ->  Result  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
+~~END~~
+
+
+set babelfish_statistics profile OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- declared variable name with length > 63
+declare @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr += 1
+select @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- variable names starting with @@
+declare @@a int = 1;
+select @@a = @@a + 1
+select @@a 
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+declare @@a int = 1;
+select @@a += 1
+select @@a 
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr + 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+truncate table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr + id from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = id + @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr += id from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+truncate table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_statistics profile On;
+GO
+
+-- error while evaluating const expression
+declare @a int = 1;
+select @a = 1 / 0 from local_var_tst
+select * from local_var_tst where id = @a
+GO
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+Query Text: select * from local_var_tst where id = "@a"
+Gather  (cost=0.00..20.28 rows=13 width=4) (actual rows=1 loops=1)
+  Workers Planned: 3
+  Workers Launched: 3
+  ->  Parallel Seq Scan on local_var_tst  (cost=0.00..20.28 rows=4 width=4) (actual rows=0 loops=4)
+        Filter: (id = 1)
+~~END~~
+
+
+set babelfish_statistics profile OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+drop table local_var_tst
+GO
+
+create table ident_tst(id_num INT IDENTITY(1, 1), b varchar(10))
+GO
+
+insert into ident_tst values ('test')
+GO
+~~ROW COUNT: 1~~
+
+
+declare @a int = 1
+select @a = @@IDENTITY
+select @a
+select 1 where @a = @@IDENTITY
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- additional testing for update with dynamic variables
+GO
+
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+set QUOTED_IDENTIFIER on
+GO
+
+declare @i varchar(100)
+update local_var_tst set id = id + 10, @i = cast("xmax" as varchar(100))
+select 1 where @i IS NOT NULL
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+set QUOTED_IDENTIFIER off
+GO
+
+select * from local_var_tst order by id;
+GO
+~~START~~
+int
+11
+12
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- long identifier with update
+declare @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx int
+update local_var_tst set id =10, @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx = id
+select @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+10
+~~END~~
+
+
+select * from local_var_tst
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- @@ variables
+declare @@incnjkdnc int
+update local_var_tst set id =10, @@incnjkdnc = id
+select @@incnjkdnc
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+10
+~~END~~
+
+
+select * from local_var_tst
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int 
+update local_var_tst set id = id + 2, @i = id * 5;
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+20
+~~END~~
+
+
+select * from local_var_tst order by id;
+GO
+~~START~~
+int
+3
+4
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int, @j int;
+update local_var_tst set id =10, @i = case when @j =0 then 1 else 0 end;
+select @i, @j
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+0#!#<NULL>
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int, @j int;
+update local_var_tst set id = 10, @j = id, @i = case when @j =0 then 1 else 0 end;
+select @i, @j
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+0#!#10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int, @j int = 0
+update local_var_tst set id =10, @i = charindex('a','a',@j)
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+declare @i int, @j int = 0
+update local_var_tst set id =10, @i = charindex('a','a',@j);
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+declare @i int, @j int;
+update local_var_tst set id = 10, @j = id, @i = @j * 2
+select @i, @j
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i = id * 2 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+select * from local_var_tst
+go
+~~START~~
+int
+2
+1
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i += id * 2 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+select * from local_var_tst
+go
+~~START~~
+int
+2
+1
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i VARCHAR(200) = ''
+update local_var_tst set id = id * 2, @i = @i + cast(id as varchar(20))
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+24
+~~END~~
+
+
+select * from local_var_tst order by id
+go
+~~START~~
+int
+2
+4
+~~END~~
+
+
+-- @i should be NULL as no row passes the qual condition
+declare @i int 
+update local_var_tst set id =10, @i = id * 5 where id = 1
+select @i
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from local_var_tst order by id
+go
+~~START~~
+int
+2
+4
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i = id * 5 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+5
+~~END~~
+
+
+select * from local_var_tst order by id
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int 
+set @i = 0
+update local_var_tst set id = @i, @i = id * 5
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+0
+0
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- trim is re-written by antlr
+declare @i varchar(200) 
+select @i = ''
+update local_var_tst set id = @i, @i = TRIM(@i + cast(id as varchar(10)));
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+00
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+0
+0
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- variables in the where clause should be treated as const
+declare @i int = 1;
+update local_var_tst set id = @i * 100, @i = id * 2 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+200
+~~END~~
+
+
+select * from local_var_tst order by id;
+GO
+~~START~~
+int
+2
+100
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1;
+update local_var_tst set id = @i * 100, @i = @@IDENTITY
+select @i
+select 1 where @i = @@IDENTITY
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+select * from local_var_tst
+GO
+~~START~~
+int
+100
+100
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE PARTITION FUNCTION RangePF1 ( INT )  
+AS RANGE RIGHT FOR VALUES (10, 100, 1000) ;  
+GO
+
+declare @i int = -1;
+SELECT @i = $PARTITION.RangePF1 (10);
+select @i
+update local_var_tst set id = @i, @i = $PARTITION.RangePF1 (10);
+select @i
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+2
+2
+~~END~~
+
+
+DROP PARTITION FUNCTION RangePF1 
+GO
+
+CREATE PROCEDURE var_with_procedure (@i int, @a numeric(10,4) OUTPUT) AS
+BEGIN
+  update local_var_tst set id = @i * 2, @a = id * 5 where id = @i
+  select @a
+END;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @input int = 1, @res int;
+exec var_with_procedure @input, @res
+select @res
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+numeric
+10.0000
+~~END~~
+
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from local_var_tst
+go
+~~START~~
+int
+2
+2
+~~END~~
+
+
+declare @input int = 2, @a int;
+exec var_with_procedure @input, @a
+select @a
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+numeric
+20.0000
+~~END~~
+
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+DROP PROCEDURE var_with_procedure;
+GO
+
+DROP TABLE local_var_tst
+GO
+
+create table local_var_tst_1 (id int) 
+GO
+
+insert into local_var_tst_1 values (1)
+insert into local_var_tst_1 values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create unique index idx_local_var_tst_1 on local_var_tst_1(id)
+GO
+
+
+SELECT set_config('enable_indexscan', '1', false);
+SELECT set_config('enable_indexonlyscan', '0', false);
+SELECT set_config('enable_seqscan', '0', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+declare @i int = 1
+update local_var_tst_1 set id = @i, @i = id * 5 where id = 1
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+5
+~~END~~
+
+
+declare @i int = 1
+update local_var_tst_1 set id = 10 output deleted.id where id = 1
+select @i
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT set_config('enable_indexscan', '1', false);
+SELECT set_config('enable_indexonlyscan', '1', false);
+SELECT set_config('enable_seqscan', '1', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+DROP TABLE local_var_tst_1
+GO
+
+CREATE TABLE update_test_tbl (
+    age int,
+    fname char(10),
+    lname char(10),
+    city nchar(20)
+)
+GO
+
+TRUNCATE TABLE update_test_tbl
+GO
+
+INSERT INTO update_test_tbl(age, fname, lname, city) 
+VALUES  (50, 'fname1', 'lname1', 'london'),
+        (34, 'fname2', 'lname2', 'paris'),
+        (35, 'fname3', 'lname3', 'brussels'),
+        (90, 'fname4', 'lname4', 'new york'),
+        (26, 'fname5', 'lname5', 'los angeles'),
+        (74, 'fname6', 'lname6', 'tokyo'),
+        (44, 'fname7', 'lname7', 'oslo'),
+        (19, 'fname8', 'lname8', 'hong kong'),
+        (61, 'fname9', 'lname9', 'shanghai'),
+        (29, 'fname10', 'lname10', 'mumbai')
+GO
+~~ROW COUNT: 10~~
+
+
+CREATE TABLE update_test_tbl2 (
+    year int,
+    lname char(10),
+)
+GO
+
+TRUNCATE TABLE update_test_tbl2
+GO
+
+INSERT INTO update_test_tbl2(year, lname) 
+VALUES  (51, 'lname1'),
+        (34, 'lname3'),
+        (25, 'lname8'),
+        (95, 'lname9'),
+        (36, 'lname10')
+GO
+~~ROW COUNT: 5~~
+
+
+UPDATE update_test_tbl SET fname = 'fname13'
+FROM update_test_tbl t1
+INNER JOIN update_test_tbl2 t2
+ON t1.lname = t2.lname
+WHERE year > 50
+GO
+~~ROW COUNT: 2~~
+
+
+declare @a varchar(4000) = '';
+UPDATE update_test_tbl SET fname = 'fname13', @a = @a + fname
+FROM update_test_tbl t1
+INNER JOIN update_test_tbl2 t2
+ON t1.lname = t2.lname
+WHERE year > 50
+select @a
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+fname13   fname13   
+~~END~~
+
+
+DROP TABLE update_test_tbl2;
+GO
+
+DROP TABLE update_test_tbl
+GO
+
+drop table ident_tst
+GO
+
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 0, @j int
+update local_var_tst set id = id + 2, @i = id, @j = @i * 2, @i = @j
+select @i, @j
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Babelfish does not support assignment to the same variable in SELECT. variable name: "@i")~~
+
+
+declare @i int = 0, @j int
+update local_var_tst set id = id + 2, @i += id, @j = @i * 2
+select @i, @j
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+7#!#14
+~~END~~
+
+
+select * from local_var_tst order by id
+GO
+~~START~~
+int
+3
+4
+~~END~~
+
+
+drop table local_var_tst
+GO
+
+
+
+-- end of test_dynamic_local_vars
+-- Setup test table
+create table t1 (a int, b int, c varchar(50));
+go
+
+CREATE PROCEDURE reset_t1
+AS
+BEGIN
+    TRUNCATE TABLE t1;
+    INSERT INTO t1 VALUES (1, 10, 'first');
+    INSERT INTO t1 VALUES (2, 20, 'second');
+    INSERT INTO t1 VALUES (3, 30, 'third');
+    INSERT INTO t1 VALUES (4, 40, 'fourth');
+END
+GO
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Using local variable without assignment
+-- in targetlist
+declare @a int;
+set @a = 5;
+select a, b, @a as param_value from t1 where a < 3;
+go
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+CREATE PROCEDURE proc_targetlist_param @a int
+AS
+BEGIN
+    select a, b, @a as param_value from t1 where a < 3;
+END
+GO
+
+EXEC proc_targetlist_param @a = 5;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+DROP PROCEDURE proc_targetlist_param;
+GO
+
+EXEC sp_executesql N'select a, b, @a as param_value from t1 where a < 3', N'@a int', @a = 5;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+-- in qual
+declare @a int;
+set @a = 2;
+select * from t1 where a = @a;
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+CREATE PROCEDURE proc_qual_param @a int
+AS
+BEGIN
+    select * from t1 where a = @a;
+END
+GO
+
+EXEC proc_qual_param @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+DROP PROCEDURE proc_qual_param;
+GO
+
+EXEC sp_executesql N'select * from t1 where a = @a', N'@a int', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+declare @filter int;
+set @filter = 1;
+update t1 set b = 5942 where a = @filter;
+select * from t1 where a = @filter;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+CREATE PROCEDURE proc_update_filter @filter int
+AS
+BEGIN
+    update t1 set b = 5942 where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC reset_t1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+EXEC proc_update_filter @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_filter;
+GO
+
+EXEC reset_t1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC sp_executesql N'update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter', N'@filter int', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create table t_temp (a int);
+insert into t_temp values (1), (2), (3), (4);
+declare @del_val int;
+set @del_val = 2;
+delete from t_temp where a = @del_val;
+select * from t_temp order by a;
+drop table t_temp;
+go
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- both
+declare @update_val int, @filter int;
+set @update_val = 100;
+set @filter = 1;
+update t1 set b = @update_val where a = @filter;
+select * from t1 where a = @filter;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @filter int;
+set @filter = 1;
+update t1 set b = @filter where a = @filter;
+select * from t1 where a = @filter;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- top(NULL) from BABEL-1181
+-- Local variable in TOP clause
+declare @a int;
+set @a = 2;
+select top (@a) * from t1 order by a;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @a int;
+set @a = 2;
+select top (NULL) * from t1 order by a;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- TOP with NULL local variable (should error)
+declare @top_null int;
+set @top_null = NULL;
+select top (@top_null) * from t1;
+go
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- TOP with local variable from subquery
+declare @top_val int;
+set @top_val = (select 2);
+select top (@top_val) * from t1 order by a;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @top_val int;
+declare @fetch_val int;
+set @top_val = (select @fetch_val);
+select top (@top_val) * from t1 order by a;
+go
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Local variable assignment
+-- in targetlist
+declare @result int;
+select @result = b from t1 where a = 2;
+select @result;
+go
+~~START~~
+int
+20
+~~END~~
+
+
+-- Local variable assignment with parameter in target list and WHERE
+declare @i int, @result int;
+set @i = 2;
+select @result = b from t1 where a = @i;
+select @result;
+go
+~~START~~
+int
+20
+~~END~~
+
+
+declare @i int, @result int;
+set @i = 2;
+select @result = b + @i from t1 where a = @i;
+select @result;
+go
+~~START~~
+int
+22
+~~END~~
+
+
+-- Multiple local variable assignments
+declare @var1 int, @var2 int, @param int;
+set @param = 2;
+select @var1 = a, @var2 = b from t1 where a = @param;
+select @var1, @var2;
+go
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+-- Local variable assignment over multiple rows
+declare @result int, @threshold int;
+set @threshold = 2;
+select @result = sum(b) from t1 where a > @threshold;
+select @result;
+go
+~~START~~
+int
+70
+~~END~~
+
+
+-- Local variable in GROUP BY HAVING clause
+-- TODO: make tables with proper groups for this
+declare @having_val int;
+set @having_val = 15;
+select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a;
+go
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+create table group_table_t1 (a int, b int, c varchar(50));
+insert into group_table_t1 values (1, 3, '1abbcc');
+insert into group_table_t1 values (1, 4, 'a2bbcc');
+insert into group_table_t1 values (2, 5, 'aa3bcc');
+insert into group_table_t1 values (2, 6, 'aab4cc');
+insert into group_table_t1 values (3, 50000, 'aabb5c');
+insert into group_table_t1 values (3, 60000, 'aabbc6');
+declare @having_val int;
+set @having_val = 3;
+select a, sum(b) as total from group_table_t1 group by a having sum(b) > @having_val order by a;
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#7
+2#!#11
+3#!#110000
+~~END~~
+
+declare @having_val int;
+set @having_val = 3;
+select @having_val = @having_val + 1234 from group_table_t1 group by b having sum(b) > @having_val;
+select @having_val
+go
+~~START~~
+int
+6173
+~~END~~
+
+
+drop table group_table_t1;
+go
+
+declare @having_val int;
+set @having_val = 15;
+select @having_val = @having_val + 1 from t1 group by a having sum(b) > @having_val;
+select @having_val
+go
+~~START~~
+int
+18
+~~END~~
+
+
+-- in CASE expression
+declare @threshold int;
+set @threshold = 2;
+select a, case when a > @threshold then 'high' else 'low' end as category from t1;
+go
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- local variable assignment in CASE with local variable assignment
+declare @threshold int, @result varchar(10);
+set @threshold = 2;
+select @result = case when a > @threshold then 'high' else 'low' end from t1 order by a;
+select @result;
+go
+~~START~~
+varchar
+high
+~~END~~
+
+
+declare @threshold int, @result varchar(10), @at int;
+set @threshold = 2;
+set @at = 3;
+select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at;
+select @result;
+go
+~~START~~
+varchar
+high
+~~END~~
+
+
+-- Local variable with string operations
+declare @search varchar(10);
+set @search = 'sec';
+select * from t1 where c like '%' + @search + '%';
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+declare @search varchar(10);
+set @search = 'i';
+select @search = @search + 'rd' from t1 where c like '%' + @search + '%';
+select @search;
+go
+~~START~~
+varchar
+irdrd
+~~END~~
+
+
+declare @result varchar(100), @prefix varchar(10);
+set @prefix = 'Value: ';
+select @result = @prefix + c from t1 order by a;
+select @result;
+go
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+declare @multiplier int;
+set @multiplier = 2;
+select a, (select @multiplier * b) as doubled_b from t1 where a < 3;
+go
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+declare @multiplier int;
+set @multiplier = 2;
+select a, (select @multiplier = @multiplier * b) from t1 where a < 3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+declare @val int;
+set @val = 10;
+select a, (select b + (select @val)) as nested_calc from t1 where a < 3;
+go
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+declare @val int;
+set @val = 2;
+select * from t1 where b > (select max(b) from t1 where a < @val);
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+declare @val int;
+set @val = 2;
+select * from t1 where (select @val = @val + 1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 3 and character position 17)~~
+
+
+declare @offset int;
+set @offset = 10;
+select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer;
+go
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+declare @null_param int;
+set @null_param = NULL;
+select * from t1 where a = @null_param;
+go
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- Local variable in CTE
+declare @cte_filter int;
+set @cte_filter = 2;
+with cte as (select * from t1 where a > @cte_filter)
+select * from cte;
+go
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+declare @cte_filter int;
+set @cte_filter = 1;
+with cte as (select * from t1 where a > @cte_filter)
+select @cte_filter = @cte_filter + 3 from cte;
+select @cte_filter;
+go
+~~START~~
+int
+10
+~~END~~
+
+
+declare @filter1 int, @filter2 int;
+set @filter1 = 1;
+set @filter2 = 3;
+with cte1 as (select * from t1 where a > @filter1),
+     cte2 as (select * from cte1 where a <= @filter2)
+select * from cte2;
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+declare @filter1 int, @filter2 int;
+set @filter1 = 1;
+with cte1 as (select * from t1 where a > @filter1),
+     cte2 as (select @filter1 = @filter1 + 3 from cte1)
+select * from cte2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+declare @partition_val int;
+set @partition_val = 2;
+select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+go
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+declare @partition_val int;
+set @partition_val = 2;
+select @partition_val = @partition_val + 1, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+go
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Local variable assignment in UPDATE
+-- returned values for the `captured` variables _will_ differ from sql server (BABEL-5188)
+declare @captured int, @filter int;
+set @filter = 2;
+update t1 set b = b + 5, @captured = b where a = @filter;
+select @captured;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Multiple local variable assignments in UPDATE
+declare @captured1 int, @captured2 int, @filter int, @increment int;
+set @filter = 2;
+set @increment = 5;
+update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter;
+select @captured1, @captured2;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- UPDATE with local variable in subquery
+declare @multiplier int;
+set @multiplier = 2;
+update t1 set b = (select @multiplier * 10) where a = 1;
+select * from t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- DELETE with local variable in subquery
+create table t_temp (a int);
+insert into t_temp values (1), (2), (3), (4);
+declare @threshold int;
+set @threshold = 2;
+delete from t_temp where a in (select a from t_temp where a <= @threshold);
+select * from t_temp order by a;
+drop table t_temp;
+go
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- local variable in INSERT VALUES
+declare @val1 int, @val2 int;
+set @val1 = 5;
+set @val2 = 50;
+create table t_temp (a int, b int);
+insert into t_temp values (@val1, @val2);
+select * from t_temp;
+set @val1 = 51;
+set @val2 = 501;
+insert into t_temp values (@val1, @val2);
+select * from t_temp;
+drop table t_temp;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+51#!#501
+~~END~~
+
+
+-- local variable in OFFSET FETCH
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = NULL;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- OFFSET NULL should error (BABEL-6347)
+declare @offset_val int, @fetch_val int;
+set @offset_val = NULL;
+set @fetch_val = 2;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @offset_val int, @fetch_val int;
+set @fetch_val = 2;
+select * from t1 order by a offset NULL rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select a, @fetch_val = NULL from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select a, @offset_val = NULL from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+
+
+-- Additional procedure and planned statement versions
+-- Ref: delete with local variable
+CREATE PROCEDURE proc_delete_param @del_val int
+AS
+BEGIN
+    create table t_temp (a int);
+    insert into t_temp values (1), (2), (3), (4);
+    delete from t_temp where a = @del_val;
+    select * from t_temp order by a;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_delete_param @del_val = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+DROP PROCEDURE proc_delete_param;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a = @del_val; select * from t_temp order by a; drop table t_temp', N'@del_val int', @del_val = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- Ref: update with both local variables
+CREATE PROCEDURE proc_update_both @update_val int, @filter int
+AS
+BEGIN
+    update t1 set b = @update_val where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC proc_update_both @update_val = 100, @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_both;
+GO
+
+EXEC sp_executesql N'update t1 set b = @update_val where a = @filter; select * from t1 where a = @filter', N'@update_val int, @filter int', @update_val = 100, @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: update with same variable in both places
+CREATE PROCEDURE proc_update_same @filter int
+AS
+BEGIN
+    update t1 set b = @filter where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC proc_update_same @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_same;
+GO
+
+EXEC sp_executesql N'update t1 set b = @filter where a = @filter; select * from t1 where a = @filter', N'@filter int', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: TOP with local variable
+CREATE PROCEDURE proc_top_param @a int
+AS
+BEGIN
+    select top (@a) * from t1 order by a;
+END
+GO
+
+EXEC proc_top_param @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+DROP PROCEDURE proc_top_param;
+GO
+
+EXEC sp_executesql N'select top (@a) * from t1 order by a', N'@a int', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: TOP with NULL local variable
+CREATE PROCEDURE proc_top_null @top_null int
+AS
+BEGIN
+    select top (@top_null) * from t1;
+END
+GO
+
+EXEC proc_top_null @top_null = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP PROCEDURE proc_top_null;
+GO
+
+EXEC sp_executesql N'select top (@top_null) * from t1', N'@top_null int', @top_null = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Ref: TOP with local variable from subquery
+CREATE PROCEDURE proc_top_subquery
+AS
+BEGIN
+    select top (select NULL) * from t1 order by a;
+END
+GO
+
+EXEC proc_top_subquery;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP PROCEDURE proc_top_subquery;
+GO
+
+EXEC sp_executesql N'select top (select NULL) * from t1 order by a';
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Ref: local variable assignment in targetlist
+CREATE PROCEDURE proc_assign_targetlist @i int, @result int OUTPUT
+AS
+BEGIN
+    select @result = b from t1 where a = @i;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_targetlist @i = 2, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+DROP PROCEDURE proc_assign_targetlist;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = b from t1 where a = @i', N'@i int, @result int OUTPUT', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+-- Ref: local variable assignment with parameter in target and WHERE
+CREATE PROCEDURE proc_assign_both @i int, @result int OUTPUT
+AS
+BEGIN
+    select @result = b + @i from t1 where a = @i;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_both @i = 2, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+int
+22
+~~END~~
+
+
+DROP PROCEDURE proc_assign_both;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = b + @i from t1 where a = @i', N'@i int, @result int OUTPUT', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+22
+~~END~~
+
+
+-- Ref: multiple local variable assignments
+CREATE PROCEDURE proc_assign_multiple @param int, @var1 int OUTPUT, @var2 int OUTPUT
+AS
+BEGIN
+    select @var1 = a, @var2 = b from t1 where a = @param;
+END
+GO
+
+declare @out1 int, @out2 int;
+EXEC proc_assign_multiple @param = 2, @var1 = @out1 OUTPUT, @var2 = @out2 OUTPUT;
+select @out1, @out2;
+GO
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+DROP PROCEDURE proc_assign_multiple;
+GO
+
+declare @var1 int, @var2 int;
+EXEC sp_executesql N'select @var1 = a, @var2 = b from t1 where a = @param', N'@param int, @var1 int OUTPUT, @var2 int OUTPUT', @param = 2, @var1 = @var1 OUTPUT, @var2 = @var2 OUTPUT;
+select @var1, @var2;
+GO
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+-- Ref: local variable assignment over multiple rows
+CREATE PROCEDURE proc_assign_aggregate @threshold int, @result int OUTPUT
+AS
+BEGIN
+    select @result = sum(b) from t1 where a > @threshold;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_aggregate @threshold = 2, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+int
+70
+~~END~~
+
+
+DROP PROCEDURE proc_assign_aggregate;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = sum(b) from t1 where a > @threshold', N'@threshold int, @result int OUTPUT', @threshold = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+70
+~~END~~
+
+
+-- Ref: local variable in GROUP BY HAVING
+CREATE PROCEDURE proc_having_param @having_val int
+AS
+BEGIN
+    select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a;
+END
+GO
+
+EXEC proc_having_param @having_val = 15;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+DROP PROCEDURE proc_having_param;
+GO
+
+EXEC sp_executesql N'select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a', N'@having_val int', @having_val = 15;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+-- Ref: CASE expression with local variable
+CREATE PROCEDURE proc_case_param @threshold int
+AS
+BEGIN
+    select a, case when a > @threshold then 'high' else 'low' end as category from t1;
+END
+GO
+
+EXEC proc_case_param @threshold = 2;
+GO
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+DROP PROCEDURE proc_case_param;
+GO
+
+EXEC sp_executesql N'select a, case when a > @threshold then ''high'' else ''low'' end as category from t1', N'@threshold int', @threshold = 2;
+GO
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- Ref: local variable assignment in CASE
+CREATE PROCEDURE proc_case_assign @threshold int, @at int, @result varchar(10) OUTPUT
+AS
+BEGIN
+    select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at;
+END
+GO
+
+declare @out varchar(10);
+EXEC proc_case_assign @threshold = 2, @at = 3, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+varchar
+high
+~~END~~
+
+
+DROP PROCEDURE proc_case_assign;
+GO
+
+declare @result varchar(10);
+EXEC sp_executesql N'select @result = case when a > @threshold then ''high'' else ''low'' end from t1 where a = @at', N'@threshold int, @at int, @result varchar(10) OUTPUT', @threshold = 2, @at = 3, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+high
+~~END~~
+
+
+-- Ref: local variable with string operations
+CREATE PROCEDURE proc_string_like @search varchar(10)
+AS
+BEGIN
+    select * from t1 where c like '%' + @search + '%';
+END
+GO
+
+EXEC proc_string_like @search = 'sec';
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+DROP PROCEDURE proc_string_like;
+GO
+
+EXEC sp_executesql N'select * from t1 where c like ''%'' + @search + ''%''', N'@search varchar(10)', @search = 'sec';
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: string concatenation with assignment
+CREATE PROCEDURE proc_string_concat @prefix varchar(10), @result varchar(100) OUTPUT
+AS
+BEGIN
+    select @result = @prefix + c from t1 order by a;
+END
+GO
+
+declare @out varchar(100);
+EXEC proc_string_concat @prefix = 'Value: ', @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+DROP PROCEDURE proc_string_concat;
+GO
+
+declare @result varchar(100);
+EXEC sp_executesql N'select @result = @prefix + c from t1 order by a', N'@prefix varchar(10), @result varchar(100) OUTPUT', @prefix = 'Value: ', @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+-- Ref: subquery with local variable
+CREATE PROCEDURE proc_subquery_param @multiplier int
+AS
+BEGIN
+    select a, (select @multiplier * b) as doubled_b from t1 where a < 3;
+END
+GO
+
+EXEC proc_subquery_param @multiplier = 2;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+DROP PROCEDURE proc_subquery_param;
+GO
+
+EXEC sp_executesql N'select a, (select @multiplier * b) as doubled_b from t1 where a < 3', N'@multiplier int', @multiplier = 2;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+-- Ref: nested subquery with local variable
+CREATE PROCEDURE proc_nested_subquery @val int
+AS
+BEGIN
+    select a, (select b + (select @val)) as nested_calc from t1 where a < 3;
+END
+GO
+
+EXEC proc_nested_subquery @val = 10;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+DROP PROCEDURE proc_nested_subquery;
+GO
+
+EXEC sp_executesql N'select a, (select b + (select @val)) as nested_calc from t1 where a < 3', N'@val int', @val = 10;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+-- Ref: subquery in WHERE with local variable
+CREATE PROCEDURE proc_where_subquery @val int
+AS
+BEGIN
+    select * from t1 where b > (select max(b) from t1 where a < @val);
+END
+GO
+
+EXEC proc_where_subquery @val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+DROP PROCEDURE proc_where_subquery;
+GO
+
+EXEC sp_executesql N'select * from t1 where b > (select max(b) from t1 where a < @val)', N'@val int', @val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: correlated subquery with local variable
+CREATE PROCEDURE proc_correlated_subquery @offset int
+AS
+BEGIN
+    select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer;
+END
+GO
+
+EXEC proc_correlated_subquery @offset = 10;
+GO
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+DROP PROCEDURE proc_correlated_subquery;
+GO
+
+EXEC sp_executesql N'select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer', N'@offset int', @offset = 10;
+GO
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+-- Ref: NULL parameter
+CREATE PROCEDURE proc_null_param @null_param int
+AS
+BEGIN
+    select * from t1 where a = @null_param;
+END
+GO
+
+EXEC proc_null_param @null_param = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+DROP PROCEDURE proc_null_param;
+GO
+
+EXEC sp_executesql N'select * from t1 where a = @null_param', N'@null_param int', @null_param = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- Ref: CTE with local variable
+CREATE PROCEDURE proc_cte_param @cte_filter int
+AS
+BEGIN
+    with cte as (select * from t1 where a > @cte_filter)
+    select * from cte;
+END
+GO
+
+EXEC proc_cte_param @cte_filter = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+DROP PROCEDURE proc_cte_param;
+GO
+
+EXEC sp_executesql N'with cte as (select * from t1 where a > @cte_filter) select * from cte', N'@cte_filter int', @cte_filter = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: multiple CTEs with local variables
+CREATE PROCEDURE proc_multiple_cte @filter1 int, @filter2 int
+AS
+BEGIN
+    with cte1 as (select * from t1 where a > @filter1),
+         cte2 as (select * from cte1 where a <= @filter2)
+    select * from cte2;
+END
+GO
+
+EXEC proc_multiple_cte @filter1 = 1, @filter2 = 3;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+DROP PROCEDURE proc_multiple_cte;
+GO
+
+EXEC sp_executesql N'with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2', N'@filter1 int, @filter2 int', @filter1 = 1, @filter2 = 3;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: window function with local variable
+CREATE PROCEDURE proc_window_param @partition_val int
+AS
+BEGIN
+    select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+END
+GO
+
+EXEC proc_window_param @partition_val = 2;
+GO
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+DROP PROCEDURE proc_window_param;
+GO
+
+EXEC sp_executesql N'select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1', N'@partition_val int', @partition_val = 2;
+GO
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+-- Ref: UPDATE with local variable assignment
+CREATE PROCEDURE proc_update_assign @filter int, @captured int OUTPUT
+AS
+BEGIN
+    update t1 set b = b + 5, @captured = b where a = @filter;
+END
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @out int;
+EXEC proc_update_assign @filter = 2, @captured = @out OUTPUT;
+select @out;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+DROP PROCEDURE proc_update_assign;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @captured int;
+EXEC sp_executesql N'update t1 set b = b + 5, @captured = b where a = @filter', N'@filter int, @captured int OUTPUT', @filter = 2, @captured = @captured OUTPUT;
+select @captured;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with multiple assignments
+CREATE PROCEDURE proc_update_multi_assign @filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT
+AS
+BEGIN
+    update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter;
+END
+GO
+
+declare @out1 int, @out2 int;
+EXEC proc_update_multi_assign @filter = 2, @increment = 5, @captured1 = @out1 OUTPUT, @captured2 = @out2 OUTPUT;
+select @out1, @out2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+DROP PROCEDURE proc_update_multi_assign;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @captured1 int, @captured2 int;
+EXEC sp_executesql N'update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter', N'@filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT', @filter = 2, @increment = 5, @captured1 = @captured1 OUTPUT, @captured2 = @captured2 OUTPUT;
+select @captured1, @captured2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with subquery
+CREATE PROCEDURE proc_update_subquery @multiplier int
+AS
+BEGIN
+    update t1 set b = (select @multiplier * 10) where a = 1;
+    select * from t1 where a = 1;
+END
+GO
+
+EXEC proc_update_subquery @multiplier = 2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_subquery;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+EXEC sp_executesql N'update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1', N'@multiplier int', @multiplier = 2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: DELETE with subquery
+CREATE PROCEDURE proc_delete_subquery @threshold int
+AS
+BEGIN
+    create table t_temp (a int);
+    insert into t_temp values (1), (2), (3), (4);
+    delete from t_temp where a in (select a from t_temp where a <= @threshold);
+    select * from t_temp order by a;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_delete_subquery @threshold = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+DROP PROCEDURE proc_delete_subquery;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a in (select a from t_temp where a <= @threshold); select * from t_temp order by a; drop table t_temp', N'@threshold int', @threshold = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- Ref: INSERT with local variables
+CREATE PROCEDURE proc_insert_params @val1 int, @val2 int
+AS
+BEGIN
+    create table t_temp (a int, b int);
+    insert into t_temp values (@val1, @val2);
+    select * from t_temp;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_insert_params @val1 = 5, @val2 = 50;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+DROP PROCEDURE proc_insert_params;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int, b int); insert into t_temp values (@val1, @val2); select * from t_temp; drop table t_temp', N'@val1 int, @val2 int', @val1 = 5, @val2 = 50;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+-- Ref: OFFSET FETCH with local variables
+CREATE PROCEDURE proc_offset_fetch @offset_val int, @fetch_val int
+AS
+BEGIN
+    select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+END
+GO
+
+EXEC proc_offset_fetch @offset_val = 1, @fetch_val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+DROP PROCEDURE proc_offset_fetch;
+GO
+
+EXEC sp_executesql N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', N'@offset_val int, @fetch_val int', @offset_val = 1, @fetch_val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: OFFSET FETCH with NULL fetch
+CREATE PROCEDURE proc_offset_null_fetch @offset_val int, @fetch_val int
+AS
+BEGIN
+    select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+END
+GO
+
+EXEC proc_offset_null_fetch @offset_val = 1, @fetch_val = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP PROCEDURE proc_offset_null_fetch;
+GO
+
+EXEC sp_executesql N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', N'@offset_val int, @fetch_val int', @offset_val = 1, @fetch_val = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: targetlist param
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select a, b, @a as param_value from t1 where a < 3', @a = 5;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+-- Ref: qual param
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select * from t1 where a = @a', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: update filter
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int', N'update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+EXEC reset_t1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: delete with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@del_val int', N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a = @del_val; select * from t_temp order by a; drop table t_temp', @del_val = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- Ref: update with both local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@update_val int, @filter int', N'update t1 set b = @update_val where a = @filter; select * from t1 where a = @filter', @update_val = 100, @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: update with same variable in both places
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int', N'update t1 set b = @filter where a = @filter; select * from t1 where a = @filter', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: TOP with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select top (@a) * from t1 order by a', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: TOP with NULL local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@top_null int', N'select top (@top_null) * from t1', @top_null = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Ref: local variable assignment in targetlist
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@i int, @result int OUTPUT', N'select @result = b from t1 where a = @i', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+-- Ref: local variable assignment with parameter in target and WHERE
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@i int, @result int OUTPUT', N'select @result = b + @i from t1 where a = @i', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+22
+~~END~~
+
+
+-- Ref: multiple local variable assignments
+declare @var1 int, @var2 int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@param int, @var1 int OUTPUT, @var2 int OUTPUT', N'select @var1 = a, @var2 = b from t1 where a = @param', @param = 2, @var1 = @var1 OUTPUT, @var2 = @var2 OUTPUT;
+select @var1, @var2;
+GO
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+-- Ref: local variable assignment over multiple rows
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int, @result int OUTPUT', N'select @result = sum(b) from t1 where a > @threshold', @threshold = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+70
+~~END~~
+
+
+-- Ref: local variable in GROUP BY HAVING
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@having_val int', N'select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a', @having_val = 15;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+-- Ref: CASE expression with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int', N'select a, case when a > @threshold then ''high'' else ''low'' end as category from t1', @threshold = 2;
+GO
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- Ref: local variable assignment in CASE
+declare @result varchar(10);
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int, @at int, @result varchar(10) OUTPUT', N'select @result = case when a > @threshold then ''high'' else ''low'' end from t1 where a = @at', @threshold = 2, @at = 3, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+high
+~~END~~
+
+
+-- Ref: local variable with string operations
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@search varchar(10)', N'select * from t1 where c like ''%'' + @search + ''%''', @search = 'sec';
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: string concatenation with assignment
+declare @result varchar(100);
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@prefix varchar(10), @result varchar(100) OUTPUT', N'select @result = @prefix + c from t1 order by a', @prefix = 'Value: ', @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+-- Ref: subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@multiplier int', N'select a, (select @multiplier * b) as doubled_b from t1 where a < 3', @multiplier = 2;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+-- Ref: nested subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val int', N'select a, (select b + (select @val)) as nested_calc from t1 where a < 3', @val = 10;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+-- Ref: subquery in WHERE with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val int', N'select * from t1 where b > (select max(b) from t1 where a < @val)', @val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: correlated subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset int', N'select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer', @offset = 10;
+GO
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+-- Ref: NULL parameter
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@null_param int', N'select * from t1 where a = @null_param', @null_param = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- Ref: CTE with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@cte_filter int', N'with cte as (select * from t1 where a > @cte_filter) select * from cte', @cte_filter = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: multiple CTEs with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter1 int, @filter2 int', N'with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2', @filter1 = 1, @filter2 = 3;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: window function with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@partition_val int', N'select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1', @partition_val = 2;
+GO
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+-- Ref: UPDATE with local variable assignment
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @captured int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int, @captured int OUTPUT', N'update t1 set b = b + 5, @captured = b where a = @filter', @filter = 2, @captured = @captured OUTPUT;
+select @captured;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with multiple assignments
+declare @captured1 int, @captured2 int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT', N'update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter', @filter = 2, @increment = 5, @captured1 = @captured1 OUTPUT, @captured2 = @captured2 OUTPUT;
+select @captured1, @captured2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with subquery
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@multiplier int', N'update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1', @multiplier = 2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: DELETE with subquery
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int', N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a in (select a from t_temp where a <= @threshold); select * from t_temp order by a; drop table t_temp', @threshold = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- Ref: INSERT with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val1 int, @val2 int', N'create table t_temp (a int, b int); insert into t_temp values (@val1, @val2); select * from t_temp; drop table t_temp', @val1 = 5, @val2 = 50;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+-- Ref: OFFSET FETCH with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset_val int, @fetch_val int', N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', @offset_val = 1, @fetch_val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: OFFSET FETCH with NULL fetch
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset_val int, @fetch_val int', N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', @offset_val = 1, @fetch_val = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+
+-- cleanup
+drop procedure reset_t1;
+go
+
+drop table t1;
+go

--- a/test/JDBC/expected/params_in_generic_plan.out
+++ b/test/JDBC/expected/params_in_generic_plan.out
@@ -1,0 +1,4788 @@
+SELECT set_config('plan_cache_mode', 'force_generic_plan', false);
+go
+~~START~~
+text
+force_generic_plan
+~~END~~
+
+
+-- test_dynamic_local_vars
+-- simple vars
+declare @i int
+declare @j int
+set @i = 10
+set @j = @i + 10
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+
+declare @i int
+declare @j int
+select @i = 10, @j = @i + 10
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+
+declare @i int
+declare @j int = 0;
+select @i = 10, @j = @i + @j * 2
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#10
+~~END~~
+
+
+declare @i int
+declare @j int
+select @i = 10, @j = @i + 10
+select @j += 10
+select @i, @j
+GO
+~~START~~
+int#!#int
+10#!#30
+~~END~~
+
+
+-- should throw an error
+declare @i int 
+select @i = 0, @i += 2
+select @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Babelfish does not support assignment to the same variable in SELECT. variable name: "@i")~~
+
+
+declare @i int
+select @i = 10, @i += 10
+select @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Babelfish does not support assignment to the same variable in SELECT. variable name: "@i")~~
+
+
+-- sub-expr
+declare @i int
+set @i = 10
+select @i += (5 - 1)
+select @i
+GO
+~~START~~
+int
+14
+~~END~~
+
+
+DECLARE @a int
+select @a = (select ~cast('1' as int))
+select @a
+go
+~~START~~
+int
+-2
+~~END~~
+
+
+
+DECLARE @Counter INT = 1;
+DECLARE @MaxValue INT = 10;
+WHILE @Counter <= @MaxValue
+BEGIN
+    DECLARE @IsEven BIT;
+    
+    IF @Counter % 2 = 0
+        SET @IsEven = 1;
+    ELSE
+        SET @IsEven = 0;
+    
+    IF @IsEven = 1
+        SELECT CAST(@Counter AS VARCHAR(2)) + ' is even';
+    ELSE
+        SELECT CAST(@Counter AS VARCHAR(2)) + ' is odd';
+    
+    SET @Counter = @Counter + 1;
+END;
+GO
+~~START~~
+varchar
+1 is odd
+~~END~~
+
+~~START~~
+varchar
+2 is even
+~~END~~
+
+~~START~~
+varchar
+3 is odd
+~~END~~
+
+~~START~~
+varchar
+4 is even
+~~END~~
+
+~~START~~
+varchar
+5 is odd
+~~END~~
+
+~~START~~
+varchar
+6 is even
+~~END~~
+
+~~START~~
+varchar
+7 is odd
+~~END~~
+
+~~START~~
+varchar
+8 is even
+~~END~~
+
+~~START~~
+varchar
+9 is odd
+~~END~~
+
+~~START~~
+varchar
+10 is even
+~~END~~
+
+
+declare @a numeric (10, 4);
+declare @b numeric (10, 4);
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+~~START~~
+numeric#!#numeric
+100.4100#!#200.8200
+~~END~~
+
+~~START~~
+numeric
+301.2300
+~~END~~
+
+
+declare @a numeric;
+declare @b numeric (10, 4);
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+~~START~~
+numeric#!#numeric
+100#!#200.8200
+~~END~~
+
+~~START~~
+numeric
+300.8200
+~~END~~
+
+
+declare @a varbinary
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+74
+~~END~~
+
+
+declare @a varbinary(max)
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+746573745F62696E
+~~END~~
+
+
+declare @a varbinary(10)
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+746573745F62696E
+~~END~~
+
+
+declare @a varbinary
+declare @b varbinary
+select @a = cast('test_bin' as varbinary), @b = @a
+select @a, @b
+GO
+~~START~~
+varbinary#!#varbinary
+74#!#74
+~~END~~
+
+
+declare @a varbinary(max)
+select @a = cast('test_bin' as varbinary)
+select @a
+GO
+~~START~~
+varbinary
+746573745F62696E
+~~END~~
+
+
+DECLARE @a varchar
+set @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @v varchar(20);
+SELECT @v = NULL;
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+~~START~~
+int#!#int#!#int
+0#!#<NULL>#!#<NULL>
+~~END~~
+
+
+DECLARE @a varchar(max)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+-- collate can not be used with local variables
+DECLARE @v varchar(20) collate BBF_Unicode_CP1_CI_As = 'ci_as';
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'collate' at line 2 and character position 23)~~
+
+
+declare @source int;
+declare @target sql_variant;
+select @source = 1.0
+select @target = cast(@source as varchar(10));
+SELECT sql_variant_property(@target, 'basetype');
+select @target
+GO
+~~START~~
+sql_variant
+varchar
+~~END~~
+
+~~START~~
+sql_variant
+1
+~~END~~
+
+
+declare @source int;
+declare @target varchar(10);
+select @source = 1.0
+select cast(@source as varchar(10))
+select @target = cast(@source as varchar(10));
+select @target
+GO
+~~START~~
+varchar
+1
+~~END~~
+
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @a pg_catalog.varchar
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DECLARE @a pg_catalog.varchar(100)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DECLARE @a pg_catalog.varchar(10)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+10#!#10
+~~END~~
+
+~~START~~
+varchar
+1234567890
+~~END~~
+
+
+DECLARE @a varchar
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+1#!#1
+~~END~~
+
+~~START~~
+varchar
+1
+~~END~~
+
+
+DECLARE @a varchar(100)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DECLARE @a varchar(10)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+10#!#10
+~~END~~
+
+~~START~~
+varchar
+1234567890
+~~END~~
+
+
+DECLARE @a int
+set @a = 0
+select @a ^= 1
+select @a
+go
+~~START~~
+int
+1
+~~END~~
+
+
+DECLARE @a int
+set @a = 0
+select @a += ~@a
+select @a
+go
+~~START~~
+int
+-1
+~~END~~
+
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- quoted identifiers
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += "a""b''c'd", @v2 += "x""y''z";
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCa"b''c'd#!#XYZx"y''z
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += "a""b''c'd", @v2 += @v + "x""y''z";
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCa"b''c'd#!#XYZABCa"b''c'dx"y''z
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += @v + "x""y''z";
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCd'c''b"a#!#XYZABCd'c''b"ax"y''z
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += @v + reverse("x""y''z");
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCd'c''b"a#!#XYZABCd'c''b"az''y"x
+~~END~~
+
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += REVERSE( @v + reverse("x""y''z"));
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCd'c''b"a#!#XYZx"y''za"b''c'dCBA
+~~END~~
+
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+declare @v varchar(20) = 'ABC', @v2 varchar(20)='XYZ';
+select @v += 'abc', @v2 += 'xyz';
+select @v, @v2
+GO
+~~START~~
+varchar#!#varchar
+ABCabc#!#XYZxyz
+~~END~~
+
+
+declare @a int = 1, @b int = 2;
+select @a = 2, @b = @a + 2
+select @a, @b
+GO
+~~START~~
+int#!#int
+2#!#4
+~~END~~
+
+
+declare @a int = 1, @b int = 2;
+select @a += 2, @b -= @a + 2
+select @a, @b
+GO
+~~START~~
+int#!#int
+3#!#-3
+~~END~~
+
+
+-- xml methods
+DECLARE @a bit = 1
+DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
+SELECT @a |= @xml.exist('/artists/artist/@name')
+select @a
+GO
+~~START~~
+bit
+1
+~~END~~
+
+
+DECLARE @a bit = 1
+DECLARE @xml XML;
+SELECT @xml  = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>', @a |= @xml.exist('/artists/artist/@name')
+select @a
+GO
+~~START~~
+bit
+1
+~~END~~
+
+
+-- test all kind of udts
+create type udt from NCHAR
+go
+
+declare @a udt
+select @a = 'anc'
+select @a
+GO
+~~START~~
+nchar
+a
+~~END~~
+
+
+DROP type udt 
+GO
+
+create type varchar_max from varchar(max)
+GO
+
+DECLARE @a varchar_max
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+~~START~~
+int#!#int
+35#!#35
+~~END~~
+
+~~START~~
+varchar
+12345678901234567890123456789012345
+~~END~~
+
+
+DROP type varchar_max
+GO
+
+create type num_def from numeric
+GO
+
+declare @a numeric;
+declare @b num_def;
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+~~START~~
+numeric#!#numeric
+100#!#201
+~~END~~
+
+~~START~~
+numeric
+301
+~~END~~
+
+
+drop type num_def
+GO
+
+/*
+ * select/update test
+ */
+create table local_var_tst (id int) 
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (6)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- txn does not affect local variables
+begin tran
+declare @i int 
+update local_var_tst set id = 5, @i = id * 5
+select @i
+ROLLBACK tran
+select @i
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int
+25
+~~END~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+1
+2
+6
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- should return 4
+declare @i int 
+select @i = 1
+select @i = id * 2 from local_var_tst where id = @i
+select @i
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+declare @i int 
+select @i = 1
+select @i = @i + id * 2 from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+declare @i int 
+select @i = 1
+select @i = id * 2 + @i from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+declare @i int 
+select @i = 1
+select @i += id * 2 from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- 3 parts name 
+declare @i int 
+select @i = 1
+select @i += master.dbo.local_var_tst.id * 2 from local_var_tst
+select @i
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- local var name same as column
+declare @id int = 1
+select @id += master.dbo.local_var_tst.id * 2 from local_var_tst
+select @id
+GO
+~~START~~
+int
+7
+~~END~~
+
+
+-- should throw an error
+declare @i int
+declare @j int
+set @i = 10
+set @j = 0;
+select @i += (select @j = @j + id from local_var_tst)
+select @i
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+DECLARE @ans INT
+SELECT @ans = AVG(id) FROM local_var_tst
+select @ans
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+-- local variable inside functions
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans = AVG(id) FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func();
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+DROP FUNCTION var_inside_func();
+GO
+
+-- show throw an error
+CREATE FUNCTION var_inside_func()
+RETURNS @tab table (a int) as
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans += id from local_var_tst
+    select @ans
+END
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: SELECT statement returning result to a client cannot be used in a function)~~
+
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans += id FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func()
+go
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func(@def int)
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT;
+    select @ans = @def;
+    SELECT @ans += id FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func(0)
+go
+~~START~~
+int
+3
+~~END~~
+
+
+declare @def int = 1;
+select var_inside_func(@def)
+go
+~~START~~
+int
+4
+~~END~~
+
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    select @ans = 0
+    SELECT @ans += id + @ans FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func()
+go
+~~START~~
+int
+4
+~~END~~
+
+
+drop function if exists var_inside_func
+go
+
+-- variable with procedure
+CREATE PROCEDURE var_with_procedure (@a numeric(10,4) OUTPUT) AS
+BEGIN
+  SET @a=100.41;
+  select @a as a;
+END;
+GO
+
+exec var_with_procedure 2.000;
+GO
+~~START~~
+numeric
+100.4100
+~~END~~
+
+
+-- value of @out should remain 2.000
+declare @out numeric(10,4);
+set @out = 2.000;
+exec var_with_procedure 2.000;
+select @out
+GO
+~~START~~
+numeric
+100.4100
+~~END~~
+
+~~START~~
+numeric
+2.0000
+~~END~~
+
+
+drop procedure var_with_procedure;
+GO
+
+CREATE PROCEDURE var_with_procedure_1 (@a numeric(10,4) OUTPUT, @b numeric(10,4) OUTPUT) AS
+BEGIN
+  SET @a=100.41;
+  SET @b=200.82;
+  select @a+@b as r;
+END;
+GO
+
+EXEC var_with_procedure_1 2.000, 3.000;
+GO
+~~START~~
+numeric
+301.2300
+~~END~~
+
+
+-- value of @a should be 100
+DECLARE @a INT;
+EXEC var_with_procedure_1 @a OUT, 3.000;
+SELECT @a;
+GO
+~~START~~
+numeric
+301.2300
+~~END~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+drop procedure var_with_procedure_1;
+GO
+
+CREATE PROCEDURE var_with_procedure_2
+AS
+BEGIN
+  declare @a int
+  declare @b int
+  set @a = 1
+  return
+  select @b=@a+1
+END
+GO
+
+exec var_with_procedure_2
+GO
+
+DROP PROCEDURE var_with_procedure_2
+GO
+
+-- insert testing with local variables
+truncate table dbo.local_var_tst
+go
+
+-- should throw an error
+declare @a int = 1
+insert into local_var_tst select @a = @a + 1
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+-- syntax error
+declare @a int = 1
+insert into local_var_tst values (@a = @a + 1)
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near '=' at line 3 and character position 37)~~
+
+
+declare @a int = 1
+insert into local_var_tst values (@a + 1)
+GO
+~~ROW COUNT: 1~~
+
+
+-- output clause with insert
+declare @a int = 1
+declare @mytbl table(a int)
+insert local_var_tst output inserted.id into @mytbl values (@a + 1) 
+select * from @mytbl
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+-- output clause with delete
+declare @a int = 1
+declare @mytbl table(a int)
+delete local_var_tst output deleted.id into @mytbl where id = @a + 1
+select * from @mytbl
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+2
+~~END~~
+
+
+drop table dbo.local_var_tst
+go
+
+create table local_var_tst_1 (a int, b int)
+GO
+
+insert into local_var_tst_1 values (1,3), (2, 4)
+go
+~~ROW COUNT: 2~~
+
+
+
+-- select test with multi-variable assignment
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += b from local_var_tst_1
+select @a, @b
+go
+~~START~~
+int#!#int
+3#!#7
+~~END~~
+
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += @a + b from local_var_tst_1
+select @a, @b
+go
+~~START~~
+int#!#int
+3#!#11
+~~END~~
+
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += @a + ~b from local_var_tst_1
+select @a, @b
+go
+~~START~~
+int#!#int
+3#!#-5
+~~END~~
+
+
+drop table local_var_tst_1
+go
+
+create table local_var_str_tst (id varchar(100))
+GO
+
+insert into local_var_str_tst values ('abc'), (' '), ('def')
+GO
+~~ROW COUNT: 3~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i = @i + id from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+abc def
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i = id + @i from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+def abc
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i += id from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+abc def
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i = reverse(@i + 'id') from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+didiid
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = ''
+select @i += reverse(id) from local_var_str_tst
+select @i
+go
+~~START~~
+varchar
+cba fed
+~~END~~
+
+
+declare @i varchar(1000)
+set @i = 'abc'
+select @i = reverse(@i)
+select @i
+go
+~~START~~
+varchar
+cba
+~~END~~
+
+
+-- function call like trim, ltrim, etc will be rewritten by ANTLR
+declare @i varchar(1000)
+set @i = ' '
+select @i += id from local_var_str_tst
+select len(@i), @i
+select @i = trim(@i)
+select len(@i), @i
+go
+~~START~~
+int#!#varchar
+8#!# abc def
+~~END~~
+
+~~START~~
+int#!#varchar
+7#!#abc def
+~~END~~
+
+
+drop table local_var_str_tst;
+go
+
+-- $PARTITION is rewritten by ANTLR
+CREATE PARTITION FUNCTION RangePF1 ( INT )  
+AS RANGE RIGHT FOR VALUES (10, 100, 1000) ;  
+GO
+
+declare @res int = -1;
+SELECT @res = $PARTITION.RangePF1 (10);
+select @res
+select 1 where @res = $PARTITION.RangePF1 (10);
+SELECT @res = $PARTITION.RangePF1 (@res);
+select @res
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+DROP PARTITION FUNCTION RangePF1 
+GO
+
+CREATE SEQUENCE CountBy1  
+    START WITH 1  
+    INCREMENT BY 1 ;
+GO
+
+-- NEXT VALUE FOR gets re-written by ANTLR
+DECLARE @myvar1 BIGINT = NEXT VALUE FOR CountBy1 ;
+DECLARE @myvar2 BIGINT ;  
+DECLARE @myvar3 BIGINT ;  
+select @myvar2 = NEXT VALUE FOR CountBy1 ;  
+SELECT @myvar3 = NEXT VALUE FOR CountBy1 ;  
+SELECT @myvar1 AS myvar1, @myvar2 AS myvar2, @myvar3 AS myvar3 ;  
+GO
+~~START~~
+bigint#!#bigint#!#bigint
+1#!#2#!#3
+~~END~~
+
+
+DROP SEQUENCE CountBy1
+GO
+
+-- any @@ is also re-written by ANTLR
+declare @pid int = 0
+select @pid += @@spid
+select 1 where @pid = @@spid
+go
+~~START~~
+int
+1
+~~END~~
+
+
+-- float point notation also gets rewritten by ANTLR e.g., 2.1E, -.2e+, -2.e-
+declare @a float = 0
+select @a = 2.1E
+select @a
+select @a = -.2e+
+select @a 
+select @a = -2.e-
+select @a
+go
+~~START~~
+float
+2.1
+~~END~~
+
+~~START~~
+float
+-0.2
+~~END~~
+
+~~START~~
+float
+-2.0
+~~END~~
+
+
+-- variables only in select target list shows dynamic behavior
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1
+declare @j int = 0
+select @j += id, @i = id + 1  from local_var_tst where id = @i
+select @i, @j
+go
+~~START~~
+int#!#int
+2#!#2
+~~END~~
+
+
+declare @i int = 1
+select @i = id * 2 from local_var_tst where id = @i
+select @i
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_statistics profile On;
+GO
+
+declare @i int = 1
+declare @j int = 0
+select @j += id, @i = id + 1  from local_var_tst where id = @i
+select @i, @j
+go
+~~START~~
+text
+Query Text: select       sys.pltsql_assign_var(3, @j + cast((id) as int)),      sys.pltsql_assign_var(2, cast((id + 1) as int))  from local_var_tst where id = "@i"
+Seq Scan on local_var_tst  (cost=0.00..42.01 rows=13 width=8) (actual rows=2 loops=1)
+  Filter: (id = 1)
+  Rows Removed by Filter: 1
+~~END~~
+
+~~START~~
+int#!#int
+2#!#2
+~~END~~
+
+~~START~~
+text
+Query Text: select "@i", "@j"
+Result  (cost=0.00..0.01 rows=1 width=8) (actual rows=1 loops=1)
+~~END~~
+
+
+declare @i int = 1
+select @i = @i * 2 from local_var_tst where id = @i
+select @i
+GO
+~~START~~
+text
+Query Text: select      sys.pltsql_assign_var(2, cast((@i * 2) as int)) from local_var_tst where id = "@i"
+Seq Scan on local_var_tst  (cost=0.00..41.94 rows=13 width=4) (actual rows=2 loops=1)
+  Filter: (id = 1)
+  Rows Removed by Filter: 1
+~~END~~
+
+~~START~~
+int
+4
+~~END~~
+
+~~START~~
+text
+Query Text: select "@i"
+Result  (cost=0.00..0.01 rows=1 width=4) (actual rows=1 loops=1)
+~~END~~
+
+
+set babelfish_statistics profile OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+-- declared variable name with length > 63
+declare @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr += 1
+select @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- variable names starting with @@
+declare @@a int = 1;
+select @@a = @@a + 1
+select @@a 
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+declare @@a int = 1;
+select @@a += 1
+select @@a 
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr + 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+truncate table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (1)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr + id from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = id + @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr += id from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+~~START~~
+int
+5
+~~END~~
+
+
+truncate table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+GO
+~~ROW COUNT: 1~~
+
+
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+
+
+set babelfish_statistics profile On;
+GO
+
+-- error while evaluating const expression
+declare @a int = 1;
+select @a = 1 / 0 from local_var_tst
+select * from local_var_tst where id = @a
+GO
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+text
+Query Text: select * from local_var_tst where id = "@a"
+Seq Scan on local_var_tst  (cost=0.00..41.88 rows=13 width=4) (actual rows=1 loops=1)
+  Filter: (id = 1)
+~~END~~
+
+
+set babelfish_statistics profile OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+drop table local_var_tst
+GO
+
+create table ident_tst(id_num INT IDENTITY(1, 1), b varchar(10))
+GO
+
+insert into ident_tst values ('test')
+GO
+~~ROW COUNT: 1~~
+
+
+declare @a int = 1
+select @a = @@IDENTITY
+select @a
+select 1 where @a = @@IDENTITY
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- additional testing for update with dynamic variables
+GO
+
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+set QUOTED_IDENTIFIER on
+GO
+
+declare @i varchar(100)
+update local_var_tst set id = id + 10, @i = cast("xmax" as varchar(100))
+select 1 where @i IS NOT NULL
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+set QUOTED_IDENTIFIER off
+GO
+
+select * from local_var_tst order by id;
+GO
+~~START~~
+int
+11
+12
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- long identifier with update
+declare @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx int
+update local_var_tst set id =10, @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx = id
+select @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+10
+~~END~~
+
+
+select * from local_var_tst
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- @@ variables
+declare @@incnjkdnc int
+update local_var_tst set id =10, @@incnjkdnc = id
+select @@incnjkdnc
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+10
+~~END~~
+
+
+select * from local_var_tst
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int 
+update local_var_tst set id = id + 2, @i = id * 5;
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+20
+~~END~~
+
+
+select * from local_var_tst order by id;
+GO
+~~START~~
+int
+3
+4
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int, @j int;
+update local_var_tst set id =10, @i = case when @j =0 then 1 else 0 end;
+select @i, @j
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+0#!#<NULL>
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int, @j int;
+update local_var_tst set id = 10, @j = id, @i = case when @j =0 then 1 else 0 end;
+select @i, @j
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+0#!#10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int, @j int = 0
+update local_var_tst set id =10, @i = charindex('a','a',@j)
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+declare @i int, @j int = 0
+update local_var_tst set id =10, @i = charindex('a','a',@j);
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+declare @i int, @j int;
+update local_var_tst set id = 10, @j = id, @i = @j * 2
+select @i, @j
+go
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+20#!#10
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+10
+10
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i = id * 2 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+select * from local_var_tst
+go
+~~START~~
+int
+2
+1
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i += id * 2 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+3
+~~END~~
+
+
+select * from local_var_tst
+go
+~~START~~
+int
+2
+1
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i VARCHAR(200) = ''
+update local_var_tst set id = id * 2, @i = @i + cast(id as varchar(20))
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+24
+~~END~~
+
+
+select * from local_var_tst order by id
+go
+~~START~~
+int
+2
+4
+~~END~~
+
+
+-- @i should be NULL as no row passes the qual condition
+declare @i int 
+update local_var_tst set id =10, @i = id * 5 where id = 1
+select @i
+GO
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from local_var_tst order by id
+go
+~~START~~
+int
+2
+4
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i = id * 5 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+5
+~~END~~
+
+
+select * from local_var_tst order by id
+go
+~~START~~
+int
+1
+2
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int 
+set @i = 0
+update local_var_tst set id = @i, @i = id * 5
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+0
+0
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- trim is re-written by antlr
+declare @i varchar(200) 
+select @i = ''
+update local_var_tst set id = @i, @i = TRIM(@i + cast(id as varchar(10)));
+select @i
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+00
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+0
+0
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- variables in the where clause should be treated as const
+declare @i int = 1;
+update local_var_tst set id = @i * 100, @i = id * 2 where id = @i
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+200
+~~END~~
+
+
+select * from local_var_tst order by id;
+GO
+~~START~~
+int
+2
+100
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 1;
+update local_var_tst set id = @i * 100, @i = @@IDENTITY
+select @i
+select 1 where @i = @@IDENTITY
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+select * from local_var_tst
+GO
+~~START~~
+int
+100
+100
+~~END~~
+
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE PARTITION FUNCTION RangePF1 ( INT )  
+AS RANGE RIGHT FOR VALUES (10, 100, 1000) ;  
+GO
+
+declare @i int = -1;
+SELECT @i = $PARTITION.RangePF1 (10);
+select @i
+update local_var_tst set id = @i, @i = $PARTITION.RangePF1 (10);
+select @i
+GO
+~~START~~
+int
+2
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+select * from local_var_tst;
+GO
+~~START~~
+int
+2
+2
+~~END~~
+
+
+DROP PARTITION FUNCTION RangePF1 
+GO
+
+CREATE PROCEDURE var_with_procedure (@i int, @a numeric(10,4) OUTPUT) AS
+BEGIN
+  update local_var_tst set id = @i * 2, @a = id * 5 where id = @i
+  select @a
+END;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @input int = 1, @res int;
+exec var_with_procedure @input, @res
+select @res
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+numeric
+10.0000
+~~END~~
+
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+select * from local_var_tst
+go
+~~START~~
+int
+2
+2
+~~END~~
+
+
+declare @input int = 2, @a int;
+exec var_with_procedure @input, @a
+select @a
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+numeric
+20.0000
+~~END~~
+
+~~START~~
+int
+<NULL>
+~~END~~
+
+
+DROP PROCEDURE var_with_procedure;
+GO
+
+DROP TABLE local_var_tst
+GO
+
+create table local_var_tst_1 (id int) 
+GO
+
+insert into local_var_tst_1 values (1)
+insert into local_var_tst_1 values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create unique index idx_local_var_tst_1 on local_var_tst_1(id)
+GO
+
+
+SELECT set_config('enable_indexscan', '1', false);
+SELECT set_config('enable_indexonlyscan', '0', false);
+SELECT set_config('enable_seqscan', '0', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+~~START~~
+text
+off
+~~END~~
+
+
+declare @i int = 1
+update local_var_tst_1 set id = @i, @i = id * 5 where id = 1
+select @i
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+5
+~~END~~
+
+
+declare @i int = 1
+update local_var_tst_1 set id = 10 output deleted.id where id = 1
+select @i
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT set_config('enable_indexscan', '1', false);
+SELECT set_config('enable_indexonlyscan', '1', false);
+SELECT set_config('enable_seqscan', '1', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+~~START~~
+text
+on
+~~END~~
+
+
+DROP TABLE local_var_tst_1
+GO
+
+CREATE TABLE update_test_tbl (
+    age int,
+    fname char(10),
+    lname char(10),
+    city nchar(20)
+)
+GO
+
+TRUNCATE TABLE update_test_tbl
+GO
+
+INSERT INTO update_test_tbl(age, fname, lname, city) 
+VALUES  (50, 'fname1', 'lname1', 'london'),
+        (34, 'fname2', 'lname2', 'paris'),
+        (35, 'fname3', 'lname3', 'brussels'),
+        (90, 'fname4', 'lname4', 'new york'),
+        (26, 'fname5', 'lname5', 'los angeles'),
+        (74, 'fname6', 'lname6', 'tokyo'),
+        (44, 'fname7', 'lname7', 'oslo'),
+        (19, 'fname8', 'lname8', 'hong kong'),
+        (61, 'fname9', 'lname9', 'shanghai'),
+        (29, 'fname10', 'lname10', 'mumbai')
+GO
+~~ROW COUNT: 10~~
+
+
+CREATE TABLE update_test_tbl2 (
+    year int,
+    lname char(10),
+)
+GO
+
+TRUNCATE TABLE update_test_tbl2
+GO
+
+INSERT INTO update_test_tbl2(year, lname) 
+VALUES  (51, 'lname1'),
+        (34, 'lname3'),
+        (25, 'lname8'),
+        (95, 'lname9'),
+        (36, 'lname10')
+GO
+~~ROW COUNT: 5~~
+
+
+UPDATE update_test_tbl SET fname = 'fname13'
+FROM update_test_tbl t1
+INNER JOIN update_test_tbl2 t2
+ON t1.lname = t2.lname
+WHERE year > 50
+GO
+~~ROW COUNT: 2~~
+
+
+declare @a varchar(4000) = '';
+UPDATE update_test_tbl SET fname = 'fname13', @a = @a + fname
+FROM update_test_tbl t1
+INNER JOIN update_test_tbl2 t2
+ON t1.lname = t2.lname
+WHERE year > 50
+select @a
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+varchar
+fname13   fname13   
+~~END~~
+
+
+DROP TABLE update_test_tbl2;
+GO
+
+DROP TABLE update_test_tbl
+GO
+
+drop table ident_tst
+GO
+
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @i int = 0, @j int
+update local_var_tst set id = id + 2, @i = id, @j = @i * 2, @i = @j
+select @i, @j
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Babelfish does not support assignment to the same variable in SELECT. variable name: "@i")~~
+
+
+declare @i int = 0, @j int
+update local_var_tst set id = id + 2, @i += id, @j = @i * 2
+select @i, @j
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+int#!#int
+7#!#14
+~~END~~
+
+
+select * from local_var_tst order by id
+GO
+~~START~~
+int
+3
+4
+~~END~~
+
+
+drop table local_var_tst
+GO
+
+
+
+-- end of test_dynamic_local_vars
+-- Setup test table
+create table t1 (a int, b int, c varchar(50));
+go
+
+CREATE PROCEDURE reset_t1
+AS
+BEGIN
+    TRUNCATE TABLE t1;
+    INSERT INTO t1 VALUES (1, 10, 'first');
+    INSERT INTO t1 VALUES (2, 20, 'second');
+    INSERT INTO t1 VALUES (3, 30, 'third');
+    INSERT INTO t1 VALUES (4, 40, 'fourth');
+END
+GO
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Using local variable without assignment
+-- in targetlist
+declare @a int;
+set @a = 5;
+select a, b, @a as param_value from t1 where a < 3;
+go
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+CREATE PROCEDURE proc_targetlist_param @a int
+AS
+BEGIN
+    select a, b, @a as param_value from t1 where a < 3;
+END
+GO
+
+EXEC proc_targetlist_param @a = 5;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+DROP PROCEDURE proc_targetlist_param;
+GO
+
+EXEC sp_executesql N'select a, b, @a as param_value from t1 where a < 3', N'@a int', @a = 5;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+-- in qual
+declare @a int;
+set @a = 2;
+select * from t1 where a = @a;
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+CREATE PROCEDURE proc_qual_param @a int
+AS
+BEGIN
+    select * from t1 where a = @a;
+END
+GO
+
+EXEC proc_qual_param @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+DROP PROCEDURE proc_qual_param;
+GO
+
+EXEC sp_executesql N'select * from t1 where a = @a', N'@a int', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+declare @filter int;
+set @filter = 1;
+update t1 set b = 5942 where a = @filter;
+select * from t1 where a = @filter;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+CREATE PROCEDURE proc_update_filter @filter int
+AS
+BEGIN
+    update t1 set b = 5942 where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC reset_t1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+EXEC proc_update_filter @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_filter;
+GO
+
+EXEC reset_t1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+EXEC sp_executesql N'update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter', N'@filter int', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+create table t_temp (a int);
+insert into t_temp values (1), (2), (3), (4);
+declare @del_val int;
+set @del_val = 2;
+delete from t_temp where a = @del_val;
+select * from t_temp order by a;
+drop table t_temp;
+go
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- both
+declare @update_val int, @filter int;
+set @update_val = 100;
+set @filter = 1;
+update t1 set b = @update_val where a = @filter;
+select * from t1 where a = @filter;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+declare @filter int;
+set @filter = 1;
+update t1 set b = @filter where a = @filter;
+select * from t1 where a = @filter;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- top(NULL) from BABEL-1181
+-- Local variable in TOP clause
+declare @a int;
+set @a = 2;
+select top (@a) * from t1 order by a;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @a int;
+set @a = 2;
+select top (NULL) * from t1 order by a;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- TOP with NULL local variable (should error)
+declare @top_null int;
+set @top_null = NULL;
+select top (@top_null) * from t1;
+go
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- TOP with local variable from subquery
+declare @top_val int;
+set @top_val = (select 2);
+select top (@top_val) * from t1 order by a;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @top_val int;
+declare @fetch_val int;
+set @top_val = (select @fetch_val);
+select top (@top_val) * from t1 order by a;
+go
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Local variable assignment
+-- in targetlist
+declare @result int;
+select @result = b from t1 where a = 2;
+select @result;
+go
+~~START~~
+int
+20
+~~END~~
+
+
+-- Local variable assignment with parameter in target list and WHERE
+declare @i int, @result int;
+set @i = 2;
+select @result = b from t1 where a = @i;
+select @result;
+go
+~~START~~
+int
+20
+~~END~~
+
+
+declare @i int, @result int;
+set @i = 2;
+select @result = b + @i from t1 where a = @i;
+select @result;
+go
+~~START~~
+int
+22
+~~END~~
+
+
+-- Multiple local variable assignments
+declare @var1 int, @var2 int, @param int;
+set @param = 2;
+select @var1 = a, @var2 = b from t1 where a = @param;
+select @var1, @var2;
+go
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+-- Local variable assignment over multiple rows
+declare @result int, @threshold int;
+set @threshold = 2;
+select @result = sum(b) from t1 where a > @threshold;
+select @result;
+go
+~~START~~
+int
+70
+~~END~~
+
+
+-- Local variable in GROUP BY HAVING clause
+-- TODO: make tables with proper groups for this
+declare @having_val int;
+set @having_val = 15;
+select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a;
+go
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+create table group_table_t1 (a int, b int, c varchar(50));
+insert into group_table_t1 values (1, 3, '1abbcc');
+insert into group_table_t1 values (1, 4, 'a2bbcc');
+insert into group_table_t1 values (2, 5, 'aa3bcc');
+insert into group_table_t1 values (2, 6, 'aab4cc');
+insert into group_table_t1 values (3, 50000, 'aabb5c');
+insert into group_table_t1 values (3, 60000, 'aabbc6');
+declare @having_val int;
+set @having_val = 3;
+select a, sum(b) as total from group_table_t1 group by a having sum(b) > @having_val order by a;
+go
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#7
+2#!#11
+3#!#110000
+~~END~~
+
+declare @having_val int;
+set @having_val = 3;
+select @having_val = @having_val + 1234 from group_table_t1 group by b having sum(b) > @having_val;
+select @having_val
+go
+~~START~~
+int
+6173
+~~END~~
+
+
+drop table group_table_t1;
+go
+
+declare @having_val int;
+set @having_val = 15;
+select @having_val = @having_val + 1 from t1 group by a having sum(b) > @having_val;
+select @having_val
+go
+~~START~~
+int
+18
+~~END~~
+
+
+-- in CASE expression
+declare @threshold int;
+set @threshold = 2;
+select a, case when a > @threshold then 'high' else 'low' end as category from t1;
+go
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- local variable assignment in CASE with local variable assignment
+declare @threshold int, @result varchar(10);
+set @threshold = 2;
+select @result = case when a > @threshold then 'high' else 'low' end from t1 order by a;
+select @result;
+go
+~~START~~
+varchar
+high
+~~END~~
+
+
+declare @threshold int, @result varchar(10), @at int;
+set @threshold = 2;
+set @at = 3;
+select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at;
+select @result;
+go
+~~START~~
+varchar
+high
+~~END~~
+
+
+-- Local variable with string operations
+declare @search varchar(10);
+set @search = 'sec';
+select * from t1 where c like '%' + @search + '%';
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+declare @search varchar(10);
+set @search = 'i';
+select @search = @search + 'rd' from t1 where c like '%' + @search + '%';
+select @search;
+go
+~~START~~
+varchar
+irdrd
+~~END~~
+
+
+declare @result varchar(100), @prefix varchar(10);
+set @prefix = 'Value: ';
+select @result = @prefix + c from t1 order by a;
+select @result;
+go
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+declare @multiplier int;
+set @multiplier = 2;
+select a, (select @multiplier * b) as doubled_b from t1 where a < 3;
+go
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+declare @multiplier int;
+set @multiplier = 2;
+select a, (select @multiplier = @multiplier * b) from t1 where a < 3;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+declare @val int;
+set @val = 10;
+select a, (select b + (select @val)) as nested_calc from t1 where a < 3;
+go
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+declare @val int;
+set @val = 2;
+select * from t1 where b > (select max(b) from t1 where a < @val);
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+declare @val int;
+set @val = 2;
+select * from t1 where (select @val = @val + 1);
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'where' at line 3 and character position 17)~~
+
+
+declare @offset int;
+set @offset = 10;
+select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer;
+go
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+declare @null_param int;
+set @null_param = NULL;
+select * from t1 where a = @null_param;
+go
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- Local variable in CTE
+declare @cte_filter int;
+set @cte_filter = 2;
+with cte as (select * from t1 where a > @cte_filter)
+select * from cte;
+go
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+declare @cte_filter int;
+set @cte_filter = 1;
+with cte as (select * from t1 where a > @cte_filter)
+select @cte_filter = @cte_filter + 3 from cte;
+select @cte_filter;
+go
+~~START~~
+int
+10
+~~END~~
+
+
+declare @filter1 int, @filter2 int;
+set @filter1 = 1;
+set @filter2 = 3;
+with cte1 as (select * from t1 where a > @filter1),
+     cte2 as (select * from cte1 where a <= @filter2)
+select * from cte2;
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+declare @filter1 int, @filter2 int;
+set @filter1 = 1;
+with cte1 as (select * from t1 where a > @filter1),
+     cte2 as (select @filter1 = @filter1 + 3 from cte1)
+select * from cte2;
+go
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: variable assignment can be used only in top-level SELECT)~~
+
+
+declare @partition_val int;
+set @partition_val = 2;
+select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+go
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+declare @partition_val int;
+set @partition_val = 2;
+select @partition_val = @partition_val + 1, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+go
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Local variable assignment in UPDATE
+-- returned values for the `captured` variables _will_ differ from sql server (BABEL-5188)
+declare @captured int, @filter int;
+set @filter = 2;
+update t1 set b = b + 5, @captured = b where a = @filter;
+select @captured;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Multiple local variable assignments in UPDATE
+declare @captured1 int, @captured2 int, @filter int, @increment int;
+set @filter = 2;
+set @increment = 5;
+update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter;
+select @captured1, @captured2;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- UPDATE with local variable in subquery
+declare @multiplier int;
+set @multiplier = 2;
+update t1 set b = (select @multiplier * 10) where a = 1;
+select * from t1 where a = 1;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- DELETE with local variable in subquery
+create table t_temp (a int);
+insert into t_temp values (1), (2), (3), (4);
+declare @threshold int;
+set @threshold = 2;
+delete from t_temp where a in (select a from t_temp where a <= @threshold);
+select * from t_temp order by a;
+drop table t_temp;
+go
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- local variable in INSERT VALUES
+declare @val1 int, @val2 int;
+set @val1 = 5;
+set @val2 = 50;
+create table t_temp (a int, b int);
+insert into t_temp values (@val1, @val2);
+select * from t_temp;
+set @val1 = 51;
+set @val2 = 501;
+insert into t_temp values (@val1, @val2);
+select * from t_temp;
+drop table t_temp;
+go
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+51#!#501
+~~END~~
+
+
+-- local variable in OFFSET FETCH
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = NULL;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- OFFSET NULL should error (BABEL-6347)
+declare @offset_val int, @fetch_val int;
+set @offset_val = NULL;
+set @fetch_val = 2;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @offset_val int, @fetch_val int;
+set @fetch_val = 2;
+select * from t1 order by a offset NULL rows fetch next @fetch_val rows only;
+go
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select a, @fetch_val = NULL from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select a, @offset_val = NULL from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+~~ERROR (Code: 141)~~
+
+~~ERROR (Message: A SELECT statement that assigns a value to a variable must not be combined with data-retrieval operations)~~
+
+
+
+-- Additional procedure and planned statement versions
+-- Ref: delete with local variable
+CREATE PROCEDURE proc_delete_param @del_val int
+AS
+BEGIN
+    create table t_temp (a int);
+    insert into t_temp values (1), (2), (3), (4);
+    delete from t_temp where a = @del_val;
+    select * from t_temp order by a;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_delete_param @del_val = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+DROP PROCEDURE proc_delete_param;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a = @del_val; select * from t_temp order by a; drop table t_temp', N'@del_val int', @del_val = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- Ref: update with both local variables
+CREATE PROCEDURE proc_update_both @update_val int, @filter int
+AS
+BEGIN
+    update t1 set b = @update_val where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC proc_update_both @update_val = 100, @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_both;
+GO
+
+EXEC sp_executesql N'update t1 set b = @update_val where a = @filter; select * from t1 where a = @filter', N'@update_val int, @filter int', @update_val = 100, @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: update with same variable in both places
+CREATE PROCEDURE proc_update_same @filter int
+AS
+BEGIN
+    update t1 set b = @filter where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC proc_update_same @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_same;
+GO
+
+EXEC sp_executesql N'update t1 set b = @filter where a = @filter; select * from t1 where a = @filter', N'@filter int', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: TOP with local variable
+CREATE PROCEDURE proc_top_param @a int
+AS
+BEGIN
+    select top (@a) * from t1 order by a;
+END
+GO
+
+EXEC proc_top_param @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+DROP PROCEDURE proc_top_param;
+GO
+
+EXEC sp_executesql N'select top (@a) * from t1 order by a', N'@a int', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: TOP with NULL local variable
+CREATE PROCEDURE proc_top_null @top_null int
+AS
+BEGIN
+    select top (@top_null) * from t1;
+END
+GO
+
+EXEC proc_top_null @top_null = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP PROCEDURE proc_top_null;
+GO
+
+EXEC sp_executesql N'select top (@top_null) * from t1', N'@top_null int', @top_null = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Ref: TOP with local variable from subquery
+CREATE PROCEDURE proc_top_subquery
+AS
+BEGIN
+    select top (select NULL) * from t1 order by a;
+END
+GO
+
+EXEC proc_top_subquery;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP PROCEDURE proc_top_subquery;
+GO
+
+EXEC sp_executesql N'select top (select NULL) * from t1 order by a';
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Ref: local variable assignment in targetlist
+CREATE PROCEDURE proc_assign_targetlist @i int, @result int OUTPUT
+AS
+BEGIN
+    select @result = b from t1 where a = @i;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_targetlist @i = 2, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+DROP PROCEDURE proc_assign_targetlist;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = b from t1 where a = @i', N'@i int, @result int OUTPUT', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+-- Ref: local variable assignment with parameter in target and WHERE
+CREATE PROCEDURE proc_assign_both @i int, @result int OUTPUT
+AS
+BEGIN
+    select @result = b + @i from t1 where a = @i;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_both @i = 2, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+int
+22
+~~END~~
+
+
+DROP PROCEDURE proc_assign_both;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = b + @i from t1 where a = @i', N'@i int, @result int OUTPUT', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+22
+~~END~~
+
+
+-- Ref: multiple local variable assignments
+CREATE PROCEDURE proc_assign_multiple @param int, @var1 int OUTPUT, @var2 int OUTPUT
+AS
+BEGIN
+    select @var1 = a, @var2 = b from t1 where a = @param;
+END
+GO
+
+declare @out1 int, @out2 int;
+EXEC proc_assign_multiple @param = 2, @var1 = @out1 OUTPUT, @var2 = @out2 OUTPUT;
+select @out1, @out2;
+GO
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+DROP PROCEDURE proc_assign_multiple;
+GO
+
+declare @var1 int, @var2 int;
+EXEC sp_executesql N'select @var1 = a, @var2 = b from t1 where a = @param', N'@param int, @var1 int OUTPUT, @var2 int OUTPUT', @param = 2, @var1 = @var1 OUTPUT, @var2 = @var2 OUTPUT;
+select @var1, @var2;
+GO
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+-- Ref: local variable assignment over multiple rows
+CREATE PROCEDURE proc_assign_aggregate @threshold int, @result int OUTPUT
+AS
+BEGIN
+    select @result = sum(b) from t1 where a > @threshold;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_aggregate @threshold = 2, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+int
+70
+~~END~~
+
+
+DROP PROCEDURE proc_assign_aggregate;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = sum(b) from t1 where a > @threshold', N'@threshold int, @result int OUTPUT', @threshold = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+70
+~~END~~
+
+
+-- Ref: local variable in GROUP BY HAVING
+CREATE PROCEDURE proc_having_param @having_val int
+AS
+BEGIN
+    select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a;
+END
+GO
+
+EXEC proc_having_param @having_val = 15;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+DROP PROCEDURE proc_having_param;
+GO
+
+EXEC sp_executesql N'select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a', N'@having_val int', @having_val = 15;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+-- Ref: CASE expression with local variable
+CREATE PROCEDURE proc_case_param @threshold int
+AS
+BEGIN
+    select a, case when a > @threshold then 'high' else 'low' end as category from t1;
+END
+GO
+
+EXEC proc_case_param @threshold = 2;
+GO
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+DROP PROCEDURE proc_case_param;
+GO
+
+EXEC sp_executesql N'select a, case when a > @threshold then ''high'' else ''low'' end as category from t1', N'@threshold int', @threshold = 2;
+GO
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- Ref: local variable assignment in CASE
+CREATE PROCEDURE proc_case_assign @threshold int, @at int, @result varchar(10) OUTPUT
+AS
+BEGIN
+    select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at;
+END
+GO
+
+declare @out varchar(10);
+EXEC proc_case_assign @threshold = 2, @at = 3, @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+varchar
+high
+~~END~~
+
+
+DROP PROCEDURE proc_case_assign;
+GO
+
+declare @result varchar(10);
+EXEC sp_executesql N'select @result = case when a > @threshold then ''high'' else ''low'' end from t1 where a = @at', N'@threshold int, @at int, @result varchar(10) OUTPUT', @threshold = 2, @at = 3, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+high
+~~END~~
+
+
+-- Ref: local variable with string operations
+CREATE PROCEDURE proc_string_like @search varchar(10)
+AS
+BEGIN
+    select * from t1 where c like '%' + @search + '%';
+END
+GO
+
+EXEC proc_string_like @search = 'sec';
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+DROP PROCEDURE proc_string_like;
+GO
+
+EXEC sp_executesql N'select * from t1 where c like ''%'' + @search + ''%''', N'@search varchar(10)', @search = 'sec';
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: string concatenation with assignment
+CREATE PROCEDURE proc_string_concat @prefix varchar(10), @result varchar(100) OUTPUT
+AS
+BEGIN
+    select @result = @prefix + c from t1 order by a;
+END
+GO
+
+declare @out varchar(100);
+EXEC proc_string_concat @prefix = 'Value: ', @result = @out OUTPUT;
+select @out;
+GO
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+DROP PROCEDURE proc_string_concat;
+GO
+
+declare @result varchar(100);
+EXEC sp_executesql N'select @result = @prefix + c from t1 order by a', N'@prefix varchar(10), @result varchar(100) OUTPUT', @prefix = 'Value: ', @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+-- Ref: subquery with local variable
+CREATE PROCEDURE proc_subquery_param @multiplier int
+AS
+BEGIN
+    select a, (select @multiplier * b) as doubled_b from t1 where a < 3;
+END
+GO
+
+EXEC proc_subquery_param @multiplier = 2;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+DROP PROCEDURE proc_subquery_param;
+GO
+
+EXEC sp_executesql N'select a, (select @multiplier * b) as doubled_b from t1 where a < 3', N'@multiplier int', @multiplier = 2;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+-- Ref: nested subquery with local variable
+CREATE PROCEDURE proc_nested_subquery @val int
+AS
+BEGIN
+    select a, (select b + (select @val)) as nested_calc from t1 where a < 3;
+END
+GO
+
+EXEC proc_nested_subquery @val = 10;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+DROP PROCEDURE proc_nested_subquery;
+GO
+
+EXEC sp_executesql N'select a, (select b + (select @val)) as nested_calc from t1 where a < 3', N'@val int', @val = 10;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+-- Ref: subquery in WHERE with local variable
+CREATE PROCEDURE proc_where_subquery @val int
+AS
+BEGIN
+    select * from t1 where b > (select max(b) from t1 where a < @val);
+END
+GO
+
+EXEC proc_where_subquery @val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+DROP PROCEDURE proc_where_subquery;
+GO
+
+EXEC sp_executesql N'select * from t1 where b > (select max(b) from t1 where a < @val)', N'@val int', @val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: correlated subquery with local variable
+CREATE PROCEDURE proc_correlated_subquery @offset int
+AS
+BEGIN
+    select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer;
+END
+GO
+
+EXEC proc_correlated_subquery @offset = 10;
+GO
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+DROP PROCEDURE proc_correlated_subquery;
+GO
+
+EXEC sp_executesql N'select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer', N'@offset int', @offset = 10;
+GO
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+-- Ref: NULL parameter
+CREATE PROCEDURE proc_null_param @null_param int
+AS
+BEGIN
+    select * from t1 where a = @null_param;
+END
+GO
+
+EXEC proc_null_param @null_param = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+DROP PROCEDURE proc_null_param;
+GO
+
+EXEC sp_executesql N'select * from t1 where a = @null_param', N'@null_param int', @null_param = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- Ref: CTE with local variable
+CREATE PROCEDURE proc_cte_param @cte_filter int
+AS
+BEGIN
+    with cte as (select * from t1 where a > @cte_filter)
+    select * from cte;
+END
+GO
+
+EXEC proc_cte_param @cte_filter = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+DROP PROCEDURE proc_cte_param;
+GO
+
+EXEC sp_executesql N'with cte as (select * from t1 where a > @cte_filter) select * from cte', N'@cte_filter int', @cte_filter = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: multiple CTEs with local variables
+CREATE PROCEDURE proc_multiple_cte @filter1 int, @filter2 int
+AS
+BEGIN
+    with cte1 as (select * from t1 where a > @filter1),
+         cte2 as (select * from cte1 where a <= @filter2)
+    select * from cte2;
+END
+GO
+
+EXEC proc_multiple_cte @filter1 = 1, @filter2 = 3;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+DROP PROCEDURE proc_multiple_cte;
+GO
+
+EXEC sp_executesql N'with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2', N'@filter1 int, @filter2 int', @filter1 = 1, @filter2 = 3;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: window function with local variable
+CREATE PROCEDURE proc_window_param @partition_val int
+AS
+BEGIN
+    select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+END
+GO
+
+EXEC proc_window_param @partition_val = 2;
+GO
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+DROP PROCEDURE proc_window_param;
+GO
+
+EXEC sp_executesql N'select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1', N'@partition_val int', @partition_val = 2;
+GO
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+-- Ref: UPDATE with local variable assignment
+CREATE PROCEDURE proc_update_assign @filter int, @captured int OUTPUT
+AS
+BEGIN
+    update t1 set b = b + 5, @captured = b where a = @filter;
+END
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @out int;
+EXEC proc_update_assign @filter = 2, @captured = @out OUTPUT;
+select @out;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+DROP PROCEDURE proc_update_assign;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @captured int;
+EXEC sp_executesql N'update t1 set b = b + 5, @captured = b where a = @filter', N'@filter int, @captured int OUTPUT', @filter = 2, @captured = @captured OUTPUT;
+select @captured;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with multiple assignments
+CREATE PROCEDURE proc_update_multi_assign @filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT
+AS
+BEGIN
+    update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter;
+END
+GO
+
+declare @out1 int, @out2 int;
+EXEC proc_update_multi_assign @filter = 2, @increment = 5, @captured1 = @out1 OUTPUT, @captured2 = @out2 OUTPUT;
+select @out1, @out2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+DROP PROCEDURE proc_update_multi_assign;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @captured1 int, @captured2 int;
+EXEC sp_executesql N'update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter', N'@filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT', @filter = 2, @increment = 5, @captured1 = @captured1 OUTPUT, @captured2 = @captured2 OUTPUT;
+select @captured1, @captured2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with subquery
+CREATE PROCEDURE proc_update_subquery @multiplier int
+AS
+BEGIN
+    update t1 set b = (select @multiplier * 10) where a = 1;
+    select * from t1 where a = 1;
+END
+GO
+
+EXEC proc_update_subquery @multiplier = 2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+DROP PROCEDURE proc_update_subquery;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+EXEC sp_executesql N'update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1', N'@multiplier int', @multiplier = 2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: DELETE with subquery
+CREATE PROCEDURE proc_delete_subquery @threshold int
+AS
+BEGIN
+    create table t_temp (a int);
+    insert into t_temp values (1), (2), (3), (4);
+    delete from t_temp where a in (select a from t_temp where a <= @threshold);
+    select * from t_temp order by a;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_delete_subquery @threshold = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+DROP PROCEDURE proc_delete_subquery;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a in (select a from t_temp where a <= @threshold); select * from t_temp order by a; drop table t_temp', N'@threshold int', @threshold = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- Ref: INSERT with local variables
+CREATE PROCEDURE proc_insert_params @val1 int, @val2 int
+AS
+BEGIN
+    create table t_temp (a int, b int);
+    insert into t_temp values (@val1, @val2);
+    select * from t_temp;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_insert_params @val1 = 5, @val2 = 50;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+DROP PROCEDURE proc_insert_params;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int, b int); insert into t_temp values (@val1, @val2); select * from t_temp; drop table t_temp', N'@val1 int, @val2 int', @val1 = 5, @val2 = 50;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+-- Ref: OFFSET FETCH with local variables
+CREATE PROCEDURE proc_offset_fetch @offset_val int, @fetch_val int
+AS
+BEGIN
+    select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+END
+GO
+
+EXEC proc_offset_fetch @offset_val = 1, @fetch_val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+DROP PROCEDURE proc_offset_fetch;
+GO
+
+EXEC sp_executesql N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', N'@offset_val int, @fetch_val int', @offset_val = 1, @fetch_val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: OFFSET FETCH with NULL fetch
+CREATE PROCEDURE proc_offset_null_fetch @offset_val int, @fetch_val int
+AS
+BEGIN
+    select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+END
+GO
+
+EXEC proc_offset_null_fetch @offset_val = 1, @fetch_val = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP PROCEDURE proc_offset_null_fetch;
+GO
+
+EXEC sp_executesql N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', N'@offset_val int, @fetch_val int', @offset_val = 1, @fetch_val = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: targetlist param
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select a, b, @a as param_value from t1 where a < 3', @a = 5;
+GO
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+-- Ref: qual param
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select * from t1 where a = @a', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: update filter
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int', N'update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+
+EXEC reset_t1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: delete with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@del_val int', N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a = @del_val; select * from t_temp order by a; drop table t_temp', @del_val = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- Ref: update with both local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@update_val int, @filter int', N'update t1 set b = @update_val where a = @filter; select * from t1 where a = @filter', @update_val = 100, @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: update with same variable in both places
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int', N'update t1 set b = @filter where a = @filter; select * from t1 where a = @filter', @filter = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+
+EXEC reset_t1
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+-- Ref: TOP with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select top (@a) * from t1 order by a', @a = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: TOP with NULL local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@top_null int', N'select top (@top_null) * from t1', @top_null = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- Ref: local variable assignment in targetlist
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@i int, @result int OUTPUT', N'select @result = b from t1 where a = @i', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+20
+~~END~~
+
+
+-- Ref: local variable assignment with parameter in target and WHERE
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@i int, @result int OUTPUT', N'select @result = b + @i from t1 where a = @i', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+22
+~~END~~
+
+
+-- Ref: multiple local variable assignments
+declare @var1 int, @var2 int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@param int, @var1 int OUTPUT, @var2 int OUTPUT', N'select @var1 = a, @var2 = b from t1 where a = @param', @param = 2, @var1 = @var1 OUTPUT, @var2 = @var2 OUTPUT;
+select @var1, @var2;
+GO
+~~START~~
+int#!#int
+2#!#20
+~~END~~
+
+
+-- Ref: local variable assignment over multiple rows
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int, @result int OUTPUT', N'select @result = sum(b) from t1 where a > @threshold', @threshold = 2, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+int
+70
+~~END~~
+
+
+-- Ref: local variable in GROUP BY HAVING
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@having_val int', N'select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a', @having_val = 15;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+-- Ref: CASE expression with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int', N'select a, case when a > @threshold then ''high'' else ''low'' end as category from t1', @threshold = 2;
+GO
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- Ref: local variable assignment in CASE
+declare @result varchar(10);
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int, @at int, @result varchar(10) OUTPUT', N'select @result = case when a > @threshold then ''high'' else ''low'' end from t1 where a = @at', @threshold = 2, @at = 3, @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+high
+~~END~~
+
+
+-- Ref: local variable with string operations
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@search varchar(10)', N'select * from t1 where c like ''%'' + @search + ''%''', @search = 'sec';
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- Ref: string concatenation with assignment
+declare @result varchar(100);
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@prefix varchar(10), @result varchar(100) OUTPUT', N'select @result = @prefix + c from t1 order by a', @prefix = 'Value: ', @result = @result OUTPUT;
+select @result;
+GO
+~~START~~
+varchar
+Value: fourth
+~~END~~
+
+
+-- Ref: subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@multiplier int', N'select a, (select @multiplier * b) as doubled_b from t1 where a < 3', @multiplier = 2;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+-- Ref: nested subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val int', N'select a, (select b + (select @val)) as nested_calc from t1 where a < 3', @val = 10;
+GO
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+-- Ref: subquery in WHERE with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val int', N'select * from t1 where b > (select max(b) from t1 where a < @val)', @val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: correlated subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset int', N'select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer', @offset = 10;
+GO
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+-- Ref: NULL parameter
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@null_param int', N'select * from t1 where a = @null_param', @null_param = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- Ref: CTE with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@cte_filter int', N'with cte as (select * from t1 where a > @cte_filter) select * from cte', @cte_filter = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- Ref: multiple CTEs with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter1 int, @filter2 int', N'with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2', @filter1 = 1, @filter2 = 3;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: window function with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@partition_val int', N'select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1', @partition_val = 2;
+GO
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+-- Ref: UPDATE with local variable assignment
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+declare @captured int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int, @captured int OUTPUT', N'update t1 set b = b + 5, @captured = b where a = @filter', @filter = 2, @captured = @captured OUTPUT;
+select @captured;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+25
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with multiple assignments
+declare @captured1 int, @captured2 int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT', N'update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter', @filter = 2, @increment = 5, @captured1 = @captured1 OUTPUT, @captured2 = @captured2 OUTPUT;
+select @captured1, @captured2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+2#!#27
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: UPDATE with subquery
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@multiplier int', N'update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1', @multiplier = 2;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+~~ROW COUNT: 4~~
+
+
+-- Ref: DELETE with subquery
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int', N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a in (select a from t_temp where a <= @threshold); select * from t_temp order by a; drop table t_temp', @threshold = 2;
+GO
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- Ref: INSERT with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val1 int, @val2 int', N'create table t_temp (a int, b int); insert into t_temp values (@val1, @val2); select * from t_temp; drop table t_temp', @val1 = 5, @val2 = 50;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+-- Ref: OFFSET FETCH with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset_val int, @fetch_val int', N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', @offset_val = 1, @fetch_val = 2;
+GO
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- Ref: OFFSET FETCH with NULL fetch
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset_val int, @fetch_val int', N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', @offset_val = 1, @fetch_val = NULL;
+GO
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+
+-- cleanup
+drop procedure reset_t1;
+go
+
+drop table t1;
+go

--- a/test/JDBC/expected/params_in_generic_plan_rpc.out
+++ b/test/JDBC/expected/params_in_generic_plan_rpc.out
@@ -1,0 +1,355 @@
+CREATE TABLE t1 (a int, b int, c varchar(50));
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+SELECT set_config('plan_cache_mode', 'force_generic_plan', false);
+~~START~~
+text
+force_generic_plan
+~~END~~
+
+
+-- select with parameter in targetlist and WHERE
+prepst#!#select a, b, ? as param_value from t1 where a < 3#!#int|-|a|-|5
+~~START~~
+int#!#int#!#int
+1#!#10#!#5
+2#!#20#!#5
+~~END~~
+
+
+-- select with parameter in WHERE
+prepst#!#select * from t1 where a = ?#!#int|-|a|-|2
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+~~END~~
+
+
+-- update with parameter in WHERE and select
+prepst#!#update t1 set b = 5942 where a = ?; select * from t1 where a = ?#!#int|-|filter|-|1#!#int|-|filter|-|1
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#5942#!#first
+~~END~~
+
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+
+-- create temp table, delete with parameter, select, drop
+prepst#!#create table t_temp4 (a int); insert into t_temp4 values (1), (2), (3), (4); delete from t_temp4 where a = ?; select * from t_temp4 order by a; drop table t_temp4#!#int|-|delval|-|2
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+3
+4
+~~END~~
+
+
+-- update with two parameters (three param uses total)
+prepst#!#update t1 set b = ? where a = ?; select * from t1 where a = ?#!#int|-|updateval|-|100#!#int|-|filter|-|1#!#int|-|filter|-|1
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#100#!#first
+~~END~~
+
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+
+-- update with same parameter in SET and WHERE (three uses)
+prepst#!#update t1 set b = ? where a = ?; select * from t1 where a = ?#!#int|-|filter|-|1#!#int|-|filter|-|1#!#int|-|filter|-|1
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#1#!#first
+~~END~~
+
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+
+-- TOP with parameter
+prepst#!#select top (?) * from t1 order by a#!#int|-|a|-|2
+~~START~~
+int#!#int#!#varchar
+1#!#10#!#first
+2#!#20#!#second
+~~END~~
+
+
+-- TOP with NULL parameter
+prepst#!#select top (?) * from t1#!#int|-|topnull|-|<NULL>
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- TOP with subquery returning NULL
+prepst#!#select top (select NULL) * from t1 order by a
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+-- variable assignment in targetlist with OUTPUT parameter
+prepst#!#select ? = b from t1 where a = ?#!#int|-|i|-|2#!#int|-|result|-|<NULL>
+
+-- variable assignment with parameter in expression and WHERE (i used twice)
+prepst#!#select ? = b + ? from t1 where a = ?#!#int|-|i|-|2#!#int|-|i|-|2#!#int|-|result|-|<NULL>
+
+-- multiple variable assignments with OUTPUT parameters
+prepst#!#select ? = a, ? = b from t1 where a = ?#!#int|-|param|-|2#!#int|-|var1|-|<NULL>#!#int|-|var2|-|<NULL>
+
+-- aggregate with variable assignment
+prepst#!#select ? = sum(b) from t1 where a > ?#!#int|-|threshold|-|2#!#int|-|result|-|<NULL>
+
+-- GROUP BY HAVING with parameter
+prepst#!#select a, sum(b) as total from t1 group by a having sum(b) > ? order by a#!#int|-|havingval|-|15
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+4#!#40
+~~END~~
+
+
+-- CASE expression with parameter
+prepst#!#select a, case when a > ? then 'high' else 'low' end as category from t1#!#int|-|threshold|-|2
+~~START~~
+int#!#varchar
+1#!#low
+2#!#low
+3#!#high
+4#!#high
+~~END~~
+
+
+-- CASE with variable assignment and OUTPUT
+prepst#!#select ? = case when a > ? then 'high' else 'low' end from t1 where a = ?#!#int|-|threshold|-|2#!#int|-|at|-|3#!#varchar(10)|-|result|-|<NULL>
+
+-- subquery with parameter
+prepst#!#select a, (select ? * b) as doubled_b from t1 where a < 3#!#int|-|multiplier|-|2
+~~START~~
+int#!#int
+1#!#20
+2#!#40
+~~END~~
+
+
+-- nested subquery with parameter
+prepst#!#select a, (select b + (select ?)) as nested_calc from t1 where a < 3#!#int|-|val|-|10
+~~START~~
+int#!#int
+1#!#20
+2#!#30
+~~END~~
+
+
+-- subquery in WHERE with parameter
+prepst#!#select * from t1 where b > (select max(b) from t1 where a < ?)#!#int|-|val|-|2
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- correlated subquery with parameter
+prepst#!#select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + ?) as count_greater from t1 t_outer#!#int|-|offset|-|10
+~~START~~
+int#!#int
+1#!#2
+2#!#1
+3#!#0
+4#!#0
+~~END~~
+
+
+-- NULL parameter
+prepst#!#select * from t1 where a = ?#!#int|-|nullparam|-|<NULL>
+~~START~~
+int#!#int#!#varchar
+~~END~~
+
+
+-- CTE with parameter
+prepst#!#with cte as (select * from t1 where a > ?) select * from cte#!#int|-|ctefilter|-|2
+~~START~~
+int#!#int#!#varchar
+3#!#30#!#third
+4#!#40#!#fourth
+~~END~~
+
+
+-- multiple CTEs with parameters
+prepst#!#with cte1 as (select * from t1 where a > ?), cte2 as (select * from cte1 where a <= ?) select * from cte2#!#int|-|filter1|-|1#!#int|-|filter2|-|3
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- window function with parameter
+prepst#!#select a, b, row_number() over (order by case when a > ? then a else b end) as rn from t1#!#int|-|partitionval|-|2
+~~START~~
+int#!#int#!#bigint
+3#!#30#!#1
+4#!#40#!#2
+1#!#10#!#3
+2#!#20#!#4
+~~END~~
+
+
+-- UPDATE with variable assignment
+prepst#!#update t1 set b = b + 5, ? = b where a = ?#!#int|-|filter|-|2#!#int|-|captured|-|<NULL>
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+
+-- UPDATE with multiple variable assignments (filter, increment, captured1 used twice, captured2)
+prepst#!#update t1 set b = b + ?, ? = a, ? = ? + b where a = ?#!#int|-|filter|-|2#!#int|-|increment|-|5#!#int|-|captured1|-|<NULL>#!#int|-|captured1|-|<NULL>#!#int|-|captured2|-|<NULL>
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+
+-- UPDATE with subquery
+prepst#!#update t1 set b = (select ? * 10) where a = 1; select * from t1 where a = 1#!#int|-|multiplier|-|2
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+1#!#20#!#first
+~~END~~
+
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (2, 20, 'second');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (3, 30, 'third');
+~~ROW COUNT: 1~~
+
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+~~ROW COUNT: 1~~
+
+
+-- DELETE with subquery
+prepst#!#create table t_temp5 (a int); insert into t_temp5 values (1), (2), (3), (4); delete from t_temp5 where a in (select a from t_temp5 where a <= ?); select * from t_temp5 order by a; drop table t_temp5#!#int|-|threshold|-|2
+~~ROW COUNT: 4~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+3
+4
+~~END~~
+
+
+-- INSERT with parameters
+prepst#!#create table t_temp6 (a int, b int); insert into t_temp6 values (?, ?); select * from t_temp6; drop table t_temp6#!#int|-|val1|-|5#!#int|-|val2|-|50
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+5#!#50
+~~END~~
+
+
+-- OFFSET FETCH with parameters
+prepst#!#select * from t1 order by a offset ? rows fetch next ? rows only#!#int|-|offsetval|-|1#!#int|-|fetchval|-|2
+~~START~~
+int#!#int#!#varchar
+2#!#20#!#second
+3#!#30#!#third
+~~END~~
+
+
+-- OFFSET FETCH with NULL fetch
+prepst#!#select * from t1 order by a offset ? rows fetch next ? rows only#!#int|-|offsetval|-|1#!#int|-|fetchval|-|<NULL>
+~~START~~
+int#!#int#!#varchar
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: A TOP or FETCH clause contains an invalid value.)~~
+
+
+DROP TABLE t1;

--- a/test/JDBC/input/params_in_generic_plan.sql
+++ b/test/JDBC/input/params_in_generic_plan.sql
@@ -1,0 +1,2522 @@
+SELECT set_config('plan_cache_mode', 'force_generic_plan', false);
+go
+
+-- test_dynamic_local_vars
+-- parallel_query_expected
+-- simple vars
+declare @i int
+declare @j int
+set @i = 10
+set @j = @i + 10
+select @i, @j
+GO
+
+declare @i int
+declare @j int
+select @i = 10, @j = @i + 10
+select @i, @j
+GO
+
+declare @i int
+declare @j int = 0;
+select @i = 10, @j = @i + @j * 2
+select @i, @j
+GO
+
+declare @i int
+declare @j int
+select @i = 10, @j = @i + 10
+select @j += 10
+select @i, @j
+GO
+
+-- should throw an error
+declare @i int 
+select @i = 0, @i += 2
+select @i
+GO
+
+declare @i int
+select @i = 10, @i += 10
+select @i
+GO
+
+-- sub-expr
+declare @i int
+set @i = 10
+select @i += (5 - 1)
+select @i
+GO
+
+DECLARE @a int
+select @a = (select ~cast('1' as int))
+select @a
+go
+
+DECLARE @Counter INT = 1;
+DECLARE @MaxValue INT = 10;
+
+WHILE @Counter <= @MaxValue
+BEGIN
+    DECLARE @IsEven BIT;
+    
+    IF @Counter % 2 = 0
+        SET @IsEven = 1;
+    ELSE
+        SET @IsEven = 0;
+    
+    IF @IsEven = 1
+        SELECT CAST(@Counter AS VARCHAR(2)) + ' is even';
+    ELSE
+        SELECT CAST(@Counter AS VARCHAR(2)) + ' is odd';
+    
+    SET @Counter = @Counter + 1;
+END;
+GO
+
+declare @a numeric (10, 4);
+declare @b numeric (10, 4);
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+
+declare @a numeric;
+declare @b numeric (10, 4);
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+
+declare @a varbinary
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+
+declare @a varbinary(max)
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+
+declare @a varbinary(10)
+set @a = cast('test_bin' as varbinary)
+select @a
+GO
+
+declare @a varbinary
+declare @b varbinary
+select @a = cast('test_bin' as varbinary), @b = @a
+select @a, @b
+GO
+
+declare @a varbinary(max)
+select @a = cast('test_bin' as varbinary)
+select @a
+GO
+
+DECLARE @a varchar
+set @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @v varchar(20);
+SELECT @v = NULL;
+SELECT ISNUMERIC(@v), LEN(@v), DATALENGTH(@v)
+GO
+
+DECLARE @a varchar(max)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+-- collate can not be used with local variables
+DECLARE @v varchar(20) collate BBF_Unicode_CP1_CI_As = 'ci_as';
+GO
+
+declare @source int;
+declare @target sql_variant;
+select @source = 1.0
+select @target = cast(@source as varchar(10));
+SELECT sql_variant_property(@target, 'basetype');
+select @target
+GO
+
+declare @source int;
+declare @target varchar(10);
+select @source = 1.0
+select cast(@source as varchar(10))
+select @target = cast(@source as varchar(10));
+select @target
+GO
+
+DECLARE @a pg_catalog.varchar
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @a pg_catalog.varchar(100)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @a pg_catalog.varchar(10)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @a varchar
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @a varchar(100)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @a varchar(10)
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DECLARE @a int
+set @a = 0
+select @a ^= 1
+select @a
+go
+
+DECLARE @a int
+set @a = 0
+select @a += ~@a
+select @a
+go
+
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- quoted identifiers
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += "a""b''c'd", @v2 += "x""y''z";
+select @v, @v2
+GO
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += "a""b''c'd", @v2 += @v + "x""y''z";
+select @v, @v2
+GO
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += @v + "x""y''z";
+select @v, @v2
+GO
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += @v + reverse("x""y''z");
+select @v, @v2
+GO
+
+declare @v varchar(20) = "ABC", @v2 varchar(20)="XYZ";
+select @v += reverse("a""b''c'd"), @v2 += REVERSE( @v + reverse("x""y''z"));
+select @v, @v2
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+declare @v varchar(20) = 'ABC', @v2 varchar(20)='XYZ';
+select @v += 'abc', @v2 += 'xyz';
+select @v, @v2
+GO
+
+declare @a int = 1, @b int = 2;
+select @a = 2, @b = @a + 2
+select @a, @b
+GO
+
+declare @a int = 1, @b int = 2;
+select @a += 2, @b -= @a + 2
+select @a, @b
+GO
+
+-- xml methods
+DECLARE @a bit = 1
+DECLARE @xml XML = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>'
+SELECT @a |= @xml.exist('/artists/artist/@name')
+select @a
+GO
+
+DECLARE @a bit = 1
+DECLARE @xml XML;
+SELECT @xml  = '<artists> <artist name="John Doe"/> <artist name="Edward Poe"/> <artist name="Mark The Great"/> </artists>', @a |= @xml.exist('/artists/artist/@name')
+select @a
+GO
+
+-- test all kind of udts
+create type udt from NCHAR
+go
+
+declare @a udt
+select @a = 'anc'
+select @a
+GO
+
+DROP type udt 
+GO
+
+create type varchar_max from varchar(max)
+GO
+
+DECLARE @a varchar_max
+SELECT @a = '12345678901234567890123456789012345';
+SELECT LEN(@a), DATALENGTH(@a)
+SELECT @a
+GO
+
+DROP type varchar_max
+GO
+
+create type num_def from numeric
+GO
+
+declare @a numeric;
+declare @b num_def;
+SET @a=100.41;
+SET @b=200.82;
+SELECT @a, @b
+select @a+@b as r;
+GO
+
+drop type num_def
+GO
+
+/*
+ * select/update test
+ */
+create table local_var_tst (id int) 
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (6)
+GO
+
+-- txn does not affect local variables
+begin tran
+declare @i int 
+update local_var_tst set id = 5, @i = id * 5
+select @i
+ROLLBACK tran
+select @i
+GO
+
+select * from local_var_tst;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+-- should return 4
+declare @i int 
+select @i = 1
+select @i = id * 2 from local_var_tst where id = @i
+select @i
+GO
+
+declare @i int 
+select @i = 1
+select @i = @i + id * 2 from local_var_tst
+select @i
+GO
+
+declare @i int 
+select @i = 1
+select @i = id * 2 + @i from local_var_tst
+select @i
+GO
+
+declare @i int 
+select @i = 1
+select @i += id * 2 from local_var_tst
+select @i
+GO
+
+-- 3 parts name 
+declare @i int 
+select @i = 1
+select @i += master.dbo.local_var_tst.id * 2 from local_var_tst
+select @i
+GO
+
+-- local var name same as column
+declare @id int = 1
+select @id += master.dbo.local_var_tst.id * 2 from local_var_tst
+select @id
+GO
+
+-- should throw an error
+declare @i int
+declare @j int
+set @i = 10
+set @j = 0;
+select @i += (select @j = @j + id from local_var_tst)
+select @i
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+DECLARE @ans INT
+SELECT @ans = AVG(id) FROM local_var_tst
+select @ans
+GO
+
+-- local variable inside functions
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans = AVG(id) FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func();
+GO
+
+DROP FUNCTION var_inside_func();
+GO
+
+-- show throw an error
+CREATE FUNCTION var_inside_func()
+RETURNS @tab table (a int) as
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans += id from local_var_tst
+    select @ans
+END
+GO
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    SELECT @ans += id FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func()
+go
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func(@def int)
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT;
+    select @ans = @def;
+    SELECT @ans += id FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func(0)
+go
+
+declare @def int = 1;
+select var_inside_func(@def)
+go
+
+drop function if exists var_inside_func
+go
+
+CREATE FUNCTION var_inside_func()
+RETURNS INT AS
+BEGIN
+    DECLARE @ans INT
+    select @ans = 0
+    SELECT @ans += id + @ans FROM local_var_tst
+    RETURN @ans
+END
+GO
+
+select var_inside_func()
+go
+
+drop function if exists var_inside_func
+go
+
+-- variable with procedure
+CREATE PROCEDURE var_with_procedure (@a numeric(10,4) OUTPUT) AS
+BEGIN
+  SET @a=100.41;
+  select @a as a;
+END;
+GO
+
+exec var_with_procedure 2.000;
+GO
+
+-- value of @out should remain 2.000
+declare @out numeric(10,4);
+set @out = 2.000;
+exec var_with_procedure 2.000;
+select @out
+GO
+
+drop procedure var_with_procedure;
+GO
+
+CREATE PROCEDURE var_with_procedure_1 (@a numeric(10,4) OUTPUT, @b numeric(10,4) OUTPUT) AS
+BEGIN
+  SET @a=100.41;
+  SET @b=200.82;
+  select @a+@b as r;
+END;
+GO
+
+EXEC var_with_procedure_1 2.000, 3.000;
+GO
+
+-- value of @a should be 100
+DECLARE @a INT;
+EXEC var_with_procedure_1 @a OUT, 3.000;
+SELECT @a;
+GO
+
+drop procedure var_with_procedure_1;
+GO
+
+CREATE PROCEDURE var_with_procedure_2
+AS
+BEGIN
+  declare @a int
+  declare @b int
+  set @a = 1
+  return
+  select @b=@a+1
+END
+GO
+
+exec var_with_procedure_2
+GO
+
+DROP PROCEDURE var_with_procedure_2
+GO
+
+-- insert testing with local variables
+truncate table dbo.local_var_tst
+go
+
+-- should throw an error
+declare @a int = 1
+insert into local_var_tst select @a = @a + 1
+GO
+
+-- syntax error
+declare @a int = 1
+insert into local_var_tst values (@a = @a + 1)
+GO
+
+declare @a int = 1
+insert into local_var_tst values (@a + 1)
+GO
+
+-- output clause with insert
+declare @a int = 1
+declare @mytbl table(a int)
+insert local_var_tst output inserted.id into @mytbl values (@a + 1) 
+select * from @mytbl
+GO
+
+-- output clause with delete
+declare @a int = 1
+declare @mytbl table(a int)
+delete local_var_tst output deleted.id into @mytbl where id = @a + 1
+select * from @mytbl
+GO
+
+drop table dbo.local_var_tst
+go
+
+create table local_var_tst_1 (a int, b int)
+GO
+
+insert into local_var_tst_1 values (1,3), (2, 4)
+go
+
+-- select test with multi-variable assignment
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += b from local_var_tst_1
+select @a, @b
+go
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += @a + b from local_var_tst_1
+select @a, @b
+go
+
+declare @a int = 0
+declare @b int = 0
+select @a += a, @b += @a + ~b from local_var_tst_1
+select @a, @b
+go
+
+drop table local_var_tst_1
+go
+
+create table local_var_str_tst (id varchar(100))
+GO
+
+insert into local_var_str_tst values ('abc'), (' '), ('def')
+GO
+
+declare @i varchar(1000)
+set @i = ''
+select @i = @i + id from local_var_str_tst
+select @i
+go
+
+declare @i varchar(1000)
+set @i = ''
+select @i = id + @i from local_var_str_tst
+select @i
+go
+
+declare @i varchar(1000)
+set @i = ''
+select @i += id from local_var_str_tst
+select @i
+go
+
+declare @i varchar(1000)
+set @i = ''
+select @i = reverse(@i + 'id') from local_var_str_tst
+select @i
+go
+
+declare @i varchar(1000)
+set @i = ''
+select @i += reverse(id) from local_var_str_tst
+select @i
+go
+
+declare @i varchar(1000)
+set @i = 'abc'
+select @i = reverse(@i)
+select @i
+go
+
+-- function call like trim, ltrim, etc will be rewritten by ANTLR
+declare @i varchar(1000)
+set @i = ' '
+select @i += id from local_var_str_tst
+select len(@i), @i
+select @i = trim(@i)
+select len(@i), @i
+go
+
+drop table local_var_str_tst;
+go
+
+-- $PARTITION is rewritten by ANTLR
+CREATE PARTITION FUNCTION RangePF1 ( INT )  
+AS RANGE RIGHT FOR VALUES (10, 100, 1000) ;  
+GO
+
+declare @res int = -1;
+SELECT @res = $PARTITION.RangePF1 (10);
+select @res
+select 1 where @res = $PARTITION.RangePF1 (10);
+SELECT @res = $PARTITION.RangePF1 (@res);
+select @res
+GO
+
+DROP PARTITION FUNCTION RangePF1 
+GO
+
+CREATE SEQUENCE CountBy1  
+    START WITH 1  
+    INCREMENT BY 1 ;
+GO
+
+-- NEXT VALUE FOR gets re-written by ANTLR
+DECLARE @myvar1 BIGINT = NEXT VALUE FOR CountBy1 ;
+DECLARE @myvar2 BIGINT ;  
+DECLARE @myvar3 BIGINT ;  
+select @myvar2 = NEXT VALUE FOR CountBy1 ;  
+SELECT @myvar3 = NEXT VALUE FOR CountBy1 ;  
+SELECT @myvar1 AS myvar1, @myvar2 AS myvar2, @myvar3 AS myvar3 ;  
+GO
+
+DROP SEQUENCE CountBy1
+GO
+
+-- any @@ is also re-written by ANTLR
+declare @pid int = 0
+select @pid += @@spid
+select 1 where @pid = @@spid
+go
+
+-- float point notation also gets rewritten by ANTLR e.g., 2.1E, -.2e+, -2.e-
+declare @a float = 0
+select @a = 2.1E
+select @a
+select @a = -.2e+
+select @a 
+select @a = -2.e-
+select @a
+go
+
+-- variables only in select target list shows dynamic behavior
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (1)
+GO
+
+declare @i int = 1
+declare @j int = 0
+select @j += id, @i = id + 1  from local_var_tst where id = @i
+select @i, @j
+go
+
+declare @i int = 1
+select @i = id * 2 from local_var_tst where id = @i
+select @i
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+
+set babelfish_statistics profile On;
+GO
+
+declare @i int = 1
+declare @j int = 0
+select @j += id, @i = id + 1  from local_var_tst where id = @i
+select @i, @j
+go
+
+declare @i int = 1
+select @i = @i * 2 from local_var_tst where id = @i
+select @i
+GO
+
+set babelfish_statistics profile OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+
+-- declared variable name with length > 63
+declare @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr += 1
+select @abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+
+-- variable names starting with @@
+declare @@a int = 1;
+select @@a = @@a + 1
+select @@a 
+GO
+
+declare @@a int = 1;
+select @@a += 1
+select @@a 
+GO
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr + 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+
+truncate table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+insert into local_var_tst values (1)
+GO
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr + id from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr = id + @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+
+declare @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr int = 1
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr += id from local_var_tst
+select @@abcbjbnjfbjrnfjrnfkrelnfksnrfenjkfrfrfrfrfrfnknslkrnflkernklfnkmklfr
+GO
+
+truncate table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'off', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'off', false);
+GO
+
+set babelfish_statistics profile On;
+GO
+
+-- error while evaluating const expression
+declare @a int = 1;
+select @a = 1 / 0 from local_var_tst
+select * from local_var_tst where id = @a
+GO
+
+set babelfish_statistics profile OFF
+GO
+
+select set_config('babelfishpg_tsql.explain_timing', 'on', false);
+GO
+
+select set_config('babelfishpg_tsql.explain_summary', 'on', false);
+GO
+
+drop table local_var_tst
+GO
+
+create table ident_tst(id_num INT IDENTITY(1, 1), b varchar(10))
+GO
+
+insert into ident_tst values ('test')
+GO
+
+declare @a int = 1
+select @a = @@IDENTITY
+select @a
+select 1 where @a = @@IDENTITY
+GO
+
+-- additional testing for update with dynamic variables
+GO
+
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+
+set QUOTED_IDENTIFIER on
+GO
+
+declare @i varchar(100)
+update local_var_tst set id = id + 10, @i = cast("xmax" as varchar(100))
+select 1 where @i IS NOT NULL
+GO
+
+set QUOTED_IDENTIFIER off
+GO
+
+select * from local_var_tst order by id;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+-- long identifier with update
+declare @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx int
+update local_var_tst set id =10, @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx = id
+select @incnjkdncjknxdjnkxnknvjkdfjvbdfbvjbdfhjbvjdbfvkjbdnjnlkanjfnvjnjfdlsahdnuejncdiebnjcnjksndjnjxndjcx
+GO
+
+select * from local_var_tst
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+-- @@ variables
+declare @@incnjkdnc int
+update local_var_tst set id =10, @@incnjkdnc = id
+select @@incnjkdnc
+GO
+
+select * from local_var_tst
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int 
+update local_var_tst set id = id + 2, @i = id * 5;
+select @i
+GO
+
+select * from local_var_tst order by id;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int, @j int;
+update local_var_tst set id =10, @i = case when @j =0 then 1 else 0 end;
+select @i, @j
+go
+
+select * from local_var_tst;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int, @j int;
+update local_var_tst set id = 10, @j = id, @i = case when @j =0 then 1 else 0 end;
+select @i, @j
+go
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int, @j int = 0
+update local_var_tst set id =10, @i = charindex('a','a',@j)
+select @i
+GO
+
+select * from local_var_tst;
+GO
+
+declare @i int, @j int = 0
+update local_var_tst set id =10, @i = charindex('a','a',@j);
+select @i
+GO
+
+select * from local_var_tst;
+GO
+
+declare @i int, @j int;
+update local_var_tst set id = 10, @j = id, @i = @j * 2
+select @i, @j
+go
+
+select * from local_var_tst;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int = 1
+update local_var_tst set id = @i, @i = id * 2 where id = @i
+select @i
+GO
+
+select * from local_var_tst
+go
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int = 1
+update local_var_tst set id = @i, @i += id * 2 where id = @i
+select @i
+GO
+
+select * from local_var_tst
+go
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i VARCHAR(200) = ''
+update local_var_tst set id = id * 2, @i = @i + cast(id as varchar(20))
+select @i
+GO
+
+select * from local_var_tst order by id
+go
+
+-- @i should be NULL as no row passes the qual condition
+declare @i int 
+update local_var_tst set id =10, @i = id * 5 where id = 1
+select @i
+GO
+
+select * from local_var_tst order by id
+go
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+
+declare @i int = 1
+update local_var_tst set id = @i, @i = id * 5 where id = @i
+select @i
+GO
+
+select * from local_var_tst order by id
+go
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int 
+set @i = 0
+update local_var_tst set id = @i, @i = id * 5
+select @i
+GO
+
+select * from local_var_tst;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+-- trim is re-written by antlr
+declare @i varchar(200) 
+select @i = ''
+update local_var_tst set id = @i, @i = TRIM(@i + cast(id as varchar(10)));
+select @i
+GO
+
+select * from local_var_tst;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+-- variables in the where clause should be treated as const
+
+declare @i int = 1;
+update local_var_tst set id = @i * 100, @i = id * 2 where id = @i
+select @i
+GO
+
+select * from local_var_tst order by id;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int = 1;
+update local_var_tst set id = @i * 100, @i = @@IDENTITY
+select @i
+select 1 where @i = @@IDENTITY
+GO
+
+select * from local_var_tst
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+CREATE PARTITION FUNCTION RangePF1 ( INT )  
+AS RANGE RIGHT FOR VALUES (10, 100, 1000) ;  
+GO
+
+declare @i int = -1;
+SELECT @i = $PARTITION.RangePF1 (10);
+select @i
+update local_var_tst set id = @i, @i = $PARTITION.RangePF1 (10);
+select @i
+GO
+
+select * from local_var_tst;
+GO
+
+DROP PARTITION FUNCTION RangePF1 
+GO
+
+CREATE PROCEDURE var_with_procedure (@i int, @a numeric(10,4) OUTPUT) AS
+BEGIN
+  update local_var_tst set id = @i * 2, @a = id * 5 where id = @i
+  select @a
+END;
+GO
+
+TRUNCATE table local_var_tst
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @input int = 1, @res int;
+exec var_with_procedure @input, @res
+select @res
+GO
+
+select * from local_var_tst
+go
+
+declare @input int = 2, @a int;
+exec var_with_procedure @input, @a
+select @a
+GO
+
+DROP PROCEDURE var_with_procedure;
+GO
+
+DROP TABLE local_var_tst
+GO
+
+create table local_var_tst_1 (id int) 
+GO
+
+insert into local_var_tst_1 values (1)
+insert into local_var_tst_1 values (2)
+GO
+
+create unique index idx_local_var_tst_1 on local_var_tst_1(id)
+GO
+
+
+SELECT set_config('enable_indexscan', '1', false);
+SELECT set_config('enable_indexonlyscan', '0', false);
+SELECT set_config('enable_seqscan', '0', false);
+GO
+
+declare @i int = 1
+update local_var_tst_1 set id = @i, @i = id * 5 where id = 1
+select @i
+GO
+
+declare @i int = 1
+update local_var_tst_1 set id = 10 output deleted.id where id = 1
+select @i
+GO
+
+SELECT set_config('enable_indexscan', '1', false);
+SELECT set_config('enable_indexonlyscan', '1', false);
+SELECT set_config('enable_seqscan', '1', false);
+GO
+
+DROP TABLE local_var_tst_1
+GO
+
+CREATE TABLE update_test_tbl (
+    age int,
+    fname char(10),
+    lname char(10),
+    city nchar(20)
+)
+GO
+
+TRUNCATE TABLE update_test_tbl
+GO
+
+INSERT INTO update_test_tbl(age, fname, lname, city) 
+VALUES  (50, 'fname1', 'lname1', 'london'),
+        (34, 'fname2', 'lname2', 'paris'),
+        (35, 'fname3', 'lname3', 'brussels'),
+        (90, 'fname4', 'lname4', 'new york'),
+        (26, 'fname5', 'lname5', 'los angeles'),
+        (74, 'fname6', 'lname6', 'tokyo'),
+        (44, 'fname7', 'lname7', 'oslo'),
+        (19, 'fname8', 'lname8', 'hong kong'),
+        (61, 'fname9', 'lname9', 'shanghai'),
+        (29, 'fname10', 'lname10', 'mumbai')
+GO
+
+CREATE TABLE update_test_tbl2 (
+    year int,
+    lname char(10),
+)
+GO
+
+TRUNCATE TABLE update_test_tbl2
+GO
+
+INSERT INTO update_test_tbl2(year, lname) 
+VALUES  (51, 'lname1'),
+        (34, 'lname3'),
+        (25, 'lname8'),
+        (95, 'lname9'),
+        (36, 'lname10')
+GO
+
+UPDATE update_test_tbl SET fname = 'fname13'
+FROM update_test_tbl t1
+INNER JOIN update_test_tbl2 t2
+ON t1.lname = t2.lname
+WHERE year > 50
+GO
+
+declare @a varchar(4000) = '';
+UPDATE update_test_tbl SET fname = 'fname13', @a = @a + fname
+FROM update_test_tbl t1
+INNER JOIN update_test_tbl2 t2
+ON t1.lname = t2.lname
+WHERE year > 50
+select @a
+GO
+
+DROP TABLE update_test_tbl2;
+GO
+
+DROP TABLE update_test_tbl
+GO
+
+drop table ident_tst
+GO
+
+create table local_var_tst (id int) 
+GO
+
+insert into local_var_tst values (1)
+insert into local_var_tst values (2)
+GO
+
+declare @i int = 0, @j int
+update local_var_tst set id = id + 2, @i = id, @j = @i * 2, @i = @j
+select @i, @j
+GO
+
+declare @i int = 0, @j int
+update local_var_tst set id = id + 2, @i += id, @j = @i * 2
+select @i, @j
+GO
+
+select * from local_var_tst order by id
+GO
+
+drop table local_var_tst
+GO
+
+-- end of test_dynamic_local_vars
+
+
+-- Setup test table
+create table t1 (a int, b int, c varchar(50));
+go
+
+CREATE PROCEDURE reset_t1
+AS
+BEGIN
+    TRUNCATE TABLE t1;
+    INSERT INTO t1 VALUES (1, 10, 'first');
+    INSERT INTO t1 VALUES (2, 20, 'second');
+    INSERT INTO t1 VALUES (3, 30, 'third');
+    INSERT INTO t1 VALUES (4, 40, 'fourth');
+END
+GO
+
+EXEC reset_t1
+GO
+
+-- Using local variable without assignment
+-- in targetlist
+declare @a int;
+set @a = 5;
+select a, b, @a as param_value from t1 where a < 3;
+go
+
+CREATE PROCEDURE proc_targetlist_param @a int
+AS
+BEGIN
+    select a, b, @a as param_value from t1 where a < 3;
+END
+GO
+
+EXEC proc_targetlist_param @a = 5;
+GO
+
+DROP PROCEDURE proc_targetlist_param;
+GO
+
+EXEC sp_executesql N'select a, b, @a as param_value from t1 where a < 3', N'@a int', @a = 5;
+GO
+
+-- in qual
+declare @a int;
+set @a = 2;
+select * from t1 where a = @a;
+go
+
+CREATE PROCEDURE proc_qual_param @a int
+AS
+BEGIN
+    select * from t1 where a = @a;
+END
+GO
+
+EXEC proc_qual_param @a = 2;
+GO
+
+DROP PROCEDURE proc_qual_param;
+GO
+
+EXEC sp_executesql N'select * from t1 where a = @a', N'@a int', @a = 2;
+GO
+
+declare @filter int;
+set @filter = 1;
+update t1 set b = 5942 where a = @filter;
+select * from t1 where a = @filter;
+go
+
+CREATE PROCEDURE proc_update_filter @filter int
+AS
+BEGIN
+    update t1 set b = 5942 where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC reset_t1;
+GO
+EXEC proc_update_filter @filter = 1;
+GO
+
+DROP PROCEDURE proc_update_filter;
+GO
+
+EXEC reset_t1;
+GO
+
+EXEC sp_executesql N'update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter', N'@filter int', @filter = 1;
+GO
+
+EXEC reset_t1
+GO
+
+create table t_temp (a int);
+insert into t_temp values (1), (2), (3), (4);
+declare @del_val int;
+set @del_val = 2;
+delete from t_temp where a = @del_val;
+select * from t_temp order by a;
+drop table t_temp;
+go
+
+-- both
+declare @update_val int, @filter int;
+set @update_val = 100;
+set @filter = 1;
+update t1 set b = @update_val where a = @filter;
+select * from t1 where a = @filter;
+go
+
+EXEC reset_t1
+GO
+
+declare @filter int;
+set @filter = 1;
+update t1 set b = @filter where a = @filter;
+select * from t1 where a = @filter;
+go
+
+EXEC reset_t1
+GO
+
+-- top(NULL) from BABEL-1181
+-- Local variable in TOP clause
+declare @a int;
+set @a = 2;
+select top (@a) * from t1 order by a;
+go
+
+declare @a int;
+set @a = 2;
+select top (NULL) * from t1 order by a;
+go
+
+-- TOP with NULL local variable (should error)
+declare @top_null int;
+set @top_null = NULL;
+select top (@top_null) * from t1;
+go
+
+-- TOP with local variable from subquery
+declare @top_val int;
+set @top_val = (select 2);
+select top (@top_val) * from t1 order by a;
+go
+
+declare @top_val int;
+declare @fetch_val int;
+set @top_val = (select @fetch_val);
+select top (@top_val) * from t1 order by a;
+go
+
+-- Local variable assignment
+-- in targetlist
+declare @result int;
+select @result = b from t1 where a = 2;
+select @result;
+go
+
+-- Local variable assignment with parameter in target list and WHERE
+declare @i int, @result int;
+set @i = 2;
+select @result = b from t1 where a = @i;
+select @result;
+go
+
+declare @i int, @result int;
+set @i = 2;
+select @result = b + @i from t1 where a = @i;
+select @result;
+go
+
+-- Multiple local variable assignments
+declare @var1 int, @var2 int, @param int;
+set @param = 2;
+select @var1 = a, @var2 = b from t1 where a = @param;
+select @var1, @var2;
+go
+
+-- Local variable assignment over multiple rows
+declare @result int, @threshold int;
+set @threshold = 2;
+select @result = sum(b) from t1 where a > @threshold;
+select @result;
+go
+
+-- Local variable in GROUP BY HAVING clause
+-- TODO: make tables with proper groups for this
+declare @having_val int;
+set @having_val = 15;
+select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a;
+go
+
+create table group_table_t1 (a int, b int, c varchar(50));
+insert into group_table_t1 values (1, 3, '1abbcc');
+insert into group_table_t1 values (1, 4, 'a2bbcc');
+insert into group_table_t1 values (2, 5, 'aa3bcc');
+insert into group_table_t1 values (2, 6, 'aab4cc');
+insert into group_table_t1 values (3, 50000, 'aabb5c');
+insert into group_table_t1 values (3, 60000, 'aabbc6');
+declare @having_val int;
+set @having_val = 3;
+select a, sum(b) as total from group_table_t1 group by a having sum(b) > @having_val order by a;
+go
+declare @having_val int;
+set @having_val = 3;
+select @having_val = @having_val + 1234 from group_table_t1 group by b having sum(b) > @having_val;
+select @having_val
+go
+
+drop table group_table_t1;
+go
+
+declare @having_val int;
+set @having_val = 15;
+select @having_val = @having_val + 1 from t1 group by a having sum(b) > @having_val;
+select @having_val
+go
+
+-- in CASE expression
+declare @threshold int;
+set @threshold = 2;
+select a, case when a > @threshold then 'high' else 'low' end as category from t1;
+go
+
+-- local variable assignment in CASE with local variable assignment
+declare @threshold int, @result varchar(10);
+set @threshold = 2;
+select @result = case when a > @threshold then 'high' else 'low' end from t1 order by a;
+select @result;
+go
+
+declare @threshold int, @result varchar(10), @at int;
+set @threshold = 2;
+set @at = 3;
+select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at;
+select @result;
+go
+
+-- Local variable with string operations
+declare @search varchar(10);
+set @search = 'sec';
+select * from t1 where c like '%' + @search + '%';
+go
+
+declare @search varchar(10);
+set @search = 'i';
+select @search = @search + 'rd' from t1 where c like '%' + @search + '%';
+select @search;
+go
+
+declare @result varchar(100), @prefix varchar(10);
+set @prefix = 'Value: ';
+select @result = @prefix + c from t1 order by a;
+select @result;
+go
+
+declare @multiplier int;
+set @multiplier = 2;
+select a, (select @multiplier * b) as doubled_b from t1 where a < 3;
+go
+
+declare @multiplier int;
+set @multiplier = 2;
+select a, (select @multiplier = @multiplier * b) from t1 where a < 3;
+go
+
+declare @val int;
+set @val = 10;
+select a, (select b + (select @val)) as nested_calc from t1 where a < 3;
+go
+
+declare @val int;
+set @val = 2;
+select * from t1 where b > (select max(b) from t1 where a < @val);
+go
+
+declare @val int;
+set @val = 2;
+select * from t1 where (select @val = @val + 1);
+go
+
+declare @offset int;
+set @offset = 10;
+select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer;
+go
+
+declare @null_param int;
+set @null_param = NULL;
+select * from t1 where a = @null_param;
+go
+
+-- Local variable in CTE
+declare @cte_filter int;
+set @cte_filter = 2;
+with cte as (select * from t1 where a > @cte_filter)
+select * from cte;
+go
+
+declare @cte_filter int;
+set @cte_filter = 1;
+with cte as (select * from t1 where a > @cte_filter)
+select @cte_filter = @cte_filter + 3 from cte;
+select @cte_filter;
+go
+
+declare @filter1 int, @filter2 int;
+set @filter1 = 1;
+set @filter2 = 3;
+with cte1 as (select * from t1 where a > @filter1),
+     cte2 as (select * from cte1 where a <= @filter2)
+select * from cte2;
+go
+
+declare @filter1 int, @filter2 int;
+set @filter1 = 1;
+with cte1 as (select * from t1 where a > @filter1),
+     cte2 as (select @filter1 = @filter1 + 3 from cte1)
+select * from cte2;
+go
+
+declare @partition_val int;
+set @partition_val = 2;
+select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+go
+
+declare @partition_val int;
+set @partition_val = 2;
+select @partition_val = @partition_val + 1, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+go
+
+EXEC reset_t1
+GO
+
+-- Local variable assignment in UPDATE
+-- returned values for the `captured` variables _will_ differ from sql server (BABEL-5188)
+declare @captured int, @filter int;
+set @filter = 2;
+update t1 set b = b + 5, @captured = b where a = @filter;
+select @captured;
+go
+
+EXEC reset_t1
+GO
+
+-- Multiple local variable assignments in UPDATE
+declare @captured1 int, @captured2 int, @filter int, @increment int;
+set @filter = 2;
+set @increment = 5;
+update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter;
+select @captured1, @captured2;
+go
+
+EXEC reset_t1
+GO
+
+-- UPDATE with local variable in subquery
+declare @multiplier int;
+set @multiplier = 2;
+update t1 set b = (select @multiplier * 10) where a = 1;
+select * from t1 where a = 1;
+go
+
+EXEC reset_t1
+GO
+
+-- DELETE with local variable in subquery
+create table t_temp (a int);
+insert into t_temp values (1), (2), (3), (4);
+declare @threshold int;
+set @threshold = 2;
+delete from t_temp where a in (select a from t_temp where a <= @threshold);
+select * from t_temp order by a;
+drop table t_temp;
+go
+
+-- local variable in INSERT VALUES
+declare @val1 int, @val2 int;
+set @val1 = 5;
+set @val2 = 50;
+create table t_temp (a int, b int);
+insert into t_temp values (@val1, @val2);
+select * from t_temp;
+set @val1 = 51;
+set @val2 = 501;
+insert into t_temp values (@val1, @val2);
+select * from t_temp;
+drop table t_temp;
+go
+
+-- local variable in OFFSET FETCH
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = NULL;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+
+-- OFFSET NULL should error (BABEL-6347)
+declare @offset_val int, @fetch_val int;
+set @offset_val = NULL;
+set @fetch_val = 2;
+select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+
+declare @offset_val int, @fetch_val int;
+set @fetch_val = 2;
+select * from t1 order by a offset NULL rows fetch next @fetch_val rows only;
+go
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select a, @fetch_val = NULL from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+
+declare @offset_val int, @fetch_val int;
+set @offset_val = 1;
+set @fetch_val = 2;
+select a, @offset_val = NULL from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+go
+
+-- Additional procedure and planned statement versions
+
+-- Ref: delete with local variable
+CREATE PROCEDURE proc_delete_param @del_val int
+AS
+BEGIN
+    create table t_temp (a int);
+    insert into t_temp values (1), (2), (3), (4);
+    delete from t_temp where a = @del_val;
+    select * from t_temp order by a;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_delete_param @del_val = 2;
+GO
+
+DROP PROCEDURE proc_delete_param;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a = @del_val; select * from t_temp order by a; drop table t_temp', N'@del_val int', @del_val = 2;
+GO
+
+-- Ref: update with both local variables
+CREATE PROCEDURE proc_update_both @update_val int, @filter int
+AS
+BEGIN
+    update t1 set b = @update_val where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC proc_update_both @update_val = 100, @filter = 1;
+GO
+
+DROP PROCEDURE proc_update_both;
+GO
+
+EXEC sp_executesql N'update t1 set b = @update_val where a = @filter; select * from t1 where a = @filter', N'@update_val int, @filter int', @update_val = 100, @filter = 1;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: update with same variable in both places
+CREATE PROCEDURE proc_update_same @filter int
+AS
+BEGIN
+    update t1 set b = @filter where a = @filter;
+    select * from t1 where a = @filter;
+END
+GO
+
+EXEC proc_update_same @filter = 1;
+GO
+
+DROP PROCEDURE proc_update_same;
+GO
+
+EXEC sp_executesql N'update t1 set b = @filter where a = @filter; select * from t1 where a = @filter', N'@filter int', @filter = 1;
+GO
+
+EXEC reset_t1
+GO
+
+-- Ref: TOP with local variable
+CREATE PROCEDURE proc_top_param @a int
+AS
+BEGIN
+    select top (@a) * from t1 order by a;
+END
+GO
+
+EXEC proc_top_param @a = 2;
+GO
+
+DROP PROCEDURE proc_top_param;
+GO
+
+EXEC sp_executesql N'select top (@a) * from t1 order by a', N'@a int', @a = 2;
+GO
+
+-- Ref: TOP with NULL local variable
+CREATE PROCEDURE proc_top_null @top_null int
+AS
+BEGIN
+    select top (@top_null) * from t1;
+END
+GO
+
+EXEC proc_top_null @top_null = NULL;
+GO
+
+DROP PROCEDURE proc_top_null;
+GO
+
+EXEC sp_executesql N'select top (@top_null) * from t1', N'@top_null int', @top_null = NULL;
+GO
+
+-- Ref: TOP with local variable from subquery
+CREATE PROCEDURE proc_top_subquery
+AS
+BEGIN
+    select top (select NULL) * from t1 order by a;
+END
+GO
+
+EXEC proc_top_subquery;
+GO
+
+DROP PROCEDURE proc_top_subquery;
+GO
+
+EXEC sp_executesql N'select top (select NULL) * from t1 order by a';
+GO
+
+-- Ref: local variable assignment in targetlist
+CREATE PROCEDURE proc_assign_targetlist @i int, @result int OUTPUT
+AS
+BEGIN
+    select @result = b from t1 where a = @i;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_targetlist @i = 2, @result = @out OUTPUT;
+select @out;
+GO
+
+DROP PROCEDURE proc_assign_targetlist;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = b from t1 where a = @i', N'@i int, @result int OUTPUT', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: local variable assignment with parameter in target and WHERE
+CREATE PROCEDURE proc_assign_both @i int, @result int OUTPUT
+AS
+BEGIN
+    select @result = b + @i from t1 where a = @i;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_both @i = 2, @result = @out OUTPUT;
+select @out;
+GO
+
+DROP PROCEDURE proc_assign_both;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = b + @i from t1 where a = @i', N'@i int, @result int OUTPUT', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: multiple local variable assignments
+CREATE PROCEDURE proc_assign_multiple @param int, @var1 int OUTPUT, @var2 int OUTPUT
+AS
+BEGIN
+    select @var1 = a, @var2 = b from t1 where a = @param;
+END
+GO
+
+declare @out1 int, @out2 int;
+EXEC proc_assign_multiple @param = 2, @var1 = @out1 OUTPUT, @var2 = @out2 OUTPUT;
+select @out1, @out2;
+GO
+
+DROP PROCEDURE proc_assign_multiple;
+GO
+
+declare @var1 int, @var2 int;
+EXEC sp_executesql N'select @var1 = a, @var2 = b from t1 where a = @param', N'@param int, @var1 int OUTPUT, @var2 int OUTPUT', @param = 2, @var1 = @var1 OUTPUT, @var2 = @var2 OUTPUT;
+select @var1, @var2;
+GO
+
+-- Ref: local variable assignment over multiple rows
+CREATE PROCEDURE proc_assign_aggregate @threshold int, @result int OUTPUT
+AS
+BEGIN
+    select @result = sum(b) from t1 where a > @threshold;
+END
+GO
+
+declare @out int;
+EXEC proc_assign_aggregate @threshold = 2, @result = @out OUTPUT;
+select @out;
+GO
+
+DROP PROCEDURE proc_assign_aggregate;
+GO
+
+declare @result int;
+EXEC sp_executesql N'select @result = sum(b) from t1 where a > @threshold', N'@threshold int, @result int OUTPUT', @threshold = 2, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: local variable in GROUP BY HAVING
+CREATE PROCEDURE proc_having_param @having_val int
+AS
+BEGIN
+    select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a;
+END
+GO
+
+EXEC proc_having_param @having_val = 15;
+GO
+
+DROP PROCEDURE proc_having_param;
+GO
+
+EXEC sp_executesql N'select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a', N'@having_val int', @having_val = 15;
+GO
+
+-- Ref: CASE expression with local variable
+CREATE PROCEDURE proc_case_param @threshold int
+AS
+BEGIN
+    select a, case when a > @threshold then 'high' else 'low' end as category from t1;
+END
+GO
+
+EXEC proc_case_param @threshold = 2;
+GO
+
+DROP PROCEDURE proc_case_param;
+GO
+
+EXEC sp_executesql N'select a, case when a > @threshold then ''high'' else ''low'' end as category from t1', N'@threshold int', @threshold = 2;
+GO
+
+-- Ref: local variable assignment in CASE
+CREATE PROCEDURE proc_case_assign @threshold int, @at int, @result varchar(10) OUTPUT
+AS
+BEGIN
+    select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at;
+END
+GO
+
+declare @out varchar(10);
+EXEC proc_case_assign @threshold = 2, @at = 3, @result = @out OUTPUT;
+select @out;
+GO
+
+DROP PROCEDURE proc_case_assign;
+GO
+
+declare @result varchar(10);
+EXEC sp_executesql N'select @result = case when a > @threshold then ''high'' else ''low'' end from t1 where a = @at', N'@threshold int, @at int, @result varchar(10) OUTPUT', @threshold = 2, @at = 3, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: local variable with string operations
+CREATE PROCEDURE proc_string_like @search varchar(10)
+AS
+BEGIN
+    select * from t1 where c like '%' + @search + '%';
+END
+GO
+
+EXEC proc_string_like @search = 'sec';
+GO
+
+DROP PROCEDURE proc_string_like;
+GO
+
+EXEC sp_executesql N'select * from t1 where c like ''%'' + @search + ''%''', N'@search varchar(10)', @search = 'sec';
+GO
+
+-- Ref: string concatenation with assignment
+CREATE PROCEDURE proc_string_concat @prefix varchar(10), @result varchar(100) OUTPUT
+AS
+BEGIN
+    select @result = @prefix + c from t1 order by a;
+END
+GO
+
+declare @out varchar(100);
+EXEC proc_string_concat @prefix = 'Value: ', @result = @out OUTPUT;
+select @out;
+GO
+
+DROP PROCEDURE proc_string_concat;
+GO
+
+declare @result varchar(100);
+EXEC sp_executesql N'select @result = @prefix + c from t1 order by a', N'@prefix varchar(10), @result varchar(100) OUTPUT', @prefix = 'Value: ', @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: subquery with local variable
+CREATE PROCEDURE proc_subquery_param @multiplier int
+AS
+BEGIN
+    select a, (select @multiplier * b) as doubled_b from t1 where a < 3;
+END
+GO
+
+EXEC proc_subquery_param @multiplier = 2;
+GO
+
+DROP PROCEDURE proc_subquery_param;
+GO
+
+EXEC sp_executesql N'select a, (select @multiplier * b) as doubled_b from t1 where a < 3', N'@multiplier int', @multiplier = 2;
+GO
+
+-- Ref: nested subquery with local variable
+CREATE PROCEDURE proc_nested_subquery @val int
+AS
+BEGIN
+    select a, (select b + (select @val)) as nested_calc from t1 where a < 3;
+END
+GO
+
+EXEC proc_nested_subquery @val = 10;
+GO
+
+DROP PROCEDURE proc_nested_subquery;
+GO
+
+EXEC sp_executesql N'select a, (select b + (select @val)) as nested_calc from t1 where a < 3', N'@val int', @val = 10;
+GO
+
+-- Ref: subquery in WHERE with local variable
+CREATE PROCEDURE proc_where_subquery @val int
+AS
+BEGIN
+    select * from t1 where b > (select max(b) from t1 where a < @val);
+END
+GO
+
+EXEC proc_where_subquery @val = 2;
+GO
+
+DROP PROCEDURE proc_where_subquery;
+GO
+
+EXEC sp_executesql N'select * from t1 where b > (select max(b) from t1 where a < @val)', N'@val int', @val = 2;
+GO
+
+-- Ref: correlated subquery with local variable
+CREATE PROCEDURE proc_correlated_subquery @offset int
+AS
+BEGIN
+    select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer;
+END
+GO
+
+EXEC proc_correlated_subquery @offset = 10;
+GO
+
+DROP PROCEDURE proc_correlated_subquery;
+GO
+
+EXEC sp_executesql N'select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer', N'@offset int', @offset = 10;
+GO
+
+-- Ref: NULL parameter
+CREATE PROCEDURE proc_null_param @null_param int
+AS
+BEGIN
+    select * from t1 where a = @null_param;
+END
+GO
+
+EXEC proc_null_param @null_param = NULL;
+GO
+
+DROP PROCEDURE proc_null_param;
+GO
+
+EXEC sp_executesql N'select * from t1 where a = @null_param', N'@null_param int', @null_param = NULL;
+GO
+
+-- Ref: CTE with local variable
+CREATE PROCEDURE proc_cte_param @cte_filter int
+AS
+BEGIN
+    with cte as (select * from t1 where a > @cte_filter)
+    select * from cte;
+END
+GO
+
+EXEC proc_cte_param @cte_filter = 2;
+GO
+
+DROP PROCEDURE proc_cte_param;
+GO
+
+EXEC sp_executesql N'with cte as (select * from t1 where a > @cte_filter) select * from cte', N'@cte_filter int', @cte_filter = 2;
+GO
+
+-- Ref: multiple CTEs with local variables
+CREATE PROCEDURE proc_multiple_cte @filter1 int, @filter2 int
+AS
+BEGIN
+    with cte1 as (select * from t1 where a > @filter1),
+         cte2 as (select * from cte1 where a <= @filter2)
+    select * from cte2;
+END
+GO
+
+EXEC proc_multiple_cte @filter1 = 1, @filter2 = 3;
+GO
+
+DROP PROCEDURE proc_multiple_cte;
+GO
+
+EXEC sp_executesql N'with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2', N'@filter1 int, @filter2 int', @filter1 = 1, @filter2 = 3;
+GO
+
+-- Ref: window function with local variable
+CREATE PROCEDURE proc_window_param @partition_val int
+AS
+BEGIN
+    select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1;
+END
+GO
+
+EXEC proc_window_param @partition_val = 2;
+GO
+
+DROP PROCEDURE proc_window_param;
+GO
+
+EXEC sp_executesql N'select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1', N'@partition_val int', @partition_val = 2;
+GO
+
+-- Ref: UPDATE with local variable assignment
+CREATE PROCEDURE proc_update_assign @filter int, @captured int OUTPUT
+AS
+BEGIN
+    update t1 set b = b + 5, @captured = b where a = @filter;
+END
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+declare @out int;
+EXEC proc_update_assign @filter = 2, @captured = @out OUTPUT;
+select @out;
+GO
+
+DROP PROCEDURE proc_update_assign;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+declare @captured int;
+EXEC sp_executesql N'update t1 set b = b + 5, @captured = b where a = @filter', N'@filter int, @captured int OUTPUT', @filter = 2, @captured = @captured OUTPUT;
+select @captured;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: UPDATE with multiple assignments
+CREATE PROCEDURE proc_update_multi_assign @filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT
+AS
+BEGIN
+    update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter;
+END
+GO
+
+declare @out1 int, @out2 int;
+EXEC proc_update_multi_assign @filter = 2, @increment = 5, @captured1 = @out1 OUTPUT, @captured2 = @out2 OUTPUT;
+select @out1, @out2;
+GO
+
+DROP PROCEDURE proc_update_multi_assign;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+declare @captured1 int, @captured2 int;
+EXEC sp_executesql N'update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter', N'@filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT', @filter = 2, @increment = 5, @captured1 = @captured1 OUTPUT, @captured2 = @captured2 OUTPUT;
+select @captured1, @captured2;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: UPDATE with subquery
+CREATE PROCEDURE proc_update_subquery @multiplier int
+AS
+BEGIN
+    update t1 set b = (select @multiplier * 10) where a = 1;
+    select * from t1 where a = 1;
+END
+GO
+
+EXEC proc_update_subquery @multiplier = 2;
+GO
+
+DROP PROCEDURE proc_update_subquery;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+EXEC sp_executesql N'update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1', N'@multiplier int', @multiplier = 2;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: DELETE with subquery
+CREATE PROCEDURE proc_delete_subquery @threshold int
+AS
+BEGIN
+    create table t_temp (a int);
+    insert into t_temp values (1), (2), (3), (4);
+    delete from t_temp where a in (select a from t_temp where a <= @threshold);
+    select * from t_temp order by a;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_delete_subquery @threshold = 2;
+GO
+
+DROP PROCEDURE proc_delete_subquery;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a in (select a from t_temp where a <= @threshold); select * from t_temp order by a; drop table t_temp', N'@threshold int', @threshold = 2;
+GO
+
+-- Ref: INSERT with local variables
+CREATE PROCEDURE proc_insert_params @val1 int, @val2 int
+AS
+BEGIN
+    create table t_temp (a int, b int);
+    insert into t_temp values (@val1, @val2);
+    select * from t_temp;
+    drop table t_temp;
+END
+GO
+
+EXEC proc_insert_params @val1 = 5, @val2 = 50;
+GO
+
+DROP PROCEDURE proc_insert_params;
+GO
+
+EXEC sp_executesql N'create table t_temp (a int, b int); insert into t_temp values (@val1, @val2); select * from t_temp; drop table t_temp', N'@val1 int, @val2 int', @val1 = 5, @val2 = 50;
+GO
+
+-- Ref: OFFSET FETCH with local variables
+CREATE PROCEDURE proc_offset_fetch @offset_val int, @fetch_val int
+AS
+BEGIN
+    select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+END
+GO
+
+EXEC proc_offset_fetch @offset_val = 1, @fetch_val = 2;
+GO
+
+DROP PROCEDURE proc_offset_fetch;
+GO
+
+EXEC sp_executesql N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', N'@offset_val int, @fetch_val int', @offset_val = 1, @fetch_val = 2;
+GO
+
+-- Ref: OFFSET FETCH with NULL fetch
+CREATE PROCEDURE proc_offset_null_fetch @offset_val int, @fetch_val int
+AS
+BEGIN
+    select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only;
+END
+GO
+
+EXEC proc_offset_null_fetch @offset_val = 1, @fetch_val = NULL;
+GO
+
+DROP PROCEDURE proc_offset_null_fetch;
+GO
+
+EXEC sp_executesql N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', N'@offset_val int, @fetch_val int', @offset_val = 1, @fetch_val = NULL;
+GO
+
+EXEC reset_t1
+GO
+
+-- Ref: targetlist param
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select a, b, @a as param_value from t1 where a < 3', @a = 5;
+GO
+
+-- Ref: qual param
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select * from t1 where a = @a', @a = 2;
+GO
+
+-- Ref: update filter
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int', N'update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter', @filter = 1;
+GO
+
+EXEC reset_t1;
+GO
+
+-- Ref: delete with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@del_val int', N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a = @del_val; select * from t_temp order by a; drop table t_temp', @del_val = 2;
+GO
+
+-- Ref: update with both local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@update_val int, @filter int', N'update t1 set b = @update_val where a = @filter; select * from t1 where a = @filter', @update_val = 100, @filter = 1;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: update with same variable in both places
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int', N'update t1 set b = @filter where a = @filter; select * from t1 where a = @filter', @filter = 1;
+GO
+
+EXEC reset_t1
+GO
+
+-- Ref: TOP with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@a int', N'select top (@a) * from t1 order by a', @a = 2;
+GO
+
+-- Ref: TOP with NULL local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@top_null int', N'select top (@top_null) * from t1', @top_null = NULL;
+GO
+
+-- Ref: local variable assignment in targetlist
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@i int, @result int OUTPUT', N'select @result = b from t1 where a = @i', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: local variable assignment with parameter in target and WHERE
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@i int, @result int OUTPUT', N'select @result = b + @i from t1 where a = @i', @i = 2, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: multiple local variable assignments
+declare @var1 int, @var2 int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@param int, @var1 int OUTPUT, @var2 int OUTPUT', N'select @var1 = a, @var2 = b from t1 where a = @param', @param = 2, @var1 = @var1 OUTPUT, @var2 = @var2 OUTPUT;
+select @var1, @var2;
+GO
+
+-- Ref: local variable assignment over multiple rows
+declare @result int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int, @result int OUTPUT', N'select @result = sum(b) from t1 where a > @threshold', @threshold = 2, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: local variable in GROUP BY HAVING
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@having_val int', N'select a, sum(b) as total from t1 group by a having sum(b) > @having_val order by a', @having_val = 15;
+GO
+
+-- Ref: CASE expression with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int', N'select a, case when a > @threshold then ''high'' else ''low'' end as category from t1', @threshold = 2;
+GO
+
+-- Ref: local variable assignment in CASE
+declare @result varchar(10);
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int, @at int, @result varchar(10) OUTPUT', N'select @result = case when a > @threshold then ''high'' else ''low'' end from t1 where a = @at', @threshold = 2, @at = 3, @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: local variable with string operations
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@search varchar(10)', N'select * from t1 where c like ''%'' + @search + ''%''', @search = 'sec';
+GO
+
+-- Ref: string concatenation with assignment
+declare @result varchar(100);
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@prefix varchar(10), @result varchar(100) OUTPUT', N'select @result = @prefix + c from t1 order by a', @prefix = 'Value: ', @result = @result OUTPUT;
+select @result;
+GO
+
+-- Ref: subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@multiplier int', N'select a, (select @multiplier * b) as doubled_b from t1 where a < 3', @multiplier = 2;
+GO
+
+-- Ref: nested subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val int', N'select a, (select b + (select @val)) as nested_calc from t1 where a < 3', @val = 10;
+GO
+
+-- Ref: subquery in WHERE with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val int', N'select * from t1 where b > (select max(b) from t1 where a < @val)', @val = 2;
+GO
+
+-- Ref: correlated subquery with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset int', N'select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer', @offset = 10;
+GO
+
+-- Ref: NULL parameter
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@null_param int', N'select * from t1 where a = @null_param', @null_param = NULL;
+GO
+
+-- Ref: CTE with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@cte_filter int', N'with cte as (select * from t1 where a > @cte_filter) select * from cte', @cte_filter = 2;
+GO
+
+-- Ref: multiple CTEs with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter1 int, @filter2 int', N'with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2', @filter1 = 1, @filter2 = 3;
+GO
+
+-- Ref: window function with local variable
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@partition_val int', N'select a, b, row_number() over (order by case when a > @partition_val then a else b end) as rn from t1', @partition_val = 2;
+GO
+
+-- Ref: UPDATE with local variable assignment
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+declare @captured int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int, @captured int OUTPUT', N'update t1 set b = b + 5, @captured = b where a = @filter', @filter = 2, @captured = @captured OUTPUT;
+select @captured;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: UPDATE with multiple assignments
+declare @captured1 int, @captured2 int;
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@filter int, @increment int, @captured1 int OUTPUT, @captured2 int OUTPUT', N'update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter', @filter = 2, @increment = 5, @captured1 = @captured1 OUTPUT, @captured2 = @captured2 OUTPUT;
+select @captured1, @captured2;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: UPDATE with subquery
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@multiplier int', N'update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1', @multiplier = 2;
+GO
+
+TRUNCATE TABLE t1;
+insert into t1 values (1, 10, 'first'), (2, 20, 'second'), (3, 30, 'third'), (4, 40, 'fourth');
+GO
+
+-- Ref: DELETE with subquery
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@threshold int', N'create table t_temp (a int); insert into t_temp values (1), (2), (3), (4); delete from t_temp where a in (select a from t_temp where a <= @threshold); select * from t_temp order by a; drop table t_temp', @threshold = 2;
+GO
+
+-- Ref: INSERT with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@val1 int, @val2 int', N'create table t_temp (a int, b int); insert into t_temp values (@val1, @val2); select * from t_temp; drop table t_temp', @val1 = 5, @val2 = 50;
+GO
+
+-- Ref: OFFSET FETCH with local variables
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset_val int, @fetch_val int', N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', @offset_val = 1, @fetch_val = 2;
+GO
+
+-- Ref: OFFSET FETCH with NULL fetch
+declare @handle as int;
+EXEC sp_prepexec @handle OUTPUT, N'@offset_val int, @fetch_val int', N'select * from t1 order by a offset @offset_val rows fetch next @fetch_val rows only', @offset_val = 1, @fetch_val = NULL;
+GO
+
+-- cleanup
+
+drop procedure reset_t1;
+go
+
+drop table t1;
+go

--- a/test/JDBC/input/params_in_generic_plan_rpc.txt
+++ b/test/JDBC/input/params_in_generic_plan_rpc.txt
@@ -1,0 +1,131 @@
+CREATE TABLE t1 (a int, b int, c varchar(50));
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+SELECT set_config('plan_cache_mode', 'force_generic_plan', false);
+
+-- select with parameter in targetlist and WHERE
+prepst#!#select a, b, @a as param_value from t1 where a < 3#!#int|-|a|-|5
+
+-- select with parameter in WHERE
+prepst#!#select * from t1 where a = @a#!#int|-|a|-|2
+
+-- update with parameter in WHERE and select
+prepst#!#update t1 set b = 5942 where a = @filter; select * from t1 where a = @filter#!#int|-|filter|-|1#!#int|-|filter|-|1
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+
+-- create temp table, delete with parameter, select, drop
+prepst#!#create table t_temp4 (a int); insert into t_temp4 values (1), (2), (3), (4); delete from t_temp4 where a = @delval; select * from t_temp4 order by a; drop table t_temp4#!#int|-|delval|-|2
+
+-- update with two parameters (three param uses total)
+prepst#!#update t1 set b = @updateval where a = @filter; select * from t1 where a = @filter#!#int|-|updateval|-|100#!#int|-|filter|-|1#!#int|-|filter|-|1
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+
+-- update with same parameter in SET and WHERE (three uses)
+prepst#!#update t1 set b = @filter where a = @filter; select * from t1 where a = @filter#!#int|-|filter|-|1#!#int|-|filter|-|1#!#int|-|filter|-|1
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+
+-- TOP with parameter
+prepst#!#select top (@a) * from t1 order by a#!#int|-|a|-|2
+
+-- TOP with NULL parameter
+prepst#!#select top (@topnull) * from t1#!#int|-|topnull|-|<NULL>
+
+-- TOP with subquery returning NULL
+prepst#!#select top (select NULL) * from t1 order by a
+
+-- variable assignment in targetlist with OUTPUT parameter
+prepst#!#select @result = b from t1 where a = @i#!#int|-|i|-|2#!#int|-|result|-|<NULL>
+
+-- variable assignment with parameter in expression and WHERE (i used twice)
+prepst#!#select @result = b + @i from t1 where a = @i#!#int|-|i|-|2#!#int|-|i|-|2#!#int|-|result|-|<NULL>
+
+-- multiple variable assignments with OUTPUT parameters
+prepst#!#select @var1 = a, @var2 = b from t1 where a = @param#!#int|-|param|-|2#!#int|-|var1|-|<NULL>#!#int|-|var2|-|<NULL>
+
+-- aggregate with variable assignment
+prepst#!#select @result = sum(b) from t1 where a > @threshold#!#int|-|threshold|-|2#!#int|-|result|-|<NULL>
+
+-- GROUP BY HAVING with parameter
+prepst#!#select a, sum(b) as total from t1 group by a having sum(b) > @havingval order by a#!#int|-|havingval|-|15
+
+-- CASE expression with parameter
+prepst#!#select a, case when a > @threshold then 'high' else 'low' end as category from t1#!#int|-|threshold|-|2
+
+-- CASE with variable assignment and OUTPUT
+prepst#!#select @result = case when a > @threshold then 'high' else 'low' end from t1 where a = @at#!#int|-|threshold|-|2#!#int|-|at|-|3#!#varchar(10)|-|result|-|<NULL>
+
+-- subquery with parameter
+prepst#!#select a, (select @multiplier * b) as doubled_b from t1 where a < 3#!#int|-|multiplier|-|2
+
+-- nested subquery with parameter
+prepst#!#select a, (select b + (select @val)) as nested_calc from t1 where a < 3#!#int|-|val|-|10
+
+-- subquery in WHERE with parameter
+prepst#!#select * from t1 where b > (select max(b) from t1 where a < @val)#!#int|-|val|-|2
+
+-- correlated subquery with parameter
+prepst#!#select a, (select count(*) from t1 t_inner where t_inner.b > t_outer.b + @offset) as count_greater from t1 t_outer#!#int|-|offset|-|10
+
+-- NULL parameter
+prepst#!#select * from t1 where a = @nullparam#!#int|-|nullparam|-|<NULL>
+
+-- CTE with parameter
+prepst#!#with cte as (select * from t1 where a > @ctefilter) select * from cte#!#int|-|ctefilter|-|2
+
+-- multiple CTEs with parameters
+prepst#!#with cte1 as (select * from t1 where a > @filter1), cte2 as (select * from cte1 where a <= @filter2) select * from cte2#!#int|-|filter1|-|1#!#int|-|filter2|-|3
+
+-- window function with parameter
+prepst#!#select a, b, row_number() over (order by case when a > @partitionval then a else b end) as rn from t1#!#int|-|partitionval|-|2
+
+-- UPDATE with variable assignment
+prepst#!#update t1 set b = b + 5, @captured = b where a = @filter#!#int|-|filter|-|2#!#int|-|captured|-|<NULL>
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+
+-- UPDATE with multiple variable assignments (filter, increment, captured1 used twice, captured2)
+prepst#!#update t1 set b = b + @increment, @captured1 = a, @captured2 = @captured1 + b where a = @filter#!#int|-|filter|-|2#!#int|-|increment|-|5#!#int|-|captured1|-|<NULL>#!#int|-|captured1|-|<NULL>#!#int|-|captured2|-|<NULL>
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+
+-- UPDATE with subquery
+prepst#!#update t1 set b = (select @multiplier * 10) where a = 1; select * from t1 where a = 1#!#int|-|multiplier|-|2
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES (1, 10, 'first');
+INSERT INTO t1 VALUES (2, 20, 'second');
+INSERT INTO t1 VALUES (3, 30, 'third');
+INSERT INTO t1 VALUES (4, 40, 'fourth');
+
+-- DELETE with subquery
+prepst#!#create table t_temp5 (a int); insert into t_temp5 values (1), (2), (3), (4); delete from t_temp5 where a in (select a from t_temp5 where a <= @threshold); select * from t_temp5 order by a; drop table t_temp5#!#int|-|threshold|-|2
+
+-- INSERT with parameters
+prepst#!#create table t_temp6 (a int, b int); insert into t_temp6 values (@val1, @val2); select * from t_temp6; drop table t_temp6#!#int|-|val1|-|5#!#int|-|val2|-|50
+
+-- OFFSET FETCH with parameters
+prepst#!#select * from t1 order by a offset @offsetval rows fetch next @fetchval rows only#!#int|-|offsetval|-|1#!#int|-|fetchval|-|2
+
+-- OFFSET FETCH with NULL fetch
+prepst#!#select * from t1 order by a offset @offsetval rows fetch next @fetchval rows only#!#int|-|offsetval|-|1#!#int|-|fetchval|-|<NULL>
+
+DROP TABLE t1;


### PR DESCRIPTION
Multiple JDBC tests fail when plan_cache_mode is set to force_generic_plan.
Parameters in WHERE clauses should be evaluated once per query and treated
as constants, while parameters in SELECT clauses should be evaluated per row
as dynamic values. However, generic plans do not receive bound parameters
during planning, so Param nodes in qualifiers are not replaced with Const
nodes by eval_const_expressions. This causes parameters to be fetched
dynamically for each row instead of being evaluated once at execution start,
leading to incorrect query results.

To fix this, copy the plannedstmt and replace Param nodes with Const nodes
in plan qualifiers at ExecutorStart before execution.

Task: BABEL-5942

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/cd333380f412b1ada28758ab1fdf56453cf6f4ac

Authored-by: Saurav Samantaray <sauravay@amazon.com>


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).