### PR TITLE
Fix crash in tsql_row_to_xml_path function 

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -125,6 +125,10 @@ tsql_query_to_xml_text_ffunc(PG_FUNCTION_ARGS)
 {
 	StringInfo	res = for_xml_ffunc(fcinfo);
 
+	/* return NULL if empty result (i.e. no rows) */
+	if (res->len == 0)
+		PG_RETURN_NULL();
+
 	PG_RETURN_TEXT_P(cstring_to_text_with_len(res->data, res->len));
 }
 
@@ -256,7 +260,7 @@ validate_attribute_centric_col_names_xml(const char *element_name, TupleDesc tup
 			seen_non_att_centric = true;
 	}
 
-	if(seen_att_centric && element_name[0] == '\0')
+	if(seen_att_centric && (element_name && strlen(element_name) == 0))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_XML_PROCESSING_INSTRUCTION),
@@ -274,14 +278,15 @@ static void
 tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64)
 {
 	HeapTupleHeader td;
-	Oid			tupType;
-	int32		tupTypmod;
-	TupleDesc	tupdesc;
-	HeapTupleData tmptup;
-	HeapTuple	tuple;
-	bool		allnull = true;
-	bool		has_att_centric = false;
-	bool		first = true;
+	Oid             tupType;
+	int32           tupTypmod;
+	TupleDesc       tupdesc;
+	HeapTupleData   tmptup;
+	HeapTuple       tuple;
+	bool            allnull = true;
+	bool            has_att_centric = false;
+	bool            first = true;
+	int             inital_state_len = state->len;
 
 	td = DatumGetHeapTupleHeader(record);
 
@@ -301,7 +306,7 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 	 * each tuple is either contained in a "row" tag, or standalone if the
 	 * element_name is an empty string
 	 */
-	if (element_name[0] != '\0')
+	if (element_name && strlen(element_name) > 0)
 	{
 		/* if "''" is the input path, ignore it per TSQL behavior */
 		if (has_att_centric)
@@ -362,22 +367,30 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 		}
 	}
 
-	if (allnull)
-	{
-		/*
-		 * If all the column values are nulls, this element should be
-		 * <element_name/>, modify the already appended <element_name> to
-		 * <element_name/>.
-		 */
-		state->data[state->len - 1] = '/';
-		appendStringInfoString(state, ">");
-	}
-	else if (element_name[0] != '\0')
+	if (element_name && strlen(element_name) > 0)
 	{
 		if (has_att_centric && first)
 			appendStringInfoString(state, "/>");
 		else
-			appendStringInfo(state, "</%s>", element_name);
+		{
+			if (allnull)
+			{
+				/*
+				 * At this point, state = <output from previous rows> + '<element_name>'
+				 * 
+				 * If all the column values are nulls, this element should be
+				 * <element_name/>, modify the already appended <element_name> to
+				 * <element_name/>.
+				 */
+				if (state->len > inital_state_len)	// sanity check, should always be true
+				{
+					state->data[state->len - 1] = '/';
+					appendStringInfoString(state, ">");
+				}
+			}
+			else
+				appendStringInfo(state, "</%s>", element_name);
+		}
 	}
 	ReleaseTupleDesc(tupdesc);
 }

--- a/test/JDBC/expected/forxml-path-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-path-vu-cleanup.out
@@ -10,5 +10,8 @@ DROP VIEW for_xml_path_v3
 DROP VIEW for_xml_path_v4
 GO
 
+DROP TABLE for_xml_path_all_null
+GO
+
 DROP TABLE for_xml_path
 GO

--- a/test/JDBC/expected/forxml-path-vu-prepare.out
+++ b/test/JDBC/expected/forxml-path-vu-prepare.out
@@ -6,6 +6,20 @@ GO
 ~~ROW COUNT: 9~~
 
 
+CREATE TABLE for_xml_path_all_null (col1 INT NULL);
+GO
+
+SET NOCOUNT ON
+GO
+
+DECLARE @i INT = 1; 
+WHILE @i <= 2048 
+BEGIN
+    INSERT INTO for_xml_path_all_null VALUES (NULL);
+    SET @i = @i + 1;
+END
+GO
+
 CREATE VIEW for_xml_path_v1 AS SELECT String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
 GO
 

--- a/test/JDBC/expected/forxml-path-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-vu-verify.out
@@ -123,3 +123,29 @@ ntext
  SELECT Product, UnitPrice, EffectiveDate FROM Products WHERE UnitPrice &gt; 100
 ~~END~~
 
+
+-- BABEL-5364
+-- Crash causing query
+SELECT col1 from for_xml_path_all_null FOR XML PATH('')
+GO
+~~START~~
+ntext
+~~END~~
+
+
+SELECT col1 from for_xml_path_all_null FOR XML PATH(''), ELEMENTS, TYPE
+GO
+~~START~~
+xml
+
+~~END~~
+
+
+SELECT Top 10 col1 from for_xml_path_all_null FOR XML PATH('element')
+GO
+~~START~~
+ntext
+<element/><element/><element/><element/><element/><element/><element/><element/><element/><element/>
+~~END~~
+
+

--- a/test/JDBC/expected/forxml-path-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-vu-verify.out
@@ -133,7 +133,7 @@ ntext
 ~~END~~
 
 
-SELECT col1 from for_xml_path_all_null FOR XML PATH(''), ELEMENTS, TYPE
+SELECT col1 from for_xml_path_all_null FOR XML PATH(''), TYPE
 GO
 ~~START~~
 xml

--- a/test/JDBC/input/forxml/forxml-path-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-cleanup.sql
@@ -10,5 +10,8 @@ DROP VIEW for_xml_path_v3
 DROP VIEW for_xml_path_v4
 GO
 
+DROP TABLE for_xml_path_all_null
+GO
+
 DROP TABLE for_xml_path
 GO

--- a/test/JDBC/input/forxml/forxml-path-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-prepare.sql
@@ -4,6 +4,20 @@ GO
 INSERT INTO for_xml_path VALUES (1,'SELECT'),(2,'Product,'),(3,'UnitPrice,'),(4,'EffectiveDate'),(5,'FROM'), (6,'Products'),(7,'WHERE'),(8,'UnitPrice'),(9,'> 100');
 GO
 
+CREATE TABLE for_xml_path_all_null (col1 INT NULL);
+GO
+
+SET NOCOUNT ON
+GO
+
+DECLARE @i INT = 1; 
+WHILE @i <= 2048 
+BEGIN
+    INSERT INTO for_xml_path_all_null VALUES (NULL);
+    SET @i = @i + 1;
+END
+GO
+
 CREATE VIEW for_xml_path_v1 AS SELECT String as param1, hello.String as [@param2] FROM for_xml_path hello ORDER BY SequenceNumber FOR XML PATH('hello')
 GO
 

--- a/test/JDBC/input/forxml/forxml-path-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-verify.sql
@@ -47,3 +47,15 @@ GO
 
 EXEC for_xml_path_p4
 GO
+
+-- BABEL-5364
+-- Crash causing query
+SELECT col1 from for_xml_path_all_null FOR XML PATH('')
+GO
+
+SELECT col1 from for_xml_path_all_null FOR XML PATH(''), ELEMENTS, TYPE
+GO
+
+SELECT Top 10 col1 from for_xml_path_all_null FOR XML PATH('element')
+GO
+

--- a/test/JDBC/input/forxml/forxml-path-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-vu-verify.sql
@@ -53,7 +53,7 @@ GO
 SELECT col1 from for_xml_path_all_null FOR XML PATH('')
 GO
 
-SELECT col1 from for_xml_path_all_null FOR XML PATH(''), ELEMENTS, TYPE
+SELECT col1 from for_xml_path_all_null FOR XML PATH(''), TYPE
 GO
 
 SELECT Top 10 col1 from for_xml_path_all_null FOR XML PATH('element')


### PR DESCRIPTION
### Description

Fixed a crash in tsql_row_to_xml_path function that occurred when processing FOR XML PATH queries with all-null column values. The crash was caused by unsafe string buffer manipulation when converting null elements to self-closing XML tags without proper bounds checking.

This fix reorganizes the null-handling logic to prevent buffer underflow.

Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4661

Authored-by: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved

BABEL-5364

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).