### PR TITLE
Fix allocation of savepoint_name in correct memory context in pltsql_eval_txn_data

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -9837,7 +9837,7 @@ pltsql_eval_txn_data(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt, Cached
 		if (txn_name != NULL)
 		{
 			pfree(txnStmt->savepoint_name);
-			txnStmt->savepoint_name = pstrdup(txn_name);
+			txnStmt->savepoint_name = MemoryContextStrdup(cachedPlanSource->query_context, txn_name);
 		}
 	}
 


### PR DESCRIPTION
### Description

pltsql_eval_txn_data uses pstrdup to update savepoint_name, which allocates memory in Current Memory Context (SPI Proc). Since txnStmt lives in CachedPlanQuery context, the savepoint_name becomes a dangling pointer when SPI Proc is destroyed after statement execution. When the cached plan is reused, RollbackToSavepoint reads freed memory via strcmp, which can lead to crashes or incorrect behavior.

Hence we use MemoryContextStrdup with cachedPlanSource->query_context to ensure savepoint_name is allocated in the same context as the plan node.

### Issues Resolved

Task: BABEL-6440
Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4731

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).