### PR TITLE
Fix Invalid Read in IsTopTransactionName

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9924,6 +9924,12 @@ void
 pltsql_xact_cb(XactEvent event, void *arg)
 {
 	/*
+	 * Reset top transaction name to avoid dangling pointer after
+	 * transaction memory context is destroyed.
+	 */
+	ResetTopTransactionName();
+
+	/*
 	 * If we are doing a clean transaction shutdown, free the EState (so that
 	 * any remaining resources will be released correctly). In an abort, we
 	 * expect the regular abort recovery procedures to release everything of

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9915,7 +9915,7 @@ txn_clean_estate(bool commit)
 }
 
 /*
- * pltsql_xact_cb --- post-transaction-commit-or-abort cleanup
+ * pltsql_xact_cb --- transaction event callback for cleanup
  *
  * If a simple-expression EState was created in the current transaction,
  * it has to be cleaned up.
@@ -9927,7 +9927,10 @@ pltsql_xact_cb(XactEvent event, void *arg)
 	 * Reset top transaction name to avoid dangling pointer after
 	 * transaction memory context is destroyed.
 	 */
-	ResetTopTransactionName();
+	if (event == XACT_EVENT_COMMIT || event == XACT_EVENT_ABORT)
+	{
+		ResetTopTransactionName();
+	}
 
 	/*
 	 * If we are doing a clean transaction shutdown, free the EState (so that


### PR DESCRIPTION
### Description

SetTopTransactionName() stores the transaction name in TopTransactionContext memory. When the transaction ends, this memory is freed but the name pointer is not put NULL, leaving a dangling pointer. A subsequent call to IsTopTransactionName() then reads freed memory via strcmp().

So we introduce ResetTopTransactionName() which NULLs out TopTransactionStateData.name. This is called from pltsql_xact_cb to ensure the pointer is reset on every transaction end.

Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/739
 
### Issues Resolved

Task: BABEL-5245

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).