### PR TITLE
Fix PATINDEX failing with parentheses in search pattern

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_functions.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_functions.sql
@@ -1764,8 +1764,12 @@ declare
   v_find_result VARCHAR;
   v_pos bigint;
   v_regexp_pattern VARCHAR;
+  v_escaped_pattern VARCHAR;
   start_offset boolean;
   end_offset boolean;
+  v_char char;
+  v_len int;
+  v_in_bracket boolean;
 begin
   if pattern is null or expression is null then
     return null;
@@ -1776,15 +1780,39 @@ begin
   if sys.is_collated_ai(expression) then
     return sys.patindex_ai_collations(pattern, expression);
   end if;
-  if PG_CATALOG.left(pattern, 1) = '%' collate sys.database_default then
-    v_regexp_pattern := regexp_replace(pattern, '^%', '%#"', 'i'::pg_catalog.TEXT);
+
+  -- Escape SIMILAR TO metacharacters that are not T-SQL PATINDEX wildcards.
+  -- T-SQL PATINDEX only supports: % _ [...] [^...] [!...]
+  -- SIMILAR TO also treats ( ) | * + ? { } as special operators.
+  -- Since '#' is our escape character for substring(), we also escape literal '#'.
+  -- Characters inside [...] are already literals in SIMILAR TO, so skip those.
+  v_escaped_pattern := '';
+  v_in_bracket := false;
+  v_len := length(pattern);
+  for i in 1..v_len loop
+    v_char := substring(pattern, i, 1);
+    if v_char = '[' and not v_in_bracket then
+      v_in_bracket := true;
+      v_escaped_pattern := v_escaped_pattern || v_char;
+    elsif v_char = ']' and v_in_bracket then
+      v_in_bracket := false;
+      v_escaped_pattern := v_escaped_pattern || v_char;
+    elsif not v_in_bracket and v_char in ('(', ')', '|', '+', '*', '?', '{', '}', '#') then
+      v_escaped_pattern := v_escaped_pattern || '#' || v_char;
+    else
+      v_escaped_pattern := v_escaped_pattern || v_char;
+    end if;
+  end loop;
+
+  if PG_CATALOG.left(v_escaped_pattern, 1) = '%' collate sys.database_default then
+    v_regexp_pattern := regexp_replace(v_escaped_pattern, '^%', '%#"', 'i'::pg_catalog.TEXT);
     start_offset := true;
   else
-    v_regexp_pattern := '#"' || pattern;
+    v_regexp_pattern := '#"' || v_escaped_pattern;
     start_offset := false;
   end if;
 
-  if PG_CATALOG.right(pattern, 1) = '%' collate sys.database_default then
+  if PG_CATALOG.right(v_escaped_pattern, 1) = '%' collate sys.database_default then
     v_regexp_pattern := regexp_replace(v_regexp_pattern, '%$', '#"%', 'i'::pg_catalog.TEXT);
     end_offset := true;
   else

--- a/test/JDBC/expected/patindex.out
+++ b/test/JDBC/expected/patindex.out
@@ -526,6 +526,61 @@ int#!#nvarchar
 
 
 -- =============================================
+-- SPECIAL CHARACTERS IN PATTERN (GitHub Issue #4296)
+-- =============================================
+-- Parentheses should be treated as literal characters
+SELECT PATINDEX('%(%', 'the phone Nr is 1-(800)-CARS');
+GO
+~~START~~
+bigint
+19
+~~END~~
+
+SELECT PATINDEX('%)%', 'the phone Nr is 1-(800)-CARS');
+GO
+~~START~~
+bigint
+23
+~~END~~
+
+-- Other SIMILAR TO metacharacters should also work as literals
+SELECT PATINDEX('%+%', '2+3=5');
+GO
+~~START~~
+bigint
+2
+~~END~~
+
+SELECT PATINDEX('%*%', '2*3=6');
+GO
+~~START~~
+bigint
+2
+~~END~~
+
+SELECT PATINDEX('%?%', 'is this a question?');
+GO
+~~START~~
+bigint
+19
+~~END~~
+
+SELECT PATINDEX('%{%', 'json: {key: val}');
+GO
+~~START~~
+bigint
+7
+~~END~~
+
+-- Parentheses inside character classes should still work
+SELECT PATINDEX('%[()]%', 'call func()');
+GO
+~~START~~
+bigint
+10
+~~END~~
+
+-- =============================================
 -- CLEANUP
 -- =============================================
 -- Drop Views

--- a/test/JDBC/input/functions/string_functions/patindex.sql
+++ b/test/JDBC/input/functions/string_functions/patindex.sql
@@ -401,6 +401,33 @@ END CATCH;
 GO
 
 -- =============================================
+-- SPECIAL CHARACTERS IN PATTERN (GitHub Issue #4296)
+-- =============================================
+-- Parentheses should be treated as literal characters
+SELECT PATINDEX('%(%', 'the phone Nr is 1-(800)-CARS');
+GO
+
+SELECT PATINDEX('%)%', 'the phone Nr is 1-(800)-CARS');
+GO
+
+-- Other SIMILAR TO metacharacters should also work as literals
+SELECT PATINDEX('%+%', '2+3=5');
+GO
+
+SELECT PATINDEX('%*%', '2*3=6');
+GO
+
+SELECT PATINDEX('%?%', 'is this a question?');
+GO
+
+SELECT PATINDEX('%{%', 'json: {key: val}');
+GO
+
+-- Parentheses inside character classes should still work
+SELECT PATINDEX('%[()]%', 'call func()');
+GO
+
+-- =============================================
 -- CLEANUP
 -- =============================================
 


### PR DESCRIPTION
## Summary

Fixes #4296

`PATINDEX` uses PostgreSQL's `substring()` with SIMILAR TO syntax internally. Characters like `(`, `)`, `|`, `+`, `*`, `?`, `{`, `}` are metacharacters in SIMILAR TO but should be treated as literals in T-SQL PATINDEX patterns. When these characters appeared in the search pattern, PostgreSQL raised errors like:

```
invalid regular expression: parentheses () not balanced
```

**Root cause:** In `contrib/babelfishpg_tsql/sql/sys_functions.sql`, the `sys.PATINDEX()` function passed the pattern directly to `substring()` without escaping SIMILAR TO metacharacters that are not T-SQL PATINDEX wildcards.

**Fix:** Added pattern preprocessing that escapes SIMILAR TO metacharacters (`( ) | + * ? { } #`) using the `#` escape character, while preserving characters inside `[...]` character classes (which are already treated as literals in both T-SQL and SIMILAR TO).

**Example:**
```sql
-- Before fix: ERROR: invalid regular expression: parentheses () not balanced
-- After fix:  returns 19
SELECT PATINDEX('%(%', 'the phone Nr is 1-(800)-CARS')
```

## Test plan

- [x] Added test cases for parentheses, `+`, `*`, `?`, `{` in patterns
- [x] Added test for parentheses inside character classes `[()]`
- [x] Updated expected output
- [ ] Verify existing PATINDEX tests still pass
- [ ] Verify special characters in patterns now work correctly