### PR TITLE
Fixing memory leaks observed in ASan (#4690)

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -1638,7 +1638,7 @@ PrepareRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt, List *target
 				if (relMetaDataInfo->partName[1] == NULL)
 				{
 					if (physical_schema_name != NULL)
-						relMetaDataInfo->partName[1] = strdup(physical_schema_name);
+						relMetaDataInfo->partName[1] = pstrdup(physical_schema_name);
 					else
 						relMetaDataInfo->partName[1] = NULL;
 				}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -3009,7 +3009,7 @@ public:
 		clear_rewritten_query_fragment();
 
 		/* Now we can prepend SELECT to rewritten search_condition */
-		expr->query = strdup((std::string("SELECT ") + std::string(expr->query)).c_str());
+		expr->query = pstrdup((std::string("SELECT ") + std::string(expr->query)).c_str());
 		return expr;
 	}
 


### PR DESCRIPTION
Cherry-pick of https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4690

This commit fixes memory leaks observed when testing with ASan

1. In the function PrepareRowDescription() , strdup() allocates memory using the system's malloc(), which is completely outside PostgreSQL's memory management. This means the string stored in relMetaDataInfo->partName[1] lives in malloc-heap, not in any PostgreSQL memory context. By using pstrdup() , it allocates using palloc() inside the current memory context (MessageContext), so it's properly tracked and will be freed when that context is destroyed.

2. Similarly in the function rewrite_if_condition(), strdup uses malloc which is invisible to PostgreSQL's memory management while pstrdup allocates in the current memory context, which gets cleaned up automatically.

Task: BABEL-6422

Authored by : harshdu@amazon.com
Signed-off by : harshdu@amazon.com



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).