### PR TITLE
fix: Deep copy parameter names for prepared statements

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -2719,7 +2719,7 @@ read_param_def(InlineCodeBlockArgs *args, const char *paramdefstr)
 		FunctionParameter *p;
 
 		p = (FunctionParameter *) lfirst(lc);
-		args->argnames[i] = p->name;
+		args->argnames[i] = pstrdup(p->name);
 		args->argmodes[i] = p->mode;
 
 		/*
@@ -2769,7 +2769,11 @@ clone_inline_args(InlineCodeBlockArgs *args)
 	clone = create_args(args->numargs);
 	memcpy(clone->argtypes, args->argtypes, sizeof(Oid) * args->numargs);
 	memcpy(clone->argtypmods, args->argtypmods, sizeof(int32) * args->numargs);
-	memcpy(clone->argnames, args->argnames, sizeof(char *) * args->numargs);
+
+	/* Deep copy argument names */
+	for (int i = 0; i < args->numargs; i++)
+		clone->argnames[i] = args->argnames[i] ? pstrdup(args->argnames[i]) : NULL;
+
 	memcpy(clone->argmodes, args->argmodes, sizeof(char) * args->numargs);
 
 	return clone;

--- a/test/JDBC/expected/TestSPPrepare.out
+++ b/test/JDBC/expected/TestSPPrepare.out
@@ -970,3 +970,477 @@ int
 
 Drop table tblEmployees
 GO
+
+--- SP_PREPARE with named args
+CREATE TABLE handle (h int);
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@a int, @b int', N'select @a, @b';
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@a" not defined)~~
+
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@a" not defined)~~
+
+
+--- SP_PREPARE with named args (reverse param order)
+DELETE FROM handle;
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@b int, @a int', N'select @a, @b';
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@b" not defined)~~
+
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@b" not defined)~~
+
+
+-- mix order and types
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@x int, @y varchar(20)', N'select @x, @y';
+EXEC SP_EXECUTE @handle, @x = 1, @y = 'first';
+EXEC SP_EXECUTE @handle, @y = 'second', @x = 2;
+EXEC SP_EXECUTE @handle, @x = 3, @y = 'third';
+EXEC SP_EXECUTE @handle, @y = 'fourth', @x = 4;
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#varchar
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#first
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+~~END~~
+
+~~START~~
+int#!#varchar
+3#!#third
+~~END~~
+
+~~START~~
+int#!#varchar
+4#!#fourth
+~~END~~
+
+
+--- case-insensitive matching
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@Param1 int, @Param2 int', N'select @Param1, @Param2';
+EXEC SP_EXECUTE @handle, @param1 = 1, @PARAM2 = 2;
+EXEC SP_EXECUTE @handle, @param2 = 2, @PARAM1 = 1;
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#int
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+
+--- SP_PREPARE with named OUTPUT params
+DECLARE @handle int;
+DECLARE @out_val int;
+EXEC SP_PREPARE @handle out, N'@a int, @b int output', N'set @b = @a * 2';
+EXEC SP_EXECUTE @handle, @a = 5, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_EXECUTE @handle, @a = 7, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int
+10
+~~END~~
+
+~~START~~
+int
+14
+~~END~~
+
+
+--- SP_PREPEXEC with named args
+DELETE FROM handle;
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@a int, @b int', N'select @a, @b', 1, 2;
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@a" not defined)~~
+
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@a" not defined)~~
+
+
+--- SP_PREPEXEC with named args (reverse param order)
+DELETE FROM handle;
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@b int, @a int', N'select @a, @b', 2, 1;
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@b" not defined)~~
+
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: param "@b" not defined)~~
+
+
+-- mix order and types
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@x int, @y varchar(20)', N'select @x, @y', @y = 'zeroth', @x = 0;
+EXEC SP_EXECUTE @handle, @x = 1, @y = 'first';
+EXEC SP_EXECUTE @handle, @y = 'second', @x = 2;
+EXEC SP_EXECUTE @handle, @x = 3, @y = 'third';
+EXEC SP_EXECUTE @handle, @y = 'fourth', @x = 4;
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#varchar
+0#!#zeroth
+~~END~~
+
+~~START~~
+int#!#varchar
+1#!#first
+~~END~~
+
+~~START~~
+int#!#varchar
+2#!#second
+~~END~~
+
+~~START~~
+int#!#varchar
+3#!#third
+~~END~~
+
+~~START~~
+int#!#varchar
+4#!#fourth
+~~END~~
+
+
+--- case-insensitive matching
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@Param1 int, @Param2 int', N'select @Param1, @Param2', @pArAm1 = 1, @PaRaM2 = 2;
+EXEC SP_EXECUTE @handle, @param1 = 1, @PARAM2 = 2;
+EXEC SP_EXECUTE @handle, @param2 = 2, @PARAM1 = 1;
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+~~START~~
+int#!#int
+1#!#2
+~~END~~
+
+
+--- SP_PREPEXEC with named OUTPUT params
+DECLARE @handle int;
+DECLARE @out_val int;
+EXEC SP_PREPEXEC @handle out, N'@a int, @b int output', N'set @b = @a * 2', @a = 5, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_EXECUTE @handle, @a = 7, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_UNPREPARE @handle;
+GO
+~~START~~
+int
+10
+~~END~~
+
+~~START~~
+int
+14
+~~END~~
+
+
+DROP TABLE handle;
+GO

--- a/test/JDBC/input/storedProcedures/TestSPPrepare.sql
+++ b/test/JDBC/input/storedProcedures/TestSPPrepare.sql
@@ -548,3 +548,155 @@ GO
 
 Drop table tblEmployees
 GO
+
+--- SP_PREPARE with named args
+CREATE TABLE handle (h int);
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@a int, @b int', N'select @a, @b';
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+GO
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- SP_PREPARE with named args (reverse param order)
+DELETE FROM handle;
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@b int, @a int', N'select @a, @b';
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+GO
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+
+-- mix order and types
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@x int, @y varchar(20)', N'select @x, @y';
+EXEC SP_EXECUTE @handle, @x = 1, @y = 'first';
+EXEC SP_EXECUTE @handle, @y = 'second', @x = 2;
+EXEC SP_EXECUTE @handle, @x = 3, @y = 'third';
+EXEC SP_EXECUTE @handle, @y = 'fourth', @x = 4;
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- case-insensitive matching
+DECLARE @handle int;
+EXEC SP_PREPARE @handle out, N'@Param1 int, @Param2 int', N'select @Param1, @Param2';
+EXEC SP_EXECUTE @handle, @param1 = 1, @PARAM2 = 2;
+EXEC SP_EXECUTE @handle, @param2 = 2, @PARAM1 = 1;
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- SP_PREPARE with named OUTPUT params
+DECLARE @handle int;
+DECLARE @out_val int;
+EXEC SP_PREPARE @handle out, N'@a int, @b int output', N'set @b = @a * 2';
+EXEC SP_EXECUTE @handle, @a = 5, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_EXECUTE @handle, @a = 7, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- SP_PREPEXEC with named args
+DELETE FROM handle;
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@a int, @b int', N'select @a, @b', 1, 2;
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+GO
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 1, 2;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2;
+EXEC SP_EXECUTE @handle, 2, @a = 1; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- SP_PREPEXEC with named args (reverse param order)
+DELETE FROM handle;
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@b int, @a int', N'select @a, @b', 2, 1;
+INSERT INTO handle VALUES (@handle);
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+GO
+
+-- reuse handle
+DECLARE @handle int;
+SELECT @handle = h FROM handle;
+EXEC SP_EXECUTE @handle, 2, 1;
+EXEC SP_EXECUTE @handle, @a = 1, @b = 2;
+EXEC SP_EXECUTE @handle, @b = 2, @a = 1;
+EXEC SP_EXECUTE @handle, 2, @a = 1;
+EXEC SP_EXECUTE @handle, 1, @b = 2; -- should error
+EXEC SP_UNPREPARE @handle;
+GO
+
+-- mix order and types
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@x int, @y varchar(20)', N'select @x, @y', @y = 'zeroth', @x = 0;
+EXEC SP_EXECUTE @handle, @x = 1, @y = 'first';
+EXEC SP_EXECUTE @handle, @y = 'second', @x = 2;
+EXEC SP_EXECUTE @handle, @x = 3, @y = 'third';
+EXEC SP_EXECUTE @handle, @y = 'fourth', @x = 4;
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- case-insensitive matching
+DECLARE @handle int;
+EXEC SP_PREPEXEC @handle out, N'@Param1 int, @Param2 int', N'select @Param1, @Param2', @pArAm1 = 1, @PaRaM2 = 2;
+EXEC SP_EXECUTE @handle, @param1 = 1, @PARAM2 = 2;
+EXEC SP_EXECUTE @handle, @param2 = 2, @PARAM1 = 1;
+EXEC SP_UNPREPARE @handle;
+GO
+
+--- SP_PREPEXEC with named OUTPUT params
+DECLARE @handle int;
+DECLARE @out_val int;
+EXEC SP_PREPEXEC @handle out, N'@a int, @b int output', N'set @b = @a * 2', @a = 5, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_EXECUTE @handle, @a = 7, @b = @out_val output;
+SELECT @out_val;
+EXEC SP_UNPREPARE @handle;
+GO
+
+DROP TABLE handle;
+GO


### PR DESCRIPTION
### Description

Currently, when cloning arguments to pltsql functions, we only copy the pointer to the argument names, which means that when a prepared statement is stored, the strings containing the parameter names are not retained.

When later executing a prepared statement using its handle, we don't have the original param names, and so we cannot call them using their arguments.

To fix this, we copy the argument names as well when cloning the struct.

Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4705

### Issues Resolved
BABEL-6391

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).