### PR TITLE
[TEST-ONLY] Added ORDER BY Clause in BABEL-4294 to fix flaky test failures

### DIFF
--- a/test/JDBC/expected/BABEL-4294-vu-verify.out
+++ b/test/JDBC/expected/BABEL-4294-vu-verify.out
@@ -16,15 +16,16 @@ select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
 inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
 inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
 GROUP BY babel_4294_t2.val
+ORDER BY babel_4294_t2.val
 go
 ~~START~~
 int#!#int
 1#!#11
-1#!#13
-1#!#12
 1#!#11
-1#!#13
 1#!#12
+1#!#12
+1#!#13
+1#!#13
 ~~END~~
 
 

--- a/test/JDBC/expected/parallel_query/BABEL-4294-vu-verify.out
+++ b/test/JDBC/expected/parallel_query/BABEL-4294-vu-verify.out
@@ -16,14 +16,15 @@ select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
 inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
 inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
 GROUP BY babel_4294_t2.val
+ORDER BY babel_4294_t2.val
 go
 ~~START~~
 int#!#int
 1#!#11
-1#!#12
-1#!#13
 1#!#11
 1#!#12
+1#!#12
+1#!#13
 1#!#13
 ~~END~~
 

--- a/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-verify.mix
+++ b/test/JDBC/input/pg_hint_plan/BABEL-4294-vu-verify.mix
@@ -17,6 +17,7 @@ select COUNT( babel_4294_t3.val), babel_4294_t2.val from babel_4294_t1
 inner join babel_4294_t2 on babel_4294_t1.id = babel_4294_t2.babel_4294_t1_id
 inner join babel_4294_t3 on babel_4294_t1.id = babel_4294_t3.babel_4294_t1_id
 GROUP BY babel_4294_t2.val
+ORDER BY babel_4294_t2.val
 go
 
 -- Used force parallel mode to create a parallel worker


### PR DESCRIPTION
### Description
BABEL-4294-vu-verify test can fail with query output ordering difference, to fix this added ORDER BY Clause to test to get deterministic results.

Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved

NA

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).