### PR TITLE
Improve run_pgindent and add AGENTS.md development guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,10 @@
 babelfish_extensions/
 ├── contrib/
 │   ├── babelfishpg_tsql/     # T-SQL language support
+│   │   └── src/              # Core: pl_exec.c, pl_comp.c, hooks.c, tsqlIface.cpp
 │   ├── babelfishpg_tds/      # TDS protocol support
-│   ├── babelfishpg_common/   # Shared data types (geometry, geography, money, etc.)
+│   │   └── src/backend/tds/  # TDS protocol handlers
+│   ├── babelfishpg_common/   # Shared data types (geometry, geography, etc.)
 │   ├── babelfishpg_money/    # money type
 │   └── babelfishpg_unit/     # Unit testing framework
 ├── test/
@@ -16,14 +18,35 @@ babelfish_extensions/
 │   ├── python/               # Python driver tests + isolation tests (.spec)
 │   ├── dotnet/               # .NET driver tests
 │   └── odbc/                 # ODBC driver tests
+├── .github/
+│   └── pull_request_template.md  # PR description template
 └── dev-tools.sh              # Developer build and test script
 ```
 
+## Workspace Setup
+
+Both repos must be in the same parent directory (the workspace root):
+```
+<workspace>/
+├── postgresql_modified_for_babelfish/   # Engine source
+├── babelfish_extensions/                # Extensions source
+└── postgres/                            # Built PostgreSQL (created by initpg)
+```
+
+All commands below run from the workspace root.
+
+For first-time environment setup (dependencies, ANTLR, cmake), see `contrib/README.md`.
+
+## Branch Naming
+
+| Type | Extensions | Engine |
+|---|---|---|
+| Dev | `BABEL_{major}_X_DEV` | `BABEL_{major}_X_DEV__PG_{pg_major}_X` |
+| Stable | `BABEL_{major}_{minor}_STABLE` | `BABEL_{major}_{minor}_STABLE__PG_{pg_major}_{pg_minor}` |
+
+Both repos must be on matching branches. List branches from GitHub to find the latest stable for a given version.
+
 ## Build and Test
-
-All commands run from the workspace root (parent of both `babelfish_extensions` and `postgresql_modified_for_babelfish`).
-
-For detailed prerequisites (ICU, ANTLR, cmake, etc.) and manual build steps, see `contrib/README.md`. The `dev-tools.sh` script automates most of this workflow.
 
 ### First-time setup
 ```bash
@@ -32,31 +55,61 @@ For detailed prerequisites (ICU, ANTLR, cmake, etc.) and manual build steps, see
 ./babelfish_extensions/dev-tools.sh initbbf   # Initialize Babelfish
 ```
 
+### Verify setup
+
+Verify both PostgreSQL and TDS endpoints:
+```bash
+# PostgreSQL endpoint
+./postgres/bin/psql -U babelfish_user -d babelfish_db -c "SELECT 1"
+
+# TDS endpoint (sqlcmd or Python)
+sqlcmd -S localhost -U babelfish_user -P 12345678 -Q "SELECT 1"
+# or
+python3 -c "import pymssql; c = pymssql.connect('localhost','babelfish_user','12345678','master'); c.cursor().execute('SELECT 1'); print('OK')"
+```
+
 ### Daily development
 ```bash
-./babelfish_extensions/dev-tools.sh buildbbf  # Build extensions + restart DB
-./babelfish_extensions/dev-tools.sh buildall  # Build PG + extensions + restart DB
+./babelfish_extensions/dev-tools.sh buildbbf      # Build extensions + restart DB
+./babelfish_extensions/dev-tools.sh buildall      # Build PG + extensions + restart DB
 ./babelfish_extensions/dev-tools.sh run_pgindent  # Format code (required before PR)
 ```
 
 ### Running tests
+
+`dev-tools.sh` supports JDBC tests:
 ```bash
-./babelfish_extensions/dev-tools.sh test normal                          # All JDBC tests (multi-db)
-./babelfish_extensions/dev-tools.sh test normal single-db                # Single-db mode
-./babelfish_extensions/dev-tools.sh test upgrade multi-db test/JDBC/upgrade/15_11  # Upgrade tests
+./babelfish_extensions/dev-tools.sh test normal                  # Full run (multi-db)
+./babelfish_extensions/dev-tools.sh test normal single-db        # Full run (single-db)
+./babelfish_extensions/dev-tools.sh test prepare multi-db <dir>  # Schedule-based vu-prepare
+./babelfish_extensions/dev-tools.sh test verify multi-db <dir>   # Schedule-based vu-verify
 ```
+
+For running a single test, see `test/JDBC/README.md`.
+
+For other frameworks (Python, .NET, ODBC), see their respective directories under `test/`.
 
 ### Upgrade testing
 ```bash
-./babelfish_extensions/dev-tools.sh minor_version_upgrade SOURCE_WS     # ALTER EXTENSION UPDATE
-./babelfish_extensions/dev-tools.sh pg_upgrade SOURCE_WS TARGET_WS      # Major version upgrade
+./babelfish_extensions/dev-tools.sh minor_version_upgrade <source_ws>
+./babelfish_extensions/dev-tools.sh pg_upgrade <source_ws>
 ```
 
-## PR Checklist
+## Pre-Commit Checklist
 
+- [ ] `buildbbf` succeeds
+- [ ] Modified/added tests pass locally
 - [ ] `run_pgindent` applied
-- [ ] `test normal` passes in both multi-db and single-db modes
-- [ ] Upgrade tests pass if DDL or catalog changed
-- [ ] `test/python/expected/upgrade_validation/expected_dependency.out` updated if new functions added
-- [ ] PR description includes JIRA link, change summary, test scenarios covered, breaking changes
-- [ ] Two senior engineer approvals obtained
+- [ ] `expected_dependency.out` updated if new functions added
+
+## Commit
+
+- [ ] `git commit --signoff`
+
+## Pre-PR Checklist
+
+- [ ] GitHub Actions pass after push
+
+## PR
+
+- [ ] Fill `.github/pull_request_template.md` accordingly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ python3 -c "import pymssql; c = pymssql.connect('localhost','babelfish_user','12
 ```bash
 ./babelfish_extensions/dev-tools.sh buildbbf      # Build extensions + restart DB
 ./babelfish_extensions/dev-tools.sh buildall      # Build PG + extensions + restart DB
-./babelfish_extensions/dev-tools.sh run_pgindent  # Format code (required before PR)
+./babelfish_extensions/dev-tools.sh run_pgindent "" path/to/file.c # Format a single file (required before PR)
+./babelfish_extensions/dev-tools.sh run_pgindent                   # Format all extensions
 ```
 
 ### Running tests
@@ -95,11 +96,18 @@ For other frameworks (Python, .NET, ODBC), see their respective directories unde
 ./babelfish_extensions/dev-tools.sh pg_upgrade <source_ws>
 ```
 
+## Feature Branch
+
+Create a feature branch from the target dev branch. Never commit directly to dev branches.
+```bash
+git checkout -b <JIRA-ID>-short-description BABEL_{major}_X_DEV
+```
+
 ## Pre-Commit Checklist
 
 - [ ] `buildbbf` succeeds
 - [ ] Modified/added tests pass locally
-- [ ] `run_pgindent` applied
+- [ ] `run_pgindent` applied on modified `.c` and `.h` files; only commit pgindent changes on lines you modified, discard unrelated formatting changes from pre-existing code
 - [ ] `expected_dependency.out` updated if new functions added
 
 ## Commit

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -61,8 +61,8 @@ if [ ! $1 ]; then
     echo "  sum_coverage [TARGET_WS]"
     echo "      summarize code coverage"
     echo ""
-    echo "  run_pgindent [TARGET_WS]"
-    echo "      run pgindent"
+    echo "  run_pgindent [TARGET_WS] [PATH]"
+    echo "      format C code with pgindent; PATH is an optional file or directory to indent"
     exit 0
 fi
 
@@ -226,65 +226,48 @@ restore() {
 }
 
 run_pgindent() {
-    cd $1/postgres/lib
+    local ws=$1
+    local indent_path=$2
+    local pgindent=$ws/postgresql_modified_for_babelfish/src/tools/pgindent/pgindent
+    local extensions=("babelfishpg_money" "babelfishpg_common" "babelfishpg_tds" "babelfishpg_tsql")
 
-    echo "dumping typedefs for babelfishpg_mpney to /tmp/babelfishpg_money.typedefs.."
-    objdump -W babelfishpg_money.so | egrep -A3 DW_TAG_typedef | perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-     next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-     next if $flds[-1] =~ /^DW_FORM_str/;\
-     print $flds[-1],"\n"; }'  | sort | uniq > /tmp/babelfishpg_money.typedefs
+    cd $ws/postgres/lib
+    for ext in "${extensions[@]}"; do
+        echo "Dumping typedefs for $ext..."
+        objdump -W ${ext}.so | egrep -A3 DW_TAG_typedef | perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);
+         next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";
+         next if $flds[-1] =~ /^DW_FORM_str/;
+         print $flds[-1],"\n"; }'  | sort | uniq > /tmp/${ext}.typedefs
+    done
 
-    echo "dumping typedefs for babelfishpg_common to /tmp/babelfishpg_common.typedefs.."
-    objdump -W babelfishpg_common.so | egrep -A3 DW_TAG_typedef | perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-     next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-     next if $flds[-1] =~ /^DW_FORM_str/;\
-     print $flds[-1],"\n"; }'  | sort | uniq > /tmp/babelfishpg_common.typedefs
+    if [ ! -f "$ws/postgres/bin/pg_bsd_indent" ]; then
+        echo "Building pg_bsd_indent from in-tree source..."
+        cd $ws/postgresql_modified_for_babelfish/src/tools/pg_bsd_indent
+        make PG_CONFIG=$ws/postgres/bin/pg_config
+        cp pg_bsd_indent $ws/postgres/bin/
+    fi
 
-    echo "dumping typedefs for babelfishpg_tds to /tmp/babelfishpg_tds.typedefs.."
-    objdump -W babelfishpg_tds.so | egrep -A3 DW_TAG_typedef | perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-     next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-     next if $flds[-1] =~ /^DW_FORM_str/;\
-     print $flds[-1],"\n"; }'  | sort | uniq > /tmp/babelfishpg_tds.typedefs
-
-    echo "dumping typedefs for babelfishpg_tsql to /tmp/babelfishpg_tsql.typedefs.."
-    objdump -W babelfishpg_tsql.so | egrep -A3 DW_TAG_typedef | perl -e ' while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-     next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-     next if $flds[-1] =~ /^DW_FORM_str/;\
-     print $flds[-1],"\n"; }'  | sort | uniq > /tmp/babelfishpg_tsql.typedefs
-
-    cd $1
-    echo "Clone and build pg_bsd_indent which is required by pgindent..."
-    git clone https://git.postgresql.org/git/pg_bsd_indent.git
-    cd pg_bsd_indent/
-    make PG_CONFIG=$1/postgres/bin/pg_config
-    cp pg_bsd_indent $1/postgres/bin/
-
-    cd $1/babelfish_extensions
-
-    echo ""
-    echo "Running pgindent on babelfishpg_money..."
-    cd contrib/babelfishpg_money
-    $1/postgresql_modified_for_babelfish/src/tools/pgindent/pgindent --typedefs=/tmp/babelfishpg_money.typedefs
-
-    echo ""
-    echo "Running pgindent on babelfishpg_common..."
-    cd ../babelfishpg_common
-    $1/postgresql_modified_for_babelfish/src/tools/pgindent/pgindent --typedefs=/tmp/babelfishpg_common.typedefs
+    if [ -n "$indent_path" ]; then
+        local typedefs=/tmp/babelfishpg_tsql.typedefs
+        for ext in "${extensions[@]}"; do
+            echo "$indent_path" | grep -q "$ext" && typedefs=/tmp/${ext}.typedefs && break
+        done
+        echo "Running pgindent on $indent_path..."
+        $pgindent --typedefs=$typedefs "$indent_path"
+    else
+        cd $ws/babelfish_extensions
+        for ext in "${extensions[@]}"; do
+            echo "Running pgindent on $ext..."
+            local extra=""
+            [ "$ext" == "babelfishpg_tsql" ] && extra="--exclude=exclude_file_from_pgindent"
+            cd contrib/$ext
+            $pgindent --typedefs=/tmp/${ext}.typedefs $extra
+            cd $ws/babelfish_extensions
+        done
+    fi
 
     echo ""
-    echo "Running pgindent on babelfishpg_tds..."
-    cd ../babelfishpg_tds
-    $1/postgresql_modified_for_babelfish/src/tools/pgindent/pgindent --typedefs=/tmp/babelfishpg_tds.typedefs
-
-    echo ""
-    echo "Running pgindent on babelfishpg_tsql..."
-    cd ../babelfishpg_tsql
-    $1/postgresql_modified_for_babelfish/src/tools/pgindent/pgindent --typedefs=/tmp/babelfishpg_tsql.typedefs --exclude="exclude_file_from_pgindent"
-
-    echo ""
-    echo "pgindent is ran successfully against $1."
-    echo "Please re-build all the extensions to make sure that there is no compilation error."
-    echo ""
+    echo "pgindent completed. Please re-build to verify no compilation errors."
 }
 
 init_lcov(){
@@ -481,9 +464,11 @@ elif [ "$1" == "dumprestore" ]; then
     echo "Restored on target workspace ($TARGET_WS)!"
     exit 0
 elif [ "$1" == "run_pgindent" ]; then
+    INDENT_PATH=$3
+    [ -n "$INDENT_PATH" ] && INDENT_PATH=$(realpath "$INDENT_PATH")
     init_pg $TARGET_WS $TARGET_WS
     build_bbf $TARGET_WS $TARGET_WS
-    run_pgindent $TARGET_WS
+    run_pgindent $TARGET_WS $INDENT_PATH
 elif [ "$1" == "initpg_coverage" ]; then
     init_pg_coverage $TARGET_WS $TARGET_WS
     exit 0


### PR DESCRIPTION
### Description

Currently, `dev-tools.sh run_pgindent` clones `pg_bsd_indent` from an external PostgreSQL git repo that fails to compile with GCC 7 on Amazon Linux 2. The pgindent logic also uses copy-pasted blocks for each extension, making it hard to maintain.

With this change:
- `run_pgindent` builds `pg_bsd_indent` from the in-tree engine source (`src/tools/pg_bsd_indent`), fixing the GCC 7 build failure
- Skips `pg_bsd_indent` rebuild if the binary already exists
- Replaces copy-pasted objdump/pgindent blocks with a loop over extensions
- Adds an optional PATH argument to run pgindent on a single file or directory: `./dev-tools.sh run_pgindent "" path/to/file.c`

Additionally, `AGENTS.md` is updated with workspace setup instructions, branch naming conventions, verify setup commands (both PostgreSQL and TDS endpoints), feature branch workflow, and structured pre-commit/commit/pre-PR/PR checklists.

### Issues Resolved

BABEL-6428

### Test Scenarios Covered

* **Tooling impact -** Verified `run_pgindent` with no PATH (all extensions), with single file PATH, and with directory PATH. Verified `pg_bsd_indent` builds from in-tree source on Amazon Linux 2.

### Check List
- [x] Commits are signed per the DCO using --signoff