### PR TITLE
Fix handling of non-regular relation RTEs in walker

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4606,6 +4606,7 @@ is_query_using_regular_relation_walker(Node *node, void *context)
         RangeTblEntry *rte = (RangeTblEntry *) node;
 		if (rte->rtekind == RTE_RELATION && rte->relkind == 'r')
 			return true;
+		return false;
     }
     
     if (IsA(node, Query))

--- a/test/JDBC/input/BABEL-IMPLICIT_TRAN.sql
+++ b/test/JDBC/input/BABEL-IMPLICIT_TRAN.sql
@@ -238,6 +238,41 @@ DEALLOCATE implicit_tran_cursor;
 SELECT @@TRANCOUNT;
 GO
 
+-- Select from system view should start implicit transaction
+SELECT @@TRANCOUNT
+SELECT DISTINCT 'OK' FROM pg_stat_activity
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
+-- Subquery in FROM should not error
+SELECT @@TRANCOUNT
+SELECT * FROM (SELECT 1 AS x) sub
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
+-- Set-returning function in FROM should not error
+SELECT @@TRANCOUNT
+SELECT * FROM generate_series(1, 3)
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
+-- CTE should not error
+SELECT @@TRANCOUNT
+WITH cte AS (SELECT 1 AS x) SELECT * FROM cte
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
+-- VALUES clause in FROM should not error
+SELECT @@TRANCOUNT
+SELECT * FROM (VALUES (1), (2), (3)) AS t(x)
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
 -- Cleanup
 SET IMPLICIT_TRANSACTIONS OFF
 GO

--- a/test/JDBC/sql_expected/BABEL-IMPLICIT_TRAN.out
+++ b/test/JDBC/sql_expected/BABEL-IMPLICIT_TRAN.out
@@ -590,6 +590,120 @@ int
 ~~END~~
 
 
+-- Select from system view should start implicit transaction
+SELECT @@TRANCOUNT
+SELECT DISTINCT 'OK' FROM pg_stat_activity
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+text
+OK
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- Subquery in FROM should not error
+SELECT @@TRANCOUNT
+SELECT * FROM (SELECT 1 AS x) sub
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- Set-returning function in FROM should not error
+SELECT @@TRANCOUNT
+SELECT * FROM generate_series(1, 3)
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- CTE should not error
+SELECT @@TRANCOUNT
+WITH cte AS (SELECT 1 AS x) SELECT * FROM cte
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- VALUES clause in FROM should not error
+SELECT @@TRANCOUNT
+SELECT * FROM (VALUES (1), (2), (3)) AS t(x)
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
 -- Cleanup
 SET IMPLICIT_TRANSACTIONS OFF
 GO


### PR DESCRIPTION
### Description
Currently, when IMPLICIT_TRANSACTIONS is set to ON, queries with non-regular relation RTEs (like for system views or CTEs) were not handled by is_query_using_regular_relation_walker(), and the node was passed to expression_tree_walker, which does not handle RTE nodes.
To fix this, we return false to let range_table_walker handle the node.

Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4694

### Issues Resolved
BABEL-3756

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).