### PR TITLE
Materializing CTEs in sql_modules views

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -2032,6 +2032,7 @@ WHERE ao.type = 'TR';
 GRANT SELECT ON sys.all_sql_modules_internal TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.all_sql_modules AS
+WITH all_sql_modules_cte AS MATERIALIZED (
 SELECT
      CAST(t1.object_id as int)
     ,CAST(t1.definition as sys.nvarchar)
@@ -2043,10 +2044,13 @@ SELECT
     ,CAST(t1.null_on_null_input as sys.bit)
     ,CAST(t1.execute_as_principal_id as int)
     ,CAST(t1.uses_native_compilation as sys.bit)
-FROM sys.all_sql_modules_internal t1;
+FROM sys.all_sql_modules_internal t1
+)
+SELECT * FROM all_sql_modules_cte;
 GRANT SELECT ON sys.all_sql_modules TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.system_sql_modules AS
+WITH system_sql_modules_cte AS MATERIALIZED ( 
 SELECT
      CAST(t1.object_id as int)
     ,CAST(t1.definition as sys.nvarchar)
@@ -2059,10 +2063,13 @@ SELECT
     ,CAST(t1.execute_as_principal_id as int)
     ,CAST(t1.uses_native_compilation as sys.bit)
 FROM sys.all_sql_modules_internal t1
-WHERE t1.is_ms_shipped = 1;
+WHERE t1.is_ms_shipped = 1
+)
+SELECT * FROM system_sql_modules_cte;
 GRANT SELECT ON sys.system_sql_modules TO PUBLIC;
 
 CREATE OR REPLACE VIEW sys.sql_modules AS
+WITH sql_modules_cte AS MATERIALIZED (
 SELECT
      CAST(t1.object_id as int)
     ,CAST(t1.definition as sys.nvarchar)
@@ -2075,7 +2082,9 @@ SELECT
     ,CAST(t1.execute_as_principal_id as int)
     ,CAST(t1.uses_native_compilation as sys.bit)
 FROM sys.all_sql_modules_internal t1
-WHERE t1.is_ms_shipped = 0;
+WHERE t1.is_ms_shipped = 0
+)
+SELECT * FROM sql_modules_cte;
 GRANT SELECT ON sys.sql_modules TO PUBLIC;
 
 CREATE VIEW sys.syscharsets

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.9.0--4.10.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--4.9.0--4.10.0.sql
@@ -604,6 +604,62 @@ left join sys.shipped_objects_not_in_sys nis on nis.name = ('TT_' || tt.name || 
 ) ot;
 GRANT SELECT ON sys.all_objects TO PUBLIC;
 
+CREATE OR REPLACE VIEW sys.all_sql_modules AS
+WITH all_sql_modules_cte AS MATERIALIZED (
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar)
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+)
+SELECT * FROM all_sql_modules_cte;
+GRANT SELECT ON sys.all_sql_modules TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.system_sql_modules AS
+WITH system_sql_modules_cte AS MATERIALIZED ( 
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar)
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+WHERE t1.is_ms_shipped = 1
+)
+SELECT * FROM system_sql_modules_cte;
+GRANT SELECT ON sys.system_sql_modules TO PUBLIC;
+
+CREATE OR REPLACE VIEW sys.sql_modules AS
+WITH sql_modules_cte AS MATERIALIZED (
+SELECT
+     CAST(t1.object_id as int)
+    ,CAST(t1.definition as sys.nvarchar)
+    ,CAST(t1.uses_ansi_nulls as sys.bit)
+    ,CAST(t1.uses_quoted_identifier as sys.bit)
+    ,CAST(t1.is_schema_bound as sys.bit)
+    ,CAST(t1.uses_database_collation as sys.bit)
+    ,CAST(t1.is_recompiled as sys.bit)
+    ,CAST(t1.null_on_null_input as sys.bit)
+    ,CAST(t1.execute_as_principal_id as int)
+    ,CAST(t1.uses_native_compilation as sys.bit)
+FROM sys.all_sql_modules_internal t1
+WHERE t1.is_ms_shipped = 0
+)
+SELECT * FROM sql_modules_cte;
+GRANT SELECT ON sys.sql_modules TO PUBLIC;
+
 DROP PROCEDURE sys.babelfish_drop_deprecated_object(varchar, varchar, varchar);
 
 -- After upgrade, always run analyze for all babelfish catalogs.


### PR DESCRIPTION
### Description
Wrapping sys.all_sql_modules, sys.sql_modules, and sys.system_sql_modules with MATERIALIZED CTEs to prevent PostgreSQL from inlining and re-evaluating sys.all_sql_modules_internal per row during joins. This significantly reduces query execution time when these views are joined with other system views in databases with a large number of objects.

Following improvement in performance was observed on 17.9 instance with 5000 Procedures (changes applied incrementally):

 Query tested: SSMS Object Explorer stored procedure enumeration query for non-natively compiled procedures (`uses_native_compilation=0`)

| Stage | Views Modified | Execution Time | Improvement |
|-------|---------------|----------------|-------------|
| Before (no fix) | — | 1244s (20:44) | — |
| Step 1 | sys.all_sql_modules | 21s | ~59x |
| Step 2 | sys.all_sql_modules + sys.sql_modules | 16s | ~78x |
| Step 3 | sys.all_sql_modules + sys.sql_modules + sys.system_sql_modules | 10.6s | ~117x |

### Issues Resolved

Task: BABEL-6447
Cherry-picked from https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4763

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###

- **Use case based** - 

- **Boundary conditions** - 

- **Arbitrary inputs** -

- **Negative test cases** -

- **Minor version upgrade tests** -

- **Major version upgrade tests** -

- **Performance tests** -

- **Tooling impact** -

- **Client tests** -



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).