### PR TITLE
[BABEL] Add GUC enable_new_insert_exec for INSERT...EXEC redesign

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -956,8 +956,8 @@ define_custom_variables(void)
 							 NULL,
 							 &pltsql_enable_new_insert_exec,
 							 false,
-							 PGC_USERSET,
-							 GUC_NOT_IN_SAMPLE,
+							 PGC_SUSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("babelfishpg_tsql.noexec",

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -59,6 +59,7 @@ bool		pltsql_disable_batch_auto_commit = false;
 bool		pltsql_disable_internal_savepoint = false;
 bool		pltsql_disable_txn_in_triggers = false;
 bool		pltsql_recursive_triggers = false;
+bool		pltsql_enable_new_insert_exec = false;
 bool		pltsql_noexec = false;
 bool		pltsql_showplan_all = false;
 bool		pltsql_showplan_text = false;
@@ -948,6 +949,15 @@ define_custom_variables(void)
 							 false,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_new_insert_exec",
+							 gettext_noop("Enables INSERT...EXEC redesign code path"),
+							 NULL,
+							 &pltsql_enable_new_insert_exec,
+							 false,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("babelfishpg_tsql.noexec",

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -24,6 +24,7 @@ extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;
 extern bool pltsql_weak_view_binding;
 extern bool pltsql_no_browsetable;
+extern bool pltsql_enable_new_insert_exec;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;


### PR DESCRIPTION
### Description

**Background: INSERT...EXEC Redesign**

The current INSERT...EXEC implementation has limitations with transaction handling, error recovery, and TRY-CATCH compatibility. We're redesigning it using a **temp table buffering approach**:
1. Procedure output is captured into a temporary buffer table via a custom DestReceiver
2. After procedure execution completes, buffered rows are flushed to the target table
3. This enables proper TRY-CATCH error handling and transaction semantics matching SQL Server

**PR Series Overview:**
| PR | Focus | Description |
|----|-------|-------------|
| **PR0** | **GUC** | **Feature flag to gate the new code path** |
| PR1 | Parser | Parse INSERT...EXEC and extract target table info |
| PR2 | Executor | Core state management and schema detection |
| PR3 | DestReceiver | Capture procedure output to temp table |
| PR4 | Temp Table | Create/drop temp buffer table with correct schema |
| PR5 | Flush | Transfer buffered data to target table |
| PR6 | Integration | Wire everything together with tests |

**PR Chain:** ← None | [PR1 →](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4781)

**This PR:**

Adds a new GUC `babelfishpg_tsql.enable_new_insert_exec` (default: `false`, superuser-only) to gate the redesigned INSERT...EXEC code path.
- **Default off**: Preserves existing behavior for all users
- **Superuser-only**: Prevents unauthorized access to experimental code path
- **Currently unused**: Will be wired up in subsequent PRs

### Issues Resolved
PR0 of Task: [BABEL-5522](https://jira.rds.a2z.com/browse/BABEL-5522)

### Test Scenarios Covered
* **Use case based -** N/A (GUC-only change, no behavioral impact yet)
* **Boundary conditions -** N/A
* **Arbitrary inputs -** N/A
* **Negative test cases -** N/A
* **Minor version upgrade tests -** N/A
* **Major version upgrade tests -** N/A
* **Performance tests -** N/A
* **Tooling impact -** None
* **Client tests -** N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.
