### PR TITLE
[OSS-Only] Use stable PG 16 dump utilities in TAP Test (#4685)

### DIFF
--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -8,6 +8,8 @@ jobs:
       NEW_INSTALL_DIR: psql_target
       ENGINE_BRANCH_OLD: BABEL_2_6_STABLE__PG_14_9
       EXTENSION_BRANCH_OLD: BABEL_2_6_STABLE
+      INSTALL_DIR_16: psql16
+      ENGINE_BRANCH_16: BABEL_4_6_STABLE__PG_16_9
 
     runs-on: ubuntu-22.04
     steps:
@@ -36,9 +38,17 @@ jobs:
           sudo -E apt-get install krb5-admin-server krb5-kdc krb5-user libkrb5-dev -y -qq
         shell: bash
 
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_16}}
+        id: build-modified-postgres-16
+        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_BRANCH_16}}
+          install_dir: ${{env.INSTALL_DIR_16}}
+
       - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_OLD}}
         id: build-modified-postgres-old
-        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        if: always() && steps.build-modified-postgres-16.outcome == 'success'
         uses: ./.github/composite-actions/build-modified-postgres
         with:
           engine_branch: ${{env.ENGINE_BRANCH_OLD}}
@@ -150,6 +160,7 @@ jobs:
           export PG_CONFIG=~/${{env.NEW_INSTALL_DIR}}/bin/pg_config
           export PATH=/opt/mssql-tools/bin:$PATH
           export oldinstall=$HOME/${{env.OLD_INSTALL_DIR}}
+          export installdir16=$HOME/${{env.INSTALL_DIR_16}}
 
           cd contrib/babelfishpg_tds
           make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/002_tdskerberos.pl t/003_bbfextnotloaded.pl t/004_bbfdumprestore.pl"


### PR DESCRIPTION
### Description

Updated dump/restore tap-tests to use v16 dump utility to dump older versions.

Task: No-Jira
Signed-off-by: Rucha Kulkarni <ruchask@amazon.com>


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).