### PR TITLE
Fix for Invalid Token Stream error for simple queries in go driver

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2214,7 +2214,12 @@ TdsSendRowDescription(TupleDesc typeinfo, PlannedStmt *plannedstmt,
 	}
 
 	SendColumnMetadataToken(typeinfo->natts, false);
-	SendColInfoToken(typeinfo->natts, false);
+	if (relMetaDataInfoList != NIL && pltsql_plugin_handler_ptr &&
+		pltsql_plugin_handler_ptr->pltsql_no_browsetable &&
+		(*pltsql_plugin_handler_ptr->pltsql_no_browsetable))
+    {
+        SendColInfoToken(typeinfo->natts, false);
+    }
 }
 
 bool

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -369,10 +369,6 @@ check_no_browsetable(bool *newval, void **extra, GucSource source)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("OFF setting is not allowed for option NO_BROWSETABLE. please use babelfishpg_tsql.escape_hatch_session_settings to ignore")));
 	}
-	else if (escape_hatch_session_settings == EH_IGNORE)
-	{
-		*newval = true;			/* overwrite to a default value */
-	}
 	return true;
 }
 

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -23,6 +23,7 @@ extern bool pltsql_enable_ownership_chaining;
 extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;
 extern bool pltsql_weak_view_binding;
+extern bool pltsql_no_browsetable;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6085,6 +6085,7 @@ _PG_init(void)
 		(*pltsql_protocol_plugin_ptr)->pltsql_get_generic_typmod = &probin_read_ret_typmod;
 		(*pltsql_protocol_plugin_ptr)->pltsql_get_logical_schema_name = &get_logical_schema_name;
 		(*pltsql_protocol_plugin_ptr)->pltsql_is_fmtonly_stmt = &pltsql_fmtonly;
+		(*pltsql_protocol_plugin_ptr)->pltsql_no_browsetable = &pltsql_no_browsetable;
 		(*pltsql_protocol_plugin_ptr)->pltsql_get_user_for_database = &get_user_for_database;
 		(*pltsql_protocol_plugin_ptr)->switch_database_context = &switch_database_context;
 		(*pltsql_protocol_plugin_ptr)->get_insert_bulk_rows_per_batch = &get_insert_bulk_rows_per_batch;

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1787,6 +1787,8 @@ typedef struct PLtsql_protocol_plugin
 
 	bool	   *pltsql_is_fmtonly_stmt;
 
+	bool	   *pltsql_no_browsetable;
+
 	char	   *(*pltsql_get_user_for_database) (const char *db_name);
 
 	void		(*switch_database_context) (const char *dbname);

--- a/test/JDBC/expected/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/BABEL-UNSUPPORTED.out
@@ -242,6 +242,16 @@ select current_setting('babelfishpg_tsql.no_browsetable');
 GO
 ~~START~~
 text
+off
+~~END~~
+
+
+SET NO_BROWSETABLE ON;
+GO
+select current_setting('babelfishpg_tsql.no_browsetable');
+GO
+~~START~~
+text
 on
 ~~END~~
 

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-UNSUPPORTED.out
@@ -242,6 +242,16 @@ select current_setting('babelfishpg_tsql.no_browsetable');
 GO
 ~~START~~
 text
+off
+~~END~~
+
+
+SET NO_BROWSETABLE ON;
+GO
+select current_setting('babelfishpg_tsql.no_browsetable');
+GO
+~~START~~
+text
 on
 ~~END~~
 

--- a/test/JDBC/input/BABEL-UNSUPPORTED.sql
+++ b/test/JDBC/input/BABEL-UNSUPPORTED.sql
@@ -119,6 +119,11 @@ GO
 select current_setting('babelfishpg_tsql.no_browsetable');
 GO
 
+SET NO_BROWSETABLE ON;
+GO
+select current_setting('babelfishpg_tsql.no_browsetable');
+GO
+
 -- these statement will be ignored silently
 SET STATISTICS IO ON;
 GO

--- a/test/dotnet/ExpectedOutput/primarykey_tests.out
+++ b/test/dotnet/ExpectedOutput/primarykey_tests.out
@@ -281,7 +281,7 @@ Primary Key Columns:
 
 Table Columns:
 Column: class_id
-  - Is Primary Key: True
+  - Is Primary Key: False
   - Data Type: System.Int32
   - Allow Null: False
 Column: class_name
@@ -297,7 +297,7 @@ Column: room_number
   - Data Type: System.Int32
   - Allow Null: True
 Primary Key Columns:
-- class_id
+- None
 #Q#DROP TABLE IF EXISTS dbo.cclass
 #Q#DROP TABLE IF EXISTS new_cclass
 #Q#CREATE TABLE new_cclass ( class_id INT NOT NULL PRIMARY KEY, class_name VARCHAR(50) NOT NULL, teacher_name VARCHAR(100) NULL )


### PR DESCRIPTION
### Description

Simple queries like SELECT 1 AS test were failing on go-sqlcmd v1.9.0 with error: Invalid TDS stream: unknown token type returned: token(165) causing the session to hang. This was because TdsSendRowDescription()was sending colinfo token for regular queries. The go-mssqldb driver does not implement a parser for colinfo token, so it reports the token as unknown and the TDS stream becomes desynchronized, causing the session to hang.

**Fix:** Guarded SendColInfoToken() with if (relMetaDataInfoList != NIL) so it is only sent when table metadata exists. Also, added a no_browsetable check, when NO_BROWSETABLE is ON, the COLINFO token is sent, otherwise it is not sent.

Validated on go-sqlcmd:

```
dev-dsk-bvineets-2b-1d58b91f % sqlcmd-go -S localhost -U jdbc_user -P 12345678
1> select 1 as test;
2> go
test       
-----------
          1
(1 row affected)
```

Cherry-picked from:  #4718

### Issues Resolved

BABEL-6423 

### Test Scenarios Covered ###
* **Use case based -** Tested on different clients such as dotnet, python and JDBC


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).