### PR TITLE
[TEST ONLY] Fix sys-configurations test to handle dynamic user connections value

### DIFF
--- a/test/JDBC/expected/sys-configurations-vu-prepare.out
+++ b/test/JDBC/expected/sys-configurations-vu-prepare.out
@@ -2,11 +2,21 @@ USE master;
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v1 AS
-SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
+SELECT configuration_id, name,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       minimum, maximum,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value_in_use END as value_in_use,
+       description, is_dynamic, is_advanced
+FROM sys.configurations
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p1 AS
-SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
+SELECT configuration_id, name,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       minimum, maximum,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value_in_use END as value_in_use,
+       description, is_dynamic, is_advanced
+FROM sys.configurations
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f1()
@@ -18,11 +28,15 @@ END
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v2 AS
-SELECT * FROM sys.syscurconfigs
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.syscurconfigs
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p2 AS
-SELECT * FROM sys.syscurconfigs
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.syscurconfigs
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f2()
@@ -34,11 +48,15 @@ END
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v3 AS
-SELECT * FROM sys.sysconfigures
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.sysconfigures
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p3 AS
-SELECT * FROM sys.sysconfigures
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.sysconfigures
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f3()

--- a/test/JDBC/expected/sys-configurations-vu-verify.out
+++ b/test/JDBC/expected/sys-configurations-vu-verify.out
@@ -4,32 +4,32 @@ GO
 SELECT * FROM sys_configurations_vu_prepare_v1
 GO
 ~~START~~
-int#!#nvarchar#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
-103#!#user connections#!#1#!#262143#!#Sets the maximum number of concurrent connections.#!#0#!#1
-115#!#nested triggers#!#0#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
-124#!#default language#!#0#!#9999#!#default language#!#1#!#0
-505#!#network packet size (B)#!#512#!#32767#!#Sets the default packet size for all the clients being connected#!#1#!#1
-1126#!#default full-text language#!#0#!#2147483647#!#default full-text language#!#1#!#1
-1127#!#two digit year cutoff#!#1753#!#9999#!#two digit year cutoff#!#1#!#1
-1534#!#user options#!#0#!#32767#!#user options#!#1#!#0
-1555#!#transform noise words#!#0#!#1#!#Transform noise words for full-text query#!#1#!#1
-16387#!#SMO and DMO XPs#!#0#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
+int#!#nvarchar#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
+103#!#user connections#!#<NULL>#!#1#!#262143#!#<NULL>#!#Sets the maximum number of concurrent connections.#!#0#!#1
+115#!#nested triggers#!#1#!#0#!#1#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
+124#!#default language#!#0#!#0#!#9999#!#0#!#default language#!#1#!#0
+505#!#network packet size (B)#!#4096#!#512#!#32767#!#4096#!#Sets the default packet size for all the clients being connected#!#1#!#1
+1126#!#default full-text language#!#1033#!#0#!#2147483647#!#1033#!#default full-text language#!#1#!#1
+1127#!#two digit year cutoff#!#2049#!#1753#!#9999#!#2049#!#two digit year cutoff#!#1#!#1
+1534#!#user options#!#0#!#0#!#32767#!#0#!#user options#!#1#!#0
+1555#!#transform noise words#!#0#!#0#!#1#!#0#!#Transform noise words for full-text query#!#1#!#1
+16387#!#SMO and DMO XPs#!#1#!#0#!#1#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
 ~~END~~
 
 
 EXEC sys_configurations_vu_prepare_p1
 GO
 ~~START~~
-int#!#nvarchar#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
-103#!#user connections#!#1#!#262143#!#Sets the maximum number of concurrent connections.#!#0#!#1
-115#!#nested triggers#!#0#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
-124#!#default language#!#0#!#9999#!#default language#!#1#!#0
-505#!#network packet size (B)#!#512#!#32767#!#Sets the default packet size for all the clients being connected#!#1#!#1
-1126#!#default full-text language#!#0#!#2147483647#!#default full-text language#!#1#!#1
-1127#!#two digit year cutoff#!#1753#!#9999#!#two digit year cutoff#!#1#!#1
-1534#!#user options#!#0#!#32767#!#user options#!#1#!#0
-1555#!#transform noise words#!#0#!#1#!#Transform noise words for full-text query#!#1#!#1
-16387#!#SMO and DMO XPs#!#0#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
+int#!#nvarchar#!#sql_variant#!#sql_variant#!#sql_variant#!#sql_variant#!#nvarchar#!#bit#!#bit
+103#!#user connections#!#<NULL>#!#1#!#262143#!#<NULL>#!#Sets the maximum number of concurrent connections.#!#0#!#1
+115#!#nested triggers#!#1#!#0#!#1#!#1#!#Allow triggers to be invoked within triggers#!#1#!#0
+124#!#default language#!#0#!#0#!#9999#!#0#!#default language#!#1#!#0
+505#!#network packet size (B)#!#4096#!#512#!#32767#!#4096#!#Sets the default packet size for all the clients being connected#!#1#!#1
+1126#!#default full-text language#!#1033#!#0#!#2147483647#!#1033#!#default full-text language#!#1#!#1
+1127#!#two digit year cutoff#!#2049#!#1753#!#9999#!#2049#!#two digit year cutoff#!#1#!#1
+1534#!#user options#!#0#!#0#!#32767#!#0#!#user options#!#1#!#0
+1555#!#transform noise words#!#0#!#0#!#1#!#0#!#Transform noise words for full-text query#!#1#!#1
+16387#!#SMO and DMO XPs#!#1#!#0#!#1#!#1#!#Enable or disable SMO and DMO XPs#!#1#!#1
 ~~END~~
 
 
@@ -53,7 +53,7 @@ sql_variant#!#int#!#nvarchar#!#smallint
 2049#!#1127#!#two digit year cutoff#!#3
 0#!#1555#!#Transform noise words for full-text query#!#3
 4096#!#505#!#Sets the default packet size for all the clients being connected#!#3
-100#!#103#!#Sets the maximum number of concurrent connections.#!#2
+<NULL>#!#103#!#Sets the maximum number of concurrent connections.#!#2
 ~~END~~
 
 
@@ -69,7 +69,7 @@ sql_variant#!#int#!#nvarchar#!#smallint
 2049#!#1127#!#two digit year cutoff#!#3
 0#!#1555#!#Transform noise words for full-text query#!#3
 4096#!#505#!#Sets the default packet size for all the clients being connected#!#3
-100#!#103#!#Sets the maximum number of concurrent connections.#!#2
+<NULL>#!#103#!#Sets the maximum number of concurrent connections.#!#2
 ~~END~~
 
 
@@ -93,7 +93,7 @@ sql_variant#!#int#!#nvarchar#!#smallint
 2049#!#1127#!#two digit year cutoff#!#3
 0#!#1555#!#Transform noise words for full-text query#!#3
 4096#!#505#!#Sets the default packet size for all the clients being connected#!#3
-100#!#103#!#Sets the maximum number of concurrent connections.#!#2
+<NULL>#!#103#!#Sets the maximum number of concurrent connections.#!#2
 ~~END~~
 
 
@@ -109,7 +109,7 @@ sql_variant#!#int#!#nvarchar#!#smallint
 2049#!#1127#!#two digit year cutoff#!#3
 0#!#1555#!#Transform noise words for full-text query#!#3
 4096#!#505#!#Sets the default packet size for all the clients being connected#!#3
-100#!#103#!#Sets the maximum number of concurrent connections.#!#2
+<NULL>#!#103#!#Sets the maximum number of concurrent connections.#!#2
 ~~END~~
 
 

--- a/test/JDBC/input/views/sys-configurations-vu-prepare.sql
+++ b/test/JDBC/input/views/sys-configurations-vu-prepare.sql
@@ -2,11 +2,21 @@ USE master;
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v1 AS
-SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
+SELECT configuration_id, name,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       minimum, maximum,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value_in_use END as value_in_use,
+       description, is_dynamic, is_advanced
+FROM sys.configurations
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p1 AS
-SELECT configuration_id, name, minimum, maximum, description, is_dynamic, is_advanced FROM sys.configurations
+SELECT configuration_id, name,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       minimum, maximum,
+       CASE WHEN configuration_id = 103 THEN CAST(NULL AS sql_variant) ELSE value_in_use END as value_in_use,
+       description, is_dynamic, is_advanced
+FROM sys.configurations
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f1()
@@ -18,11 +28,15 @@ END
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v2 AS
-SELECT * FROM sys.syscurconfigs
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.syscurconfigs
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p2 AS
-SELECT * FROM sys.syscurconfigs
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.syscurconfigs
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f2()
@@ -34,11 +48,15 @@ END
 GO
 
 CREATE VIEW sys_configurations_vu_prepare_v3 AS
-SELECT * FROM sys.sysconfigures
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.sysconfigures
 GO
 
 CREATE PROC sys_configurations_vu_prepare_p3 AS
-SELECT * FROM sys.sysconfigures
+SELECT CASE WHEN config = 103 THEN CAST(NULL AS sql_variant) ELSE value END as value,
+       config, comment, status
+FROM sys.sysconfigures
 GO
 
 CREATE FUNCTION sys_configurations_vu_prepare_f3()


### PR DESCRIPTION
### Description

Fix sys-configurations test to handle dynamic user connections value as the connection value differ based on the db instance the test is run on.

### Issues Resolved

BABEL-6366

### Test Scenarios Covered ###
* **Use case based -**
Yes

* **Boundary conditions -**
Yes

* **Arbitrary inputs -**
Yes

* **Negative test cases -**
Yes

* **Minor version upgrade tests -**
Yes

* **Major version upgrade tests -**
Yes

* **Performance tests -**
NA

* **Tooling impact -**
NA

* **Client tests -**
NA


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).