### PR TITLE
Fix missing xmlns:xsi namespace on elements when using FOR XML RAW('') with ELEMENTS XSINIL

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -282,17 +282,26 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 			if (!isnull)
 			{
 				allnull = false;
-				/* Normal element: <col>value</col> */
-				appendStringInfo(state, "<%s>%s</%s>",
-								 colname,
-								 map_sql_value_to_xml_value(colval, datatype_oid, true),
-								 colname);
+				/* When RAW('') is used with XSINIL, add xmlns to each element */
+				if ((element_name && strlen(element_name) == 0) && xsinil)
+					appendStringInfo(state, "<%s " XML_XMLNS_XSI ">%s</%s>",
+									 colname,
+									 map_sql_value_to_xml_value(colval, datatype_oid, true),
+									 colname);
+				else
+					appendStringInfo(state, "<%s>%s</%s>",
+									 colname,
+									 map_sql_value_to_xml_value(colval, datatype_oid, true),
+									 colname);
 			}
 			else if (xsinil)
 			{
 				allnull = false;
-				/* XSINIL: <col xsi:nil="true"/> */
-				appendStringInfo(state, "<%s " XML_XSI_NIL "/>", colname);
+				/* When RAW('') is used with XSINIL, add xmlns to each element */
+				if (element_name && strlen(element_name) == 0)
+					appendStringInfo(state, "<%s " XML_XMLNS_XSI " " XML_XSI_NIL "/>", colname);
+				else
+					appendStringInfo(state, "<%s " XML_XSI_NIL "/>", colname);
 			}
 			/* else: ABSENT - skip NULL columns (do nothing) */
 		}

--- a/test/JDBC/expected/forxml-raw-elements-vu-verify.out
+++ b/test/JDBC/expected/forxml-raw-elements-vu-verify.out
@@ -1932,3 +1932,54 @@ ntext
 <row><emp_name>Alice</emp_name><salary>70000</salary><avg_salary>70000</avg_salary></row><row><emp_name>Bob</emp_name><salary>55000</salary><avg_salary>52500</avg_salary></row><row><emp_name>Diana</emp_name><avg_salary>52500</avg_salary></row><row><emp_name>Jane</emp_name><salary>60000</salary><avg_salary>60000</avg_salary></row><row><emp_name>John</emp_name><salary>50000</salary><avg_salary>52500</avg_salary></row>
 ~~END~~
 
+
+GO
+
+
+-- ============================================
+-- SECTION: RAW('') with ELEMENTS XSINIL - xmlns:xsi namespace on each element
+-- ============================================
+-- RAW('') with ELEMENTS XSINIL - namespace should appear on each element
+SELECT * FROM forxml_raw_elements_t1 WHERE id = 3 FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<id xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">3</id><name xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Bob</name><salary xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/><department xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Finance</department>
+~~END~~
+
+
+-- RAW('') with ELEMENTS XSINIL - UNION ALL with NULLs
+SELECT 1 AS a, NULL AS b UNION ALL SELECT NULL AS a, 2 AS b FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">1</a><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/><a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2</b>
+~~END~~
+
+
+-- RAW('') with ELEMENTS XSINIL and ROOT
+SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL, ROOT('data');
+GO
+~~START~~
+ntext
+<data><a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">1</a><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/></data>
+~~END~~
+
+
+-- RAW('') with ELEMENTS XSINIL - all NULLs
+SELECT NULL AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+~~END~~
+
+
+-- RAW('') with ELEMENTS XSINIL - no NULLs (namespace still on each element)
+SELECT 1 AS a, 2 AS b FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">1</a><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2</b>
+~~END~~
+

--- a/test/JDBC/input/forxml/forxml-raw-elements-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-raw-elements-vu-verify.sql
@@ -916,3 +916,29 @@ INNER JOIN (
 ORDER BY e.emp_name
 FOR XML RAW, ELEMENTS;
 GO
+
+GO
+
+-- ============================================
+-- SECTION: RAW('') with ELEMENTS XSINIL - xmlns:xsi namespace on each element
+-- ============================================
+
+-- RAW('') with ELEMENTS XSINIL - namespace should appear on each element
+SELECT * FROM forxml_raw_elements_t1 WHERE id = 3 FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+
+-- RAW('') with ELEMENTS XSINIL - UNION ALL with NULLs
+SELECT 1 AS a, NULL AS b UNION ALL SELECT NULL AS a, 2 AS b FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+
+-- RAW('') with ELEMENTS XSINIL and ROOT
+SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL, ROOT('data');
+GO
+
+-- RAW('') with ELEMENTS XSINIL - all NULLs
+SELECT NULL AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL;
+GO
+
+-- RAW('') with ELEMENTS XSINIL - no NULLs (namespace still on each element)
+SELECT 1 AS a, 2 AS b FOR XML RAW(''), ELEMENTS XSINIL;
+GO


### PR DESCRIPTION
### Description

Currently, when using FOR XML RAW('') , ELEMENTS XSINIL (empty element name), Babelfish omits the xmlns:xsi namespace declaration from the output elements. T-SQL places `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" `on every element when there is no row wrapper element, since there is no parent element to inherit the namespace from.

For example, `SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL` produces:

Babelfish (before): `<a>1</a><b xsi:nil="true"/>`

T-SQL:  `<a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">1</a>
<b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>`

With this change, Babelfish now adds the xmlns:xsi namespace declaration to each element when RAW('') is used with ELEMENTS XSINIL, matching T-SQL behavior. This applies to both non-null elements and nil elements. 

Authored-by: Japleen Kaur <amjj@amazon.com>
Signed-off-by: Japleen Kaur <amjj@amazon.com>

Cherry-picked from PR [4750](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4750)

### Issues Resolved

BABEL-6445
Related Issue : BABEL-6379 (Resolved)

### Test Scenarios Covered ###
* **Use case based -** RAW('') with ELEMENTS XSINIL using table data with NULL columns, UNION ALL with NULLs in different positions, RAW('') with ELEMENTS XSINIL and ROOT, all NULLs, no NULLs


* **Boundary conditions -** All columns NULL, no columns NULL, single row, multiple rows via UNION ALL


* **Arbitrary inputs -** Various column types (INT, VARCHAR)


* **Negative test cases -** N/A


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** N/A


* **Client tests -** N/A



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).