### PR TITLE
Add ELEMENTS directive support for FOR XML PATH clause

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -26,7 +26,7 @@
 
 static StringInfo for_xml_ffunc(PG_FUNCTION_ARGS);
 static void tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool elements, bool xsinil);
-static void tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64);
+static void tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool xsinil);
 static void update_tsql_datatype_and_val(HeapTuple tuple, TupleDesc tupdesc, Oid *datatype_oid, Datum *colval, bool binary_base64, int i);
 
 PG_FUNCTION_INFO_V1(tsql_query_to_xml_sfunc);
@@ -102,7 +102,7 @@ tsql_query_to_xml_sfunc(PG_FUNCTION_ARGS)
 					 errmsg("AUTO mode is not supported")));
 			break;
 		case TSQL_FORXML_PATH:	/* FOR XML PATH */
-			tsql_row_to_xml_path(state, record, element_name, binary_base64);
+			tsql_row_to_xml_path(state, record, element_name, binary_base64, xsinil);
 			break;
 		case TSQL_FORXML_EXPLICIT:
 
@@ -328,7 +328,7 @@ validate_attribute_centric_col_names_xml(const char *element_name, TupleDesc tup
  * Map an SQL row to an XML element in PATH mode.
  */
 static void
-tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64)
+tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool xsinil)
 {
 	HeapTupleHeader td;
 	Oid			tupType;
@@ -362,10 +362,19 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 	{
 		/* if "''" is the input path, ignore it per TSQL behavior */
 		if (has_att_centric)
-			appendStringInfo(state, "<%s ", element_name);
+		{
+			if (xsinil)
+				appendStringInfo(state, "<%s " XML_XMLNS_XSI, element_name);
+			else
+				appendStringInfo(state, "<%s", element_name);
+		}
 		else
-			appendStringInfo(state, "<%s>", element_name);
-
+		{
+			if (xsinil)
+				appendStringInfo(state, "<%s " XML_XMLNS_XSI ">", element_name);
+			else
+				appendStringInfo(state, "<%s>", element_name);
+		}
 	}
 
 	/* process the tuple into tags */
@@ -391,7 +400,7 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 			allnull = false;
 			if(NameStr(att->attname)[0] == '@')
 			{
-				appendStringInfo(state, "%s=\"%s\" ",
+				appendStringInfo(state, " %s=\"%s\"",
 								 NameStr(att->attname)+1,
 								 map_sql_value_to_xml_value(colval, datatype_oid, true));
 			}
@@ -410,10 +419,44 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 				}
 				else
 				{
-					appendStringInfo(state, "<%s>%s</%s>",
-									 colname,
-									 map_sql_value_to_xml_value(colval, datatype_oid, true),
-									 colname);
+					/* When PATH('') is used with XSINIL, add xmlns to each element */
+					if (element_name[0] == '\0' && xsinil)
+						appendStringInfo(state, "<%s " XML_XMLNS_XSI ">%s</%s>",
+										 colname,
+										 map_sql_value_to_xml_value(colval, datatype_oid, true),
+										 colname);
+					else
+						appendStringInfo(state, "<%s>%s</%s>",
+										 colname,
+										 map_sql_value_to_xml_value(colval, datatype_oid, true),
+										 colname);
+				}
+			}
+		}
+		else if (xsinil)
+		{
+			/*
+     		* XSINIL: Output NULL columns with xsi:nil="true".
+     		* Skip attribute-centric columns (prefixed with '@') as
+     		* xsi:nil is only valid on XML elements, not on attributes.
+     		*/
+			if (NameStr(att->attname)[0] != '@')
+			{
+				allnull = false;
+
+				if (has_att_centric && first)
+				{
+					appendStringInfoChar(state, '>');
+					first = false;
+				}
+
+				if (strncmp(NameStr(att->attname), "?column?", 8) != 0)
+				{
+					/* When PATH('') is used with XSINIL, add xmlns to each element */
+					if (element_name[0] == '\0')
+						appendStringInfo(state, "<%s " XML_XMLNS_XSI " " XML_XSI_NIL "/>", colname);
+					else
+						appendStringInfo(state, "<%s " XML_XSI_NIL "/>", colname);
 				}
 			}
 		}
@@ -432,7 +475,9 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 	else if (element_name[0] != '\0')
 	{
 		if (has_att_centric && first)
+		{
 			appendStringInfoString(state, "/>");
+		}
 		else
 			appendStringInfo(state, "</%s>", element_name);
 	}

--- a/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-cleanup.out
@@ -1,0 +1,71 @@
+-- Drop functions
+DROP FUNCTION IF EXISTS forxml_path_elements_func1;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func2;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func3;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func4;
+GO
+
+-- Drop dependent views
+DROP VIEW IF EXISTS forxml_path_elements_dep_view1;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view2;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view3;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view4;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view5;
+GO
+
+-- Drop regular view
+DROP VIEW IF EXISTS forxml_path_elements_regular_view;
+GO
+
+-- Drop procedures
+DROP PROCEDURE IF EXISTS forxml_path_elements_p1;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p2;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p3;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p4;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p5;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p6;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p7;
+GO
+
+-- Drop tables
+DROP TABLE IF EXISTS forxml_path_elements_t1;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t2;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t3;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t4;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t5;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t6;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t7;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_special;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_unicode;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_long_cols;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_orders;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_customers;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_products;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_order_items;
+GO

--- a/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-prepare.out
+++ b/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-prepare.out
@@ -1,0 +1,457 @@
+
+-- ============================================
+-- SECTION: Base Tables
+-- ============================================
+CREATE TABLE forxml_path_elements_t1 (
+    ID INT,
+    Name VARCHAR(50),
+    Department VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t1 VALUES (1, 'John', 'Sales');
+INSERT INTO forxml_path_elements_t1 VALUES (2, 'Jane', NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (3, 'Bob', 'IT');
+INSERT INTO forxml_path_elements_t1 VALUES (4, NULL, NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (5, NULL, 'HR');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Multiple Data Types Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t2 (
+    IntCol INT,
+    VarcharCol VARCHAR(50),
+    BitCol BIT,
+    DecimalCol DECIMAL(10,2),
+    DateCol DATE
+);
+GO
+
+INSERT INTO forxml_path_elements_t2 VALUES (100, 'Text1', 1, 99.99, '2024-01-01');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, NULL, NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t2 VALUES (200, NULL, 0, NULL, '2024-06-15');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, 'Text2', NULL, 50.00, NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: NULL Patterns Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t3 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (1, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, 'Val', NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, 'Val');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Attribute-Centric Test Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t4 (
+    ID INT,
+    Name VARCHAR(50),
+    Value VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t4 VALUES (1, 'Item1', 'Value1');
+INSERT INTO forxml_path_elements_t4 VALUES (2, NULL, 'Value2');
+INSERT INTO forxml_path_elements_t4 VALUES (3, 'Item3', NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Single Column Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t5 (
+    SingleCol VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t5 VALUES ('Value');
+INSERT INTO forxml_path_elements_t5 VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Many Columns Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t6 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50),
+    Col4 INT,
+    Col5 VARCHAR(50),
+    Col6 BIT,
+    Col7 VARCHAR(50),
+    Col8 INT
+);
+GO
+
+INSERT INTO forxml_path_elements_t6 VALUES (1, 'A', 'B', 2, 'C', 1, 'D', 3);
+INSERT INTO forxml_path_elements_t6 VALUES (NULL, NULL, 'B', NULL, 'C', NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t6 VALUES (1, NULL, NULL, 2, NULL, NULL, 'D', NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Text Content Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t7 (
+    ID INT,
+    TextCol VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_t7 VALUES (1, 'Normal Text');
+INSERT INTO forxml_path_elements_t7 VALUES (2, NULL);
+INSERT INTO forxml_path_elements_t7 VALUES (3, 'Text with special chars');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Special Characters Table
+-- ============================================
+CREATE TABLE forxml_path_elements_special (
+    ID INT,
+    Value VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_special VALUES (1, 'a & b');
+INSERT INTO forxml_path_elements_special VALUES (2, 'a < b');
+INSERT INTO forxml_path_elements_special VALUES (3, 'a > b');
+INSERT INTO forxml_path_elements_special VALUES (4, 'say "hello"');
+INSERT INTO forxml_path_elements_special VALUES (5, 'it''s working');
+INSERT INTO forxml_path_elements_special VALUES (6, '<tag>value</tag>');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Unicode/Multibyte Values Table
+-- ============================================
+CREATE TABLE forxml_path_elements_unicode (
+    ID INT,
+    Name NVARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_unicode VALUES (1, N'日本語');
+INSERT INTO forxml_path_elements_unicode VALUES (2, N'中文');
+INSERT INTO forxml_path_elements_unicode VALUES (3, N'한국어');
+INSERT INTO forxml_path_elements_unicode VALUES (4, N'العربية');
+INSERT INTO forxml_path_elements_unicode VALUES (5, N'émoji 😀');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Long Column Names Table (>64 characters)
+-- ============================================
+CREATE TABLE forxml_path_elements_long_cols (
+    ID INT,
+    this_is_a_very_long_column_name_that_exceeds_sixty_four_characters_in_length VARCHAR(50),
+    another_extremely_long_column_name_for_testing_xml_element_generation_limits VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_long_cols VALUES (1, 'value1', 'value2');
+INSERT INTO forxml_path_elements_long_cols VALUES (2, NULL, 'value3');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Tables for JOIN Queries
+-- ============================================
+CREATE TABLE forxml_path_elements_orders (
+    OrderID INT,
+    CustomerID INT,
+    OrderDate DATE,
+    TotalAmount DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_orders VALUES (1, 1, '2024-01-15', 100.00);
+INSERT INTO forxml_path_elements_orders VALUES (2, 1, '2024-02-20', 250.00);
+INSERT INTO forxml_path_elements_orders VALUES (3, 2, '2024-03-10', NULL);
+INSERT INTO forxml_path_elements_orders VALUES (4, 3, NULL, 175.50);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE forxml_path_elements_customers (
+    CustomerID INT,
+    CustomerName VARCHAR(50),
+    City VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_customers VALUES (1, 'Acme Corp', 'New York');
+INSERT INTO forxml_path_elements_customers VALUES (2, 'Tech Inc', NULL);
+INSERT INTO forxml_path_elements_customers VALUES (3, NULL, 'Boston');
+INSERT INTO forxml_path_elements_customers VALUES (4, 'Global Ltd', 'Chicago');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE forxml_path_elements_products (
+    ProductID INT,
+    ProductName VARCHAR(50),
+    Price DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_products VALUES (1, 'Widget', 25.00);
+INSERT INTO forxml_path_elements_products VALUES (2, 'Gadget', NULL);
+INSERT INTO forxml_path_elements_products VALUES (3, NULL, 75.00);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE forxml_path_elements_order_items (
+    OrderID INT,
+    ProductID INT,
+    Quantity INT
+);
+GO
+
+INSERT INTO forxml_path_elements_order_items VALUES (1, 1, 2);
+INSERT INTO forxml_path_elements_order_items VALUES (1, 2, NULL);
+INSERT INTO forxml_path_elements_order_items VALUES (2, 1, 5);
+INSERT INTO forxml_path_elements_order_items VALUES (3, 3, 1);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Stored Procedures (using FOR XML PATH, ELEMENTS)
+-- ============================================
+CREATE PROCEDURE forxml_path_elements_p1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p5 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+CREATE PROCEDURE forxml_path_elements_p7 @DeptFilter VARCHAR(50) AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE Department = @DeptFilter OR Department IS NULL FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p6 @empid INT AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+
+
+-- ============================================
+-- SECTION: Regular Views (not using FOR XML)
+-- ============================================
+CREATE VIEW forxml_path_elements_regular_view AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID <= 3;
+GO
+
+
+-- ============================================
+-- SECTION: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+CREATE VIEW forxml_path_elements_dep_view1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "ELEMENTS")~~
+
+
+CREATE VIEW forxml_path_elements_dep_view2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "ELEMENTS")~~
+
+
+CREATE VIEW forxml_path_elements_dep_view3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "ELEMENTS")~~
+
+
+CREATE VIEW forxml_path_elements_dep_view4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Employees'), ELEMENTS XSINIL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "ELEMENTS")~~
+
+
+CREATE VIEW forxml_path_elements_dep_view5 AS
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error at or near "ELEMENTS")~~
+
+
+
+-- ============================================
+-- SECTION: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+CREATE FUNCTION forxml_path_elements_func1()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func2()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func3()
+RETURNS XML
+AS
+BEGIN
+    DECLARE @result XML;
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID <= 2 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func4(@empid INT)
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO

--- a/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-verify.out
@@ -1,0 +1,1140 @@
+
+-- ============================================
+-- SECTION 1: Basic ELEMENTS directive
+-- ============================================
+-- Without ELEMENTS (regression test)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee');
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+-- With ELEMENTS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+-- With ELEMENTS ABSENT
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+-- With ELEMENTS XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 2: NULL handling with ELEMENTS XSINIL
+-- ============================================
+-- Single row with no NULL values
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+-- Single row with NULL in middle column
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+-- Single row with all NULLs except ID
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+-- Row with NULL ID (ID=5 has NULL name and non-NULL dept)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 5 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+-- All NULL columns
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></row>
+~~END~~
+
+
+-- Mixed NULL and non-NULL values
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name xsi:nil="true"/><Status>Active</Status></Record>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 3: NULL handling with ELEMENTS ABSENT
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Employee><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Employee><ID>4</ID></Employee>
+~~END~~
+
+
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH('row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Record><ID>1</ID><Status>Active</Status></Record>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 4: ELEMENTS with ROOT directive
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+-- Different order of directives
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 5: ELEMENTS with TYPE directive
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS XSINIL;
+GO
+~~START~~
+xml
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS ABSENT;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), TYPE, ELEMENTS XSINIL;
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+-- All directives combined - different order
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE, ROOT('Data');
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 6: Empty element name (PATH(''))
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<ID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2</ID><Name xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Jane</Name><Department xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<ID>2</ID><Name>Jane</Name>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 7: Multiple data types
+-- ============================================
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol xsi:nil="true"/><BitCol xsi:nil="true"/><DecimalCol xsi:nil="true"/><DateCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>200</IntCol><VarcharCol xsi:nil="true"/><BitCol>0</BitCol><DecimalCol xsi:nil="true"/><DateCol>2024-06-15</DateCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol>Text2</VarcharCol><BitCol xsi:nil="true"/><DecimalCol>50.00</DecimalCol><DateCol xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row><Row/><Row><IntCol>200</IntCol><BitCol>0</BitCol><DateCol>2024-06-15</DateCol></Row><Row><VarcharCol>Text2</VarcharCol><DecimalCol>50.00</DecimalCol></Row>
+~~END~~
+
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol = 100 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row>
+~~END~~
+
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol xsi:nil="true"/><BitCol xsi:nil="true"/><DecimalCol xsi:nil="true"/><DateCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol>Text2</VarcharCol><BitCol xsi:nil="true"/><DecimalCol>50.00</DecimalCol><DateCol xsi:nil="true"/></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 8: Various NULL patterns
+-- ============================================
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1>1</Col1><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2>Val</Col2><Col3 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3>Val</Col3></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row/><Row><Col1>1</Col1></Row><Row><Col2>Val</Col2></Row><Row><Col3>Val</Col3></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row/>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 9: Attribute-centric columns with ELEMENTS
+-- ============================================
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@Name' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@Name' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+-- Attribute-centric column with NULL value and XSINIL
+SELECT ID, Name AS [@Name], Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@Name' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+-- Multiple attribute-centric columns with ELEMENTS XSINIL
+SELECT ID AS [@ID], Name AS [@Name], Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="1" Name="John"><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="2" Name="Jane"><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="3" Name="Bob"><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="4"><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="5"><Department>HR</Department></Employee>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 10: Single column table
+-- ============================================
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SingleCol>Value</SingleCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SingleCol xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><SingleCol>Value</SingleCol></Row><Row/>
+~~END~~
+
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SingleCol xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row/>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 11: Many columns
+-- ============================================
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1>1</Col1><Col2>A</Col2><Col3>B</Col3><Col4>2</Col4><Col5>C</Col5><Col6>1</Col6><Col7>D</Col7><Col8>3</Col8></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3>B</Col3><Col4 xsi:nil="true"/><Col5>C</Col5><Col6 xsi:nil="true"/><Col7 xsi:nil="true"/><Col8 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1>1</Col1><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/><Col4>2</Col4><Col5 xsi:nil="true"/><Col6 xsi:nil="true"/><Col7>D</Col7><Col8 xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><Col1>1</Col1><Col2>A</Col2><Col3>B</Col3><Col4>2</Col4><Col5>C</Col5><Col6>1</Col6><Col7>D</Col7><Col8>3</Col8></Row><Row><Col3>B</Col3><Col5>C</Col5></Row><Row><Col1>1</Col1><Col4>2</Col4><Col7>D</Col7></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 12: Text content
+-- ============================================
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><TextCol>Normal Text</TextCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><TextCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><TextCol>Text with special chars</TextCol></Row>
+~~END~~
+
+
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><TextCol>Normal Text</TextCol></Row><Row><ID>2</ID></Row><Row><ID>3</ID><TextCol>Text with special chars</TextCol></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 13: Empty result set
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 14: Special characters in values
+-- ============================================
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Value>a &amp; b</Value></Row><Row><ID>2</ID><Value>a &lt; b</Value></Row><Row><ID>3</ID><Value>a &gt; b</Value></Row><Row><ID>4</ID><Value>say "hello"</Value></Row><Row><ID>5</ID><Value>it's working</Value></Row><Row><ID>6</ID><Value>&lt;tag&gt;value&lt;/tag&gt;</Value></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Value>a &amp; b</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Value>a &lt; b</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Value>a &gt; b</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Value>say "hello"</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Value>it's working</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>6</ID><Value>&lt;tag&gt;value&lt;/tag&gt;</Value></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Value>a &amp; b</Value></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 6 FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>6</ID><Value>&lt;tag&gt;value&lt;/tag&gt;</Value></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 15: Unicode/Multibyte values (data values, not element names)
+-- ============================================
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Name>日本語</Name></Row><Row><ID>2</ID><Name>中文</Name></Row><Row><ID>3</ID><Name>한국어</Name></Row><Row><ID>4</ID><Name>العربية</Name></Row><Row><ID>5</ID><Name>émoji 😀</Name></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>日本語</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>中文</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>한국어</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name>العربية</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name>émoji 😀</Name></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_unicode WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Name>日本語</Name></Row>
+~~END~~
+
+
+SELECT N'日本語' AS JapaneseName, N'中文' AS ChineseName FOR XML PATH('Names'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Names><JapaneseName>日本語</JapaneseName><ChineseName>中文</ChineseName></Names>
+~~END~~
+
+
+SELECT N'Ελληνικά' AS Greek, N'Русский' AS Russian FOR XML PATH('Names'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Names xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Greek>Ελληνικά</Greek><Russian>Русский</Russian></Names>
+~~END~~
+
+
+SELECT N'مرحبا' AS Arabic, N'שלום' AS Hebrew FOR XML PATH('Names'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Names><Arabic>مرحبا</Arabic><Hebrew>שלום</Hebrew></Names>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 16: Long column names (>64 characters)
+-- ============================================
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact>value1</this_is_a_very_long_column_name_that_exceeds_sixty_four_charact><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value2</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row><Row><ID>2</ID><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value3</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact>value1</this_is_a_very_long_column_name_that_exceeds_sixty_four_charact><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value2</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact xsi:nil="true"/><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value3</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('LongColTest'), ELEMENTS, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><LongColTest><ID>1</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact>value1</this_is_a_very_long_column_name_that_exceeds_sixty_four_charact><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value2</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></LongColTest><LongColTest><ID>2</ID><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value3</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></LongColTest></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 17: Boundary cases for element names
+-- ============================================
+-- Single character element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('E'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></E>
+~~END~~
+
+
+-- Element name with numbers
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee123'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee123>
+~~END~~
+
+
+-- Element name starting with underscore
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('_Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></_Employee>
+~~END~~
+
+
+-- Element name with hyphens
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee-Record'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee-Record>
+~~END~~
+
+
+-- Element name with periods
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee.Record'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee.Record>
+~~END~~
+
+
+-- Default element name (no name specified) with XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH, ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></row>
+~~END~~
+
+
+-- NULL in element name position
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(NULL), ELEMENTS XSINIL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'NULL' at line 2 and character position 70)~~
+
+
+-- Very long element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 18: Complex JOIN queries
+-- ============================================
+-- INNER JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><TotalAmount>100.00</TotalAmount></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><TotalAmount>250.00</TotalAmount></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><TotalAmount xsi:nil="true"/></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><OrderID>4</OrderID><TotalAmount>175.50</TotalAmount></Order>
+~~END~~
+
+
+-- LEFT JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><OrderID>4</OrderID><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Global Ltd</CustomerName><OrderID xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder>
+~~END~~
+
+
+-- Multiple JOINs
+SELECT c.CustomerName, o.OrderID, p.ProductName, oi.Quantity
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+INNER JOIN forxml_path_elements_order_items oi ON o.OrderID = oi.OrderID
+INNER JOIN forxml_path_elements_products p ON oi.ProductID = p.ProductID
+ORDER BY o.OrderID, p.ProductID
+FOR XML PATH('OrderDetail'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><ProductName>Widget</ProductName><Quantity>2</Quantity></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><ProductName>Gadget</ProductName><Quantity xsi:nil="true"/></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><ProductName>Widget</ProductName><Quantity>5</Quantity></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><ProductName xsi:nil="true"/><Quantity>1</Quantity></OrderDetail>
+~~END~~
+
+
+-- LEFT JOIN with NULLs and ROOT
+SELECT c.CustomerName, c.City, o.OrderDate, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><City xsi:nil="true"/><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><City>Boston</City><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Global Ltd</CustomerName><City>Chicago</City><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
+~~END~~
+
+
+-- RIGHT JOIN
+SELECT c.CustomerName, o.OrderID, o.OrderDate
+FROM forxml_path_elements_customers c
+RIGHT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><OrderDate>2024-01-15</OrderDate></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><OrderDate>2024-02-20</OrderDate></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><OrderDate>2024-03-10</OrderDate></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><OrderID>4</OrderID><OrderDate xsi:nil="true"/></Order>
+~~END~~
+
+
+-- CROSS JOIN
+SELECT a.ID AS ID1, a.Name AS Name1, b.ID AS ID2, b.Name AS Name2
+FROM forxml_path_elements_t1 a
+CROSS JOIN forxml_path_elements_t1 b
+WHERE a.ID < b.ID AND a.ID <= 2
+ORDER BY a.ID, b.ID
+FOR XML PATH('Pair'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>2</ID2><Name2>Jane</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>3</ID2><Name2>Bob</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>4</ID2><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>5</ID2><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>2</ID1><Name1>Jane</Name1><ID2>3</ID2><Name2>Bob</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>2</ID1><Name1>Jane</Name1><ID2>4</ID2><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>2</ID1><Name1>Jane</Name1><ID2>5</ID2><Name2 xsi:nil="true"/></Pair>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 19: Subqueries
+-- ============================================
+-- Subquery in SELECT with ELEMENTS XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS Result;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+-- Correlated subquery with ELEMENTS XSINIL
+SELECT t1.ID, 
+    (SELECT Name, Department FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH('Details'), ELEMENTS XSINIL, TYPE) AS Details 
+FROM forxml_path_elements_t1 t1
+WHERE t1.ID <= 3;
+GO
+~~START~~
+int#!#xml
+1#!#<Details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Name>John</Name><Department>Sales</Department></Details>
+2#!#<Details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Name>Jane</Name><Department xsi:nil="true"/></Details>
+3#!#<Details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Name>Bob</Name><Department>IT</Department></Details>
+~~END~~
+
+
+SELECT 
+    ID,
+    (SELECT Name FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH(''), ELEMENTS, TYPE) AS NameElement
+FROM forxml_path_elements_t1 t1
+WHERE ID <= 2;
+GO
+~~START~~
+int#!#xml
+1#!#<Name>John</Name>
+2#!#<Name>Jane</Name>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 20: ORDER BY, GROUP BY, TOP
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY Name FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+SELECT TOP 3 ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee>
+~~END~~
+
+
+SELECT Department, COUNT(*) AS EmpCount 
+FROM forxml_path_elements_t1 
+GROUP BY Department 
+ORDER BY Department
+FOR XML PATH('Dept'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department xsi:nil="true"/><EmpCount>2</EmpCount></Dept><Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department>HR</Department><EmpCount>1</EmpCount></Dept><Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department>IT</Department><EmpCount>1</EmpCount></Dept><Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department>Sales</Department><EmpCount>1</EmpCount></Dept>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 21: Stored Procedures
+-- ============================================
+EXEC forxml_path_elements_p1;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p2;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p3;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p4;
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+EXEC forxml_path_elements_p5;
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+EXEC forxml_path_elements_p6 @empid = 1;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p6 @empid = 4;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p6 @empid = 999;
+GO
+~~START~~
+ntext
+~~END~~
+
+
+-- Procedure with department filter
+EXEC forxml_path_elements_p7 'Sales';
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p7 NULL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+
+
+-- ============================================
+-- SECTION 22: SELECT INTO variable
+-- ============================================
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+SELECT @xml_var AS result;
+GO
+~~START~~
+varchar
+<Employee><ID>1</ID><Name>John</Name></Employee>
+~~END~~
+
+
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+SELECT @xml_var AS result;
+GO
+~~START~~
+varchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+SELECT @xml_var AS result;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID></Employee>
+~~END~~
+
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data'), TYPE);
+SELECT @xml_var AS result;
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 23: SELECT...INTO (create new table)
+-- ============================================
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into1;
+GO
+
+SELECT * FROM forxml_path_elements_into1;
+GO
+~~START~~
+xml
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+DROP TABLE forxml_path_elements_into1;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, TYPE) AS XMLData INTO forxml_path_elements_into2;
+GO
+
+SELECT * FROM forxml_path_elements_into2;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+DROP TABLE forxml_path_elements_into2;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into3;
+GO
+
+SELECT * FROM forxml_path_elements_into3;
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+DROP TABLE forxml_path_elements_into3;
+GO
+
+
+-- ============================================
+-- SECTION 24: Regular view with FOR XML
+-- ============================================
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 25: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+SELECT * FROM forxml_path_elements_dep_view1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "forxml_path_elements_dep_view1" does not exist)~~
+
+
+SELECT * FROM forxml_path_elements_dep_view2;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "forxml_path_elements_dep_view2" does not exist)~~
+
+
+SELECT * FROM forxml_path_elements_dep_view3;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "forxml_path_elements_dep_view3" does not exist)~~
+
+
+SELECT * FROM forxml_path_elements_dep_view4;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "forxml_path_elements_dep_view4" does not exist)~~
+
+
+SELECT * FROM forxml_path_elements_dep_view5;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "forxml_path_elements_dep_view5" does not exist)~~
+
+
+
+-- ============================================
+-- SECTION 26: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+SELECT dbo.forxml_path_elements_func1() AS result;
+GO
+~~START~~
+nvarchar
+<Employee><ID>1</ID><Name>John</Name></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func2() AS result;
+GO
+~~START~~
+nvarchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func3() AS result;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func4(1) AS result;
+GO
+~~START~~
+nvarchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func4(4) AS result;
+GO
+~~START~~
+nvarchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 27: XML methods on FOR XML result
+-- ============================================
+-- Using .value() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Name)[1]', 'VARCHAR(50)') AS extracted_name;
+GO
+~~START~~
+varchar
+John
+~~END~~
+
+
+-- Using .value() method on NULL element with XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Department)[1]', 'VARCHAR(50)') AS extracted_dept;
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- Using .query() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE).query('/Data/Employee[1]') AS query_result;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'XML QUERY' is not currently supported in Babelfish)~~
+
+
+-- Using .exist() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).exist('/Employee/Department') AS element_exists;
+GO
+~~START~~
+bit
+1
+~~END~~
+
+
+-- CAST result to XML type with XSINIL
+SELECT CAST((SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS XML) AS casted_xml;
+GO
+~~START~~
+xml
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+

--- a/test/JDBC/expected/forxml-path-elements-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-path-elements-vu-cleanup.out
@@ -1,0 +1,71 @@
+-- Drop functions
+DROP FUNCTION IF EXISTS forxml_path_elements_func1;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func2;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func3;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func4;
+GO
+
+-- Drop dependent views
+DROP VIEW IF EXISTS forxml_path_elements_dep_view1;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view2;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view3;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view4;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view5;
+GO
+
+-- Drop regular view
+DROP VIEW IF EXISTS forxml_path_elements_regular_view;
+GO
+
+-- Drop procedures
+DROP PROCEDURE IF EXISTS forxml_path_elements_p1;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p2;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p3;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p4;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p5;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p6;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p7;
+GO
+
+-- Drop tables
+DROP TABLE IF EXISTS forxml_path_elements_t1;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t2;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t3;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t4;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t5;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t6;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t7;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_special;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_unicode;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_long_cols;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_orders;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_customers;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_products;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_order_items;
+GO

--- a/test/JDBC/expected/forxml-path-elements-vu-prepare.out
+++ b/test/JDBC/expected/forxml-path-elements-vu-prepare.out
@@ -1,0 +1,437 @@
+
+-- ============================================
+-- SECTION: Base Tables
+-- ============================================
+CREATE TABLE forxml_path_elements_t1 (
+    ID INT,
+    Name VARCHAR(50),
+    Department VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t1 VALUES (1, 'John', 'Sales');
+INSERT INTO forxml_path_elements_t1 VALUES (2, 'Jane', NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (3, 'Bob', 'IT');
+INSERT INTO forxml_path_elements_t1 VALUES (4, NULL, NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (5, NULL, 'HR');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Multiple Data Types Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t2 (
+    IntCol INT,
+    VarcharCol VARCHAR(50),
+    BitCol BIT,
+    DecimalCol DECIMAL(10,2),
+    DateCol DATE
+);
+GO
+
+INSERT INTO forxml_path_elements_t2 VALUES (100, 'Text1', 1, 99.99, '2024-01-01');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, NULL, NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t2 VALUES (200, NULL, 0, NULL, '2024-06-15');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, 'Text2', NULL, 50.00, NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: NULL Patterns Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t3 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (1, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, 'Val', NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, 'Val');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Attribute-Centric Test Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t4 (
+    ID INT,
+    Name VARCHAR(50),
+    Value VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t4 VALUES (1, 'Item1', 'Value1');
+INSERT INTO forxml_path_elements_t4 VALUES (2, NULL, 'Value2');
+INSERT INTO forxml_path_elements_t4 VALUES (3, 'Item3', NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Single Column Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t5 (
+    SingleCol VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t5 VALUES ('Value');
+INSERT INTO forxml_path_elements_t5 VALUES (NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Many Columns Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t6 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50),
+    Col4 INT,
+    Col5 VARCHAR(50),
+    Col6 BIT,
+    Col7 VARCHAR(50),
+    Col8 INT
+);
+GO
+
+INSERT INTO forxml_path_elements_t6 VALUES (1, 'A', 'B', 2, 'C', 1, 'D', 3);
+INSERT INTO forxml_path_elements_t6 VALUES (NULL, NULL, 'B', NULL, 'C', NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t6 VALUES (1, NULL, NULL, 2, NULL, NULL, 'D', NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Text Content Table
+-- ============================================
+CREATE TABLE forxml_path_elements_t7 (
+    ID INT,
+    TextCol VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_t7 VALUES (1, 'Normal Text');
+INSERT INTO forxml_path_elements_t7 VALUES (2, NULL);
+INSERT INTO forxml_path_elements_t7 VALUES (3, 'Text with special chars');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Special Characters Table
+-- ============================================
+CREATE TABLE forxml_path_elements_special (
+    ID INT,
+    Value VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_special VALUES (1, 'a & b');
+INSERT INTO forxml_path_elements_special VALUES (2, 'a < b');
+INSERT INTO forxml_path_elements_special VALUES (3, 'a > b');
+INSERT INTO forxml_path_elements_special VALUES (4, 'say "hello"');
+INSERT INTO forxml_path_elements_special VALUES (5, 'it''s working');
+INSERT INTO forxml_path_elements_special VALUES (6, '<tag>value</tag>');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Unicode/Multibyte Values Table
+-- ============================================
+CREATE TABLE forxml_path_elements_unicode (
+    ID INT,
+    Name NVARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_unicode VALUES (1, N'日本語');
+INSERT INTO forxml_path_elements_unicode VALUES (2, N'中文');
+INSERT INTO forxml_path_elements_unicode VALUES (3, N'한국어');
+INSERT INTO forxml_path_elements_unicode VALUES (4, N'العربية');
+INSERT INTO forxml_path_elements_unicode VALUES (5, N'émoji 😀');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Long Column Names Table (>64 characters)
+-- ============================================
+CREATE TABLE forxml_path_elements_long_cols (
+    ID INT,
+    this_is_a_very_long_column_name_that_exceeds_sixty_four_characters_in_length VARCHAR(50),
+    another_extremely_long_column_name_for_testing_xml_element_generation_limits VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_long_cols VALUES (1, 'value1', 'value2');
+INSERT INTO forxml_path_elements_long_cols VALUES (2, NULL, 'value3');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Tables for JOIN Queries
+-- ============================================
+CREATE TABLE forxml_path_elements_orders (
+    OrderID INT,
+    CustomerID INT,
+    OrderDate DATE,
+    TotalAmount DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_orders VALUES (1, 1, '2024-01-15', 100.00);
+INSERT INTO forxml_path_elements_orders VALUES (2, 1, '2024-02-20', 250.00);
+INSERT INTO forxml_path_elements_orders VALUES (3, 2, '2024-03-10', NULL);
+INSERT INTO forxml_path_elements_orders VALUES (4, 3, NULL, 175.50);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE forxml_path_elements_customers (
+    CustomerID INT,
+    CustomerName VARCHAR(50),
+    City VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_customers VALUES (1, 'Acme Corp', 'New York');
+INSERT INTO forxml_path_elements_customers VALUES (2, 'Tech Inc', NULL);
+INSERT INTO forxml_path_elements_customers VALUES (3, NULL, 'Boston');
+INSERT INTO forxml_path_elements_customers VALUES (4, 'Global Ltd', 'Chicago');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE forxml_path_elements_products (
+    ProductID INT,
+    ProductName VARCHAR(50),
+    Price DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_products VALUES (1, 'Widget', 25.00);
+INSERT INTO forxml_path_elements_products VALUES (2, 'Gadget', NULL);
+INSERT INTO forxml_path_elements_products VALUES (3, NULL, 75.00);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TABLE forxml_path_elements_order_items (
+    OrderID INT,
+    ProductID INT,
+    Quantity INT
+);
+GO
+
+INSERT INTO forxml_path_elements_order_items VALUES (1, 1, 2);
+INSERT INTO forxml_path_elements_order_items VALUES (1, 2, NULL);
+INSERT INTO forxml_path_elements_order_items VALUES (2, 1, 5);
+INSERT INTO forxml_path_elements_order_items VALUES (3, 3, 1);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION: Stored Procedures (using FOR XML PATH, ELEMENTS)
+-- ============================================
+CREATE PROCEDURE forxml_path_elements_p1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p5 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+CREATE PROCEDURE forxml_path_elements_p7 @DeptFilter VARCHAR(50) AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE Department = @DeptFilter OR Department IS NULL FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p6 @empid INT AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+
+
+-- ============================================
+-- SECTION: Regular Views (not using FOR XML)
+-- ============================================
+CREATE VIEW forxml_path_elements_regular_view AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID <= 3;
+GO
+
+
+-- ============================================
+-- SECTION: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+CREATE VIEW forxml_path_elements_dep_view1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Employees'), ELEMENTS XSINIL;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view5 AS
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+
+-- ============================================
+-- SECTION: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+CREATE FUNCTION forxml_path_elements_func1()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func2()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func3()
+RETURNS XML
+AS
+BEGIN
+    DECLARE @result XML;
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID <= 2 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func4(@empid INT)
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO

--- a/test/JDBC/expected/forxml-path-elements-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-elements-vu-verify.out
@@ -1,0 +1,1226 @@
+
+-- ============================================
+-- SECTION 1: Basic ELEMENTS directive
+-- ============================================
+-- Without ELEMENTS (regression test)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee');
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+-- With ELEMENTS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+-- With ELEMENTS ABSENT
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+-- With ELEMENTS XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 2: NULL handling with ELEMENTS XSINIL
+-- ============================================
+-- Single row with no NULL values
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+-- Single row with NULL in middle column
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+-- Single row with all NULLs except ID
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+-- Row with NULL ID (ID=5 has NULL name and non-NULL dept)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 5 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+-- All NULL columns
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></row>
+~~END~~
+
+
+-- Mixed NULL and non-NULL values
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name xsi:nil="true"/><Status>Active</Status></Record>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 3: NULL handling with ELEMENTS ABSENT
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Employee><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Employee><ID>4</ID></Employee>
+~~END~~
+
+
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH('row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Record><ID>1</ID><Status>Active</Status></Record>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 4: ELEMENTS with ROOT directive
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+-- Different order of directives
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 5: ELEMENTS with TYPE directive
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS XSINIL;
+GO
+~~START~~
+xml
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS ABSENT;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), TYPE, ELEMENTS XSINIL;
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+-- All directives combined - different order
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE, ROOT('Data');
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 6: Empty element name (PATH(''))
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<ID xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2</ID><Name xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Jane</Name><Department xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<ID>2</ID><Name>Jane</Name>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 7: Multiple data types
+-- ============================================
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol xsi:nil="true"/><BitCol xsi:nil="true"/><DecimalCol xsi:nil="true"/><DateCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>200</IntCol><VarcharCol xsi:nil="true"/><BitCol>0</BitCol><DecimalCol xsi:nil="true"/><DateCol>2024-06-15</DateCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol>Text2</VarcharCol><BitCol xsi:nil="true"/><DecimalCol>50.00</DecimalCol><DateCol xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row><Row/><Row><IntCol>200</IntCol><BitCol>0</BitCol><DateCol>2024-06-15</DateCol></Row><Row><VarcharCol>Text2</VarcharCol><DecimalCol>50.00</DecimalCol></Row>
+~~END~~
+
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol = 100 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row>
+~~END~~
+
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol xsi:nil="true"/><BitCol xsi:nil="true"/><DecimalCol xsi:nil="true"/><DateCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol>Text2</VarcharCol><BitCol xsi:nil="true"/><DecimalCol>50.00</DecimalCol><DateCol xsi:nil="true"/></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 8: Various NULL patterns
+-- ============================================
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1>1</Col1><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2>Val</Col2><Col3 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3>Val</Col3></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row/><Row><Col1>1</Col1></Row><Row><Col2>Val</Col2></Row><Row><Col3>Val</Col3></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row/>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 9: Attribute-centric columns with ELEMENTS
+-- ============================================
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@Name' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@Name' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+-- Attribute-centric column with NULL value and XSINIL
+SELECT ID, Name AS [@Name], Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Attribute-centric column '@Name' must not come after a non-attribute-centric sibling in XML hierarchy in FOR XML PATH.)~~
+
+
+-- Multiple attribute-centric columns with ELEMENTS XSINIL
+SELECT ID AS [@ID], Name AS [@Name], Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="1" Name="John"><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="2" Name="Jane"><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="3" Name="Bob"><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="4"><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID="5"><Department>HR</Department></Employee>
+~~END~~
+
+
+-- INNER JOIN with attribute-centric columns
+SELECT c.CustomerName AS [@CustomerName], o.OrderID AS [@OrderID], o.TotalAmount
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CustomerName="Acme Corp" OrderID="1"><TotalAmount>100.00</TotalAmount></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CustomerName="Acme Corp" OrderID="2"><TotalAmount>250.00</TotalAmount></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CustomerName="Tech Inc" OrderID="3"><TotalAmount xsi:nil="true"/></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OrderID="4"><TotalAmount>175.50</TotalAmount></Order>
+~~END~~
+
+
+-- LEFT JOIN with attribute-centric columns
+SELECT c.CustomerName AS [@Name], o.TotalAmount AS [@Amount], o.OrderID
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Acme Corp" Amount="100.00"><OrderID>1</OrderID></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Acme Corp" Amount="250.00"><OrderID>2</OrderID></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Tech Inc"><OrderID>3</OrderID></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Amount="175.50"><OrderID>4</OrderID></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Global Ltd"><OrderID xsi:nil="true"/></CustomerOrder>
+~~END~~
+
+
+-- Multiple JOINs with mixed attribute and element columns
+SELECT c.CustomerName AS [@Customer], o.OrderID AS [@OrderID], oi.Quantity AS [@Qty], p.ProductName
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+INNER JOIN forxml_path_elements_order_items oi ON o.OrderID = oi.OrderID
+INNER JOIN forxml_path_elements_products p ON oi.ProductID = p.ProductID
+ORDER BY o.OrderID, p.ProductID
+FOR XML PATH('OrderDetail'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Customer="Acme Corp" OrderID="1" Qty="2"><ProductName>Widget</ProductName></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Customer="Acme Corp" OrderID="1"><ProductName>Gadget</ProductName></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Customer="Acme Corp" OrderID="2" Qty="5"><ProductName>Widget</ProductName></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Customer="Tech Inc" OrderID="3" Qty="1"><ProductName xsi:nil="true"/></OrderDetail>
+~~END~~
+
+
+-- LEFT JOIN with attribute-centric columns and ROOT
+SELECT c.CustomerName AS [@Name], c.City AS [@City], o.OrderDate, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Acme Corp" City="New York"><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Acme Corp" City="New York"><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Tech Inc"><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" City="Boston"><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Global Ltd" City="Chicago"><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
+~~END~~
+
+
+-- RIGHT JOIN with attribute-centric columns
+SELECT c.CustomerName AS [@CustomerName], o.OrderDate AS [@Date], o.OrderID
+FROM forxml_path_elements_customers c
+RIGHT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CustomerName="Acme Corp" Date="2024-01-15"><OrderID>1</OrderID></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CustomerName="Acme Corp" Date="2024-02-20"><OrderID>2</OrderID></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" CustomerName="Tech Inc" Date="2024-03-10"><OrderID>3</OrderID></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><OrderID>4</OrderID></Order>
+~~END~~
+
+
+-- CROSS JOIN with attribute-centric columns
+SELECT a.ID AS [@ID1], b.ID AS [@ID2], a.Name AS Name1, b.Name AS Name2
+FROM forxml_path_elements_t1 a
+CROSS JOIN forxml_path_elements_t1 b
+WHERE a.ID < b.ID AND a.ID <= 2
+ORDER BY a.ID, b.ID
+FOR XML PATH('Pair'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="1" ID2="2"><Name1>John</Name1><Name2>Jane</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="1" ID2="3"><Name1>John</Name1><Name2>Bob</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="1" ID2="4"><Name1>John</Name1><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="1" ID2="5"><Name1>John</Name1><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="2" ID2="3"><Name1>Jane</Name1><Name2>Bob</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="2" ID2="4"><Name1>Jane</Name1><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ID1="2" ID2="5"><Name1>Jane</Name1><Name2 xsi:nil="true"/></Pair>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 10: Single column table
+-- ============================================
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SingleCol>Value</SingleCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SingleCol xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><SingleCol>Value</SingleCol></Row><Row/>
+~~END~~
+
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SingleCol xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row/>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 11: Many columns
+-- ============================================
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1>1</Col1><Col2>A</Col2><Col3>B</Col3><Col4>2</Col4><Col5>C</Col5><Col6>1</Col6><Col7>D</Col7><Col8>3</Col8></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/><Col3>B</Col3><Col4 xsi:nil="true"/><Col5>C</Col5><Col6 xsi:nil="true"/><Col7 xsi:nil="true"/><Col8 xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Col1>1</Col1><Col2 xsi:nil="true"/><Col3 xsi:nil="true"/><Col4>2</Col4><Col5 xsi:nil="true"/><Col6 xsi:nil="true"/><Col7>D</Col7><Col8 xsi:nil="true"/></Row>
+~~END~~
+
+
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><Col1>1</Col1><Col2>A</Col2><Col3>B</Col3><Col4>2</Col4><Col5>C</Col5><Col6>1</Col6><Col7>D</Col7><Col8>3</Col8></Row><Row><Col3>B</Col3><Col5>C</Col5></Row><Row><Col1>1</Col1><Col4>2</Col4><Col7>D</Col7></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 12: Text content
+-- ============================================
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><TextCol>Normal Text</TextCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><TextCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><TextCol>Text with special chars</TextCol></Row>
+~~END~~
+
+
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><TextCol>Normal Text</TextCol></Row><Row><ID>2</ID></Row><Row><ID>3</ID><TextCol>Text with special chars</TextCol></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 13: Empty result set
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+~~START~~
+ntext
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 14: Special characters in values
+-- ============================================
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Value>a &amp; b</Value></Row><Row><ID>2</ID><Value>a &lt; b</Value></Row><Row><ID>3</ID><Value>a &gt; b</Value></Row><Row><ID>4</ID><Value>say "hello"</Value></Row><Row><ID>5</ID><Value>it's working</Value></Row><Row><ID>6</ID><Value>&lt;tag&gt;value&lt;/tag&gt;</Value></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Value>a &amp; b</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Value>a &lt; b</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Value>a &gt; b</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Value>say "hello"</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Value>it's working</Value></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>6</ID><Value>&lt;tag&gt;value&lt;/tag&gt;</Value></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Value>a &amp; b</Value></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 6 FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>6</ID><Value>&lt;tag&gt;value&lt;/tag&gt;</Value></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 15: Unicode/Multibyte values (data values, not element names)
+-- ============================================
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Name>日本語</Name></Row><Row><ID>2</ID><Name>中文</Name></Row><Row><ID>3</ID><Name>한국어</Name></Row><Row><ID>4</ID><Name>العربية</Name></Row><Row><ID>5</ID><Name>émoji 😀</Name></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>日本語</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>中文</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>한국어</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name>العربية</Name></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name>émoji 😀</Name></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_unicode WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><Name>日本語</Name></Row>
+~~END~~
+
+
+SELECT N'日本語' AS JapaneseName, N'中文' AS ChineseName FOR XML PATH('Names'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Names><JapaneseName>日本語</JapaneseName><ChineseName>中文</ChineseName></Names>
+~~END~~
+
+
+SELECT N'Ελληνικά' AS Greek, N'Русский' AS Russian FOR XML PATH('Names'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Names xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Greek>Ελληνικά</Greek><Russian>Русский</Russian></Names>
+~~END~~
+
+
+SELECT N'مرحبا' AS Arabic, N'שלום' AS Hebrew FOR XML PATH('Names'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Names><Arabic>مرحبا</Arabic><Hebrew>שלום</Hebrew></Names>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 16: Long column names (>64 characters)
+-- ============================================
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Row><ID>1</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact>value1</this_is_a_very_long_column_name_that_exceeds_sixty_four_charact><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value2</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row><Row><ID>2</ID><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value3</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact>value1</this_is_a_very_long_column_name_that_exceeds_sixty_four_charact><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value2</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact xsi:nil="true"/><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value3</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></Row>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('LongColTest'), ELEMENTS, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><LongColTest><ID>1</ID><this_is_a_very_long_column_name_that_exceeds_sixty_four_charact>value1</this_is_a_very_long_column_name_that_exceeds_sixty_four_charact><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value2</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></LongColTest><LongColTest><ID>2</ID><another_extremely_long_column_name_for_testing_x005F_xml_element_gene>value3</another_extremely_long_column_name_for_testing_x005F_xml_element_gene></LongColTest></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 17: Boundary cases for element names
+-- ============================================
+-- Single character element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('E'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></E><E xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></E>
+~~END~~
+
+
+-- Element name with numbers
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee123'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee123><Employee123 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee123>
+~~END~~
+
+
+-- Element name starting with underscore
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('_Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></_Employee><_Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></_Employee>
+~~END~~
+
+
+-- Element name with hyphens
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee-Record'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee-Record><Employee-Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee-Record>
+~~END~~
+
+
+-- Element name with periods
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee.Record'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee.Record><Employee.Record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee.Record>
+~~END~~
+
+
+-- Default element name (no name specified) with XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH, ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></row><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></row>
+~~END~~
+
+
+-- NULL in element name position
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(NULL), ELEMENTS XSINIL;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: syntax error near 'NULL' at line 2 and character position 70)~~
+
+
+-- Very long element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions><VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 18: Complex JOIN queries
+-- ============================================
+-- INNER JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><TotalAmount>100.00</TotalAmount></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><TotalAmount>250.00</TotalAmount></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><TotalAmount xsi:nil="true"/></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><OrderID>4</OrderID><TotalAmount>175.50</TotalAmount></Order>
+~~END~~
+
+
+-- LEFT JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><OrderID>4</OrderID><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Global Ltd</CustomerName><OrderID xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder>
+~~END~~
+
+
+-- Multiple JOINs
+SELECT c.CustomerName, o.OrderID, p.ProductName, oi.Quantity
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+INNER JOIN forxml_path_elements_order_items oi ON o.OrderID = oi.OrderID
+INNER JOIN forxml_path_elements_products p ON oi.ProductID = p.ProductID
+ORDER BY o.OrderID, p.ProductID
+FOR XML PATH('OrderDetail'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><ProductName>Widget</ProductName><Quantity>2</Quantity></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><ProductName>Gadget</ProductName><Quantity xsi:nil="true"/></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><ProductName>Widget</ProductName><Quantity>5</Quantity></OrderDetail><OrderDetail xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><ProductName xsi:nil="true"/><Quantity>1</Quantity></OrderDetail>
+~~END~~
+
+
+-- LEFT JOIN with NULLs and ROOT
+SELECT c.CustomerName, c.City, o.OrderDate, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><City xsi:nil="true"/><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><City>Boston</City><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Global Ltd</CustomerName><City>Chicago</City><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
+~~END~~
+
+
+-- RIGHT JOIN
+SELECT c.CustomerName, o.OrderID, o.OrderDate
+FROM forxml_path_elements_customers c
+RIGHT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>1</OrderID><OrderDate>2024-01-15</OrderDate></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><OrderID>2</OrderID><OrderDate>2024-02-20</OrderDate></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><OrderID>3</OrderID><OrderDate>2024-03-10</OrderDate></Order><Order xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><OrderID>4</OrderID><OrderDate xsi:nil="true"/></Order>
+~~END~~
+
+
+-- CROSS JOIN
+SELECT a.ID AS ID1, a.Name AS Name1, b.ID AS ID2, b.Name AS Name2
+FROM forxml_path_elements_t1 a
+CROSS JOIN forxml_path_elements_t1 b
+WHERE a.ID < b.ID AND a.ID <= 2
+ORDER BY a.ID, b.ID
+FOR XML PATH('Pair'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>2</ID2><Name2>Jane</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>3</ID2><Name2>Bob</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>4</ID2><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>1</ID1><Name1>John</Name1><ID2>5</ID2><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>2</ID1><Name1>Jane</Name1><ID2>3</ID2><Name2>Bob</Name2></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>2</ID1><Name1>Jane</Name1><ID2>4</ID2><Name2 xsi:nil="true"/></Pair><Pair xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID1>2</ID1><Name1>Jane</Name1><ID2>5</ID2><Name2 xsi:nil="true"/></Pair>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 19: Subqueries
+-- ============================================
+-- Subquery in SELECT with ELEMENTS XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS Result;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+-- Correlated subquery with ELEMENTS XSINIL
+SELECT t1.ID, 
+    (SELECT Name, Department FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH('Details'), ELEMENTS XSINIL, TYPE) AS Details 
+FROM forxml_path_elements_t1 t1
+WHERE t1.ID <= 3;
+GO
+~~START~~
+int#!#xml
+1#!#<Details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Name>John</Name><Department>Sales</Department></Details>
+2#!#<Details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Name>Jane</Name><Department xsi:nil="true"/></Details>
+3#!#<Details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Name>Bob</Name><Department>IT</Department></Details>
+~~END~~
+
+
+SELECT 
+    ID,
+    (SELECT Name FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH(''), ELEMENTS, TYPE) AS NameElement
+FROM forxml_path_elements_t1 t1
+WHERE ID <= 2;
+GO
+~~START~~
+int#!#xml
+1#!#<Name>John</Name>
+2#!#<Name>Jane</Name>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 20: ORDER BY, GROUP BY, TOP
+-- ============================================
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY Name FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+SELECT TOP 3 ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee>
+~~END~~
+
+
+SELECT Department, COUNT(*) AS EmpCount 
+FROM forxml_path_elements_t1 
+GROUP BY Department 
+ORDER BY Department
+FOR XML PATH('Dept'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department xsi:nil="true"/><EmpCount>2</EmpCount></Dept><Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department>HR</Department><EmpCount>1</EmpCount></Dept><Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department>IT</Department><EmpCount>1</EmpCount></Dept><Dept xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Department>Sales</Department><EmpCount>1</EmpCount></Dept>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 21: Stored Procedures
+-- ============================================
+EXEC forxml_path_elements_p1;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p2;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p3;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p4;
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+EXEC forxml_path_elements_p5;
+GO
+~~START~~
+ntext
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+EXEC forxml_path_elements_p6 @empid = 1;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p6 @empid = 4;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p6 @empid = 999;
+GO
+~~START~~
+ntext
+~~END~~
+
+
+-- Procedure with department filter
+EXEC forxml_path_elements_p7 'Sales';
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+EXEC forxml_path_elements_p7 NULL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+
+
+-- ============================================
+-- SECTION 22: SELECT INTO variable
+-- ============================================
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+SELECT @xml_var AS result;
+GO
+~~START~~
+varchar
+<Employee><ID>1</ID><Name>John</Name></Employee>
+~~END~~
+
+
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+SELECT @xml_var AS result;
+GO
+~~START~~
+varchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+SELECT @xml_var AS result;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID></Employee>
+~~END~~
+
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data'), TYPE);
+SELECT @xml_var AS result;
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 23: SELECT...INTO (create new table)
+-- ============================================
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into1;
+GO
+
+SELECT * FROM forxml_path_elements_into1;
+GO
+~~START~~
+xml
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+DROP TABLE forxml_path_elements_into1;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, TYPE) AS XMLData INTO forxml_path_elements_into2;
+GO
+
+SELECT * FROM forxml_path_elements_into2;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+DROP TABLE forxml_path_elements_into2;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into3;
+GO
+
+SELECT * FROM forxml_path_elements_into3;
+GO
+~~START~~
+xml
+<Data><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+~~END~~
+
+
+DROP TABLE forxml_path_elements_into3;
+GO
+
+
+-- ============================================
+-- SECTION 24: Regular view with FOR XML
+-- ============================================
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee></Data>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 25: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+SELECT * FROM forxml_path_elements_dep_view1;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_dep_view2;
+GO
+~~START~~
+ntext
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID></Employee><Employee><ID>5</ID><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_dep_view3;
+GO
+~~START~~
+ntext
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_dep_view4;
+GO
+~~START~~
+ntext
+<Employees><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Employees>
+~~END~~
+
+
+SELECT * FROM forxml_path_elements_dep_view5;
+GO
+~~START~~
+ntext
+<Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>100</IntCol><VarcharCol>Text1</VarcharCol><BitCol>1</BitCol><DecimalCol>99.99</DecimalCol><DateCol>2024-01-01</DateCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol xsi:nil="true"/><BitCol xsi:nil="true"/><DecimalCol xsi:nil="true"/><DateCol xsi:nil="true"/></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol>200</IntCol><VarcharCol xsi:nil="true"/><BitCol>0</BitCol><DecimalCol xsi:nil="true"/><DateCol>2024-06-15</DateCol></Row><Row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><IntCol xsi:nil="true"/><VarcharCol>Text2</VarcharCol><BitCol xsi:nil="true"/><DecimalCol>50.00</DecimalCol><DateCol xsi:nil="true"/></Row>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 26: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+SELECT dbo.forxml_path_elements_func1() AS result;
+GO
+~~START~~
+nvarchar
+<Employee><ID>1</ID><Name>John</Name></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func2() AS result;
+GO
+~~START~~
+nvarchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func3() AS result;
+GO
+~~START~~
+xml
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func4(1) AS result;
+GO
+~~START~~
+nvarchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+~~END~~
+
+
+SELECT dbo.forxml_path_elements_func4(4) AS result;
+GO
+~~START~~
+nvarchar
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee>
+~~END~~
+
+
+
+-- ============================================
+-- SECTION 27: XML methods on FOR XML result
+-- ============================================
+-- Using .value() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Name)[1]', 'VARCHAR(50)') AS extracted_name;
+GO
+~~START~~
+varchar
+John
+~~END~~
+
+
+-- Using .value() method on NULL element with XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Department)[1]', 'VARCHAR(50)') AS extracted_dept;
+GO
+~~START~~
+varchar
+
+~~END~~
+
+
+-- Using .query() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE).query('/Data/Employee[1]') AS query_result;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: 'XML QUERY' is not currently supported in Babelfish)~~
+
+
+-- Using .exist() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).exist('/Employee/Department') AS element_exists;
+GO
+~~START~~
+bit
+1
+~~END~~
+
+
+-- CAST result to XML type with XSINIL
+SELECT CAST((SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS XML) AS casted_xml;
+GO
+~~START~~
+xml
+<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee>
+~~END~~
+

--- a/test/JDBC/expected/forxml-path-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-vu-verify.out
@@ -24,7 +24,7 @@ SELECT hello.String as [@param2] , string  FROM for_xml_path hello ORDER BY Sequ
 GO
 ~~START~~
 ntext
-<row param2="SELECT" ><string>SELECT</string></row><row param2="Product," ><string>Product,</string></row><row param2="UnitPrice," ><string>UnitPrice,</string></row><row param2="EffectiveDate" ><string>EffectiveDate</string></row><row param2="FROM" ><string>FROM</string></row><row param2="Products" ><string>Products</string></row><row param2="WHERE" ><string>WHERE</string></row><row param2="UnitPrice" ><string>UnitPrice</string></row><row param2="&gt; 100" ><string>&gt; 100</string></row>
+<row param2="SELECT"><string>SELECT</string></row><row param2="Product,"><string>Product,</string></row><row param2="UnitPrice,"><string>UnitPrice,</string></row><row param2="EffectiveDate"><string>EffectiveDate</string></row><row param2="FROM"><string>FROM</string></row><row param2="Products"><string>Products</string></row><row param2="WHERE"><string>WHERE</string></row><row param2="UnitPrice"><string>UnitPrice</string></row><row param2="&gt; 100"><string>&gt; 100</string></row>
 ~~END~~
 
 
@@ -33,7 +33,7 @@ SELECT String as [@param2]  FROM for_xml_path ORDER BY SequenceNumber FOR XML PA
 GO
 ~~START~~
 ntext
-<row param2="SELECT" /><row param2="Product," /><row param2="UnitPrice," /><row param2="EffectiveDate" /><row param2="FROM" /><row param2="Products" /><row param2="WHERE" /><row param2="UnitPrice" /><row param2="&gt; 100" />
+<row param2="SELECT"/><row param2="Product,"/><row param2="UnitPrice,"/><row param2="EffectiveDate"/><row param2="FROM"/><row param2="Products"/><row param2="WHERE"/><row param2="UnitPrice"/><row param2="&gt; 100"/>
 ~~END~~
 
 
@@ -78,7 +78,7 @@ SELECT * FROM for_xml_path_v3
 GO
 ~~START~~
 ntext
-<row param2="SELECT" ><string>SELECT</string></row><row param2="Product," ><string>Product,</string></row><row param2="UnitPrice," ><string>UnitPrice,</string></row><row param2="EffectiveDate" ><string>EffectiveDate</string></row><row param2="FROM" ><string>FROM</string></row><row param2="Products" ><string>Products</string></row><row param2="WHERE" ><string>WHERE</string></row><row param2="UnitPrice" ><string>UnitPrice</string></row><row param2="&gt; 100" ><string>&gt; 100</string></row>
+<row param2="SELECT"><string>SELECT</string></row><row param2="Product,"><string>Product,</string></row><row param2="UnitPrice,"><string>UnitPrice,</string></row><row param2="EffectiveDate"><string>EffectiveDate</string></row><row param2="FROM"><string>FROM</string></row><row param2="Products"><string>Products</string></row><row param2="WHERE"><string>WHERE</string></row><row param2="UnitPrice"><string>UnitPrice</string></row><row param2="&gt; 100"><string>&gt; 100</string></row>
 ~~END~~
 
 
@@ -112,7 +112,7 @@ EXEC for_xml_path_p3
 GO
 ~~START~~
 ntext
-<row param2="SELECT" ><string>SELECT</string></row><row param2="Product," ><string>Product,</string></row><row param2="UnitPrice," ><string>UnitPrice,</string></row><row param2="EffectiveDate" ><string>EffectiveDate</string></row><row param2="FROM" ><string>FROM</string></row><row param2="Products" ><string>Products</string></row><row param2="WHERE" ><string>WHERE</string></row><row param2="UnitPrice" ><string>UnitPrice</string></row><row param2="&gt; 100" ><string>&gt; 100</string></row>
+<row param2="SELECT"><string>SELECT</string></row><row param2="Product,"><string>Product,</string></row><row param2="UnitPrice,"><string>UnitPrice,</string></row><row param2="EffectiveDate"><string>EffectiveDate</string></row><row param2="FROM"><string>FROM</string></row><row param2="Products"><string>Products</string></row><row param2="WHERE"><string>WHERE</string></row><row param2="UnitPrice"><string>UnitPrice</string></row><row param2="&gt; 100"><string>&gt; 100</string></row>
 ~~END~~
 
 

--- a/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-cleanup.sql
@@ -1,0 +1,71 @@
+-- Drop functions
+DROP FUNCTION IF EXISTS forxml_path_elements_func1;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func2;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func3;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func4;
+GO
+
+-- Drop dependent views
+DROP VIEW IF EXISTS forxml_path_elements_dep_view1;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view2;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view3;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view4;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view5;
+GO
+
+-- Drop regular view
+DROP VIEW IF EXISTS forxml_path_elements_regular_view;
+GO
+
+-- Drop procedures
+DROP PROCEDURE IF EXISTS forxml_path_elements_p1;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p2;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p3;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p4;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p5;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p6;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p7;
+GO
+
+-- Drop tables
+DROP TABLE IF EXISTS forxml_path_elements_t1;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t2;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t3;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t4;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t5;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t6;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t7;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_special;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_unicode;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_long_cols;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_orders;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_customers;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_products;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_order_items;
+GO

--- a/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-prepare.sql
@@ -1,0 +1,333 @@
+-- ============================================
+-- SECTION: Base Tables
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t1 (
+    ID INT,
+    Name VARCHAR(50),
+    Department VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t1 VALUES (1, 'John', 'Sales');
+INSERT INTO forxml_path_elements_t1 VALUES (2, 'Jane', NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (3, 'Bob', 'IT');
+INSERT INTO forxml_path_elements_t1 VALUES (4, NULL, NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (5, NULL, 'HR');
+GO
+
+-- ============================================
+-- SECTION: Multiple Data Types Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t2 (
+    IntCol INT,
+    VarcharCol VARCHAR(50),
+    BitCol BIT,
+    DecimalCol DECIMAL(10,2),
+    DateCol DATE
+);
+GO
+
+INSERT INTO forxml_path_elements_t2 VALUES (100, 'Text1', 1, 99.99, '2024-01-01');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, NULL, NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t2 VALUES (200, NULL, 0, NULL, '2024-06-15');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, 'Text2', NULL, 50.00, NULL);
+GO
+
+-- ============================================
+-- SECTION: NULL Patterns Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t3 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (1, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, 'Val', NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, 'Val');
+GO
+
+-- ============================================
+-- SECTION: Attribute-Centric Test Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t4 (
+    ID INT,
+    Name VARCHAR(50),
+    Value VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t4 VALUES (1, 'Item1', 'Value1');
+INSERT INTO forxml_path_elements_t4 VALUES (2, NULL, 'Value2');
+INSERT INTO forxml_path_elements_t4 VALUES (3, 'Item3', NULL);
+GO
+
+-- ============================================
+-- SECTION: Single Column Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t5 (
+    SingleCol VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t5 VALUES ('Value');
+INSERT INTO forxml_path_elements_t5 VALUES (NULL);
+GO
+
+-- ============================================
+-- SECTION: Many Columns Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t6 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50),
+    Col4 INT,
+    Col5 VARCHAR(50),
+    Col6 BIT,
+    Col7 VARCHAR(50),
+    Col8 INT
+);
+GO
+
+INSERT INTO forxml_path_elements_t6 VALUES (1, 'A', 'B', 2, 'C', 1, 'D', 3);
+INSERT INTO forxml_path_elements_t6 VALUES (NULL, NULL, 'B', NULL, 'C', NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t6 VALUES (1, NULL, NULL, 2, NULL, NULL, 'D', NULL);
+GO
+
+-- ============================================
+-- SECTION: Text Content Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t7 (
+    ID INT,
+    TextCol VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_t7 VALUES (1, 'Normal Text');
+INSERT INTO forxml_path_elements_t7 VALUES (2, NULL);
+INSERT INTO forxml_path_elements_t7 VALUES (3, 'Text with special chars');
+GO
+
+-- ============================================
+-- SECTION: Special Characters Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_special (
+    ID INT,
+    Value VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_special VALUES (1, 'a & b');
+INSERT INTO forxml_path_elements_special VALUES (2, 'a < b');
+INSERT INTO forxml_path_elements_special VALUES (3, 'a > b');
+INSERT INTO forxml_path_elements_special VALUES (4, 'say "hello"');
+INSERT INTO forxml_path_elements_special VALUES (5, 'it''s working');
+INSERT INTO forxml_path_elements_special VALUES (6, '<tag>value</tag>');
+GO
+
+-- ============================================
+-- SECTION: Unicode/Multibyte Values Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_unicode (
+    ID INT,
+    Name NVARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_unicode VALUES (1, N'日本語');
+INSERT INTO forxml_path_elements_unicode VALUES (2, N'中文');
+INSERT INTO forxml_path_elements_unicode VALUES (3, N'한국어');
+INSERT INTO forxml_path_elements_unicode VALUES (4, N'العربية');
+INSERT INTO forxml_path_elements_unicode VALUES (5, N'émoji 😀');
+GO
+
+-- ============================================
+-- SECTION: Long Column Names Table (>64 characters)
+-- ============================================
+
+CREATE TABLE forxml_path_elements_long_cols (
+    ID INT,
+    this_is_a_very_long_column_name_that_exceeds_sixty_four_characters_in_length VARCHAR(50),
+    another_extremely_long_column_name_for_testing_xml_element_generation_limits VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_long_cols VALUES (1, 'value1', 'value2');
+INSERT INTO forxml_path_elements_long_cols VALUES (2, NULL, 'value3');
+GO
+
+-- ============================================
+-- SECTION: Tables for JOIN Queries
+-- ============================================
+
+CREATE TABLE forxml_path_elements_orders (
+    OrderID INT,
+    CustomerID INT,
+    OrderDate DATE,
+    TotalAmount DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_orders VALUES (1, 1, '2024-01-15', 100.00);
+INSERT INTO forxml_path_elements_orders VALUES (2, 1, '2024-02-20', 250.00);
+INSERT INTO forxml_path_elements_orders VALUES (3, 2, '2024-03-10', NULL);
+INSERT INTO forxml_path_elements_orders VALUES (4, 3, NULL, 175.50);
+GO
+
+CREATE TABLE forxml_path_elements_customers (
+    CustomerID INT,
+    CustomerName VARCHAR(50),
+    City VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_customers VALUES (1, 'Acme Corp', 'New York');
+INSERT INTO forxml_path_elements_customers VALUES (2, 'Tech Inc', NULL);
+INSERT INTO forxml_path_elements_customers VALUES (3, NULL, 'Boston');
+INSERT INTO forxml_path_elements_customers VALUES (4, 'Global Ltd', 'Chicago');
+GO
+
+CREATE TABLE forxml_path_elements_products (
+    ProductID INT,
+    ProductName VARCHAR(50),
+    Price DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_products VALUES (1, 'Widget', 25.00);
+INSERT INTO forxml_path_elements_products VALUES (2, 'Gadget', NULL);
+INSERT INTO forxml_path_elements_products VALUES (3, NULL, 75.00);
+GO
+
+CREATE TABLE forxml_path_elements_order_items (
+    OrderID INT,
+    ProductID INT,
+    Quantity INT
+);
+GO
+
+INSERT INTO forxml_path_elements_order_items VALUES (1, 1, 2);
+INSERT INTO forxml_path_elements_order_items VALUES (1, 2, NULL);
+INSERT INTO forxml_path_elements_order_items VALUES (2, 1, 5);
+INSERT INTO forxml_path_elements_order_items VALUES (3, 3, 1);
+GO
+
+-- ============================================
+-- SECTION: Stored Procedures (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+CREATE PROCEDURE forxml_path_elements_p1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p5 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+CREATE PROCEDURE forxml_path_elements_p7 @DeptFilter VARCHAR(50) AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE Department = @DeptFilter OR Department IS NULL FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p6 @empid INT AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+
+-- ============================================
+-- SECTION: Regular Views (not using FOR XML)
+-- ============================================
+
+CREATE VIEW forxml_path_elements_regular_view AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID <= 3;
+GO
+
+-- ============================================
+-- SECTION: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+CREATE VIEW forxml_path_elements_dep_view1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Employees'), ELEMENTS XSINIL;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view5 AS
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+CREATE FUNCTION forxml_path_elements_func1()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func2()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func3()
+RETURNS XML
+AS
+BEGIN
+    DECLARE @result XML;
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID <= 2 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func4(@empid INT)
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO

--- a/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-verify.sql
@@ -1,0 +1,559 @@
+-- ============================================
+-- SECTION 1: Basic ELEMENTS directive
+-- ============================================
+
+-- Without ELEMENTS (regression test)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee');
+GO
+
+-- With ELEMENTS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+-- With ELEMENTS ABSENT
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+-- With ELEMENTS XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 2: NULL handling with ELEMENTS XSINIL
+-- ============================================
+
+-- Single row with no NULL values
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Single row with NULL in middle column
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Single row with all NULLs except ID
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Row with NULL ID (ID=5 has NULL name and non-NULL dept)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 5 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- All NULL columns
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS XSINIL;
+GO
+
+-- Mixed NULL and non-NULL values
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 3: NULL handling with ELEMENTS ABSENT
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS ABSENT;
+GO
+
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH('row'), ELEMENTS;
+GO
+
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 4: ELEMENTS with ROOT directive
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS ABSENT;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS;
+GO
+
+-- Different order of directives
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 5: ELEMENTS with TYPE directive
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS ABSENT;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), TYPE, ELEMENTS XSINIL;
+GO
+
+-- All directives combined - different order
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 6: Empty element name (PATH(''))
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 7: Multiple data types
+-- ============================================
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol = 100 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 8: Various NULL patterns
+-- ============================================
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 9: Attribute-centric columns with ELEMENTS
+-- ============================================
+
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS ABSENT;
+GO
+
+-- Attribute-centric column with NULL value and XSINIL
+SELECT ID, Name AS [@Name], Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Multiple attribute-centric columns with ELEMENTS XSINIL
+SELECT ID AS [@ID], Name AS [@Name], Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 10: Single column table
+-- ============================================
+
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 11: Many columns
+-- ============================================
+
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 12: Text content
+-- ============================================
+
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 13: Empty result set
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 14: Special characters in values
+-- ============================================
+
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 6 FOR XML PATH('Row'), ELEMENTS;
+GO
+
+-- ============================================
+-- SECTION 15: Unicode/Multibyte values (data values, not element names)
+-- ============================================
+
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_unicode WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT N'日本語' AS JapaneseName, N'中文' AS ChineseName FOR XML PATH('Names'), ELEMENTS;
+GO
+
+SELECT N'Ελληνικά' AS Greek, N'Русский' AS Russian FOR XML PATH('Names'), ELEMENTS XSINIL;
+GO
+
+SELECT N'مرحبا' AS Arabic, N'שלום' AS Hebrew FOR XML PATH('Names'), ELEMENTS;
+GO
+
+-- ============================================
+-- SECTION 16: Long column names (>64 characters)
+-- ============================================
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('LongColTest'), ELEMENTS, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 17: Boundary cases for element names
+-- ============================================
+
+-- Single character element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('E'), ELEMENTS XSINIL;
+GO
+
+-- Element name with numbers
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee123'), ELEMENTS XSINIL;
+GO
+
+-- Element name starting with underscore
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('_Employee'), ELEMENTS XSINIL;
+GO
+
+-- Element name with hyphens
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee-Record'), ELEMENTS XSINIL;
+GO
+
+-- Element name with periods
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee.Record'), ELEMENTS XSINIL;
+GO
+
+-- Default element name (no name specified) with XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH, ELEMENTS XSINIL;
+GO
+
+-- NULL in element name position
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(NULL), ELEMENTS XSINIL;
+GO
+
+-- Very long element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 18: Complex JOIN queries
+-- ============================================
+
+-- INNER JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+
+-- LEFT JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL;
+GO
+
+-- Multiple JOINs
+SELECT c.CustomerName, o.OrderID, p.ProductName, oi.Quantity
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+INNER JOIN forxml_path_elements_order_items oi ON o.OrderID = oi.OrderID
+INNER JOIN forxml_path_elements_products p ON oi.ProductID = p.ProductID
+ORDER BY o.OrderID, p.ProductID
+FOR XML PATH('OrderDetail'), ELEMENTS XSINIL;
+GO
+
+-- LEFT JOIN with NULLs and ROOT
+SELECT c.CustomerName, c.City, o.OrderDate, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- RIGHT JOIN
+SELECT c.CustomerName, o.OrderID, o.OrderDate
+FROM forxml_path_elements_customers c
+RIGHT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+
+-- CROSS JOIN
+SELECT a.ID AS ID1, a.Name AS Name1, b.ID AS ID2, b.Name AS Name2
+FROM forxml_path_elements_t1 a
+CROSS JOIN forxml_path_elements_t1 b
+WHERE a.ID < b.ID AND a.ID <= 2
+ORDER BY a.ID, b.ID
+FOR XML PATH('Pair'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 19: Subqueries
+-- ============================================
+
+-- Subquery in SELECT with ELEMENTS XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS Result;
+GO
+
+-- Correlated subquery with ELEMENTS XSINIL
+SELECT t1.ID, 
+    (SELECT Name, Department FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH('Details'), ELEMENTS XSINIL, TYPE) AS Details 
+FROM forxml_path_elements_t1 t1
+WHERE t1.ID <= 3;
+GO
+
+SELECT 
+    ID,
+    (SELECT Name FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH(''), ELEMENTS, TYPE) AS NameElement
+FROM forxml_path_elements_t1 t1
+WHERE ID <= 2;
+GO
+
+-- ============================================
+-- SECTION 20: ORDER BY, GROUP BY, TOP
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY Name FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT TOP 3 ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT Department, COUNT(*) AS EmpCount 
+FROM forxml_path_elements_t1 
+GROUP BY Department 
+ORDER BY Department
+FOR XML PATH('Dept'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 21: Stored Procedures
+-- ============================================
+
+EXEC forxml_path_elements_p1;
+GO
+
+EXEC forxml_path_elements_p2;
+GO
+
+EXEC forxml_path_elements_p3;
+GO
+
+EXEC forxml_path_elements_p4;
+GO
+
+EXEC forxml_path_elements_p5;
+GO
+
+EXEC forxml_path_elements_p6 @empid = 1;
+GO
+
+EXEC forxml_path_elements_p6 @empid = 4;
+GO
+
+EXEC forxml_path_elements_p6 @empid = 999;
+GO
+
+-- Procedure with department filter
+EXEC forxml_path_elements_p7 'Sales';
+GO
+
+EXEC forxml_path_elements_p7 NULL;
+GO
+
+
+-- ============================================
+-- SECTION 22: SELECT INTO variable
+-- ============================================
+
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+SELECT @xml_var AS result;
+GO
+
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+SELECT @xml_var AS result;
+GO
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+SELECT @xml_var AS result;
+GO
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data'), TYPE);
+SELECT @xml_var AS result;
+GO
+
+-- ============================================
+-- SECTION 23: SELECT...INTO (create new table)
+-- ============================================
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into1;
+GO
+
+SELECT * FROM forxml_path_elements_into1;
+GO
+
+DROP TABLE forxml_path_elements_into1;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, TYPE) AS XMLData INTO forxml_path_elements_into2;
+GO
+
+SELECT * FROM forxml_path_elements_into2;
+GO
+
+DROP TABLE forxml_path_elements_into2;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into3;
+GO
+
+SELECT * FROM forxml_path_elements_into3;
+GO
+
+DROP TABLE forxml_path_elements_into3;
+GO
+
+-- ============================================
+-- SECTION 24: Regular view with FOR XML
+-- ============================================
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 25: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+SELECT * FROM forxml_path_elements_dep_view1;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view2;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view3;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view4;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view5;
+GO
+
+-- ============================================
+-- SECTION 26: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+SELECT dbo.forxml_path_elements_func1() AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func2() AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func3() AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func4(1) AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func4(4) AS result;
+GO
+
+-- ============================================
+-- SECTION 27: XML methods on FOR XML result
+-- ============================================
+
+-- Using .value() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Name)[1]', 'VARCHAR(50)') AS extracted_name;
+GO
+
+-- Using .value() method on NULL element with XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Department)[1]', 'VARCHAR(50)') AS extracted_dept;
+GO
+
+-- Using .query() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE).query('/Data/Employee[1]') AS query_result;
+GO
+
+-- Using .exist() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).exist('/Employee/Department') AS element_exists;
+GO
+
+-- CAST result to XML type with XSINIL
+SELECT CAST((SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS XML) AS casted_xml;
+GO

--- a/test/JDBC/input/forxml/forxml-path-elements-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-vu-cleanup.sql
@@ -1,0 +1,71 @@
+-- Drop functions
+DROP FUNCTION IF EXISTS forxml_path_elements_func1;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func2;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func3;
+GO
+DROP FUNCTION IF EXISTS forxml_path_elements_func4;
+GO
+
+-- Drop dependent views
+DROP VIEW IF EXISTS forxml_path_elements_dep_view1;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view2;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view3;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view4;
+GO
+DROP VIEW IF EXISTS forxml_path_elements_dep_view5;
+GO
+
+-- Drop regular view
+DROP VIEW IF EXISTS forxml_path_elements_regular_view;
+GO
+
+-- Drop procedures
+DROP PROCEDURE IF EXISTS forxml_path_elements_p1;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p2;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p3;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p4;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p5;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p6;
+GO
+DROP PROCEDURE IF EXISTS forxml_path_elements_p7;
+GO
+
+-- Drop tables
+DROP TABLE IF EXISTS forxml_path_elements_t1;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t2;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t3;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t4;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t5;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t6;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_t7;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_special;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_unicode;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_long_cols;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_orders;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_customers;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_products;
+GO
+DROP TABLE IF EXISTS forxml_path_elements_order_items;
+GO

--- a/test/JDBC/input/forxml/forxml-path-elements-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-vu-prepare.sql
@@ -1,0 +1,333 @@
+-- ============================================
+-- SECTION: Base Tables
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t1 (
+    ID INT,
+    Name VARCHAR(50),
+    Department VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t1 VALUES (1, 'John', 'Sales');
+INSERT INTO forxml_path_elements_t1 VALUES (2, 'Jane', NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (3, 'Bob', 'IT');
+INSERT INTO forxml_path_elements_t1 VALUES (4, NULL, NULL);
+INSERT INTO forxml_path_elements_t1 VALUES (5, NULL, 'HR');
+GO
+
+-- ============================================
+-- SECTION: Multiple Data Types Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t2 (
+    IntCol INT,
+    VarcharCol VARCHAR(50),
+    BitCol BIT,
+    DecimalCol DECIMAL(10,2),
+    DateCol DATE
+);
+GO
+
+INSERT INTO forxml_path_elements_t2 VALUES (100, 'Text1', 1, 99.99, '2024-01-01');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, NULL, NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t2 VALUES (200, NULL, 0, NULL, '2024-06-15');
+INSERT INTO forxml_path_elements_t2 VALUES (NULL, 'Text2', NULL, 50.00, NULL);
+GO
+
+-- ============================================
+-- SECTION: NULL Patterns Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t3 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (1, NULL, NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, 'Val', NULL);
+INSERT INTO forxml_path_elements_t3 VALUES (NULL, NULL, 'Val');
+GO
+
+-- ============================================
+-- SECTION: Attribute-Centric Test Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t4 (
+    ID INT,
+    Name VARCHAR(50),
+    Value VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t4 VALUES (1, 'Item1', 'Value1');
+INSERT INTO forxml_path_elements_t4 VALUES (2, NULL, 'Value2');
+INSERT INTO forxml_path_elements_t4 VALUES (3, 'Item3', NULL);
+GO
+
+-- ============================================
+-- SECTION: Single Column Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t5 (
+    SingleCol VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_t5 VALUES ('Value');
+INSERT INTO forxml_path_elements_t5 VALUES (NULL);
+GO
+
+-- ============================================
+-- SECTION: Many Columns Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t6 (
+    Col1 INT,
+    Col2 VARCHAR(50),
+    Col3 VARCHAR(50),
+    Col4 INT,
+    Col5 VARCHAR(50),
+    Col6 BIT,
+    Col7 VARCHAR(50),
+    Col8 INT
+);
+GO
+
+INSERT INTO forxml_path_elements_t6 VALUES (1, 'A', 'B', 2, 'C', 1, 'D', 3);
+INSERT INTO forxml_path_elements_t6 VALUES (NULL, NULL, 'B', NULL, 'C', NULL, NULL, NULL);
+INSERT INTO forxml_path_elements_t6 VALUES (1, NULL, NULL, 2, NULL, NULL, 'D', NULL);
+GO
+
+-- ============================================
+-- SECTION: Text Content Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_t7 (
+    ID INT,
+    TextCol VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_t7 VALUES (1, 'Normal Text');
+INSERT INTO forxml_path_elements_t7 VALUES (2, NULL);
+INSERT INTO forxml_path_elements_t7 VALUES (3, 'Text with special chars');
+GO
+
+-- ============================================
+-- SECTION: Special Characters Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_special (
+    ID INT,
+    Value VARCHAR(100)
+);
+GO
+
+INSERT INTO forxml_path_elements_special VALUES (1, 'a & b');
+INSERT INTO forxml_path_elements_special VALUES (2, 'a < b');
+INSERT INTO forxml_path_elements_special VALUES (3, 'a > b');
+INSERT INTO forxml_path_elements_special VALUES (4, 'say "hello"');
+INSERT INTO forxml_path_elements_special VALUES (5, 'it''s working');
+INSERT INTO forxml_path_elements_special VALUES (6, '<tag>value</tag>');
+GO
+
+-- ============================================
+-- SECTION: Unicode/Multibyte Values Table
+-- ============================================
+
+CREATE TABLE forxml_path_elements_unicode (
+    ID INT,
+    Name NVARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_unicode VALUES (1, N'日本語');
+INSERT INTO forxml_path_elements_unicode VALUES (2, N'中文');
+INSERT INTO forxml_path_elements_unicode VALUES (3, N'한국어');
+INSERT INTO forxml_path_elements_unicode VALUES (4, N'العربية');
+INSERT INTO forxml_path_elements_unicode VALUES (5, N'émoji 😀');
+GO
+
+-- ============================================
+-- SECTION: Long Column Names Table (>64 characters)
+-- ============================================
+
+CREATE TABLE forxml_path_elements_long_cols (
+    ID INT,
+    this_is_a_very_long_column_name_that_exceeds_sixty_four_characters_in_length VARCHAR(50),
+    another_extremely_long_column_name_for_testing_xml_element_generation_limits VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_long_cols VALUES (1, 'value1', 'value2');
+INSERT INTO forxml_path_elements_long_cols VALUES (2, NULL, 'value3');
+GO
+
+-- ============================================
+-- SECTION: Tables for JOIN Queries
+-- ============================================
+
+CREATE TABLE forxml_path_elements_orders (
+    OrderID INT,
+    CustomerID INT,
+    OrderDate DATE,
+    TotalAmount DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_orders VALUES (1, 1, '2024-01-15', 100.00);
+INSERT INTO forxml_path_elements_orders VALUES (2, 1, '2024-02-20', 250.00);
+INSERT INTO forxml_path_elements_orders VALUES (3, 2, '2024-03-10', NULL);
+INSERT INTO forxml_path_elements_orders VALUES (4, 3, NULL, 175.50);
+GO
+
+CREATE TABLE forxml_path_elements_customers (
+    CustomerID INT,
+    CustomerName VARCHAR(50),
+    City VARCHAR(50)
+);
+GO
+
+INSERT INTO forxml_path_elements_customers VALUES (1, 'Acme Corp', 'New York');
+INSERT INTO forxml_path_elements_customers VALUES (2, 'Tech Inc', NULL);
+INSERT INTO forxml_path_elements_customers VALUES (3, NULL, 'Boston');
+INSERT INTO forxml_path_elements_customers VALUES (4, 'Global Ltd', 'Chicago');
+GO
+
+CREATE TABLE forxml_path_elements_products (
+    ProductID INT,
+    ProductName VARCHAR(50),
+    Price DECIMAL(10,2)
+);
+GO
+
+INSERT INTO forxml_path_elements_products VALUES (1, 'Widget', 25.00);
+INSERT INTO forxml_path_elements_products VALUES (2, 'Gadget', NULL);
+INSERT INTO forxml_path_elements_products VALUES (3, NULL, 75.00);
+GO
+
+CREATE TABLE forxml_path_elements_order_items (
+    OrderID INT,
+    ProductID INT,
+    Quantity INT
+);
+GO
+
+INSERT INTO forxml_path_elements_order_items VALUES (1, 1, 2);
+INSERT INTO forxml_path_elements_order_items VALUES (1, 2, NULL);
+INSERT INTO forxml_path_elements_order_items VALUES (2, 1, 5);
+INSERT INTO forxml_path_elements_order_items VALUES (3, 3, 1);
+GO
+
+-- ============================================
+-- SECTION: Stored Procedures (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+CREATE PROCEDURE forxml_path_elements_p1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p5 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+CREATE PROCEDURE forxml_path_elements_p7 @DeptFilter VARCHAR(50) AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE Department = @DeptFilter OR Department IS NULL FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE PROCEDURE forxml_path_elements_p6 @empid INT AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+
+-- ============================================
+-- SECTION: Regular Views (not using FOR XML)
+-- ============================================
+
+CREATE VIEW forxml_path_elements_regular_view AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID <= 3;
+GO
+
+-- ============================================
+-- SECTION: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+CREATE VIEW forxml_path_elements_dep_view1 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view2 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view3 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view4 AS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Employees'), ELEMENTS XSINIL;
+GO
+
+CREATE VIEW forxml_path_elements_dep_view5 AS
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+CREATE FUNCTION forxml_path_elements_func1()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func2()
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func3()
+RETURNS XML
+AS
+BEGIN
+    DECLARE @result XML;
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID <= 2 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+    RETURN @result;
+END;
+GO
+
+CREATE FUNCTION forxml_path_elements_func4(@empid INT)
+RETURNS NVARCHAR(MAX)
+AS
+BEGIN
+    DECLARE @result NVARCHAR(MAX);
+    SELECT @result = (SELECT * FROM forxml_path_elements_t1 WHERE ID = @empid FOR XML PATH('Employee'), ELEMENTS XSINIL);
+    RETURN @result;
+END;
+GO

--- a/test/JDBC/input/forxml/forxml-path-elements-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-vu-verify.sql
@@ -1,0 +1,610 @@
+-- ============================================
+-- SECTION 1: Basic ELEMENTS directive
+-- ============================================
+
+-- Without ELEMENTS (regression test)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee');
+GO
+
+-- With ELEMENTS
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+-- With ELEMENTS ABSENT
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+-- With ELEMENTS XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 2: NULL handling with ELEMENTS XSINIL
+-- ============================================
+
+-- Single row with no NULL values
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Single row with NULL in middle column
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Single row with all NULLs except ID
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Row with NULL ID (ID=5 has NULL name and non-NULL dept)
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 5 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- All NULL columns
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS XSINIL;
+GO
+
+-- Mixed NULL and non-NULL values
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 3: NULL handling with ELEMENTS ABSENT
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 4 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+SELECT NULL AS Col1, NULL AS Col2, NULL AS Col3 FOR XML PATH('row'), ELEMENTS ABSENT;
+GO
+
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH('row'), ELEMENTS;
+GO
+
+SELECT 1 AS ID, NULL AS Name, 'Active' AS Status FOR XML PATH('Record'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 4: ELEMENTS with ROOT directive
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS ABSENT;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS;
+GO
+
+-- Different order of directives
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 5: ELEMENTS with TYPE directive
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), TYPE, ELEMENTS ABSENT;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), TYPE, ELEMENTS XSINIL;
+GO
+
+-- All directives combined - different order
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 6: Empty element name (PATH(''))
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 7: Multiple data types
+-- ============================================
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol = 100 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT IntCol, VarcharCol, BitCol, DecimalCol, DateCol FROM forxml_path_elements_t2 WHERE IntCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 8: Various NULL patterns
+-- ============================================
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT Col1, Col2, Col3 FROM forxml_path_elements_t3 WHERE Col1 IS NULL AND Col2 IS NULL AND Col3 IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 9: Attribute-centric columns with ELEMENTS
+-- ============================================
+
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name AS [@Name], Value FROM forxml_path_elements_t4 FOR XML PATH('Item'), ELEMENTS ABSENT;
+GO
+
+-- Attribute-centric column with NULL value and XSINIL
+SELECT ID, Name AS [@Name], Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- Multiple attribute-centric columns with ELEMENTS XSINIL
+SELECT ID AS [@ID], Name AS [@Name], Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+-- INNER JOIN with attribute-centric columns
+SELECT c.CustomerName AS [@CustomerName], o.OrderID AS [@OrderID], o.TotalAmount
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+
+-- LEFT JOIN with attribute-centric columns
+SELECT c.CustomerName AS [@Name], o.TotalAmount AS [@Amount], o.OrderID
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL;
+GO
+
+-- Multiple JOINs with mixed attribute and element columns
+SELECT c.CustomerName AS [@Customer], o.OrderID AS [@OrderID], oi.Quantity AS [@Qty], p.ProductName
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+INNER JOIN forxml_path_elements_order_items oi ON o.OrderID = oi.OrderID
+INNER JOIN forxml_path_elements_products p ON oi.ProductID = p.ProductID
+ORDER BY o.OrderID, p.ProductID
+FOR XML PATH('OrderDetail'), ELEMENTS XSINIL;
+GO
+
+-- LEFT JOIN with attribute-centric columns and ROOT
+SELECT c.CustomerName AS [@Name], c.City AS [@City], o.OrderDate, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- RIGHT JOIN with attribute-centric columns
+SELECT c.CustomerName AS [@CustomerName], o.OrderDate AS [@Date], o.OrderID
+FROM forxml_path_elements_customers c
+RIGHT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+
+-- CROSS JOIN with attribute-centric columns
+SELECT a.ID AS [@ID1], b.ID AS [@ID2], a.Name AS Name1, b.Name AS Name2
+FROM forxml_path_elements_t1 a
+CROSS JOIN forxml_path_elements_t1 b
+WHERE a.ID < b.ID AND a.ID <= 2
+ORDER BY a.ID, b.ID
+FOR XML PATH('Pair'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 10: Single column table
+-- ============================================
+
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT SingleCol FROM forxml_path_elements_t5 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT SingleCol FROM forxml_path_elements_t5 WHERE SingleCol IS NULL FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 11: Many columns
+-- ============================================
+
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT Col1, Col2, Col3, Col4, Col5, Col6, Col7, Col8 FROM forxml_path_elements_t6 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 12: Text content
+-- ============================================
+
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, TextCol FROM forxml_path_elements_t7 FOR XML PATH('Row'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 13: Empty result set
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 999 FOR XML PATH('Employee'), ELEMENTS ABSENT;
+GO
+
+-- ============================================
+-- SECTION 14: Special characters in values
+-- ============================================
+
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_special FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_special WHERE ID = 6 FOR XML PATH('Row'), ELEMENTS;
+GO
+
+-- ============================================
+-- SECTION 15: Unicode/Multibyte values (data values, not element names)
+-- ============================================
+
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_unicode FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_unicode WHERE ID = 1 FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT N'日本語' AS JapaneseName, N'中文' AS ChineseName FOR XML PATH('Names'), ELEMENTS;
+GO
+
+SELECT N'Ελληνικά' AS Greek, N'Русский' AS Russian FOR XML PATH('Names'), ELEMENTS XSINIL;
+GO
+
+SELECT N'مرحبا' AS Arabic, N'שלום' AS Hebrew FOR XML PATH('Names'), ELEMENTS;
+GO
+
+-- ============================================
+-- SECTION 16: Long column names (>64 characters)
+-- ============================================
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('Row'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_long_cols FOR XML PATH('LongColTest'), ELEMENTS, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 17: Boundary cases for element names
+-- ============================================
+
+-- Single character element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('E'), ELEMENTS XSINIL;
+GO
+
+-- Element name with numbers
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee123'), ELEMENTS XSINIL;
+GO
+
+-- Element name starting with underscore
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('_Employee'), ELEMENTS XSINIL;
+GO
+
+-- Element name with hyphens
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee-Record'), ELEMENTS XSINIL;
+GO
+
+-- Element name with periods
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee.Record'), ELEMENTS XSINIL;
+GO
+
+-- Default element name (no name specified) with XSINIL
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH, ELEMENTS XSINIL;
+GO
+
+-- NULL in element name position
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(NULL), ELEMENTS XSINIL;
+GO
+
+-- Very long element name
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('VeryLongElementNameThatExceedsNormalLengthToTestBoundaryConditions'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 18: Complex JOIN queries
+-- ============================================
+
+-- INNER JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+
+-- LEFT JOIN with ELEMENTS XSINIL
+SELECT c.CustomerName, o.OrderID, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL;
+GO
+
+-- Multiple JOINs
+SELECT c.CustomerName, o.OrderID, p.ProductName, oi.Quantity
+FROM forxml_path_elements_customers c
+INNER JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+INNER JOIN forxml_path_elements_order_items oi ON o.OrderID = oi.OrderID
+INNER JOIN forxml_path_elements_products p ON oi.ProductID = p.ProductID
+ORDER BY o.OrderID, p.ProductID
+FOR XML PATH('OrderDetail'), ELEMENTS XSINIL;
+GO
+
+-- LEFT JOIN with NULLs and ROOT
+SELECT c.CustomerName, c.City, o.OrderDate, o.TotalAmount
+FROM forxml_path_elements_customers c
+LEFT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY c.CustomerID, o.OrderID
+FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- RIGHT JOIN
+SELECT c.CustomerName, o.OrderID, o.OrderDate
+FROM forxml_path_elements_customers c
+RIGHT JOIN forxml_path_elements_orders o ON c.CustomerID = o.CustomerID
+ORDER BY o.OrderID
+FOR XML PATH('Order'), ELEMENTS XSINIL;
+GO
+
+-- CROSS JOIN
+SELECT a.ID AS ID1, a.Name AS Name1, b.ID AS ID2, b.Name AS Name2
+FROM forxml_path_elements_t1 a
+CROSS JOIN forxml_path_elements_t1 b
+WHERE a.ID < b.ID AND a.ID <= 2
+ORDER BY a.ID, b.ID
+FOR XML PATH('Pair'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 19: Subqueries
+-- ============================================
+
+-- Subquery in SELECT with ELEMENTS XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS Result;
+GO
+
+-- Correlated subquery with ELEMENTS XSINIL
+SELECT t1.ID, 
+    (SELECT Name, Department FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH('Details'), ELEMENTS XSINIL, TYPE) AS Details 
+FROM forxml_path_elements_t1 t1
+WHERE t1.ID <= 3;
+GO
+
+SELECT 
+    ID,
+    (SELECT Name FROM forxml_path_elements_t1 t2 WHERE t2.ID = t1.ID FOR XML PATH(''), ELEMENTS, TYPE) AS NameElement
+FROM forxml_path_elements_t1 t1
+WHERE ID <= 2;
+GO
+
+-- ============================================
+-- SECTION 20: ORDER BY, GROUP BY, TOP
+-- ============================================
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT ID, Name, Department FROM forxml_path_elements_t1 ORDER BY Name FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT TOP 3 ID, Name, Department FROM forxml_path_elements_t1 ORDER BY ID FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT Department, COUNT(*) AS EmpCount 
+FROM forxml_path_elements_t1 
+GROUP BY Department 
+ORDER BY Department
+FOR XML PATH('Dept'), ELEMENTS XSINIL;
+GO
+
+-- ============================================
+-- SECTION 21: Stored Procedures
+-- ============================================
+
+EXEC forxml_path_elements_p1;
+GO
+
+EXEC forxml_path_elements_p2;
+GO
+
+EXEC forxml_path_elements_p3;
+GO
+
+EXEC forxml_path_elements_p4;
+GO
+
+EXEC forxml_path_elements_p5;
+GO
+
+EXEC forxml_path_elements_p6 @empid = 1;
+GO
+
+EXEC forxml_path_elements_p6 @empid = 4;
+GO
+
+EXEC forxml_path_elements_p6 @empid = 999;
+GO
+
+-- Procedure with department filter
+EXEC forxml_path_elements_p7 'Sales';
+GO
+
+EXEC forxml_path_elements_p7 NULL;
+GO
+
+
+-- ============================================
+-- SECTION 22: SELECT INTO variable
+-- ============================================
+
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS);
+SELECT @xml_var AS result;
+GO
+
+DECLARE @xml_var VARCHAR(MAX);
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL);
+SELECT @xml_var AS result;
+GO
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS, TYPE);
+SELECT @xml_var AS result;
+GO
+
+DECLARE @xml_var XML;
+SELECT @xml_var = (SELECT ID, Name FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, ROOT('Data'), TYPE);
+SELECT @xml_var AS result;
+GO
+
+-- ============================================
+-- SECTION 23: SELECT...INTO (create new table)
+-- ============================================
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into1;
+GO
+
+SELECT * FROM forxml_path_elements_into1;
+GO
+
+DROP TABLE forxml_path_elements_into1;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS ABSENT, TYPE) AS XMLData INTO forxml_path_elements_into2;
+GO
+
+SELECT * FROM forxml_path_elements_into2;
+GO
+
+DROP TABLE forxml_path_elements_into2;
+GO
+
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE) AS XMLData INTO forxml_path_elements_into3;
+GO
+
+SELECT * FROM forxml_path_elements_into3;
+GO
+
+DROP TABLE forxml_path_elements_into3;
+GO
+
+-- ============================================
+-- SECTION 24: Regular view with FOR XML
+-- ============================================
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS;
+GO
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS XSINIL;
+GO
+
+SELECT * FROM forxml_path_elements_regular_view FOR XML PATH('Employee'), ELEMENTS, ROOT('Data');
+GO
+
+-- ============================================
+-- SECTION 25: Dependent Views (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+SELECT * FROM forxml_path_elements_dep_view1;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view2;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view3;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view4;
+GO
+
+SELECT * FROM forxml_path_elements_dep_view5;
+GO
+
+-- ============================================
+-- SECTION 26: Dependent Functions (using FOR XML PATH, ELEMENTS)
+-- ============================================
+
+SELECT dbo.forxml_path_elements_func1() AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func2() AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func3() AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func4(1) AS result;
+GO
+
+SELECT dbo.forxml_path_elements_func4(4) AS result;
+GO
+
+-- ============================================
+-- SECTION 27: XML methods on FOR XML result
+-- ============================================
+
+-- Using .value() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Name)[1]', 'VARCHAR(50)') AS extracted_name;
+GO
+
+-- Using .value() method on NULL element with XSINIL
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).value('(/Employee/Department)[1]', 'VARCHAR(50)') AS extracted_dept;
+GO
+
+-- Using .query() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ROOT('Data'), ELEMENTS XSINIL, TYPE).query('/Data/Employee[1]') AS query_result;
+GO
+
+-- Using .exist() method on XSINIL result
+SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH('Employee'), ELEMENTS XSINIL, TYPE).exist('/Employee/Department') AS element_exists;
+GO
+
+-- CAST result to XML type with XSINIL
+SELECT CAST((SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'), ELEMENTS XSINIL) AS XML) AS casted_xml;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -766,3 +766,6 @@ ignore#!#test_constraint_like_before_17_8-or-16_12-vu-cleanup
 ignore#!#forxml-raw-elements-before-17_9-or-18_3-vu-prepare
 ignore#!#forxml-raw-elements-before-17_9-or-18_3-vu-verify
 ignore#!#forxml-raw-elements-before-17_9-or-18_3-vu-cleanup
+ignore#!#forxml-path-elements-before-17_10-or-18_4-vu-prepare
+ignore#!#forxml-path-elements-before-17_10-or-18_4-vu-verify
+ignore#!#forxml-path-elements-before-17_10-or-18_4-vu-cleanup

--- a/test/JDBC/upgrade/13_4/schedule
+++ b/test/JDBC/upgrade/13_4/schedule
@@ -278,3 +278,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/13_5/schedule
+++ b/test/JDBC/upgrade/13_5/schedule
@@ -331,3 +331,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/13_6/schedule
+++ b/test/JDBC/upgrade/13_6/schedule
@@ -389,3 +389,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/13_7/schedule
+++ b/test/JDBC/upgrade/13_7/schedule
@@ -382,3 +382,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/13_8/schedule
+++ b/test/JDBC/upgrade/13_8/schedule
@@ -382,3 +382,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/13_9/schedule
+++ b/test/JDBC/upgrade/13_9/schedule
@@ -387,3 +387,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_10/schedule
+++ b/test/JDBC/upgrade/14_10/schedule
@@ -507,3 +507,4 @@ comparison_op_index_scan-before-15_6-or-14_11
 BABEL-5788
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_11/schedule
+++ b/test/JDBC/upgrade/14_11/schedule
@@ -506,3 +506,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_12/schedule
+++ b/test/JDBC/upgrade/14_12/schedule
@@ -507,3 +507,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_13/schedule
+++ b/test/JDBC/upgrade/14_13/schedule
@@ -507,3 +507,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_15/schedule
+++ b/test/JDBC/upgrade/14_15/schedule
@@ -504,3 +504,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_17/schedule
+++ b/test/JDBC/upgrade/14_17/schedule
@@ -501,3 +501,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_18/schedule
+++ b/test/JDBC/upgrade/14_18/schedule
@@ -504,3 +504,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_19/schedule
+++ b/test/JDBC/upgrade/14_19/schedule
@@ -502,3 +502,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_20/schedule
+++ b/test/JDBC/upgrade/14_20/schedule
@@ -502,3 +502,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_22/schedule
+++ b/test/JDBC/upgrade/14_22/schedule
@@ -501,3 +501,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_23/schedule
+++ b/test/JDBC/upgrade/14_23/schedule
@@ -501,3 +501,4 @@ comparison_op_index_scan-before-17_8-or-16_12
 BABEL-5788
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_3/schedule
+++ b/test/JDBC/upgrade/14_3/schedule
@@ -419,3 +419,4 @@ ascii_function_before-17_7-or-16_11
 comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_5/schedule
+++ b/test/JDBC/upgrade/14_5/schedule
@@ -432,3 +432,4 @@ comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 BABEL-SP_DATATYPE_INFO
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_6/schedule
+++ b/test/JDBC/upgrade/14_6/schedule
@@ -474,3 +474,4 @@ comparison_op_index_scan-before-15_2-or-14_7
 BABEL-5788
 babel_convert_with_style-before-14_8-or-15_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_7/schedule
+++ b/test/JDBC/upgrade/14_7/schedule
@@ -497,3 +497,4 @@ comparison_op_index_scan-before-15_6-or-14_11
 BABEL-5788
 babel_convert_with_style-before-14_8-or-15_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_8/schedule
+++ b/test/JDBC/upgrade/14_8/schedule
@@ -499,3 +499,4 @@ comparison_op_index_scan-before-15_6-or-14_11
 BABEL-5788
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/14_9/schedule
+++ b/test/JDBC/upgrade/14_9/schedule
@@ -502,3 +502,4 @@ comparison_op_index_scan-before-15_6-or-14_11
 BABEL-5788
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_1/schedule
+++ b/test/JDBC/upgrade/15_1/schedule
@@ -481,3 +481,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style-before-14_8-or-15_3 
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_10/schedule
+++ b/test/JDBC/upgrade/15_10/schedule
@@ -605,3 +605,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_12/schedule
+++ b/test/JDBC/upgrade/15_12/schedule
@@ -602,3 +602,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_13/schedule
+++ b/test/JDBC/upgrade/15_13/schedule
@@ -610,3 +610,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_14/schedule
+++ b/test/JDBC/upgrade/15_14/schedule
@@ -612,3 +612,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_15/schedule
+++ b/test/JDBC/upgrade/15_15/schedule
@@ -608,3 +608,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_17/schedule
+++ b/test/JDBC/upgrade/15_17/schedule
@@ -607,3 +607,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_binary-before-17_7-or-16_11
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_18/schedule
+++ b/test/JDBC/upgrade/15_18/schedule
@@ -607,3 +607,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_binary-before-17_7-or-16_11
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_2/schedule
+++ b/test/JDBC/upgrade/15_2/schedule
@@ -517,3 +517,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style-before-14_8-or-15_3 
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_3/schedule
+++ b/test/JDBC/upgrade/15_3/schedule
@@ -537,3 +537,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_4/schedule
+++ b/test/JDBC/upgrade/15_4/schedule
@@ -550,3 +550,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_5/schedule
+++ b/test/JDBC/upgrade/15_5/schedule
@@ -586,3 +586,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style-before-15_7
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_6/schedule
+++ b/test/JDBC/upgrade/15_6/schedule
@@ -602,3 +602,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style-before-15_7
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_7/schedule
+++ b/test/JDBC/upgrade/15_7/schedule
@@ -611,3 +611,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/15_8/schedule
+++ b/test/JDBC/upgrade/15_8/schedule
@@ -603,3 +603,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_1/schedule
+++ b/test/JDBC/upgrade/16_1/schedule
@@ -597,3 +597,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_10/schedule
+++ b/test/JDBC/upgrade/16_10/schedule
@@ -650,3 +650,4 @@ BABEL-1664
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
 sys-fn-varbintohexsubstring
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_11/schedule
+++ b/test/JDBC/upgrade/16_11/schedule
@@ -647,3 +647,4 @@ babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
 sys-fn-varbintohexsubstring
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_13/schedule
+++ b/test/JDBC/upgrade/16_13/schedule
@@ -650,3 +650,4 @@ babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
 sys-fn-varbintohexsubstring
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_14/schedule
+++ b/test/JDBC/upgrade/16_14/schedule
@@ -650,3 +650,4 @@ babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
 sys-fn-varbintohexsubstring
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_2/schedule
+++ b/test/JDBC/upgrade/16_2/schedule
@@ -613,3 +613,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style-before-14_12-or-16_3
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_3/schedule
+++ b/test/JDBC/upgrade/16_3/schedule
@@ -619,3 +619,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_4/schedule
+++ b/test/JDBC/upgrade/16_4/schedule
@@ -634,3 +634,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_6/schedule
+++ b/test/JDBC/upgrade/16_6/schedule
@@ -640,3 +640,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_8/schedule
+++ b/test/JDBC/upgrade/16_8/schedule
@@ -647,3 +647,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/16_9/schedule
+++ b/test/JDBC/upgrade/16_9/schedule
@@ -650,3 +650,4 @@ BABEL-5788
 BABEL-1664-before-16_10-or-17_6
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/17_10/schedule
+++ b/test/JDBC/upgrade/17_10/schedule
@@ -678,4 +678,4 @@ string_aggregate
 babel_convert_with_style
 forxml-raw-elements
 forxml-raw-elements-1gb-limit
-forxml-path-elements-before-17_10-or-18_4
+forxml-path-elements

--- a/test/JDBC/upgrade/17_10/schedule
+++ b/test/JDBC/upgrade/17_10/schedule
@@ -678,3 +678,4 @@ string_aggregate
 babel_convert_with_style
 forxml-raw-elements
 forxml-raw-elements-1gb-limit
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -645,3 +645,4 @@ babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
 sys-fn-varbintohexsubstring-before-16_10-or-17_6
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/17_5/schedule
+++ b/test/JDBC/upgrade/17_5/schedule
@@ -658,3 +658,4 @@ BABEL-1664-before-16_10-or-17_6
 string_aggregate
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/17_6/schedule
+++ b/test/JDBC/upgrade/17_6/schedule
@@ -669,3 +669,4 @@ string_aggregate
 babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/17_7/schedule
+++ b/test/JDBC/upgrade/17_7/schedule
@@ -670,3 +670,4 @@ BABEL-1664
 string_aggregate
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/17_9/schedule
+++ b/test/JDBC/upgrade/17_9/schedule
@@ -677,3 +677,4 @@ babel_string_to_money_reg
 string_aggregate
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/18_3/schedule
+++ b/test/JDBC/upgrade/18_3/schedule
@@ -677,3 +677,4 @@ babel_string_to_money_reg
 string_aggregate
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
+forxml-path-elements-before-17_10-or-18_4

--- a/test/JDBC/upgrade/latest/schedule
+++ b/test/JDBC/upgrade/latest/schedule
@@ -678,3 +678,4 @@ string_aggregate
 babel_convert_with_style
 forxml-raw-elements
 forxml-raw-elements-1gb-limit
+forxml-path-elements


### PR DESCRIPTION
## Description
Added support for ELEMENTS directive in FOR XML PATH clause.
JIRA : BABEL-2750

Cherry-picked from : PR [4618](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4618#issue-4009559559)

## Changes
- Added ELEMENTS XSINIL support for FOR XML PATH
- Added upgrade SQL for function signature changes
- Added backward compatibility for old 6-argument aggregate calls
- Added JDBC tests for PATH ELEMENTS scenarios

## Test Cases
- ELEMENTS XSINIL with NULL handling
- Various PATH scenarios with XSINIL
- Backward compatibility with existing views

## Related
- Similar to FOR XML RAW ELEMENTS support