### PR TITLE
Add install-deps.sh and update AGENTS.md with build workflow

### DIFF
--- a/.github/scripts/install-deps.sh
+++ b/.github/scripts/install-deps.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -e
+
+ANTLR_VERSION="${ANTLR_VERSION:-4.13.2}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+install_packages() {
+    echo "Installing OS packages..."
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+    fi
+
+    case "$ID" in
+        ubuntu|debian)
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt-get update
+            sudo apt-get install -y uuid-dev flex openjdk-21-jre \
+                libicu-dev libxml2-dev openssl libssl-dev python3-dev \
+                libossp-uuid-dev libpq-dev pkg-config g++ build-essential bison \
+                wget unzip
+            ;;
+        amzn|rhel|centos)
+            sudo yum install -y libicu-devel libxml2-devel \
+                openssl-devel uuid-devel postgresql-devel gcc gcc-c++ java \
+                make bison flex python3-devel \
+                wget unzip tar gzip which
+            ;;
+        *)
+            echo "Unsupported OS: ${ID:-unknown}. See contrib/README.md."
+            exit 1
+            ;;
+    esac
+}
+
+install_cmake() {
+    if command -v cmake &>/dev/null; then
+        echo "cmake already installed: $(cmake --version | head -1)"
+        return
+    fi
+
+    echo "Installing cmake..."
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+    fi
+
+    case "$ID" in
+        ubuntu|debian)
+            sudo apt-get install -y cmake
+            ;;
+        amzn|rhel|centos)
+            sudo yum install -y cmake3
+            sudo alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 1
+            ;;
+    esac
+}
+
+install_antlr() {
+    if [ -f "/usr/local/lib/libantlr4-runtime.so.${ANTLR_VERSION}" ] || \
+       [ -f "/usr/local/lib64/libantlr4-runtime.so.${ANTLR_VERSION}" ]; then
+        echo "ANTLR ${ANTLR_VERSION} runtime already installed."
+        return
+    fi
+
+    echo "Installing ANTLR4 C++ runtime ${ANTLR_VERSION}..."
+
+    local jar="$REPO_DIR/contrib/babelfishpg_tsql/antlr/thirdparty/antlr/antlr-${ANTLR_VERSION}-complete.jar"
+    if [ -f "$jar" ]; then
+        sudo cp "$jar" /usr/local/lib/
+    fi
+
+    local work_dir=$(mktemp -d)
+    cd "$work_dir"
+    wget -q "http://www.antlr.org/download/antlr4-cpp-runtime-${ANTLR_VERSION}-source.zip"
+    unzip -qd antlr4 "antlr4-cpp-runtime-${ANTLR_VERSION}-source.zip"
+    cd antlr4 && mkdir -p build && cd build
+    cmake .. -DANTLR_JAR_LOCATION="/usr/local/lib/antlr-${ANTLR_VERSION}-complete.jar" -DCMAKE_INSTALL_PREFIX=/usr/local
+    make -j$(nproc)
+    sudo make install
+    rm -rf "$work_dir"
+
+    # Symlink lib64 → lib if needed (AL2/RHEL installs to lib64)
+    if [ -f "/usr/local/lib64/libantlr4-runtime.so.${ANTLR_VERSION}" ] && \
+       [ ! -f "/usr/local/lib/libantlr4-runtime.so.${ANTLR_VERSION}" ]; then
+        sudo ln -s "/usr/local/lib64/libantlr4-runtime.so.${ANTLR_VERSION}" \
+                    "/usr/local/lib/libantlr4-runtime.so.${ANTLR_VERSION}"
+    fi
+}
+
+# Main
+install_packages
+install_cmake
+install_antlr
+
+echo ""
+echo "Dependencies installed successfully."
+echo "Next: run dev-tools.sh initpg, initdb, buildbbf, initbbf"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ babelfish_extensions/
 │   ├── dotnet/               # .NET driver tests
 │   └── odbc/                 # ODBC driver tests
 ├── .github/
-│   └── pull_request_template.md  # PR description template
+│   ├── scripts/
+│   │   └── install-deps.sh        # First-time dependency installer
+│   └── pull_request_template.md   # PR description template
 └── dev-tools.sh              # Developer build and test script
 ```
 
@@ -35,8 +37,6 @@ Both repos must be in the same parent directory (the workspace root):
 
 All commands below run from the workspace root.
 
-For first-time environment setup (dependencies, ANTLR, cmake), see `contrib/README.md`.
-
 ## Branch Naming
 
 | Type | Extensions | Engine |
@@ -49,10 +49,18 @@ Both repos must be on matching branches. List branches from GitHub to find the l
 ## Build and Test
 
 ### First-time setup
+
+Install dependencies (or see `contrib/README.md` for manual steps):
 ```bash
-./babelfish_extensions/dev-tools.sh initpg    # Build PostgreSQL engine
-./babelfish_extensions/dev-tools.sh initdb    # Initialize data directory
-./babelfish_extensions/dev-tools.sh initbbf   # Initialize Babelfish
+./.github/scripts/install-deps.sh
+```
+
+Build and initialize:
+```bash
+./babelfish_extensions/dev-tools.sh initpg      # Build PostgreSQL engine
+./babelfish_extensions/dev-tools.sh initdb       # Init data directory (restart may fail — expected)
+./babelfish_extensions/dev-tools.sh buildbbf     # Build extensions + restart
+./babelfish_extensions/dev-tools.sh initbbf      # Initialize Babelfish (creates jdbc_user / babelfish_db)
 ```
 
 ### Verify setup
@@ -60,20 +68,20 @@ Both repos must be on matching branches. List branches from GitHub to find the l
 Verify both PostgreSQL and TDS endpoints:
 ```bash
 # PostgreSQL endpoint
-./postgres/bin/psql -U babelfish_user -d babelfish_db -c "SELECT 1"
+psql -U jdbc_user -d babelfish_db -c "SELECT 1"
 
 # TDS endpoint (sqlcmd or Python)
-sqlcmd -S localhost -U babelfish_user -P 12345678 -Q "SELECT 1"
+sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT 1"
 # or
-python3 -c "import pymssql; c = pymssql.connect('localhost','babelfish_user','12345678','master'); c.cursor().execute('SELECT 1'); print('OK')"
+python3 -c "import pymssql; c = pymssql.connect('localhost','jdbc_user','12345678','master'); c.cursor().execute('SELECT 1'); print('OK')"
 ```
 
 ### Daily development
 ```bash
 ./babelfish_extensions/dev-tools.sh buildbbf      # Build extensions + restart DB
 ./babelfish_extensions/dev-tools.sh buildall      # Build PG + extensions + restart DB
-./babelfish_extensions/dev-tools.sh run_pgindent "" path/to/file.c # Format a single file (required before PR)
-./babelfish_extensions/dev-tools.sh run_pgindent                   # Format all extensions
+./babelfish_extensions/dev-tools.sh run_pgindent "" path/to/file.c  # Format a single file
+./babelfish_extensions/dev-tools.sh run_pgindent                    # Format all extensions
 ```
 
 ### Running tests

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -70,6 +70,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 cd $SCRIPT_DIR
 cd ..
 CUR_WS=$PWD
+export PATH=$CUR_WS/postgres/bin:$PATH
 echo "Current Workspace: $CUR_WS"
 
 TARGET_WS=$2


### PR DESCRIPTION
### Description

Currently, first-time Babelfish setup requires manually following contrib/README.md to install dependencies, cmake, and ANTLR4 runtime. This is error-prone and differs between Ubuntu and Amazon Linux.

With this change:
- `.github/scripts/install-deps.sh` automates first-time dependency setup (OS packages, cmake, ANTLR4 C++ runtime) on Ubuntu and Amazon Linux
- `AGENTS.md` updated with correct build order (initpg → initdb → buildbbf → initbbf), correct user/db names (jdbc_user/babelfish_db), and install-deps.sh reference
- `dev-tools.sh` adds postgres/bin to PATH for initbbf compatibility

Validated with Docker on both Ubuntu 22.04 and Amazon Linux 2.

### Issues Resolved

BABEL-6428

### Test Scenarios Covered

* **Tooling impact -** Docker build tested on Ubuntu 22.04 and Amazon Linux 2: install-deps.sh + initpg + initdb + buildbbf + initbbf + SELECT 1 verification.

### Check List
- [x] Commits are signed per the DCO using --signoff