### PR TITLE
Fix to skip SPI_finish for inconsistent SPI connection in terminate_batch

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -4917,7 +4917,7 @@ terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 			 SPI_depth, current_spi_stack_depth);
 		
 	while (current_spi_stack_depth-- >= SPI_depth)
-		if ((rc = SPI_finish()) != SPI_OK_FINISH)
+		if ((rc = SPI_finish_safe()) != SPI_OK_FINISH)
 			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	if (send_error)
@@ -5070,8 +5070,6 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	int 		current_spi_stack_depth;
 	bool 		send_error = false;
 
-	create_queryEnv2(CacheMemoryContext, false);
-
 	nonatomic = support_tsql_trans ||
 		(fcinfo->context &&
 		 IsA(fcinfo->context, CallContext) &&
@@ -5093,6 +5091,8 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 	if ((rc = SPI_connect_ext(nonatomic ? SPI_OPT_NONATOMIC : 0)) != SPI_OK_CONNECT)
 		elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 	PortalContext = savedPortalCxt;
+
+	create_queryEnv2(CacheMemoryContext, false);
 
 	SPI_setCurrentInternalTxnMode(true);
 	current_spi_stack_depth = SPI_get_depth();

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -521,7 +521,6 @@ sp_describe_first_result_set_internal(PG_FUNCTION_ARGS)
 
 				pfree(query);
 				pfree(sp_describe_first_result_set_view_name);
-				SPI_finish();
 				RESUME_INTERRUPTS();
 				PG_RE_THROW();
 			}
@@ -1721,7 +1720,6 @@ create_xp_qv_in_master_dbo_internal(PG_FUNCTION_ARGS)
 	}
 	PG_CATCH();
 	{
-		SPI_finish();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -1814,7 +1812,6 @@ create_xp_instance_regread_in_master_dbo_internal(PG_FUNCTION_ARGS)
 	}
 	PG_CATCH();
 	{
-		SPI_finish();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -3489,7 +3486,6 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 		}
 		PG_CATCH();
 		{
-			SPI_finish();
 			PG_RE_THROW();
 		}
 		PG_END_TRY();
@@ -3519,7 +3515,6 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 		}
 		PG_CATCH();
 		{
-			SPI_finish();
 			PG_RE_THROW();
 		}
 		PG_END_TRY();
@@ -4076,7 +4071,6 @@ sp_enum_oledb_providers_internal(PG_FUNCTION_ARGS)
 	}
 	PG_CATCH();
 	{
-		SPI_finish();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();


### PR DESCRIPTION
### Description

SPI_finish_safe safely handles half-initialized SPI connections that can occur when OOM happens during SPI_connect_ext. For fully initialized connections, it delegates to SPI_finish and so no behavioral change on normal path.

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/725
### Issues Resolved

Task: BABEL-6349
Cherry-picked from #4629 

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).