### PR TITLE
fix(dev-tools): Remove sudo and update pg_hint_plan for PG 18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ babelfish_extensions/
 
 All commands run from the workspace root (parent of both `babelfish_extensions` and `postgresql_modified_for_babelfish`).
 
+For detailed prerequisites (ICU, ANTLR, cmake, etc.) and manual build steps, see `contrib/README.md`. The `dev-tools.sh` script automates most of this workflow.
+
 ### First-time setup
 ```bash
 ./babelfish_extensions/dev-tools.sh initpg    # Build PostgreSQL engine

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -164,16 +164,16 @@ init_db() {
     sleep 1
     bin/pg_ctl -c -D data/ -l logfile start
     cd data
-    sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
-    sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
-    sudo echo "host    all             all             0.0.0.0/0            trust" >> pg_hba.conf
+    sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
+    sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds, pg_stat_statements'/g" postgresql.conf
+    echo "host    all             all             0.0.0.0/0            trust" >> pg_hba.conf
     restart $1
 }
 
 init_pghint() {
     cd $1
     if [ ! -d "./pg_hint_plan" ]; then
-        git clone --depth 1 --branch REL17_1_7_0 https://github.com/ossc-db/pg_hint_plan.git
+        git clone --depth 1 --branch REL18_1_8_0 https://github.com/ossc-db/pg_hint_plan.git
     fi
     cd pg_hint_plan
     export PATH=$2/postgres/bin:$PATH
@@ -186,7 +186,7 @@ init_pg() {
     ./configure --prefix=$2/postgres/ --without-readline --without-zlib --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
     make -j 4
     make install
-    cd contrib && make && sudo make install
+    cd contrib && make && make install
     cp "/usr/local/lib/libantlr4-runtime.so.4.13.2" $2/postgres/lib/
     init_pghint $1 $2
 }
@@ -257,7 +257,7 @@ run_pgindent() {
     git clone https://git.postgresql.org/git/pg_bsd_indent.git
     cd pg_bsd_indent/
     make PG_CONFIG=$1/postgres/bin/pg_config
-    sudo cp pg_bsd_indent /usr/local/bin
+    cp pg_bsd_indent $1/postgres/bin/
 
     cd $1/babelfish_extensions
 
@@ -293,7 +293,7 @@ init_lcov(){
         git clone --depth 1 --branch v1.16 https://github.com/linux-test-project/lcov.git
     fi
     cd lcov
-    sudo make PREFIX=/usr install
+    make PREFIX=$1/postgres install
     export PATH=$PATH:/usr/bin/lcov
     export PATH=$PATH:/usr/bin/gcov
     export PATH=$PATH:/usr/bin/genhtml
@@ -305,8 +305,8 @@ init_pg_coverage(){
     ./configure --prefix=$2/postgres/ --without-readline --without-zlib --enable-coverage --enable-debug --enable-cassert CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
     make -j 4
     make install
-    cd contrib && make && sudo make install
-    sudo cp "/usr/local/lib/libantlr4-runtime.so.4.13.2" $2/postgres/lib/
+    cd contrib && make && make install
+    cp "/usr/local/lib/libantlr4-runtime.so.4.13.2" $2/postgres/lib/
     init_pghint $1 $2
 }
 


### PR DESCRIPTION
All build artifacts install into the workspace-local postgres/ prefix, so sudo is unnecessary. pg_bsd_indent now installs to postgres/bin/ and lcov installs to the workspace postgres prefix instead of /usr.

Also update pg_hint_plan from REL17_1_7_0 to REL18_1_8_0 to fix build failure against PG 18 (build_child_join_rel signature change).

Task: BABEL-6428

### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).