### PR TITLE
Enable BABEL_539 in 16.8 upgrade schedule (#4594)

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -298,7 +298,6 @@ static Oid  pltsql_GetNewTempObjectId(void);
 static Oid 	pltsql_GetNewTempOidWithIndex(Relation relation, Oid indexId, AttrNumber oidcolumn);
 static bool set_and_persist_temp_oid_buffer_start(Oid new_oid);
 static bool pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg);
-static EphemeralNamedRelation pltsql_get_tsql_enr_from_oid(Oid oid);
 static EphemeralNamedRelation find_object_in_enr(Oid catalog_oid, Oid object_id, QueryEnvironment *qe);
 static bool is_enr_to_sys_object_dependency(const ObjectAddress *depender, const ObjectAddress *referenced);
 static bool verify_stmt_alterdatabaseset(Node* n, const char* dbname, const char* config);
@@ -343,7 +342,6 @@ static GetNewObjectId_hook_type prev_GetNewObjectId_hook = NULL;
 static GetNewTempObjectId_hook_type prev_GetNewTempObjectId_hook = NULL;
 static GetNewTempOidWithIndex_hook_type prev_GetNewTempOidWithIndex_hook = NULL;
 static pltsql_is_local_only_inval_msg_hook_type prev_pltsql_is_local_only_inval_msg_hook = NULL;
-static pltsql_get_tsql_enr_from_oid_hook_type prev_pltsql_get_tsql_enr_from_oid_hook = NULL;
 static find_object_in_enr_hook_type prev_find_object_in_enr_hook = NULL;
 static is_enr_to_sys_object_dependency_hook_type prev_is_enr_to_sys_object_dependency_hook = NULL;
 static inherit_view_constraints_from_table_hook_type prev_inherit_view_constraints_from_table = NULL;
@@ -492,9 +490,6 @@ InstallExtendedHooks(void)
 
 	prev_pltsql_is_local_only_inval_msg_hook = pltsql_is_local_only_inval_msg_hook;
 	pltsql_is_local_only_inval_msg_hook = pltsql_is_local_only_inval_msg;
-
-	prev_pltsql_get_tsql_enr_from_oid_hook = pltsql_get_tsql_enr_from_oid_hook;
-	pltsql_get_tsql_enr_from_oid_hook = pltsql_get_tsql_enr_from_oid;
 
 	prev_find_object_in_enr_hook = find_object_in_enr_hook;
 	find_object_in_enr_hook = find_object_in_enr;
@@ -5584,12 +5579,6 @@ static bool
 pltsql_is_local_only_inval_msg(const SharedInvalidationMessage *msg)
 {
 	return SIMessageIsForTempTable(msg);
-}
-
-static EphemeralNamedRelation
-pltsql_get_tsql_enr_from_oid(const Oid oid)
-{
-	return temp_oid_buffer_size > 0 ? GetENRTempTableWithOid(oid, true) : NULL;
 }
 
 /*

--- a/test/JDBC/expected/temp_table_temp_buffer_disabled-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_temp_buffer_disabled-vu-cleanup.out
@@ -1,0 +1,7 @@
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536;
+GO
+
+-- tsql
+DROP TABLE perm_table;
+GO

--- a/test/JDBC/expected/temp_table_temp_buffer_disabled-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_temp_buffer_disabled-vu-prepare.out
@@ -1,0 +1,12 @@
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+CREATE TABLE perm_table(col1 int , name varchar(20), col2 DATE DEFAULT GETDATE());
+GO
+
+INSERT INTO perm_table(col1, name) VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
+GO
+~~ROW COUNT: 3~~
+

--- a/test/JDBC/expected/temp_table_temp_buffer_disabled-vu-verify.out
+++ b/test/JDBC/expected/temp_table_temp_buffer_disabled-vu-verify.out
@@ -1,0 +1,50 @@
+-- tsql
+CREATE TABLE #temp_table1(col1 int , col2 DATE DEFAULT GETDATE());
+GO
+
+INSERT INTO #temp_table1(col1) SELECT col1 FROM perm_table;
+GO
+~~ROW COUNT: 3~~
+
+
+ALTER TABLE #temp_table1 ALTER COLUMN col1 BIGINT;
+ALTER TABLE #temp_table1 ADD col3 INT IDENTITY;
+ALTER TABLE #temp_table1 ADD col4 TEXT;
+ALTER TABLE #temp_table1 ADD CONSTRAINT col1_def DEFAULT 0 FOR col1;
+GO
+
+INSERT INTO #temp_table1(col4) VALUES ('test1'), ('test2'), ('test3');
+GO
+~~ROW COUNT: 3~~
+
+
+SELECT col1, col3, col4 FROM #temp_table1;
+GO
+~~START~~
+bigint#!#int#!#text
+10#!#1#!#<NULL>
+20#!#2#!#<NULL>
+30#!#3#!#<NULL>
+0#!#4#!#test1
+0#!#5#!#test2
+0#!#6#!#test3
+~~END~~
+
+
+SELECT * INTO #temp_table2 FROM #temp_table1;
+GO
+
+SELECT col1, col3, col4 FROM #temp_table2;
+GO
+~~START~~
+bigint#!#int#!#text
+10#!#1#!#<NULL>
+20#!#2#!#<NULL>
+30#!#3#!#<NULL>
+0#!#4#!#test1
+0#!#5#!#test2
+0#!#6#!#test3
+~~END~~
+
+
+-- terminate-tsql-conn

--- a/test/JDBC/input/temp_tables/temp_table_temp_buffer_disabled-vu-cleanup.mix
+++ b/test/JDBC/input/temp_tables/temp_table_temp_buffer_disabled-vu-cleanup.mix
@@ -1,0 +1,7 @@
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 65536;
+GO
+
+-- tsql
+DROP TABLE perm_table;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_temp_buffer_disabled-vu-prepare.mix
+++ b/test/JDBC/input/temp_tables/temp_table_temp_buffer_disabled-vu-prepare.mix
@@ -1,0 +1,10 @@
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.temp_oid_buffer_size = 0;
+GO
+
+-- tsql
+CREATE TABLE perm_table(col1 int , name varchar(20), col2 DATE DEFAULT GETDATE());
+GO
+
+INSERT INTO perm_table(col1, name) VALUES (10, 'user1') , (20, 'user2'), (30, 'user3');
+GO

--- a/test/JDBC/input/temp_tables/temp_table_temp_buffer_disabled-vu-verify.mix
+++ b/test/JDBC/input/temp_tables/temp_table_temp_buffer_disabled-vu-verify.mix
@@ -1,0 +1,26 @@
+-- tsql
+CREATE TABLE #temp_table1(col1 int , col2 DATE DEFAULT GETDATE());
+GO
+
+INSERT INTO #temp_table1(col1) SELECT col1 FROM perm_table;
+GO
+
+ALTER TABLE #temp_table1 ALTER COLUMN col1 BIGINT;
+ALTER TABLE #temp_table1 ADD col3 INT IDENTITY;
+ALTER TABLE #temp_table1 ADD col4 TEXT;
+ALTER TABLE #temp_table1 ADD CONSTRAINT col1_def DEFAULT 0 FOR col1;
+GO
+
+INSERT INTO #temp_table1(col4) VALUES ('test1'), ('test2'), ('test3');
+GO
+
+SELECT col1, col3, col4 FROM #temp_table1;
+GO
+
+SELECT * INTO #temp_table2 FROM #temp_table1;
+GO
+
+SELECT col1, col3, col4 FROM #temp_table2;
+GO
+
+-- terminate-tsql-conn


### PR DESCRIPTION

### Description
Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/717

Task:  BABEL-6284

(cherry picked from commit 99dd952acd6b8022fac15d78a641a77a6f6e3cac)


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).