### PR TITLE
Added more tests for the fix of Crash during dropping temp table from a proc

### DIFF
--- a/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-cleanup.out
@@ -106,3 +106,39 @@ GO
 
 DROP PROC p_insert_exec_drop_table
 GO
+
+DROP PROC p_drop_if_exists_create
+GO
+
+DROP PROC p_multi_drop_create
+GO
+
+DROP PROC p_drop_create_schema_change
+GO
+
+DROP PROC p_trans_drop_create
+GO
+
+DROP PROC p_rollback_drop_create
+GO
+
+DROP PROC p_multi_tables_drop_create
+GO
+
+DROP PROC p_drop_create_with_index
+GO
+
+DROP PROC p_drop_create_constraints
+GO
+
+DROP PROC p_drop_create_alter
+GO
+
+DROP PROC p_conditional_drop_create
+GO
+
+DROP PROC p_drop_create_truncate
+GO
+
+DROP PROC p_error_drop_create
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-prepare.out
@@ -405,3 +405,180 @@ BEGIN
     SELECT 200 as id, 'after drop' as data
 END
 GO
+
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE PROC p_drop_if_exists_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    SELECT * FROM #t 
+END
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE PROC p_multi_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int, b varchar(20)) 
+    INSERT INTO #t VALUES (2, 'second') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+CREATE PROC p_drop_create_schema_change AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(id int, name varchar(50)) 
+    INSERT INTO #t VALUES (1, 'first') 
+    
+    DROP TABLE #t 
+    CREATE TABLE #t(x int, y int, z varchar(100)) 
+    INSERT INTO #t VALUES (10, 20, 'changed schema') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+CREATE PROC p_trans_drop_create AS 
+BEGIN 
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #trans_t 
+        CREATE TABLE #trans_t(a int, b varchar(30)) 
+        INSERT INTO #trans_t VALUES (1, 'in transaction') 
+    COMMIT 
+    SELECT * FROM #trans_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with rollback
+CREATE PROC p_rollback_drop_create AS 
+BEGIN 
+    CREATE TABLE #rb_t(original int) 
+    INSERT INTO #rb_t VALUES (100) 
+    
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #rb_t 
+        CREATE TABLE #rb_t(new_col varchar(20)) 
+        INSERT INTO #rb_t VALUES ('rolled back') 
+    ROLLBACK 
+    
+    SELECT * FROM #rb_t 
+END
+GO
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+CREATE PROC p_multi_tables_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t1 
+    DROP TABLE IF EXISTS #t2 
+    
+    CREATE TABLE #t1(a int) 
+    CREATE TABLE #t2(b varchar(20)) 
+    
+    INSERT INTO #t1 VALUES (1) 
+    INSERT INTO #t2 VALUES ('test') 
+    
+    DROP TABLE IF EXISTS #t1 
+    CREATE TABLE #t1(x int, y int) 
+    INSERT INTO #t1 VALUES (10, 20) 
+    
+    SELECT * FROM #t1 
+    SELECT * FROM #t2 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with indexes
+CREATE PROC p_drop_create_with_index AS 
+BEGIN 
+    DROP TABLE IF EXISTS #idx_t 
+    CREATE TABLE #idx_t(id int, name varchar(50)) 
+    CREATE INDEX idx1 ON #idx_t(id) 
+    INSERT INTO #idx_t VALUES (1, 'indexed') 
+    SELECT * FROM #idx_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with constraints
+CREATE PROC p_drop_create_constraints AS 
+BEGIN 
+    DROP TABLE IF EXISTS #const_t 
+    CREATE TABLE #const_t(id int PRIMARY KEY, val int DEFAULT 100) 
+    INSERT INTO #const_t(id) VALUES (1) 
+    INSERT INTO #const_t VALUES (2, 200) 
+    SELECT * FROM #const_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+CREATE PROC p_drop_create_alter AS 
+BEGIN 
+    DROP TABLE IF EXISTS #alter_t 
+    CREATE TABLE #alter_t(a int) 
+    INSERT INTO #alter_t VALUES (1) 
+    
+    ALTER TABLE #alter_t ADD b varchar(20) 
+    UPDATE #alter_t SET b = 'altered' 
+    
+    SELECT * FROM #alter_t 
+END
+GO
+
+-- Conditional DROP IF EXISTS + CREATE
+CREATE PROC p_conditional_drop_create AS 
+BEGIN 
+    DECLARE @flag int = 1 
+    
+    IF @flag = 1 
+    BEGIN 
+        DROP TABLE IF EXISTS #cond_t 
+        CREATE TABLE #cond_t(a int) 
+        INSERT INTO #cond_t VALUES (100) 
+    END 
+    
+    SELECT * FROM #cond_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+CREATE PROC p_drop_create_truncate AS 
+BEGIN 
+    DROP TABLE IF EXISTS #trunc_t 
+    CREATE TABLE #trunc_t(id int, data varchar(30)) 
+    INSERT INTO #trunc_t VALUES (1, 'first') 
+    INSERT INTO #trunc_t VALUES (2, 'second') 
+    
+    TRUNCATE TABLE #trunc_t 
+    INSERT INTO #trunc_t VALUES (3, 'after truncate') 
+    
+    SELECT * FROM #trunc_t 
+END
+GO
+
+-- Error handling with DROP IF EXISTS + CREATE
+CREATE PROC p_error_drop_create AS 
+BEGIN 
+    BEGIN TRY 
+        DROP TABLE IF EXISTS #err_t 
+        CREATE TABLE #err_t(id int PRIMARY KEY) 
+        INSERT INTO #err_t VALUES (1) 
+        INSERT INTO #err_t VALUES (1) -- Duplicate key error 
+    END TRY 
+    BEGIN CATCH 
+        SELECT 'Error: ' + ERROR_MESSAGE() as error_msg 
+    END CATCH 
+    
+    SELECT * FROM #err_t 
+END
+GO

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -4059,3 +4059,300 @@ int#!#varchar
 
 DROP TABLE #insert_exec_drop_target
 GO
+
+DROP TABLE #t
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(a int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE TABLE #t(x varchar(10))
+INSERT INTO #t VALUES ('original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_multi_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#second
+~~END~~
+
+
+CREATE TABLE #t(c int)
+INSERT INTO #t VALUES (999)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+EXEC p_drop_create_schema_change
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#20#!#changed schema
+~~END~~
+
+
+CREATE TABLE #t(final_col int)
+INSERT INTO #t VALUES (777)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+777
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+EXEC p_trans_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#in transaction
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with rollback
+EXEC p_rollback_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with indexes
+EXEC p_drop_create_with_index
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#indexed
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with constraints
+EXEC p_drop_create_constraints
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#100
+2#!#200
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+EXEC p_drop_create_alter
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#altered
+~~END~~
+
+
+-- Conditional DROP IF EXISTS + CREATE
+EXEC p_conditional_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+EXEC p_drop_create_truncate
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+3#!#after truncate
+~~END~~
+
+
+-- Error handling with DROP IF EXISTS + CREATE
+EXEC p_error_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error: duplicate key value violates unique constraint "#err_t_pkey"
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- Repeated calls to same procedure
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Second call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Third call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(final int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Interleaved procedure calls
+CREATE TABLE #t(a int)
+CREATE TABLE #t1(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+CREATE TABLE #t(x int)
+CREATE TABLE #t1(y int)
+GO
+
+DROP TABLE #t
+DROP TABLE #t1
+GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -408,6 +408,183 @@ BEGIN
 END
 GO
 
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE PROC p_drop_if_exists_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    SELECT * FROM #t 
+END
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE PROC p_multi_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int, b varchar(20)) 
+    INSERT INTO #t VALUES (2, 'second') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+CREATE PROC p_drop_create_schema_change AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(id int, name varchar(50)) 
+    INSERT INTO #t VALUES (1, 'first') 
+    
+    DROP TABLE #t 
+    CREATE TABLE #t(x int, y int, z varchar(100)) 
+    INSERT INTO #t VALUES (10, 20, 'changed schema') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+CREATE PROC p_trans_drop_create AS 
+BEGIN 
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #trans_t 
+        CREATE TABLE #trans_t(a int, b varchar(30)) 
+        INSERT INTO #trans_t VALUES (1, 'in transaction') 
+    COMMIT 
+    SELECT * FROM #trans_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with rollback
+CREATE PROC p_rollback_drop_create AS 
+BEGIN 
+    CREATE TABLE #rb_t(original int) 
+    INSERT INTO #rb_t VALUES (100) 
+    
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #rb_t 
+        CREATE TABLE #rb_t(new_col varchar(20)) 
+        INSERT INTO #rb_t VALUES ('rolled back') 
+    ROLLBACK 
+    
+    SELECT * FROM #rb_t 
+END
+GO
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+CREATE PROC p_multi_tables_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t1 
+    DROP TABLE IF EXISTS #t2 
+    
+    CREATE TABLE #t1(a int) 
+    CREATE TABLE #t2(b varchar(20)) 
+    
+    INSERT INTO #t1 VALUES (1) 
+    INSERT INTO #t2 VALUES ('test') 
+    
+    DROP TABLE IF EXISTS #t1 
+    CREATE TABLE #t1(x int, y int) 
+    INSERT INTO #t1 VALUES (10, 20) 
+    
+    SELECT * FROM #t1 
+    SELECT * FROM #t2 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with indexes
+CREATE PROC p_drop_create_with_index AS 
+BEGIN 
+    DROP TABLE IF EXISTS #idx_t 
+    CREATE TABLE #idx_t(id int, name varchar(50)) 
+    CREATE INDEX idx1 ON #idx_t(id) 
+    INSERT INTO #idx_t VALUES (1, 'indexed') 
+    SELECT * FROM #idx_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with constraints
+CREATE PROC p_drop_create_constraints AS 
+BEGIN 
+    DROP TABLE IF EXISTS #const_t 
+    CREATE TABLE #const_t(id int PRIMARY KEY, val int DEFAULT 100) 
+    INSERT INTO #const_t(id) VALUES (1) 
+    INSERT INTO #const_t VALUES (2, 200) 
+    SELECT * FROM #const_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+CREATE PROC p_drop_create_alter AS 
+BEGIN 
+    DROP TABLE IF EXISTS #alter_t 
+    CREATE TABLE #alter_t(a int) 
+    INSERT INTO #alter_t VALUES (1) 
+    
+    ALTER TABLE #alter_t ADD b varchar(20) 
+    UPDATE #alter_t SET b = 'altered' 
+    
+    SELECT * FROM #alter_t 
+END
+GO
+
+-- Conditional DROP IF EXISTS + CREATE
+CREATE PROC p_conditional_drop_create AS 
+BEGIN 
+    DECLARE @flag int = 1 
+    
+    IF @flag = 1 
+    BEGIN 
+        DROP TABLE IF EXISTS #cond_t 
+        CREATE TABLE #cond_t(a int) 
+        INSERT INTO #cond_t VALUES (100) 
+    END 
+    
+    SELECT * FROM #cond_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+CREATE PROC p_drop_create_truncate AS 
+BEGIN 
+    DROP TABLE IF EXISTS #trunc_t 
+    CREATE TABLE #trunc_t(id int, data varchar(30)) 
+    INSERT INTO #trunc_t VALUES (1, 'first') 
+    INSERT INTO #trunc_t VALUES (2, 'second') 
+    
+    TRUNCATE TABLE #trunc_t 
+    INSERT INTO #trunc_t VALUES (3, 'after truncate') 
+    
+    SELECT * FROM #trunc_t 
+END
+GO
+
+-- Error handling with DROP IF EXISTS + CREATE
+CREATE PROC p_error_drop_create AS 
+BEGIN 
+    BEGIN TRY 
+        DROP TABLE IF EXISTS #err_t 
+        CREATE TABLE #err_t(id int PRIMARY KEY) 
+        INSERT INTO #err_t VALUES (1) 
+        INSERT INTO #err_t VALUES (1) -- Duplicate key error 
+    END TRY 
+    BEGIN CATCH 
+        SELECT 'Error: ' + ERROR_MESSAGE() as error_msg 
+    END CATCH 
+    
+    SELECT * FROM #err_t 
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -4468,6 +4645,303 @@ int#!#varchar
 
 DROP TABLE #insert_exec_drop_target
 GO
+
+DROP TABLE #t
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(a int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE TABLE #t(x varchar(10))
+INSERT INTO #t VALUES ('original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_multi_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#second
+~~END~~
+
+
+CREATE TABLE #t(c int)
+INSERT INTO #t VALUES (999)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+EXEC p_drop_create_schema_change
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#20#!#changed schema
+~~END~~
+
+
+CREATE TABLE #t(final_col int)
+INSERT INTO #t VALUES (777)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+777
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+EXEC p_trans_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#in transaction
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with rollback
+EXEC p_rollback_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with indexes
+EXEC p_drop_create_with_index
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#indexed
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with constraints
+EXEC p_drop_create_constraints
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#100
+2#!#200
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+EXEC p_drop_create_alter
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#altered
+~~END~~
+
+
+-- Conditional DROP IF EXISTS + CREATE
+EXEC p_conditional_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+EXEC p_drop_create_truncate
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+3#!#after truncate
+~~END~~
+
+
+-- Error handling with DROP IF EXISTS + CREATE
+EXEC p_error_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error: duplicate key value violates unique constraint "#err_t_pkey"
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- Repeated calls to same procedure
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Second call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Third call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(final int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Interleaved procedure calls
+CREATE TABLE #t(a int)
+CREATE TABLE #t1(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+CREATE TABLE #t(x int)
+CREATE TABLE #t1(y int)
+GO
+
+DROP TABLE #t
+DROP TABLE #t1
+GO
 DROP VIEW enr_view
 GO
 
@@ -4575,4 +5049,40 @@ DROP PROC p_insert_exec_table_var
 GO
 
 DROP PROC p_insert_exec_drop_table
+GO
+
+DROP PROC p_drop_if_exists_create
+GO
+
+DROP PROC p_multi_drop_create
+GO
+
+DROP PROC p_drop_create_schema_change
+GO
+
+DROP PROC p_trans_drop_create
+GO
+
+DROP PROC p_rollback_drop_create
+GO
+
+DROP PROC p_multi_tables_drop_create
+GO
+
+DROP PROC p_drop_create_with_index
+GO
+
+DROP PROC p_drop_create_constraints
+GO
+
+DROP PROC p_drop_create_alter
+GO
+
+DROP PROC p_conditional_drop_create
+GO
+
+DROP PROC p_drop_create_truncate
+GO
+
+DROP PROC p_error_drop_create
 GO

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -408,6 +408,183 @@ BEGIN
 END
 GO
 
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE PROC p_drop_if_exists_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    SELECT * FROM #t 
+END
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE PROC p_multi_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int, b varchar(20)) 
+    INSERT INTO #t VALUES (2, 'second') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+CREATE PROC p_drop_create_schema_change AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(id int, name varchar(50)) 
+    INSERT INTO #t VALUES (1, 'first') 
+    
+    DROP TABLE #t 
+    CREATE TABLE #t(x int, y int, z varchar(100)) 
+    INSERT INTO #t VALUES (10, 20, 'changed schema') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+CREATE PROC p_trans_drop_create AS 
+BEGIN 
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #trans_t 
+        CREATE TABLE #trans_t(a int, b varchar(30)) 
+        INSERT INTO #trans_t VALUES (1, 'in transaction') 
+    COMMIT 
+    SELECT * FROM #trans_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with rollback
+CREATE PROC p_rollback_drop_create AS 
+BEGIN 
+    CREATE TABLE #rb_t(original int) 
+    INSERT INTO #rb_t VALUES (100) 
+    
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #rb_t 
+        CREATE TABLE #rb_t(new_col varchar(20)) 
+        INSERT INTO #rb_t VALUES ('rolled back') 
+    ROLLBACK 
+    
+    SELECT * FROM #rb_t 
+END
+GO
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+CREATE PROC p_multi_tables_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t1 
+    DROP TABLE IF EXISTS #t2 
+    
+    CREATE TABLE #t1(a int) 
+    CREATE TABLE #t2(b varchar(20)) 
+    
+    INSERT INTO #t1 VALUES (1) 
+    INSERT INTO #t2 VALUES ('test') 
+    
+    DROP TABLE IF EXISTS #t1 
+    CREATE TABLE #t1(x int, y int) 
+    INSERT INTO #t1 VALUES (10, 20) 
+    
+    SELECT * FROM #t1 
+    SELECT * FROM #t2 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with indexes
+CREATE PROC p_drop_create_with_index AS 
+BEGIN 
+    DROP TABLE IF EXISTS #idx_t 
+    CREATE TABLE #idx_t(id int, name varchar(50)) 
+    CREATE INDEX idx1 ON #idx_t(id) 
+    INSERT INTO #idx_t VALUES (1, 'indexed') 
+    SELECT * FROM #idx_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with constraints
+CREATE PROC p_drop_create_constraints AS 
+BEGIN 
+    DROP TABLE IF EXISTS #const_t 
+    CREATE TABLE #const_t(id int PRIMARY KEY, val int DEFAULT 100) 
+    INSERT INTO #const_t(id) VALUES (1) 
+    INSERT INTO #const_t VALUES (2, 200) 
+    SELECT * FROM #const_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+CREATE PROC p_drop_create_alter AS 
+BEGIN 
+    DROP TABLE IF EXISTS #alter_t 
+    CREATE TABLE #alter_t(a int) 
+    INSERT INTO #alter_t VALUES (1) 
+    
+    ALTER TABLE #alter_t ADD b varchar(20) 
+    UPDATE #alter_t SET b = 'altered' 
+    
+    SELECT * FROM #alter_t 
+END
+GO
+
+-- Conditional DROP IF EXISTS + CREATE
+CREATE PROC p_conditional_drop_create AS 
+BEGIN 
+    DECLARE @flag int = 1 
+    
+    IF @flag = 1 
+    BEGIN 
+        DROP TABLE IF EXISTS #cond_t 
+        CREATE TABLE #cond_t(a int) 
+        INSERT INTO #cond_t VALUES (100) 
+    END 
+    
+    SELECT * FROM #cond_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+CREATE PROC p_drop_create_truncate AS 
+BEGIN 
+    DROP TABLE IF EXISTS #trunc_t 
+    CREATE TABLE #trunc_t(id int, data varchar(30)) 
+    INSERT INTO #trunc_t VALUES (1, 'first') 
+    INSERT INTO #trunc_t VALUES (2, 'second') 
+    
+    TRUNCATE TABLE #trunc_t 
+    INSERT INTO #trunc_t VALUES (3, 'after truncate') 
+    
+    SELECT * FROM #trunc_t 
+END
+GO
+
+-- Error handling with DROP IF EXISTS + CREATE
+CREATE PROC p_error_drop_create AS 
+BEGIN 
+    BEGIN TRY 
+        DROP TABLE IF EXISTS #err_t 
+        CREATE TABLE #err_t(id int PRIMARY KEY) 
+        INSERT INTO #err_t VALUES (1) 
+        INSERT INTO #err_t VALUES (1) -- Duplicate key error 
+    END TRY 
+    BEGIN CATCH 
+        SELECT 'Error: ' + ERROR_MESSAGE() as error_msg 
+    END CATCH 
+    
+    SELECT * FROM #err_t 
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -4468,6 +4645,303 @@ int#!#varchar
 
 DROP TABLE #insert_exec_drop_target
 GO
+
+DROP TABLE #t
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(a int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE TABLE #t(x varchar(10))
+INSERT INTO #t VALUES ('original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_multi_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#second
+~~END~~
+
+
+CREATE TABLE #t(c int)
+INSERT INTO #t VALUES (999)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+EXEC p_drop_create_schema_change
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#20#!#changed schema
+~~END~~
+
+
+CREATE TABLE #t(final_col int)
+INSERT INTO #t VALUES (777)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+777
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+EXEC p_trans_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#in transaction
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with rollback
+EXEC p_rollback_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with indexes
+EXEC p_drop_create_with_index
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#indexed
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with constraints
+EXEC p_drop_create_constraints
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#100
+2#!#200
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+EXEC p_drop_create_alter
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#altered
+~~END~~
+
+
+-- Conditional DROP IF EXISTS + CREATE
+EXEC p_conditional_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+EXEC p_drop_create_truncate
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+3#!#after truncate
+~~END~~
+
+
+-- Error handling with DROP IF EXISTS + CREATE
+EXEC p_error_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error: duplicate key value violates unique constraint "#err_t_pkey"
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- Repeated calls to same procedure
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Second call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Third call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(final int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Interleaved procedure calls
+CREATE TABLE #t(a int)
+CREATE TABLE #t1(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+CREATE TABLE #t(x int)
+CREATE TABLE #t1(y int)
+GO
+
+DROP TABLE #t
+DROP TABLE #t1
+GO
 DROP VIEW enr_view
 GO
 
@@ -4575,4 +5049,40 @@ DROP PROC p_insert_exec_table_var
 GO
 
 DROP PROC p_insert_exec_drop_table
+GO
+
+DROP PROC p_drop_if_exists_create
+GO
+
+DROP PROC p_multi_drop_create
+GO
+
+DROP PROC p_drop_create_schema_change
+GO
+
+DROP PROC p_trans_drop_create
+GO
+
+DROP PROC p_rollback_drop_create
+GO
+
+DROP PROC p_multi_tables_drop_create
+GO
+
+DROP PROC p_drop_create_with_index
+GO
+
+DROP PROC p_drop_create_constraints
+GO
+
+DROP PROC p_drop_create_alter
+GO
+
+DROP PROC p_conditional_drop_create
+GO
+
+DROP PROC p_drop_create_truncate
+GO
+
+DROP PROC p_error_drop_create
 GO

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -408,6 +408,183 @@ BEGIN
 END
 GO
 
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE PROC p_drop_if_exists_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    SELECT * FROM #t 
+END
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE PROC p_multi_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int, b varchar(20)) 
+    INSERT INTO #t VALUES (2, 'second') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+CREATE PROC p_drop_create_schema_change AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(id int, name varchar(50)) 
+    INSERT INTO #t VALUES (1, 'first') 
+    
+    DROP TABLE #t 
+    CREATE TABLE #t(x int, y int, z varchar(100)) 
+    INSERT INTO #t VALUES (10, 20, 'changed schema') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+CREATE PROC p_trans_drop_create AS 
+BEGIN 
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #trans_t 
+        CREATE TABLE #trans_t(a int, b varchar(30)) 
+        INSERT INTO #trans_t VALUES (1, 'in transaction') 
+    COMMIT 
+    SELECT * FROM #trans_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with rollback
+CREATE PROC p_rollback_drop_create AS 
+BEGIN 
+    CREATE TABLE #rb_t(original int) 
+    INSERT INTO #rb_t VALUES (100) 
+    
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #rb_t 
+        CREATE TABLE #rb_t(new_col varchar(20)) 
+        INSERT INTO #rb_t VALUES ('rolled back') 
+    ROLLBACK 
+    
+    SELECT * FROM #rb_t 
+END
+GO
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+CREATE PROC p_multi_tables_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t1 
+    DROP TABLE IF EXISTS #t2 
+    
+    CREATE TABLE #t1(a int) 
+    CREATE TABLE #t2(b varchar(20)) 
+    
+    INSERT INTO #t1 VALUES (1) 
+    INSERT INTO #t2 VALUES ('test') 
+    
+    DROP TABLE IF EXISTS #t1 
+    CREATE TABLE #t1(x int, y int) 
+    INSERT INTO #t1 VALUES (10, 20) 
+    
+    SELECT * FROM #t1 
+    SELECT * FROM #t2 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with indexes
+CREATE PROC p_drop_create_with_index AS 
+BEGIN 
+    DROP TABLE IF EXISTS #idx_t 
+    CREATE TABLE #idx_t(id int, name varchar(50)) 
+    CREATE INDEX idx1 ON #idx_t(id) 
+    INSERT INTO #idx_t VALUES (1, 'indexed') 
+    SELECT * FROM #idx_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with constraints
+CREATE PROC p_drop_create_constraints AS 
+BEGIN 
+    DROP TABLE IF EXISTS #const_t 
+    CREATE TABLE #const_t(id int PRIMARY KEY, val int DEFAULT 100) 
+    INSERT INTO #const_t(id) VALUES (1) 
+    INSERT INTO #const_t VALUES (2, 200) 
+    SELECT * FROM #const_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+CREATE PROC p_drop_create_alter AS 
+BEGIN 
+    DROP TABLE IF EXISTS #alter_t 
+    CREATE TABLE #alter_t(a int) 
+    INSERT INTO #alter_t VALUES (1) 
+    
+    ALTER TABLE #alter_t ADD b varchar(20) 
+    UPDATE #alter_t SET b = 'altered' 
+    
+    SELECT * FROM #alter_t 
+END
+GO
+
+-- Conditional DROP IF EXISTS + CREATE
+CREATE PROC p_conditional_drop_create AS 
+BEGIN 
+    DECLARE @flag int = 1 
+    
+    IF @flag = 1 
+    BEGIN 
+        DROP TABLE IF EXISTS #cond_t 
+        CREATE TABLE #cond_t(a int) 
+        INSERT INTO #cond_t VALUES (100) 
+    END 
+    
+    SELECT * FROM #cond_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+CREATE PROC p_drop_create_truncate AS 
+BEGIN 
+    DROP TABLE IF EXISTS #trunc_t 
+    CREATE TABLE #trunc_t(id int, data varchar(30)) 
+    INSERT INTO #trunc_t VALUES (1, 'first') 
+    INSERT INTO #trunc_t VALUES (2, 'second') 
+    
+    TRUNCATE TABLE #trunc_t 
+    INSERT INTO #trunc_t VALUES (3, 'after truncate') 
+    
+    SELECT * FROM #trunc_t 
+END
+GO
+
+-- Error handling with DROP IF EXISTS + CREATE
+CREATE PROC p_error_drop_create AS 
+BEGIN 
+    BEGIN TRY 
+        DROP TABLE IF EXISTS #err_t 
+        CREATE TABLE #err_t(id int PRIMARY KEY) 
+        INSERT INTO #err_t VALUES (1) 
+        INSERT INTO #err_t VALUES (1) -- Duplicate key error 
+    END TRY 
+    BEGIN CATCH 
+        SELECT 'Error: ' + ERROR_MESSAGE() as error_msg 
+    END CATCH 
+    
+    SELECT * FROM #err_t 
+END
+GO
+
 -- pg_class, pg_type, pg_depend, pg_attribute, pg_constraint, pg_index, pg_sequence are all covered by below tests. 
 -------------------------------
 -- Temp Table CREATE + ROLLBACK
@@ -4469,6 +4646,303 @@ int#!#varchar
 
 DROP TABLE #insert_exec_drop_target
 GO
+
+DROP TABLE #t
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(a int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE TABLE #t(x varchar(10))
+INSERT INTO #t VALUES ('original')
+GO
+~~ROW COUNT: 1~~
+
+
+EXEC p_multi_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+2#!#second
+~~END~~
+
+
+CREATE TABLE #t(c int)
+INSERT INTO #t VALUES (999)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+999
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+EXEC p_drop_create_schema_change
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int#!#varchar
+10#!#20#!#changed schema
+~~END~~
+
+
+CREATE TABLE #t(final_col int)
+INSERT INTO #t VALUES (777)
+SELECT * FROM #t
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+777
+~~END~~
+
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+EXEC p_trans_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#in transaction
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with rollback
+EXEC p_rollback_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with indexes
+EXEC p_drop_create_with_index
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#indexed
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with constraints
+EXEC p_drop_create_constraints
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#100
+2#!#200
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+EXEC p_drop_create_alter
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+1#!#altered
+~~END~~
+
+
+-- Conditional DROP IF EXISTS + CREATE
+EXEC p_conditional_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+100
+~~END~~
+
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+EXEC p_drop_create_truncate
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar
+3#!#after truncate
+~~END~~
+
+
+-- Error handling with DROP IF EXISTS + CREATE
+EXEC p_error_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+nvarchar
+Error: duplicate key value violates unique constraint "#err_t_pkey"
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- Repeated calls to same procedure
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Second call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_drop_if_exists_create  -- Third call
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+CREATE TABLE #t(final int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Interleaved procedure calls
+CREATE TABLE #t(a int)
+CREATE TABLE #t1(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+EXEC p_multi_tables_drop_create
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+10#!#20
+~~END~~
+
+~~START~~
+varchar
+test
+~~END~~
+
+
+CREATE TABLE #t(x int)
+CREATE TABLE #t1(y int)
+GO
+
+DROP TABLE #t
+DROP TABLE #t1
+GO
 DROP VIEW enr_view
 GO
 
@@ -4576,4 +5050,40 @@ DROP PROC p_insert_exec_table_var
 GO
 
 DROP PROC p_insert_exec_drop_table
+GO
+
+DROP PROC p_drop_if_exists_create
+GO
+
+DROP PROC p_multi_drop_create
+GO
+
+DROP PROC p_drop_create_schema_change
+GO
+
+DROP PROC p_trans_drop_create
+GO
+
+DROP PROC p_rollback_drop_create
+GO
+
+DROP PROC p_multi_tables_drop_create
+GO
+
+DROP PROC p_drop_create_with_index
+GO
+
+DROP PROC p_drop_create_constraints
+GO
+
+DROP PROC p_drop_create_alter
+GO
+
+DROP PROC p_conditional_drop_create
+GO
+
+DROP PROC p_drop_create_truncate
+GO
+
+DROP PROC p_error_drop_create
 GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-cleanup.sql
@@ -106,3 +106,39 @@ GO
 
 DROP PROC p_insert_exec_drop_table
 GO
+
+DROP PROC p_drop_if_exists_create
+GO
+
+DROP PROC p_multi_drop_create
+GO
+
+DROP PROC p_drop_create_schema_change
+GO
+
+DROP PROC p_trans_drop_create
+GO
+
+DROP PROC p_rollback_drop_create
+GO
+
+DROP PROC p_multi_tables_drop_create
+GO
+
+DROP PROC p_drop_create_with_index
+GO
+
+DROP PROC p_drop_create_constraints
+GO
+
+DROP PROC p_drop_create_alter
+GO
+
+DROP PROC p_conditional_drop_create
+GO
+
+DROP PROC p_drop_create_truncate
+GO
+
+DROP PROC p_error_drop_create
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-prepare.sql
@@ -405,3 +405,180 @@ BEGIN
     SELECT 200 as id, 'after drop' as data
 END
 GO
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE PROC p_drop_if_exists_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    SELECT * FROM #t 
+END
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE PROC p_multi_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int) 
+    INSERT INTO #t VALUES (1) 
+    
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(a int, b varchar(20)) 
+    INSERT INTO #t VALUES (2, 'second') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+CREATE PROC p_drop_create_schema_change AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t 
+    CREATE TABLE #t(id int, name varchar(50)) 
+    INSERT INTO #t VALUES (1, 'first') 
+    
+    DROP TABLE #t 
+    CREATE TABLE #t(x int, y int, z varchar(100)) 
+    INSERT INTO #t VALUES (10, 20, 'changed schema') 
+    
+    SELECT * FROM #t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+CREATE PROC p_trans_drop_create AS 
+BEGIN 
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #trans_t 
+        CREATE TABLE #trans_t(a int, b varchar(30)) 
+        INSERT INTO #trans_t VALUES (1, 'in transaction') 
+    COMMIT 
+    SELECT * FROM #trans_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with rollback
+CREATE PROC p_rollback_drop_create AS 
+BEGIN 
+    CREATE TABLE #rb_t(original int) 
+    INSERT INTO #rb_t VALUES (100) 
+    
+    BEGIN TRAN 
+        DROP TABLE IF EXISTS #rb_t 
+        CREATE TABLE #rb_t(new_col varchar(20)) 
+        INSERT INTO #rb_t VALUES ('rolled back') 
+    ROLLBACK 
+    
+    SELECT * FROM #rb_t 
+END
+GO
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+CREATE PROC p_multi_tables_drop_create AS 
+BEGIN 
+    DROP TABLE IF EXISTS #t1 
+    DROP TABLE IF EXISTS #t2 
+    
+    CREATE TABLE #t1(a int) 
+    CREATE TABLE #t2(b varchar(20)) 
+    
+    INSERT INTO #t1 VALUES (1) 
+    INSERT INTO #t2 VALUES ('test') 
+    
+    DROP TABLE IF EXISTS #t1 
+    CREATE TABLE #t1(x int, y int) 
+    INSERT INTO #t1 VALUES (10, 20) 
+    
+    SELECT * FROM #t1 
+    SELECT * FROM #t2 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with indexes
+CREATE PROC p_drop_create_with_index AS 
+BEGIN 
+    DROP TABLE IF EXISTS #idx_t 
+    CREATE TABLE #idx_t(id int, name varchar(50)) 
+    CREATE INDEX idx1 ON #idx_t(id) 
+    INSERT INTO #idx_t VALUES (1, 'indexed') 
+    SELECT * FROM #idx_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with constraints
+CREATE PROC p_drop_create_constraints AS 
+BEGIN 
+    DROP TABLE IF EXISTS #const_t 
+    CREATE TABLE #const_t(id int PRIMARY KEY, val int DEFAULT 100) 
+    INSERT INTO #const_t(id) VALUES (1) 
+    INSERT INTO #const_t VALUES (2, 200) 
+    SELECT * FROM #const_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+CREATE PROC p_drop_create_alter AS 
+BEGIN 
+    DROP TABLE IF EXISTS #alter_t 
+    CREATE TABLE #alter_t(a int) 
+    INSERT INTO #alter_t VALUES (1) 
+    
+    ALTER TABLE #alter_t ADD b varchar(20) 
+    UPDATE #alter_t SET b = 'altered' 
+    
+    SELECT * FROM #alter_t 
+END
+GO
+
+-- Conditional DROP IF EXISTS + CREATE
+CREATE PROC p_conditional_drop_create AS 
+BEGIN 
+    DECLARE @flag int = 1 
+    
+    IF @flag = 1 
+    BEGIN 
+        DROP TABLE IF EXISTS #cond_t 
+        CREATE TABLE #cond_t(a int) 
+        INSERT INTO #cond_t VALUES (100) 
+    END 
+    
+    SELECT * FROM #cond_t 
+END
+GO
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+CREATE PROC p_drop_create_truncate AS 
+BEGIN 
+    DROP TABLE IF EXISTS #trunc_t 
+    CREATE TABLE #trunc_t(id int, data varchar(30)) 
+    INSERT INTO #trunc_t VALUES (1, 'first') 
+    INSERT INTO #trunc_t VALUES (2, 'second') 
+    
+    TRUNCATE TABLE #trunc_t 
+    INSERT INTO #trunc_t VALUES (3, 'after truncate') 
+    
+    SELECT * FROM #trunc_t 
+END
+GO
+
+-- Error handling with DROP IF EXISTS + CREATE
+CREATE PROC p_error_drop_create AS 
+BEGIN 
+    BEGIN TRY 
+        DROP TABLE IF EXISTS #err_t 
+        CREATE TABLE #err_t(id int PRIMARY KEY) 
+        INSERT INTO #err_t VALUES (1) 
+        INSERT INTO #err_t VALUES (1) -- Duplicate key error 
+    END TRY 
+    BEGIN CATCH 
+        SELECT 'Error: ' + ERROR_MESSAGE() as error_msg 
+    END CATCH 
+    
+    SELECT * FROM #err_t 
+END
+GO

--- a/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_rollback-vu-verify.sql
@@ -1982,3 +1982,127 @@ GO
 
 DROP TABLE #insert_exec_drop_target
 GO
+
+DROP TABLE #t
+DROP TABLE #t1
+DROP TABLE #t2
+GO
+
+---------------------------------------------------------------------------
+-- DROP TABLE IF EXISTS + CREATE TABLE in procedures (BABEL-6097)
+---------------------------------------------------------------------------
+
+-- Basic DROP IF EXISTS + CREATE pattern
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+
+CREATE TABLE #t(a int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Multiple DROP IF EXISTS + CREATE cycles
+CREATE TABLE #t(x varchar(10))
+INSERT INTO #t VALUES ('original')
+GO
+
+EXEC p_multi_drop_create
+GO
+
+CREATE TABLE #t(c int)
+INSERT INTO #t VALUES (999)
+SELECT * FROM #t
+GO
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE with different schemas
+EXEC p_drop_create_schema_change
+GO
+
+CREATE TABLE #t(final_col int)
+INSERT INTO #t VALUES (777)
+SELECT * FROM #t
+GO
+
+DROP TABLE #t
+GO
+
+-- DROP IF EXISTS + CREATE in transaction
+EXEC p_trans_drop_create
+GO
+
+-- DROP IF EXISTS + CREATE with rollback
+EXEC p_rollback_drop_create
+GO
+
+-- Multiple temp tables with DROP IF EXISTS + CREATE
+EXEC p_multi_tables_drop_create
+GO
+
+-- DROP IF EXISTS + CREATE with indexes
+EXEC p_drop_create_with_index
+GO
+
+-- DROP IF EXISTS + CREATE with constraints
+EXEC p_drop_create_constraints
+GO
+
+-- DROP IF EXISTS + CREATE with ALTER TABLE
+EXEC p_drop_create_alter
+GO
+
+-- Conditional DROP IF EXISTS + CREATE
+EXEC p_conditional_drop_create
+GO
+
+-- DROP IF EXISTS + CREATE with TRUNCATE
+EXEC p_drop_create_truncate
+GO
+
+-- Error handling with DROP IF EXISTS + CREATE
+EXEC p_error_drop_create
+GO
+
+-- Repeated calls to same procedure
+CREATE TABLE #t(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+
+EXEC p_drop_if_exists_create  -- Second call
+GO
+
+EXEC p_drop_if_exists_create  -- Third call
+GO
+
+CREATE TABLE #t(final int)  -- Should not crash
+GO
+
+DROP TABLE #t
+GO
+
+-- Interleaved procedure calls
+CREATE TABLE #t(a int)
+CREATE TABLE #t1(a int)
+GO
+
+EXEC p_drop_if_exists_create
+GO
+
+EXEC p_multi_tables_drop_create
+GO
+
+CREATE TABLE #t(x int)
+CREATE TABLE #t1(y int)
+GO
+
+DROP TABLE #t
+DROP TABLE #t1
+GO


### PR DESCRIPTION
### Description
Added more tests for the fix of Crash during dropping temp table from a proc. 

### Issues Resolved

[BABEL-6097]

Signed-off by : harshdu@amazon.com

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).