### PR TITLE
Fix memory leaks in for_xml_ffunc() by adding missing regfree() calls

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -19,8 +19,7 @@
 #include "utils/typcache.h"
 #include "catalog/pg_type.h"
 #include "catalog/namespace.h"
-
-#include <regex.h>
+#include "catalog/pg_collation.h"
 
 #include "tsql_for.h"
 
@@ -132,37 +131,48 @@ static StringInfo
 for_xml_ffunc(PG_FUNCTION_ARGS)
 {
 	StringInfo	res = makeStringInfo();
-	char	   *state = ((StringInfo) PG_GETARG_POINTER(0))->data;
+	char	   *state;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+					errmsg("unexpected null state in FOR XML processing")));
+
+	state = ((StringInfo) PG_GETARG_POINTER(0))->data;
 
 	if (state[0] == '{')		/* '{' indicates that root was specified, so
 								 * add the corresponding end tag */
 	{
-		/* set up regex to match first tag */
-		char	   *pattern = "<([^\\/>]+)[\\/]*>";
-		regex_t		preg;
-		regmatch_t	match,
-					pmatch[1];
-		StringInfoData root;
+		/*
+		 * Using PostgreSQL's textregexsubstr() to extract the root tag name.
+		 * simpler than manual regex handling and leverages PostgreSQL's 
+		 * cached regex compilation and proper memory management.
+		 */
+		text	   *state_text = cstring_to_text(state);
+		text	   *pattern_text = cstring_to_text("<([^\\/>]+)[\\/]*>");
+		Datum		root_tag_datum;
+		text	   *root_tag_text;
+		char	   *root_tag;
 
-		if (regcomp(&preg, pattern, REG_EXTENDED) != 0)
+		/* Extract the root tag name using textregexsubstr */
+		root_tag_datum = DirectFunctionCall2Coll(textregexsubstr, 
+											 C_COLLATION_OID,
+											 PointerGetDatum(state_text),
+											 PointerGetDatum(pattern_text));
+
+		if (DatumGetPointer(root_tag_datum) == NULL)
+		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
 					 errmsg("unexpected error parsing xml root tag")));
+		}
 
-		if (regexec(&preg, state, 1, pmatch, 0) != 0)
-			ereport(ERROR,
-					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("unexpected error parsing xml root tag")));
+		root_tag_text = DatumGetTextPP(root_tag_datum);
+		root_tag = text_to_cstring(root_tag_text);
 
-		match = pmatch[0];
-		/* we will be bashing the string in state, so copy it into res first */
+		/* Copy state content (skip the '{' marker) and add closing tag */
 		appendStringInfoString(res, state + 1);
-
-		/* copy the root tag */
-		state[match.rm_eo - 1] = '\0';
-		initStringInfo(&root);
-		appendStringInfoString(&root, state + match.rm_so + 1);
-		appendStringInfo(res, "</%s>", root.data);
+		appendStringInfo(res, "</%s>", root_tag);
 	}
 	else
 	{


### PR DESCRIPTION
### Description
The function for_xml_ffunc() is calling regcomp() to compile regular expressions but failing to call regfree() to release the allocated memory, causing memory leaks during FOR XML Queries.

This PR fixes memory leaks in the for_xml_ffunc() function by adding missing regfree() calls to properly clean up compiled regular expressions.

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4655

Authored-by: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved

BABEL-6403

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).