### PR TITLE
[OSS-Only] Use stable PG 15 dump utilities in TAP Test

### DIFF
--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -8,6 +8,8 @@ jobs:
       NEW_INSTALL_DIR: psql_target
       ENGINE_BRANCH_OLD: BABEL_2_6_STABLE__PG_14_9
       EXTENSION_BRANCH_OLD: BABEL_2_6_STABLE
+      INSTALL_DIR_15: psql15
+      ENGINE_BRANCH_15: BABEL_3_9_STABLE__PG_15_12
 
     runs-on: ubuntu-22.04
     steps:
@@ -36,9 +38,17 @@ jobs:
           sudo -E apt-get install krb5-admin-server krb5-kdc krb5-user libkrb5-dev -y -qq
         shell: bash
 
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_15}}
+        id: build-modified-postgres-15
+        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_BRANCH_15}}
+          install_dir: ${{env.INSTALL_DIR_15}}
+
       - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_OLD}}
         id: build-modified-postgres-old
-        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        if: always() && steps.build-modified-postgres-15.outcome == 'success'
         uses: ./.github/composite-actions/build-modified-postgres
         with:
           engine_branch: ${{env.ENGINE_BRANCH_OLD}}
@@ -133,6 +143,7 @@ jobs:
           export PG_CONFIG=~/${{env.NEW_INSTALL_DIR}}/bin/pg_config
           export PATH=/opt/mssql-tools/bin:$PATH
           export oldinstall=$HOME/${{env.OLD_INSTALL_DIR}}
+          export installdir15=$HOME/${{env.INSTALL_DIR_15}}
 
           cd contrib/babelfishpg_tds
           make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/002_tdskerberos.pl t/003_bbfextnotloaded.pl t/004_bbfdumprestore.pl"

--- a/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
+++ b/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
@@ -65,20 +65,29 @@ my $tsql_newnode = new TDSNode($newnode);
 $tsql_newnode->init_tsql('test_master', 'testdb');
 $newnode->stop;
 
+# Setup pg16 node
+my $node15 =
+  PostgreSQL::Test::Cluster->new('node_15',
+	install_path => $ENV{installdir15});
+
+my $newbindir = $newnode->config_data('--bindir');
+my $oldbindir = $oldnode->config_data('--bindir');
+my $bindir15 = $node15->config_data('--bindir');
+
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 $oldnode->start;
 my @dumpall_command = (
-	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
+	$bindir15 . '/pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $oldnode->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump1_file);
-$newnode->command_ok(\@dumpall_command, 'Dump global objects.');
+$node15->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 my @dump_command = (
-	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
+	$bindir15 . '/pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $oldnode->port, '--verbose', '--dbname', 'testdb',
 	'--file', $dump2_file);
-$newnode->command_ok(\@dump_command, 'Dump Babelfish database.');
+$node15->command_ok(\@dump_command, 'Dump Babelfish database.');
 $oldnode->stop;
 
 # Retore the dumped files on the new server.
@@ -88,7 +97,7 @@ $newnode->start;
 # dump/restore is not yet supported.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -101,7 +110,7 @@ $newnode->command_fails_like(
 # Similarly, restore of dump file should also cause a failure.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -117,7 +126,7 @@ $oldnode->start;
 
 $oldnode->command_fails_like(
 	[
-		'psql',
+		$oldbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $oldnode->port,
@@ -129,7 +138,7 @@ $oldnode->command_fails_like(
 
 $oldnode->command_fails_like(
 	[
-		'psql',
+		$oldbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $oldnode->port,
@@ -162,14 +171,14 @@ $tsql_newnode2->init_tsql('test_master', 'testdb', 'multi-db');
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 @dumpall_command = (
-	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
+	$newbindir . '/pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $newnode2->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump3_file);
 $newnode2->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump. Let's dump with the custom format
 # this time so that we cover pg_restore as well.
 @dump_command = (
-	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
+	$newbindir . '/pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $newnode2->port, '--verbose', '--dbname', 'testdb',
 	'--format', 'custom', '--file', $dump4_file);
 $newnode2->command_ok(\@dump_command, 'Dump Babelfish database.');
@@ -182,7 +191,7 @@ $newnode->start;
 # dump/restore is not yet supported.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -195,7 +204,7 @@ $newnode->command_fails_like(
 # Similarly, restore of dump file should also cause a failure.
 $newnode->command_fails_like(
 	[
-		'pg_restore',
+		$newbindir . '/pg_restore',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -213,13 +222,13 @@ $newnode->start;
 
 # Dump global objects using pg_dumpall.
 @dumpall_command = (
-	'pg_dumpall', '--database', 'postgres', '--port', $newnode->port,
+	$newbindir . '/pg_dumpall', '--database', 'postgres', '--port', $newnode->port,
 	'--roles-only', '--quote-all-identifiers', '--verbose',
 	'--no-role-passwords', '--file', $dump1_file);
 $newnode->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 @dump_command = (
-	'pg_dump', '--quote-all-identifiers', '--port', $newnode->port,
+	$newbindir . '/pg_dump', '--quote-all-identifiers', '--port', $newnode->port,
 	'--verbose', '--dbname', 'postgres',
 	'--file', $dump2_file);
 $newnode->command_ok(\@dump_command, 'Dump non-Babelfish (postgres db) database.');


### PR DESCRIPTION
### Description

Updated dump/restore tap-tests to use v15 dump utility to dump older versions.

### Issues Resolved

TAP tests are failing with following error:
```
#   Failed test 'Restore of global objects failed since target version is older than 15.5.: matches'
#   at t/004_bbfdumprestore.pl line 118.
#                   'psql:/home/runner/work/babelfish_extensions/babelfish_extensions/contrib/babelfishpg_tds/test/tmp_check/tmp_test_jdQ4/dump_all_old.sql:7: error: invalid command \restrict
# psql:/home/runner/work/babelfish_extensions/babelfish_extensions/contrib/babelfishpg_tds/test/tmp_check/tmp_test_jdQ4/dump_all_old.sql:15: error: invalid command \unrestrict
# psql:/home/runner/work/babelfish_extensions/babelfish_extensions/contrib/babelfishpg_tds/test/tmp_check/tmp_test_jdQ4/dump_all_old.sql:18: error: invalid command \restrict
# '
#     doesn't match '(?^:Target Postgres version must be 15.5 or higher for Babelfish restore.)'

#   Failed test 'Restore of Babelfish database failed since target version is older than 15.5.: matches'
#   at t/004_bbfdumprestore.pl line 130.
#                   'psql:/home/runner/work/babelfish_extensions/babelfish_extensions/contrib/babelfishpg_tds/test/tmp_check/tmp_test_jdQ4/dump_db_old.sql:5: error: invalid command \restrict
# psql:/home/runner/work/babelfish_extensions/babelfish_extensions/contrib/babelfishpg_tds/test/tmp_check/tmp_test_jdQ4/dump_db_old.sql:36: error: invalid command \unrestrict
# psql:/home/runner/work/babelfish_extensions/babelfish_extensions/contrib/babelfishpg_tds/test/tmp_check/tmp_test_jdQ4/dump_db_old.sql:39: error: invalid command \restrict
# '
#     doesn't match '(?^:Target Postgres version must be 15.5 or higher for Babelfish restore.)'
# Looks like you failed 2 tests of 18.
t/004_bbfdumprestore.pl ... 
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/18 subtests  
```

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).