### PR TITLE
Fix deprecated version for FOR XML in 6_X

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.0.0--6.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.0.0--6.1.0.sql
@@ -256,7 +256,7 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
-CALL sys.babelfish_drop_deprecated_object('aggregate', 'sys', 'tsql_select_for_xml_agg_deprecated_in_5_6_0', 'anyelement, integer, text, boolean, text');
+CALL sys.babelfish_drop_deprecated_object('aggregate', 'sys', 'tsql_select_for_xml_agg_deprecated_in_6_1_0', 'anyelement, integer, text, boolean, text');
 -- Deprecate and drop old aggregate (6 args) - tsql_select_for_xml_text_agg
 DO $$
 DECLARE
@@ -271,7 +271,7 @@ EXCEPTION WHEN OTHERS THEN
 END;
 $$;
 
-CALL sys.babelfish_drop_deprecated_object('aggregate', 'sys', 'tsql_select_for_xml_text_agg_deprecated_in_5_6_0', 'anyelement, integer, text, boolean, text');
+CALL sys.babelfish_drop_deprecated_object('aggregate', 'sys', 'tsql_select_for_xml_text_agg_deprecated_in_6_1_0', 'anyelement, integer, text, boolean, text');
 -- Deprecate and drop old function (6 args) - after aggregates are gone
 DO $$
 DECLARE
@@ -285,7 +285,7 @@ EXCEPTION WHEN OTHERS THEN
     RAISE WARNING '%', exception_message;
 END;
 $$;
-CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'tsql_query_to_xml_sfunc_deprecated_in_5_6_0');
+CALL sys.babelfish_drop_deprecated_object('function', 'sys', 'tsql_query_to_xml_sfunc_deprecated_in_6_1_0');
 
 -- Create new function with ELEMENTS parameters (8 args)
 CREATE OR REPLACE FUNCTION sys.tsql_query_to_xml_sfunc(


### PR DESCRIPTION
### Description

While cherry-picking the FOR XML RAW feature from the 5_X branch to the 6_X branch, the deprecated version constants for the following functions were not updated to reflect the 6_X branch versioning:

- `tsql_select_for_xml_agg`
- `tsql_select_for_xml_text_agg`
- `tsql_query_to_xml_sfunc`

These functions still reference `deprecated_in_5_6_0` instead of `deprecated_in_6_1_0`. This PR fixes that by updating the version suffix to the correct `6_1_0`.

**Previous PRs where this change was introduced:**
- FOR XML RAW cherry-pick: [#4601](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4601)

Authored-by: Japleen Kaur <amjj@amazon.com>
Signed-off-by: Japleen Kaur <amjj@amazon.com>

### Issues Resolved
NA

### Test Scenarios Covered
NA (No functional/logical change - only version constant rename)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md).