### PR TITLE
Remove duplicate installations from CI

### DIFF
--- a/.github/composite-actions/install-and-run-dotnet/action.yml
+++ b/.github/composite-actions/install-and-run-dotnet/action.yml
@@ -7,8 +7,6 @@ runs:
   - name: Install MSSQL Tools
     id: install-mssql-tools
     run: |
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-        curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
         sudo apt-get update
         sudo apt-get install mssql-tools18 unixodbc-dev
         echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
@@ -20,9 +18,8 @@ runs:
     if: always() && steps.install-mssql-tools.outcome == 'success'
     run: | 
       cd ~
-      wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-      sudo dpkg -i packages-microsoft-prod.deb
-      rm packages-microsoft-prod.deb
+      sudo apt-get clean
+      sudo apt-get update
       sudo apt-get install -y apt-transport-https
       sudo apt-get install -y dotnet-sdk-8.0
       sudo apt-get install -y apt-transport-https

--- a/.github/composite-actions/install-and-run-python/action.yml
+++ b/.github/composite-actions/install-and-run-python/action.yml
@@ -14,8 +14,6 @@ runs:
       id: configure-python-environment
       if: always() && steps.install-python.outcome == 'success'
       run: |
-        cd ~
-        curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
         cd ~/work/babelfish_extensions/babelfish_extensions/test/python
         mkdir sqltoolsservice
         cd sqltoolsservice

--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -5,8 +5,16 @@ runs:
     - name: Install Dependencies
       run: |
         sudo apt clean && sudo apt-get update --fix-missing -y
-        curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+        # Clean up any existing Microsoft repository configurations to avoid conflicts
+        sudo rm -f /etc/apt/sources.list.d/msprod.list
+        sudo rm -f /etc/apt/sources.list.d/packages-microsoft-com-prod.list
+        sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
+        sudo rm -f /usr/share/keyrings/microsoft-prod.gpg
+        
+        # Download and install Microsoft's GPG key properly
+        wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+        # Add Microsoft repository with proper GPG key configuration
+        echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" | sudo tee /etc/apt/sources.list.d/msprod.list
         sudo apt-get update --fix-missing -y
         sudo apt-get install gcc-9 uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python3-dev libossp-uuid-dev libpq-dev pkg-config g++ build-essential bison mssql-tools unixodbc-dev libsybdb5 freetds-dev freetds-common gdal-bin libgdal-dev libgeos-dev gdb libkrb5-dev
         sudo apt install -y ccache

--- a/.github/workflows/isolation-tests.yml
+++ b/.github/workflows/isolation-tests.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Configure Python environment
         run: |
           cd ~
-          curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           cd ~/work/babelfish_extensions/babelfish_extensions/test/python
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 python3-dev
           pip3 install pyodbc pymssql pytest pytest-xdist antlr4-python3-runtime==4.9.3

--- a/.github/workflows/tap-tests.yml
+++ b/.github/workflows/tap-tests.yml
@@ -8,6 +8,8 @@ jobs:
       NEW_INSTALL_DIR: psql_target
       ENGINE_BRANCH_OLD: BABEL_2_6_STABLE__PG_14_9
       EXTENSION_BRANCH_OLD: BABEL_2_6_STABLE
+      INSTALL_DIR_15: psql15
+      ENGINE_BRANCH_15: BABEL_3_9_STABLE__PG_15_12
 
     runs-on: ubuntu-22.04
     steps:
@@ -36,9 +38,17 @@ jobs:
           sudo -E apt-get install krb5-admin-server krb5-kdc krb5-user libkrb5-dev -y -qq
         shell: bash
 
+      - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_15}}
+        id: build-modified-postgres-15
+        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        uses: ./.github/composite-actions/build-modified-postgres
+        with:
+          engine_branch: ${{env.ENGINE_BRANCH_15}}
+          install_dir: ${{env.INSTALL_DIR_15}}
+
       - name: Build Modified Postgres using ${{env.ENGINE_BRANCH_OLD}}
         id: build-modified-postgres-old
-        if: always() && steps.install-kerberos-dependencies.outcome == 'success'
+        if: always() && steps.build-modified-postgres-15.outcome == 'success'
         uses: ./.github/composite-actions/build-modified-postgres
         with:
           engine_branch: ${{env.ENGINE_BRANCH_OLD}}
@@ -133,6 +143,7 @@ jobs:
           export PG_CONFIG=~/${{env.NEW_INSTALL_DIR}}/bin/pg_config
           export PATH=/opt/mssql-tools/bin:$PATH
           export oldinstall=$HOME/${{env.OLD_INSTALL_DIR}}
+          export installdir15=$HOME/${{env.INSTALL_DIR_15}}
 
           cd contrib/babelfishpg_tds
           make installcheck PROVE_TESTS="t/001_tdspasswd.pl t/002_tdskerberos.pl t/003_bbfextnotloaded.pl t/004_bbfdumprestore.pl"

--- a/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
+++ b/contrib/babelfishpg_tds/test/t/004_bbfdumprestore.pl
@@ -65,20 +65,29 @@ my $tsql_newnode = new TDSNode($newnode);
 $tsql_newnode->init_tsql('test_master', 'testdb');
 $newnode->stop;
 
+# Setup pg16 node
+my $node15 =
+  PostgreSQL::Test::Cluster->new('node_15',
+	install_path => $ENV{installdir15});
+
+my $newbindir = $newnode->config_data('--bindir');
+my $oldbindir = $oldnode->config_data('--bindir');
+my $bindir15 = $node15->config_data('--bindir');
+
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 $oldnode->start;
 my @dumpall_command = (
-	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
+	$bindir15 . '/pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $oldnode->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump1_file);
-$newnode->command_ok(\@dumpall_command, 'Dump global objects.');
+$node15->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 my @dump_command = (
-	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
+	$bindir15 . '/pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $oldnode->port, '--verbose', '--dbname', 'testdb',
 	'--file', $dump2_file);
-$newnode->command_ok(\@dump_command, 'Dump Babelfish database.');
+$node15->command_ok(\@dump_command, 'Dump Babelfish database.');
 $oldnode->stop;
 
 # Retore the dumped files on the new server.
@@ -88,7 +97,7 @@ $newnode->start;
 # dump/restore is not yet supported.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -101,7 +110,7 @@ $newnode->command_fails_like(
 # Similarly, restore of dump file should also cause a failure.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -117,7 +126,7 @@ $oldnode->start;
 
 $oldnode->command_fails_like(
 	[
-		'psql',
+		$oldbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $oldnode->port,
@@ -129,7 +138,7 @@ $oldnode->command_fails_like(
 
 $oldnode->command_fails_like(
 	[
-		'psql',
+		$oldbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $oldnode->port,
@@ -162,14 +171,14 @@ $tsql_newnode2->init_tsql('test_master', 'testdb', 'multi-db');
 # Dump global objects using pg_dumpall. Note that we
 # need to use dump utilities from the new node here.
 @dumpall_command = (
-	'pg_dumpall', '--database', 'testdb', '--username', 'test_master',
+	$newbindir . '/pg_dumpall', '--database', 'testdb', '--username', 'test_master',
 	'--port', $newnode2->port, '--roles-only', '--quote-all-identifiers',
 	'--verbose', '--no-role-passwords', '--file', $dump3_file);
 $newnode2->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump. Let's dump with the custom format
 # this time so that we cover pg_restore as well.
 @dump_command = (
-	'pg_dump', '--username', 'test_master', '--quote-all-identifiers',
+	$newbindir . '/pg_dump', '--username', 'test_master', '--quote-all-identifiers',
 	'--port', $newnode2->port, '--verbose', '--dbname', 'testdb',
 	'--format', 'custom', '--file', $dump4_file);
 $newnode2->command_ok(\@dump_command, 'Dump Babelfish database.');
@@ -182,7 +191,7 @@ $newnode->start;
 # dump/restore is not yet supported.
 $newnode->command_fails_like(
 	[
-		'psql',
+		$newbindir . '/psql',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -195,7 +204,7 @@ $newnode->command_fails_like(
 # Similarly, restore of dump file should also cause a failure.
 $newnode->command_fails_like(
 	[
-		'pg_restore',
+		$newbindir . '/pg_restore',
 		'-d',         'testdb',
 		'-U',         'test_master',
 		'-p',         $newnode->port,
@@ -213,13 +222,13 @@ $newnode->start;
 
 # Dump global objects using pg_dumpall.
 @dumpall_command = (
-	'pg_dumpall', '--database', 'postgres', '--port', $newnode->port,
+	$newbindir . '/pg_dumpall', '--database', 'postgres', '--port', $newnode->port,
 	'--roles-only', '--quote-all-identifiers', '--verbose',
 	'--no-role-passwords', '--file', $dump1_file);
 $newnode->command_ok(\@dumpall_command, 'Dump global objects.');
 # Dump Babelfish database using pg_dump.
 @dump_command = (
-	'pg_dump', '--quote-all-identifiers', '--port', $newnode->port,
+	$newbindir . '/pg_dump', '--quote-all-identifiers', '--port', $newnode->port,
 	'--verbose', '--dbname', 'postgres',
 	'--file', $dump2_file);
 $newnode->command_ok(\@dump_command, 'Dump non-Babelfish (postgres db) database.');


### PR DESCRIPTION
### Description

There are duplicate installations in CI which causes problem.

Signed-off-by: Bilal Kahraman <kahramannbilal@gmail.com>
(cherry picked from commit https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/5d1f0f1954aedd30dbe7889357dd81521fa6eed8)

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).