### PR TITLE
[TEST ONLY] Fix for Index and Toast Creation Not getting registered in correct QueryEnvironment (cherry-pick from 5_X)

### DIFF
--- a/test/JDBC/expected/temp_table_visibility-vu-cleanup.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-cleanup.out
@@ -45,3 +45,9 @@ GO
 
 drop procedure p_def_cons;
 GO
+
+drop procedure p_sp_executesql_index;
+GO
+
+drop procedure p_sp_executesql_toast;
+GO

--- a/test/JDBC/expected/temp_table_visibility-vu-prepare.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-prepare.out
@@ -16,6 +16,7 @@ CREATE VIEW enr_view AS
             ELSE relname
         END AS relname
     FROM sys.babelfish_get_enr_list()
+    ORDER BY relname COLLATE pg_c_utf8
 GO
 
 
@@ -35,7 +36,7 @@ go
 CREATE PROCEDURE enr_list_inner_proc
 as
     CREATE TABLE #tab_nest_level_0(a int)
-    SELECT relname FROM sys.babelfish_get_enr_list();
+    SELECT relname FROM sys.babelfish_get_enr_list() ORDER BY relname COLLATE pg_c_utf8;
 go
 
 -- Ensure to check before and after table is created.
@@ -116,5 +117,43 @@ BEGIN
 	INSERT INTO @tv_def_con(id) VALUES (2);
 	INSERT INTO @tv_def_con(id, b) VALUES (3, 'A');
 	SELECT * FROM @tv_def_con;
+END;
+GO
+
+-- SP_EXECUTESQL index creation on temp tables
+CREATE PROCEDURE p_sp_executesql_index
+AS
+BEGIN
+    CREATE TABLE #sp_exec_temp (a INT, b VARCHAR(50));
+    INSERT INTO #sp_exec_temp VALUES (1, 'one'), (2, 'two'), (3, 'three');
+    
+    DECLARE @SQL NVARCHAR(MAX) = 'CREATE INDEX idx_sp_exec ON #sp_exec_temp(a)';
+    EXEC SP_EXECUTESQL @SQL;
+    
+    SELECT * FROM #sp_exec_temp WHERE a = 2;
+    
+    DROP INDEX idx_sp_exec ON #sp_exec_temp;
+    
+    SELECT * FROM #sp_exec_temp ORDER BY a;
+    
+    DROP TABLE #sp_exec_temp;
+END;
+GO
+
+-- SP_EXECUTESQL ALTER TABLE ADD column that creates toast table
+CREATE PROCEDURE p_sp_executesql_toast
+AS
+BEGIN
+    CREATE TABLE #sp_exec_toast_temp (a INT, b VARCHAR(10));
+    INSERT INTO #sp_exec_toast_temp VALUES (1, 'test');
+    
+    DECLARE @SQL NVARCHAR(MAX) = 'ALTER TABLE #sp_exec_toast_temp ADD large_col VARCHAR(MAX)';
+    EXEC SP_EXECUTESQL @SQL;
+    
+    UPDATE #sp_exec_toast_temp SET large_col = REPLICATE('x', 5000) WHERE a = 1;
+    
+    SELECT a, b, LEN(large_col) as large_col_len FROM #sp_exec_toast_temp;
+    
+    DROP TABLE #sp_exec_toast_temp;
 END;
 GO

--- a/test/JDBC/expected/temp_table_visibility-vu-verify.out
+++ b/test/JDBC/expected/temp_table_visibility-vu-verify.out
@@ -126,9 +126,9 @@ EXEC p_index_create
 GO
 ~~START~~
 text
-idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 #t4122
 #temptable5605
+idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 ~~END~~
 
 
@@ -162,12 +162,13 @@ SELECT * FROM enr_view;
 GO
 ~~START~~
 text
-#t4122
-#temptable5605
-#sys_comprehensive
 #pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
+#sys_comprehensive
 #sys_comprehensive_pkey
+#t4122
+#temptable5605
+idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 ~~END~~
 
 
@@ -343,12 +344,13 @@ SELECT * FROM enr_view;
 GO
 ~~START~~
 text
-#t4122
-#temptable5605
 #advanced_columns
+#advanced_columns_pkey
 #pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
-#advanced_columns_pkey
+#t4122
+#temptable5605
+idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 ~~END~~
 
 
@@ -528,17 +530,18 @@ SELECT * FROM enr_view;
 GO
 ~~START~~
 text
-#t4122
-#temptable5605
 #indexed_dml
+#indexed_dml_pkey
 #pg_toast_#oid_masked#
 #pg_toast_#oid_masked#_index
-#indexed_dml_pkey
-ix_text#indexed_dml331193019682437d7418b66eb4c0d94e
-ix_int#indexed_dml035dab3da66aea81011a3eae459c604c
-ix_date#indexed_dmle2166a864eb6380802f1dd642a3fde15
-ix_money#indexed_dmlf15b16dc03c5e414c280565f841360cc
+#t4122
+#temptable5605
+idx#temptable56057f9bec28bc8902d45d905788d7aa59a1
 ix_composite#indexed_dml607dc45075f81468865d4be46b38df3e
+ix_date#indexed_dmle2166a864eb6380802f1dd642a3fde15
+ix_int#indexed_dml035dab3da66aea81011a3eae459c604c
+ix_money#indexed_dmlf15b16dc03c5e414c280565f841360cc
+ix_text#indexed_dml331193019682437d7418b66eb4c0d94e
 ~~END~~
 
 
@@ -767,3 +770,134 @@ GO
 
 ~~ERROR (Message: temporary objects cannot reference permanent non-system objects)~~
 
+
+-- SP_EXECUTESQL index creation/drop on temp tables
+EXEC p_sp_executesql_index;
+GO
+~~ROW COUNT: 3~~
+
+~~START~~
+int#!#varchar
+2#!#two
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+~~END~~
+
+
+-- SP_EXECUTESQL ALTER TABLE ADD column that creates toast table
+EXEC p_sp_executesql_toast;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#varchar#!#int
+1#!#test#!#5000
+~~END~~
+
+
+-- Inline index creation via SP_EXECUTESQL
+CREATE TABLE #temp_index1 (a INT, b VARCHAR(50));
+GO
+INSERT INTO #temp_index1 VALUES (1, 'one'), (2, 'two'), (3, 'three');
+GO
+~~ROW COUNT: 3~~
+
+
+DECLARE @sql1 NVARCHAR(MAX) = 'CREATE INDEX index1 ON #temp_index1(a)';
+EXEC SP_EXECUTESQL @sql1;
+GO
+
+SELECT * FROM #temp_index1 WHERE a = 2;
+GO
+~~START~~
+int#!#varchar
+2#!#two
+~~END~~
+
+
+DROP INDEX index1 ON #temp_index1;
+GO
+
+SELECT * FROM #temp_index1 ORDER BY a;
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+~~END~~
+
+
+DROP TABLE #temp_index1;
+GO
+
+-- Inline ALTER TABLE ADD column (text type triggers toast) via SP_EXECUTESQL
+CREATE TABLE #temp_heap1 (a INT);
+GO
+INSERT INTO #temp_heap1 VALUES (1);
+GO
+~~ROW COUNT: 1~~
+
+
+DECLARE @sql2 NVARCHAR(MAX) = 'ALTER TABLE #temp_heap1 ADD col1 TEXT';
+EXEC SP_EXECUTESQL @sql2;
+GO
+
+UPDATE #temp_heap1 SET col1 = REPLICATE('x', 5000) WHERE a = 1;
+GO
+~~ROW COUNT: 1~~
+
+
+SELECT a, LEN(col1) as col1_len FROM #temp_heap1;
+GO
+~~START~~
+int#!#int
+1#!#5000
+~~END~~
+
+
+DROP TABLE #temp_heap1;
+GO
+
+-- Index on column added via SP_EXECUTESQL
+CREATE TABLE #temp_index2 (a INT);
+GO
+INSERT INTO #temp_index2 VALUES (1), (2), (3);
+GO
+~~ROW COUNT: 3~~
+
+
+DECLARE @sql4 NVARCHAR(MAX) = 'ALTER TABLE #temp_index2 ADD b INT DEFAULT 0';
+EXEC SP_EXECUTESQL @sql4;
+GO
+
+UPDATE #temp_index2 SET b = a * 10;
+GO
+~~ROW COUNT: 3~~
+
+
+DECLARE @sql5 NVARCHAR(MAX) = 'CREATE INDEX index2 ON #temp_index2(b)';
+EXEC SP_EXECUTESQL @sql5;
+GO
+
+SELECT * FROM #temp_index2 WHERE b > 10 ORDER BY b;
+GO
+~~START~~
+int#!#int
+2#!#20
+3#!#30
+~~END~~
+
+
+DROP INDEX index2 ON #temp_index2;
+GO
+
+DROP TABLE #temp_index2;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-cleanup.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-cleanup.sql
@@ -45,3 +45,9 @@ GO
 
 drop procedure p_def_cons;
 GO
+
+drop procedure p_sp_executesql_index;
+GO
+
+drop procedure p_sp_executesql_toast;
+GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-prepare.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-prepare.sql
@@ -16,6 +16,7 @@ CREATE VIEW enr_view AS
             ELSE relname
         END AS relname
     FROM sys.babelfish_get_enr_list()
+    ORDER BY relname COLLATE pg_c_utf8
 GO
 
 CREATE PROCEDURE object_id_outer_proc
@@ -35,7 +36,7 @@ go
 CREATE PROCEDURE enr_list_inner_proc
 as
     CREATE TABLE #tab_nest_level_0(a int)
-    SELECT relname FROM sys.babelfish_get_enr_list();
+    SELECT relname FROM sys.babelfish_get_enr_list() ORDER BY relname COLLATE pg_c_utf8;
 go
 
 -- Ensure to check before and after table is created.
@@ -116,5 +117,43 @@ BEGIN
 	INSERT INTO @tv_def_con(id) VALUES (2);
 	INSERT INTO @tv_def_con(id, b) VALUES (3, 'A');
 	SELECT * FROM @tv_def_con;
+END;
+GO
+
+-- SP_EXECUTESQL index creation on temp tables
+CREATE PROCEDURE p_sp_executesql_index
+AS
+BEGIN
+    CREATE TABLE #sp_exec_temp (a INT, b VARCHAR(50));
+    INSERT INTO #sp_exec_temp VALUES (1, 'one'), (2, 'two'), (3, 'three');
+    
+    DECLARE @SQL NVARCHAR(MAX) = 'CREATE INDEX idx_sp_exec ON #sp_exec_temp(a)';
+    EXEC SP_EXECUTESQL @SQL;
+    
+    SELECT * FROM #sp_exec_temp WHERE a = 2;
+    
+    DROP INDEX idx_sp_exec ON #sp_exec_temp;
+    
+    SELECT * FROM #sp_exec_temp ORDER BY a;
+    
+    DROP TABLE #sp_exec_temp;
+END;
+GO
+
+-- SP_EXECUTESQL ALTER TABLE ADD column that creates toast table
+CREATE PROCEDURE p_sp_executesql_toast
+AS
+BEGIN
+    CREATE TABLE #sp_exec_toast_temp (a INT, b VARCHAR(10));
+    INSERT INTO #sp_exec_toast_temp VALUES (1, 'test');
+    
+    DECLARE @SQL NVARCHAR(MAX) = 'ALTER TABLE #sp_exec_toast_temp ADD large_col VARCHAR(MAX)';
+    EXEC SP_EXECUTESQL @SQL;
+    
+    UPDATE #sp_exec_toast_temp SET large_col = REPLICATE('x', 5000) WHERE a = 1;
+    
+    SELECT a, b, LEN(large_col) as large_col_len FROM #sp_exec_toast_temp;
+    
+    DROP TABLE #sp_exec_toast_temp;
 END;
 GO

--- a/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
+++ b/test/JDBC/input/temp_tables/temp_table_visibility-vu-verify.sql
@@ -375,3 +375,78 @@ CREATE TABLE #temp_table_with_default_udf (
 	num INT CHECK(custom_adder(num,10) > 100)
 )
 GO
+
+-- SP_EXECUTESQL index creation/drop on temp tables
+EXEC p_sp_executesql_index;
+GO
+
+-- SP_EXECUTESQL ALTER TABLE ADD column that creates toast table
+EXEC p_sp_executesql_toast;
+GO
+
+-- Inline index creation via SP_EXECUTESQL
+CREATE TABLE #temp_index1 (a INT, b VARCHAR(50));
+GO
+INSERT INTO #temp_index1 VALUES (1, 'one'), (2, 'two'), (3, 'three');
+GO
+
+DECLARE @sql1 NVARCHAR(MAX) = 'CREATE INDEX index1 ON #temp_index1(a)';
+EXEC SP_EXECUTESQL @sql1;
+GO
+
+SELECT * FROM #temp_index1 WHERE a = 2;
+GO
+
+DROP INDEX index1 ON #temp_index1;
+GO
+
+SELECT * FROM #temp_index1 ORDER BY a;
+GO
+
+DROP TABLE #temp_index1;
+GO
+
+-- Inline ALTER TABLE ADD column (text type triggers toast) via SP_EXECUTESQL
+CREATE TABLE #temp_heap1 (a INT);
+GO
+INSERT INTO #temp_heap1 VALUES (1);
+GO
+
+DECLARE @sql2 NVARCHAR(MAX) = 'ALTER TABLE #temp_heap1 ADD col1 TEXT';
+EXEC SP_EXECUTESQL @sql2;
+GO
+
+UPDATE #temp_heap1 SET col1 = REPLICATE('x', 5000) WHERE a = 1;
+GO
+
+SELECT a, LEN(col1) as col1_len FROM #temp_heap1;
+GO
+
+DROP TABLE #temp_heap1;
+GO
+
+-- Index on column added via SP_EXECUTESQL
+CREATE TABLE #temp_index2 (a INT);
+GO
+INSERT INTO #temp_index2 VALUES (1), (2), (3);
+GO
+
+DECLARE @sql4 NVARCHAR(MAX) = 'ALTER TABLE #temp_index2 ADD b INT DEFAULT 0';
+EXEC SP_EXECUTESQL @sql4;
+GO
+
+UPDATE #temp_index2 SET b = a * 10;
+GO
+
+DECLARE @sql5 NVARCHAR(MAX) = 'CREATE INDEX index2 ON #temp_index2(b)';
+EXEC SP_EXECUTESQL @sql5;
+GO
+
+SELECT * FROM #temp_index2 WHERE b > 10 ORDER BY b;
+GO
+
+DROP INDEX index2 ON #temp_index2;
+GO
+
+DROP TABLE #temp_index2;
+GO


### PR DESCRIPTION
### Description

Added test Cases for the Fix for Index and Toast creation in Case of ENR temp tables were getting registered in CurrentQueryEnv, while the table for which this toast is being created were in the parent queryEnv.
cherry pick from (#4596 )

### Issues Resolved

BABEL-6272

Engine PR- https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/726

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).