### PR TITLE
Updated configuration files to account for out of calendar release of PostgreSQL 17.9 minor

### DIFF
--- a/.github/configuration/upgrade-test-configuration.yml
+++ b/.github/configuration/upgrade-test-configuration.yml
@@ -169,7 +169,7 @@ upgrade-version: [{
 {
   upgrade-path: [
     {
-      version: 17.8,
+      version: 17.9,
       upgrade-type: null
     },
     { 

--- a/.github/template/version-branch-template.yml
+++ b/.github/template/version-branch-template.yml
@@ -154,8 +154,8 @@
 '17.7':
   engine_branch: BABEL_5_4_STABLE__PG_17_7
   extension_branch: BABEL_5_4_STABLE
-'17.8':
-  engine_branch: BABEL_5_5_STABLE__PG_17_8
+'17.9':
+  engine_branch: BABEL_5_5_STABLE__PG_17_9
   extension_branch: BABEL_5_5_STABLE
 'source.latest':
   engine_branch: latest


### PR DESCRIPTION
### Description

Updated configuration files to account for out of calendar release of PostgreSQL 17.9 minor



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).