### PR TITLE
Fix crash in bulk copy by nullifying index pointers after cleanup (#4447)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -75,10 +75,10 @@ jobs:
           sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql
           sqlcmd -S localhost -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
       
-      # - name: Run Dotnet Tests
-      #   id: install-and-run-dotnet
-      #   if: always() && steps.re-install-extensions-1.outcome == 'success'
-      #   uses: ./.github/composite-actions/install-and-run-dotnet
+      - name: Run Dotnet Tests
+        id: install-and-run-dotnet
+        if: always() && steps.re-install-extensions-1.outcome == 'success'
+        uses: ./.github/composite-actions/install-and-run-dotnet
       
       - name: Run ODBC Tests
         id: install-and-run-odbc-tests

--- a/.github/workflows/jdbc-tests-pgaudit-enable.yml
+++ b/.github/workflows/jdbc-tests-pgaudit-enable.yml
@@ -155,10 +155,10 @@ jobs:
           sudo PGPASSWORD=12345678 ~/${{ env.INSTALL_DIR }}/bin/psql -v ON_ERROR_STOP=1 -h localhost -d babelfish_db -U jdbc_user -c "CREATE EXTENSION pgaudit;"
           sqlcmd -S localhost -U "jdbc_user" -P 12345678 -Q "SELECT @@version GO"
 
-      # - name: Run Dotnet Tests
-      #   id: run-dotnet-tests
-      #   if: always() && steps.re-install-extensions.outcome == 'success'
-      #   uses: ./.github/composite-actions/install-and-run-dotnet
+      - name: Run Dotnet Tests
+        id: run-dotnet-tests
+        if: always() && steps.re-install-extensions.outcome == 'success'
+        uses: ./.github/composite-actions/install-and-run-dotnet
 
       - name: Start secondary server
         id: start-secondary

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -11,9 +11,9 @@ jobs:
     name: ODBC Tests
     uses: ./.github/workflows/odbc-tests.yml
   
-  # run-dotnet-tests:
-  #   name: Dotnet Tests
-  #   uses: ./.github/workflows/dotnet-tests.yml
+  run-dotnet-tests:
+    name: Dotnet Tests
+    uses: ./.github/workflows/dotnet-tests.yml
 
   run-python-tests:
     name: Python Tests
@@ -43,11 +43,11 @@ jobs:
         name:  coverage-babelfish-extensions-jdbc
         path: contrib/
     
-    # - uses: actions/download-artifact@v4
-    #   id: download-dotnet-coverage
-    #   with:
-    #     name: coverage-babelfish-extensions-dotnet
-    #     path: contrib/
+    - uses: actions/download-artifact@v4
+      id: download-dotnet-coverage
+      with:
+        name: coverage-babelfish-extensions-dotnet
+        path: contrib/
     
     - uses: actions/download-artifact@v4
       id: download-odbc-coverage

--- a/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_bulkcopy.c
@@ -423,6 +423,8 @@ CopyMultiInsertBufferFlush(CopyMultiInsertInfo *miinfo,
 		}
 		pfree(resultRelInfo->ri_IndexRelationInfo);
 		pfree(resultRelInfo->ri_IndexRelationDescs);
+		resultRelInfo->ri_IndexRelationDescs = NULL;
+		resultRelInfo->ri_IndexRelationInfo = NULL;
 		resultRelInfo->ri_NumIndices = 0;
 	}
 


### PR DESCRIPTION
In Babelfish bulk copy operations, a dangling pointer bug was causing assertion failures when ExecOpenIndices was called multiple times on the same ResultRelInfo.

The issue occurred during error handling in bulk copy operations: When CopyMultiInsertBufferFlush freed ri_IndexRelationDescs and ri_IndexRelationInfo arrays after closing indices, it did not reset these pointers to NULL. This caused problems when the flush function was called again during error cleanup (e.g., when a constraint violation triggered EndBulkCopy).

A recent PostgreSQL community commit added assertions to prevent ExecOpenIndices from being called multiple times, which exposed this dangling pointer bug. The assertion (ri_IndexRelationDescs == NULL) failed because the pointer still contained the freed memory address.

This commit fixes the issue by resetting ri_IndexRelationDescs and ri_IndexRelationInfo to NULL after freeing them, ensuring proper cleanup and preventing assertion failures.

Engine PR https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/719

Task: BABEL-6286

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).