### PR TITLE
Fix FOR XML RAW('') empty element name handling and all-NULL row outp…

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -215,7 +215,8 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 	TupleDesc       tupdesc;
 	HeapTupleData   tmptup;
 	HeapTuple       tuple;
-
+	bool            allnull = true;
+	
 	td = DatumGetHeapTupleHeader(record);
 
 	/* Extract rowtype info and find a tupdesc */
@@ -228,19 +229,34 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 	tmptup.t_data = td;
 	tuple = &tmptup;
 
-	/* Output opening tag */
-	if (elements)
+	/*
+	 * Empty element name without ELEMENTS mode is not allowed — attribute-centric
+	 * serialization requires a row tag name.
+	 */
+	if (element_name[0] == '\0' && !elements)
 	{
-		/* ELEMENTS mode: <row><col>value</col></row> */
-		if (xsinil)
-			appendStringInfo(state, "<%s " XML_XMLNS_XSI ">", element_name);
-		else
-			appendStringInfo(state, "<%s>", element_name);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_XML_PROCESSING_INSTRUCTION),
+				 errmsg("Row tag omission (empty row tag name) cannot be used "
+						"with attribute-centric FOR XML serialization.")));
 	}
-	else
+
+	/* Output opening tag (only when element_name is non-empty) */
+	if (element_name[0] != '\0')
 	{
-		/* ATTRIBUTES mode: <row col="value"/> */
-		appendStringInfo(state, "<%s", element_name);
+		if (elements)
+		{
+			/* ELEMENTS mode: <row><col>value</col></row> */
+			if (xsinil)
+				appendStringInfo(state, "<%s " XML_XMLNS_XSI ">", element_name);
+			else
+				appendStringInfo(state, "<%s>", element_name);
+		}
+		else
+		{
+			/* ATTRIBUTES mode: <row col="value"/> */
+			appendStringInfo(state, "<%s", element_name);
+		}
 	}
 
 	for (int i = 0; i < tupdesc->natts; i++)
@@ -265,6 +281,7 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 			/* ELEMENTS mode output */
 			if (!isnull)
 			{
+				allnull = false;
 				/* Normal element: <col>value</col> */
 				appendStringInfo(state, "<%s>%s</%s>",
 								 colname,
@@ -273,6 +290,7 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 			}
 			else if (xsinil)
 			{
+				allnull = false;
 				/* XSINIL: <col xsi:nil="true"/> */
 				appendStringInfo(state, "<%s " XML_XSI_NIL "/>", colname);
 			}
@@ -292,7 +310,29 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 
 	/* Output closing tag */
 	if (elements)
-		appendStringInfo(state, "</%s>", element_name);
+	{
+		if (element_name[0] == '\0')
+		{
+			/*
+			 * Empty element name with ELEMENTS: no wrapper tag needed.
+			 * Just output the child elements directly, same as PATH('').
+			 */
+		}
+		else if (allnull)
+		{
+			/*
+			 * If all column values are NULL, produce a self-closing element
+			 * like TSQL does: <row/>. Replace the '>' in the already
+			 * appended opening tag with '/' and append '>'.
+			 */
+			state->data[state->len - 1] = '/';
+			appendStringInfoChar(state, '>');
+		}
+		else
+		{
+			appendStringInfo(state, "</%s>", element_name);
+		}
+	}
 	else
 		appendStringInfoString(state, "/>");
 

--- a/test/JDBC/expected/forxml-raw-elements-before-17_9-or-18_3-vu-verify.out
+++ b/test/JDBC/expected/forxml-raw-elements-before-17_9-or-18_3-vu-verify.out
@@ -143,7 +143,7 @@ SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -170,7 +170,7 @@ SELECT NULL AS a, NULL AS b, NULL AS c, NULL AS d FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -198,7 +198,7 @@ SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS ABSENT;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -510,7 +510,7 @@ SELECT name, salary FROM forxml_raw_elements_t1 FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row><name>John</name><salary>50000</salary></row><row><name>Jane</name><salary>60000</salary></row><row><name>Bob</name></row><row><name>Alice</name><salary>70000</salary></row><row></row>
+<row><name>John</name><salary>50000</salary></row><row><name>Jane</name><salary>60000</salary></row><row><name>Bob</name></row><row><name>Alice</name><salary>70000</salary></row><row/>
 ~~END~~
 
 
@@ -950,7 +950,7 @@ SELECT CAST(NULL AS VARCHAR(10)) AS null_val FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -971,7 +971,34 @@ SELECT 1 AS a, 2 AS b FOR XML RAW(''), ELEMENTS;
 GO
 ~~START~~
 ntext
-<><a>1</a><b>2</b></>
+<a>1</a><b>2</b>
+~~END~~
+
+
+-- Empty element name without ELEMENTS (attribute-centric) - should error
+SELECT 1 AS a, 2 AS b FOR XML RAW('');
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Row tag omission (empty row tag name) cannot be used with attribute-centric FOR XML serialization.)~~
+
+
+-- All NULLs under attribute mode (no ELEMENTS)
+SELECT NULL AS a, NULL AS b FOR XML RAW;
+GO
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+-- All NULLs with empty element name and ELEMENTS
+SELECT NULL AS a, NULL AS b FOR XML RAW(''), ELEMENTS;
+GO
+~~START~~
+ntext
 ~~END~~
 
 

--- a/test/JDBC/expected/forxml-raw-elements-vu-verify.out
+++ b/test/JDBC/expected/forxml-raw-elements-vu-verify.out
@@ -143,7 +143,7 @@ SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -170,7 +170,7 @@ SELECT NULL AS a, NULL AS b, NULL AS c, NULL AS d FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -198,7 +198,7 @@ SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS ABSENT;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -510,7 +510,7 @@ SELECT name, salary FROM forxml_raw_elements_t1 FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row><name>John</name><salary>50000</salary></row><row><name>Jane</name><salary>60000</salary></row><row><name>Bob</name></row><row><name>Alice</name><salary>70000</salary></row><row></row>
+<row><name>John</name><salary>50000</salary></row><row><name>Jane</name><salary>60000</salary></row><row><name>Bob</name></row><row><name>Alice</name><salary>70000</salary></row><row/>
 ~~END~~
 
 
@@ -950,7 +950,7 @@ SELECT CAST(NULL AS VARCHAR(10)) AS null_val FOR XML RAW, ELEMENTS;
 GO
 ~~START~~
 ntext
-<row></row>
+<row/>
 ~~END~~
 
 
@@ -971,7 +971,34 @@ SELECT 1 AS a, 2 AS b FOR XML RAW(''), ELEMENTS;
 GO
 ~~START~~
 ntext
-<><a>1</a><b>2</b></>
+<a>1</a><b>2</b>
+~~END~~
+
+
+-- Empty element name without ELEMENTS (attribute-centric) - should error
+SELECT 1 AS a, 2 AS b FOR XML RAW('');
+GO
+~~START~~
+ntext
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Row tag omission (empty row tag name) cannot be used with attribute-centric FOR XML serialization.)~~
+
+
+-- All NULLs under attribute mode (no ELEMENTS)
+SELECT NULL AS a, NULL AS b FOR XML RAW;
+GO
+~~START~~
+ntext
+<row/>
+~~END~~
+
+
+-- All NULLs with empty element name and ELEMENTS
+SELECT NULL AS a, NULL AS b FOR XML RAW(''), ELEMENTS;
+GO
+~~START~~
+ntext
 ~~END~~
 
 

--- a/test/JDBC/input/forxml/forxml-raw-elements-before-17_9-or-18_3-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-raw-elements-before-17_9-or-18_3-vu-verify.sql
@@ -414,6 +414,18 @@ GO
 SELECT 1 AS a, 2 AS b FOR XML RAW(''), ELEMENTS;
 GO
 
+-- Empty element name without ELEMENTS (attribute-centric) - should error
+SELECT 1 AS a, 2 AS b FOR XML RAW('');
+GO
+
+-- All NULLs under attribute mode (no ELEMENTS)
+SELECT NULL AS a, NULL AS b FOR XML RAW;
+GO
+
+-- All NULLs with empty element name and ELEMENTS
+SELECT NULL AS a, NULL AS b FOR XML RAW(''), ELEMENTS;
+GO
+
 -- Element name with spaces
 SELECT 1 AS a FOR XML RAW('element name'), ELEMENTS;
 GO

--- a/test/JDBC/input/forxml/forxml-raw-elements-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-raw-elements-vu-verify.sql
@@ -414,6 +414,18 @@ GO
 SELECT 1 AS a, 2 AS b FOR XML RAW(''), ELEMENTS;
 GO
 
+-- Empty element name without ELEMENTS (attribute-centric) - should error
+SELECT 1 AS a, 2 AS b FOR XML RAW('');
+GO
+
+-- All NULLs under attribute mode (no ELEMENTS)
+SELECT NULL AS a, NULL AS b FOR XML RAW;
+GO
+
+-- All NULLs with empty element name and ELEMENTS
+SELECT NULL AS a, NULL AS b FOR XML RAW(''), ELEMENTS;
+GO
+
 -- Element name with spaces
 SELECT 1 AS a FOR XML RAW('element name'), ELEMENTS;
 GO


### PR DESCRIPTION
### Description
Fix FOR XML RAW behavior with empty element name and all-NULL rows

Changes are in `tsql_row_to_xml_raw()` in forxml.c. When element_name is empty, the opening and closing wrapper tags are now skipped in ELEMENTS mode (same approach as PATH mode). For attribute-centric mode (without ELEMENTS), an error is raised since empty row tag names are not valid. The self-closing tag logic for all-NULL rows was also corrected.

Authored-by: Japleen Kaur <amjj@amazon.com>
Signed-off-by: Japleen Kaur <amjj@amazon.com>

Cherry-picked from - [#4680 ](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4680)

### Issues Resolved
JIRA : BABEL-6379

1. FOR XML RAW(''), ELEMENTS — Babelfish produced `<><a>1</a><b>2</b></>` (invalid XML with empty wrapper tags). SQL Server produces `<a>1</a><b>2</b>` (no wrapper). Fixed by skipping the wrapper tag when element name is empty, consistent with how PATH('') handles it.

2. FOR XML RAW('') (without ELEMENTS) — Babelfish produced `< a="1" b="2"/> `(invalid XML). SQL Server throws: "Row tag omission (empty row tag name) cannot be used with attribute-centric FOR XML serialization." Fixed by adding the same error that PATH mode already throws for this case.

3. All-NULL rows with ELEMENTS — Babelfish produced `<row></row>`. SQL Server produces`<row/>` (self-closing tag). Fixed by replacing the closing > of the opening tag with /> when all columns are NULL.

### Test Scenarios Covered ###
* **Use case based -**
RAW(''), ELEMENTS without wrapper tag, RAW('') error without ELEMENTS, all-NULL rows producing <row/>.

* **Boundary conditions -**
Empty element name (RAW('')).

* **Arbitrary inputs -**
N/A

* **Negative test cases -**
N/A

* **Minor version upgrade tests -**
N/A

* **Major version upgrade tests -**
N/A

* **Performance tests -**
N/A

* **Tooling impact -**
N/A

* **Client tests -**
N/A


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).