### PR TITLE
Fix crash in exec_internal_grant_on_function when logical schema is null(#4660)

### DIFF
--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -644,7 +644,7 @@ get_logical_schema_name(const char *physical_schema_name, bool missingOk)
 		if (!missingOk)
 			ereport(ERROR,
 					(errcode(ERRCODE_INTERNAL_ERROR),
-					 errmsg("Could find logical schema name for: \"%s\"", physical_schema_name)));
+					 errmsg("Could not find logical schema name for: \"%s\"", physical_schema_name)));
 		return NULL;
 	}
 	datum = SysCacheGetAttr(SYSNAMESPACENAME, tuple, Anum_namespace_ext_orig_name, &isnull);
@@ -4460,7 +4460,7 @@ exec_internal_grant_on_function(Oid objectId)
 	object_name = NameStr(procedureStruct->proname);
 	phy_sch_oid = procedureStruct->pronamespace;
 	schema = get_namespace_name(phy_sch_oid);
-	logicalschema = get_logical_schema_name(schema, true);
+	logicalschema = get_logical_schema_name(schema, false);
 	object_type = procedureStruct->prokind;
 
 	/* Fetch the relation */

--- a/test/JDBC/expected/TestInteropProcedures.out
+++ b/test/JDBC/expected/TestInteropProcedures.out
@@ -251,3 +251,22 @@ GO
 -- psql     currentSchema=master_dbo,public
 DROP PROCEDURE psql_interop_proc
 GO
+
+-- psql
+CREATE SCHEMA master_s6390;
+GO
+
+GRANT ALL ON SCHEMA master_s6390 TO PUBLIC ;
+GO
+
+-- tsql
+CREATE FUNCTION s6390.f1() RETURNS INT AS BEGIN return 1 END;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Could not find logical schema name for: "master_s6390")~~
+
+
+-- psql
+DROP SCHEMA master_s6390;
+GO

--- a/test/JDBC/expected/db_securityadmin-vu-verify.out
+++ b/test/JDBC/expected/db_securityadmin-vu-verify.out
@@ -980,28 +980,28 @@ GRANT SELECT ON sys.database_principals TO babel_5135_u1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Could find logical schema name for: "sys")~~
+~~ERROR (Message: Could not find logical schema name for: "sys")~~
 
 
 REVOKE SELECT ON sys.database_principals FROM babel_5135_u1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Could find logical schema name for: "sys")~~
+~~ERROR (Message: Could not find logical schema name for: "sys")~~
 
 
 GRANT SELECT ON pg_catalog.pg_namespace TO babel_5135_u1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Could find logical schema name for: "pg_catalog")~~
+~~ERROR (Message: Could not find logical schema name for: "pg_catalog")~~
 
 
 REVOKE SELECT ON pg_catalog.pg_namespace FROM babel_5135_u1;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: Could find logical schema name for: "pg_catalog")~~
+~~ERROR (Message: Could not find logical schema name for: "pg_catalog")~~
 
 
 REVOKE SELECT ON babel_5135_db1.dbo.babel_5135_show_role_mem TO babel_5135_u1;

--- a/test/JDBC/input/interoperability/TestInteropProcedures.mix
+++ b/test/JDBC/input/interoperability/TestInteropProcedures.mix
@@ -192,3 +192,18 @@ GO
 -- psql     currentSchema=master_dbo,public
 DROP PROCEDURE psql_interop_proc
 GO
+
+-- psql
+CREATE SCHEMA master_s6390;
+GO
+
+GRANT ALL ON SCHEMA master_s6390 TO PUBLIC ;
+GO
+
+-- tsql
+CREATE FUNCTION s6390.f1() RETURNS INT AS BEGIN return 1 END;
+GO
+
+-- psql
+DROP SCHEMA master_s6390;
+GO


### PR DESCRIPTION
### Description

When creating functions in schemas created from PostgreSQL endpoint, the logical schema name is null, causing a crash in exec_internal_grant_on_function at CStringGetTextDatum(logicalschema).

Fixed an issue where the system would crash when attempting to grant permissions on functions created in PostgreSQL-endpoint schemas by adding a null check for logicalschema before calling CStringGetTextDatum.

Task: BABEL-6390

### Issues Resolved

BABEL-6390

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).