### PR TITLE
Fix STR() truncating concatenated strings

### DIFF
--- a/contrib/babelfishpg_tsql/src/string.c
+++ b/contrib/babelfishpg_tsql/src/string.c
@@ -801,7 +801,7 @@ float_str(PG_FUNCTION_ARGS)
 		}
 	}
 
-	return return_varchar_pointer(buf, size);
+	return return_varchar_pointer(buf, strlen(buf));
 }
 
 /*

--- a/test/JDBC/expected/str.out
+++ b/test/JDBC/expected/str.out
@@ -523,6 +523,32 @@ GO
 -- =============================================
 -- CLEANUP
 -- =============================================
+-- =============================================
+-- STRING CONCATENATION WITH STR() (GitHub Issue #4297)
+-- =============================================
+-- STR() result should not truncate strings appended after it
+SELECT 'distance:' + STR(123, 4, 0) + ' mi';
+GO
+~~START~~
+varchar
+distance: 123 mi
+~~END~~
+
+SELECT 'val=' + STR(42, 2, 0) + ',done';
+GO
+~~START~~
+varchar
+val=42,done
+~~END~~
+
+SELECT STR(1, 1, 0) + ' suffix';
+GO
+~~START~~
+varchar
+1 suffix
+~~END~~
+
+
 -- Drop Views
 DROP VIEW str_v1;
 DROP VIEW str_v2;

--- a/test/JDBC/input/functions/string_functions/str.sql
+++ b/test/JDBC/input/functions/string_functions/str.sql
@@ -385,6 +385,19 @@ GO
 -- CLEANUP
 -- =============================================
 
+-- =============================================
+-- STRING CONCATENATION WITH STR() (GitHub Issue #4297)
+-- =============================================
+-- STR() result should not truncate strings appended after it
+SELECT 'distance:' + STR(123, 4, 0) + ' mi';
+GO
+
+SELECT 'val=' + STR(42, 2, 0) + ',done';
+GO
+
+SELECT STR(1, 1, 0) + ' suffix';
+GO
+
 -- Drop Views
 DROP VIEW str_v1;
 DROP VIEW str_v2;


### PR DESCRIPTION
## Summary

Fixes #4297

The `STR()` function was passing `length + 1` (buffer size including null terminator) as the string length to `tsql_varchar_input()`, causing the resulting varchar to include an extra byte. This extra byte caused any strings concatenated after `STR()` to be silently lost.

**Root cause:** In `contrib/babelfishpg_tsql/src/string.c`, the `float_str()` function allocated `size = length + 1` bytes for the buffer (to accommodate the null terminator), but then passed `size` (instead of the actual string length) to `return_varchar_pointer()`.

**Fix:** Changed `return_varchar_pointer(buf, size)` to `return_varchar_pointer(buf, strlen(buf))` so the actual string length is used.

**Example:**
```sql
-- Before fix: returns 'distance: 123' (suffix lost)
-- After fix:  returns 'distance: 123 mi' (correct)
PRINT 'distance:' + STR(123, 4, 0) + ' mi'
```

## Test plan

- Added test cases for string concatenation with STR() result in `test/JDBC/input/functions/string_functions/str.sql`
- Updated expected output in `test/JDBC/expected/str.out`