### PR TITLE
[BABEL] Insert Exec Redesign PR1 parser changes

### DIFF
--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -112,7 +112,7 @@ typedef struct PLtsql_stmt_exec
 	char	   *proc_name;
 	char	   *schema_name;
 
-	InsertExecInfo insert_exec;	/* INSERT EXEC info */
+	InsertExecInfo insert_exec;
 		
 	bool		exec_with_recompile; /* forced recompile through EXECUTE */	
 } PLtsql_stmt_exec;

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -111,6 +111,8 @@ typedef struct PLtsql_stmt_exec
 	char	   *db_name;
 	char	   *proc_name;
 	char	   *schema_name;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 		
 	bool		exec_with_recompile; /* forced recompile through EXECUTE */	
 } PLtsql_stmt_exec;
@@ -170,6 +172,8 @@ typedef struct PLtsql_stmt_exec_sp
 	PLtsql_expr *opt2;
 	PLtsql_expr *opt3;
 	List	   *stropt;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 } PLtsql_stmt_exec_sp;
 
 /*
@@ -194,6 +198,8 @@ typedef struct PLtsql_stmt_exec_batch
 	PLtsql_stmt_type cmd_type;
 	int			lineno pg_node_attr(equal_ignore);
 	PLtsql_expr *expr;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 } PLtsql_stmt_exec_batch;
 
 typedef struct PLtsql_stmt_raiserror

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -10,6 +10,18 @@
  */
 
 /*
+ * INSERT EXEC info - shared by PLtsql_stmt_exec, PLtsql_stmt_exec_sp,
+ * and PLtsql_stmt_exec_batch.
+ */
+typedef struct InsertExecInfo
+{
+	char		*target;			/* Target table name (bare name only, no schema/db prefix) */
+	char		*schema;			/* Schema name, or NULL if not specified */
+	char		*db_name;			/* Database name, or NULL if not specified */
+	List		*columns;			/* List of column name strings, or NIL */
+} InsertExecInfo;
+
+/*
  * PRINT statement
  */
 typedef struct PLtsql_stmt_print

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -173,7 +173,7 @@ typedef struct PLtsql_stmt_exec_sp
 	PLtsql_expr *opt3;
 	List	   *stropt;
 
-	InsertExecInfo insert_exec;	/* INSERT EXEC info */
+	InsertExecInfo insert_exec;
 } PLtsql_stmt_exec_sp;
 
 /*
@@ -199,7 +199,7 @@ typedef struct PLtsql_stmt_exec_batch
 	int			lineno pg_node_attr(equal_ignore);
 	PLtsql_expr *expr;
 
-	InsertExecInfo insert_exec;	/* INSERT EXEC info */
+	InsertExecInfo insert_exec;
 } PLtsql_stmt_exec_batch;
 
 typedef struct PLtsql_stmt_raiserror

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -112,7 +112,7 @@ typedef struct PLtsql_stmt_exec
 	char	   *proc_name;
 	char	   *schema_name;
 
-	InsertExecInfo insert_exec;
+	InsertExecInfo *insert_exec;	/* NULL for plain EXEC, non-NULL for INSERT EXEC */
 		
 	bool		exec_with_recompile; /* forced recompile through EXECUTE */	
 } PLtsql_stmt_exec;
@@ -173,7 +173,7 @@ typedef struct PLtsql_stmt_exec_sp
 	PLtsql_expr *opt3;
 	List	   *stropt;
 
-	InsertExecInfo insert_exec;
+	InsertExecInfo *insert_exec;	/* NULL for plain EXEC, non-NULL for INSERT EXEC */
 } PLtsql_stmt_exec_sp;
 
 /*
@@ -199,7 +199,7 @@ typedef struct PLtsql_stmt_exec_batch
 	int			lineno pg_node_attr(equal_ignore);
 	PLtsql_expr *expr;
 
-	InsertExecInfo insert_exec;
+	InsertExecInfo *insert_exec;	/* NULL for plain EXEC, non-NULL for INSERT EXEC */
 } PLtsql_stmt_exec_batch;
 
 typedef struct PLtsql_stmt_raiserror

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1636,41 +1636,35 @@ public:
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
 		ParserRuleContext *container = peekContainer();
 
-		if (old_stmt && container)
+		/*
+    	 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
+    	 * a PLtsql_stmt_execsql fragment before this function is called.
+    	 * Reaching here means a broken parser state.
+    	*/
+    	Assert(old_stmt != NULL && container != NULL);
+
+		List *siblings = getCode(container);
+		ListCell *lc;
+		int pos = 0;
+
+		if (pltsql_enable_antlr_detailed_log)
+			std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
+
+		/* Find the position of the old statement */
+		foreach(lc, siblings)
 		{
-			List *siblings = getCode(container);
-			ListCell *lc;
-			int pos = 0;
-
-			if (pltsql_enable_antlr_detailed_log)
-				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
-
-			/* Find the position of the old statement */
-			foreach(lc, siblings)
-			{
-				if (lfirst(lc) == old_stmt)
-					break;
-				pos++;
-			}
-
-			/* Remove old statement and insert new one at the same position */
-			siblings = list_delete_ptr(siblings, old_stmt);
-			siblings = list_insert_nth(siblings, pos, new_stmt);
-			setCode(container, siblings);
-
-			/* Update the fragment mapping */
-			attachPLtsql_fragment(ctx, new_stmt);
-		}
-		else
-		{
-    		/*
-    		 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
-    		 * a PLtsql_stmt_execsql fragment before this function is called.
-    		* Reaching here means a broken parser state.
-    		*/
-    		Assert(false);
+			if (lfirst(lc) == old_stmt)
+				break;
+			pos++;
 		}
 
+		/* Remove old statement and insert new one at the same position */
+		siblings = list_delete_ptr(siblings, old_stmt);
+		siblings = list_insert_nth(siblings, pos, new_stmt);
+		setCode(container, siblings);
+
+		/* Update the fragment mapping */
+		attachPLtsql_fragment(ctx, new_stmt);
 	}
 
 	//////////////////////////////////////////////////////////////////////////////

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -832,7 +832,6 @@ get_insert_exec_info(TSqlParser::Dml_statementContext *ctx)
 			"INSERT EXEC requires a valid target table",
 			getLineAndPos(ctx->insert_statement()->ddl_object()));
 
-	info->is_insert_exec = true;
 	info->target  = tbl_name;
 	info->schema  = tbl_schema;
 	info->db_name = tbl_db;
@@ -861,18 +860,18 @@ get_insert_exec_info(TSqlParser::Dml_statementContext *ctx)
 }
 
 /*
- * set_insert_exec_info - Apply an InsertExecInfo to the correct statement
- * type based on cmd_type.
+ * set_insert_exec_info - Apply an InsertExecInfo pointer to the correct
+ * statement type based on cmd_type.
  */
 static void
 set_insert_exec_info(PLtsql_stmt *stmt, InsertExecInfo *info)
 {
 	if (stmt->cmd_type == PLTSQL_STMT_EXEC)
-		((PLtsql_stmt_exec *) stmt)->insert_exec = *info;
+		((PLtsql_stmt_exec *) stmt)->insert_exec = info;
 	else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-		((PLtsql_stmt_exec_batch *) stmt)->insert_exec = *info;
+		((PLtsql_stmt_exec_batch *) stmt)->insert_exec = info;
 	else if (stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
-		((PLtsql_stmt_exec_sp *) stmt)->insert_exec = *info;
+		((PLtsql_stmt_exec_sp *) stmt)->insert_exec = info;
 	else
 		Assert(false); /* INSERT EXEC can only target EXEC, EXEC_BATCH, or EXEC_SP */
 }

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -390,6 +390,59 @@ stripQuoteFromId(std::string s)
 	return s;
 }
 
+/*
+ * extract_ddl_object_names - Extract table name, schema, and database
+ * from a ddl_object parse context into output string references.
+ * Returns true if a table name was found, false otherwise.
+ */
+static bool
+extract_ddl_object_names(TSqlParser::Ddl_objectContext *ddl_object,
+                         std::string &table_name,
+                         std::string &schema_name,
+                         std::string &db_name)
+{
+    if (!ddl_object)
+        return false;
+
+    if (ddl_object->local_id())
+    {
+        table_name = ::getFullText(ddl_object->local_id());
+        return !table_name.empty();
+    }
+    else if (ddl_object->full_object_name())
+    {
+        if (ddl_object->full_object_name()->object_name)
+            table_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
+        if (ddl_object->full_object_name()->schema)
+            schema_name = stripQuoteFromId(ddl_object->full_object_name()->schema);
+        if (ddl_object->full_object_name()->database)
+            db_name = stripQuoteFromId(ddl_object->full_object_name()->database);
+        return !table_name.empty();
+    }
+
+    return false;
+}
+
+/*
+ * build_column_name_list - Build a PostgreSQL List of column name strings
+ * from a vector of raw column name strings. Each name is downcased and
+ * truncated to match identifier handling elsewhere.
+ */
+static List *
+build_column_name_list(const std::vector<std::string> &col_names)
+{
+    List *result = NIL;
+
+    for (const auto &col : col_names)
+    {
+        if (!col.empty())
+            result = lappend(result,
+                pstrdup(downcase_truncate_identifier(col.c_str(), col.length(), true)));
+    }
+
+    return result;
+}
+
 static int
 get_curr_compile_body_lineno_adjustment()
 {
@@ -747,6 +800,109 @@ add_rewritten_query_fragment_to_mutator(PLtsql_expr_query_mutator *mutator)
 	Assert(mutator);
 	for (auto &entry : rewritten_query_fragment)
 		mutator->add(entry.first, entry.second.first, entry.second.second);
+}
+
+/*
+ * get_insert_exec_info - Extract all INSERT EXEC target info from the parse
+ * context and return a populated InsertExecInfo struct.
+ */
+static InsertExecInfo *
+get_insert_exec_info(TSqlParser::Dml_statementContext *ctx)
+{
+    InsertExecInfo *info = (InsertExecInfo *) palloc0(sizeof(InsertExecInfo));
+    std::string tbl_name, tbl_schema, tbl_db;
+
+    extract_ddl_object_names(ctx->insert_statement()->ddl_object(),
+                             tbl_name, tbl_schema, tbl_db);
+
+    /*
+     * Temp tables live in pg_temp, not user schemas. Strip any schema/db
+     * the user may have provided (e.g., dbo.#temp).
+     */
+    if (!tbl_name.empty() && tbl_name[0] == '#')
+    {
+        tbl_schema.clear();
+        tbl_db.clear();
+    }
+
+    if (tbl_name.empty())
+        throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+            "INSERT EXEC requires a valid target table",
+            getLineAndPos(ctx->insert_statement()->ddl_object()));
+
+    info->is_insert_exec = true;
+    info->target  = pstrdup(downcase_truncate_identifier(tbl_name.c_str(), tbl_name.length(), true));
+    info->schema  = tbl_schema.empty() ? NULL : pstrdup(downcase_truncate_identifier(tbl_schema.c_str(), tbl_schema.length(), true));
+    info->db_name = tbl_db.empty()     ? NULL : pstrdup(downcase_truncate_identifier(tbl_db.c_str(), tbl_db.length(), true));
+
+    /* Build column list */
+    List *column_list = NIL;
+    auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
+    if (column_list_ctx)
+    {
+        std::vector<std::string> col_names;
+        for (auto col : column_list_ctx->col)
+        {
+            auto ids = col->id();
+            Assert(!ids.empty());
+            if (!ids.empty() && ids.back() != nullptr)
+                col_names.push_back(stripQuoteFromId(ids.back()));
+        }
+        column_list = build_column_name_list(col_names);
+    }
+    info->columns = column_list;
+
+    return info;
+}
+
+/*
+ * set_insert_exec_info - Apply an InsertExecInfo to the correct statement
+ * type based on cmd_type.
+ */
+static void
+set_insert_exec_info(PLtsql_stmt *stmt, InsertExecInfo *info)
+{
+    if (stmt->cmd_type == PLTSQL_STMT_EXEC)
+        ((PLtsql_stmt_exec *) stmt)->insert_exec = *info;
+    else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+        ((PLtsql_stmt_exec_batch *) stmt)->insert_exec = *info;
+    else if (stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
+        ((PLtsql_stmt_exec_sp *) stmt)->insert_exec = *info;
+    else
+        Assert(false); /* INSERT EXEC can only target EXEC, EXEC_BATCH, or EXEC_SP */
+}
+
+/*
+ * apply_exec_expression_rewriting - Apply expression rewriting for EXEC
+ * and EXEC_BATCH statement types. This handles double-quoted identifier
+ * rewriting and other query mutations for the execute statement.
+ *
+ * Note: PLTSQL_STMT_EXEC_SP (sp_executesql, sp_execute, sp_prepexec) does
+ * not need expression rewriting — system SP arguments are explicit typed
+ * parameters, not general SQL expressions containing double-quoted identifiers.
+ */
+static void
+apply_exec_expression_rewriting(PLtsql_stmt *stmt, ParserRuleContext *baseCtx)
+{
+    if (stmt->cmd_type == PLTSQL_STMT_EXEC)
+    {
+        PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) stmt;
+        PLtsql_expr_query_mutator mutator(exec_stmt->expr, baseCtx);
+        add_rewritten_query_fragment_to_mutator(&mutator);
+        mutator.run();
+    }
+    else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+    {
+        PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) stmt;
+        PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, baseCtx);
+        /*
+         * We don't call markSelectFragment here — selectFragmentOffsets was
+         * recorded with ctx->parent as key, not baseCtx. For dynamic SQL in
+         * INSERT EXEC, we rewrite the entire expression string.
+         */
+        add_rewritten_query_fragment_to_mutator(&mutator);
+        mutator.run();
+    }
 }
 
 static void
@@ -1967,6 +2123,44 @@ public:
 		statementMutator = std::make_unique<PLtsql_expr_query_mutator>(stmt->sqlstmt, ctx);
 	}
 
+	/*
+	 * handleInsertExec - Handle the INSERT EXEC new code path.
+	 * Contains the entire INSERT EXEC logic for the new implementation.
+	 */
+	void handleInsertExec(TSqlParser::Dml_statementContext *ctx)
+	{
+		/* INSERT EXEC is not allowed in functions unless target is a table variable */
+		if (is_compiling_create_function())
+		{
+			auto ddl_object = ctx->insert_statement()->ddl_object();
+			if (ddl_object && !ddl_object->local_id())
+				throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
+					"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
+		}
+
+		/* OUTPUT clause is not allowed with INSERT EXEC */
+		if (ctx->insert_statement()->output_clause())
+			throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+				"The OUTPUT clause cannot be used in an INSERT...EXEC statement.",
+				getLineAndPos(ctx->insert_statement()->output_clause()));
+
+		TSqlParser::Execute_statementContext *ctxES =
+			ctx->insert_statement()->insert_statement_value()->execute_statement();
+
+		PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
+
+		/* Extract INSERT EXEC info and apply to statement */
+		InsertExecInfo *info = get_insert_exec_info(ctx);
+		set_insert_exec_info(base_stmt, info);
+
+		/* Apply expression rewriting for EXEC and EXEC_BATCH statement types */
+		apply_exec_expression_rewriting(base_stmt, ctxES);
+
+		replaceGraftedStatement(ctx, base_stmt);
+		statementMutator.reset();
+		clear_rewritten_query_fragment();
+	}
+
 	void exitDml_statement(TSqlParser::Dml_statementContext *ctx) override
 	{
         if (ctx->bulk_insert_statement())
@@ -2003,175 +2197,7 @@ public:
 		 */
 		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{
-			/*
-			 * Check if we're inside a function - INSERT EXEC is not allowed in functions
-			 * unless the target is a table variable (local_id).
-			 */
-			if (is_compiling_create_function())
-			{
-				auto ddl_object = ctx->insert_statement()->ddl_object();
-				if (ddl_object && !ddl_object->local_id())
-				{
-					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
-						"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
-				}
-			}
-
-			/*
-			 * The OUTPUT clause cannot be used in an INSERT...EXEC statement.
-			 * Check for OUTPUT clause and throw error if present.
-			 */
-			if (ctx->insert_statement()->output_clause())
-			{
-				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
-					"The OUTPUT clause cannot be used in an INSERT...EXEC statement.",
-					getLineAndPos(ctx->insert_statement()->output_clause()));
-			}
-
-			/*
-			 * Instead of creating a PLtsql_stmt_execsql for
-			 * "INSERT INTO t EXEC p", we create a PLtsql_stmt_exec for just "EXEC p"
-			 * and set the INSERT EXEC fields. This allows exec_stmt_exec to handle
-			 * the temp table lifecycle and avoids parser-level issues.
-			 *
-			 * Note: makeExecuteStatement returns either PLtsql_stmt_exec (for procedure calls)
-			 * or PLtsql_stmt_exec_batch (for dynamic SQL like EXEC(@variable)). We need to
-			 * handle both cases and set the INSERT EXEC fields on the correct struct.
-			 */
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
-			
-			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
-			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
-
-			/* Extract target table name, schema, and database separately */
-			std::string tbl_name, tbl_schema, tbl_db;
-			auto ddl_object = ctx->insert_statement()->ddl_object();
-			if (ddl_object)
-			{
-				if (ddl_object->local_id())
-				{
-					/* Table variable like @tablevar - no schema or db */
-					tbl_name = ::getFullText(ddl_object->local_id());
-				}
-				else if (ddl_object->full_object_name())
-				{
-					if (ddl_object->full_object_name()->object_name)
-						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
-					if (ddl_object->full_object_name()->schema)
-						tbl_schema = stripQuoteFromId(ddl_object->full_object_name()->schema);
-					if (ddl_object->full_object_name()->database)
-						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
-
-					/*
-					* Temp tables live in pg_temp, not user schemas. Strip any schema
-					* prefix the user may have provided (e.g., dbo.#temp).
-					*/
-					if (!tbl_name.empty() && tbl_name[0] == '#')
-					{
-						tbl_schema.clear();
-						tbl_db.clear();
-					}
-				}
-			}
-
-			/* Extract column list */
-			std::string column_list;
-			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
-			if (column_list_ctx)
-			{
-				bool first = true;
-				for (auto col : column_list_ctx->col)
-				{
-					if (!first)
-						column_list += ", ";
-					first = false;
-					auto ids = col->id();
-					/* A column reference always has at least one identifier token per grammar */
-					Assert(!ids.empty());
-					if (!ids.empty() && ids.back() != nullptr)
-						column_list += stripQuoteFromId(ids.back());
-				}
-			}
-
-			/*
-			 * target_table must be set for INSERT EXEC — if it's empty here,
-			 * the parse tree is malformed (ddl_object missing or has no object name).
-			 */
-			if (tbl_name.empty())
-				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
-					"INSERT EXEC requires a valid target table",
-					getLineAndPos(ctx->insert_statement()->ddl_object()));
-
-			/*
-			 * Helper lambda to set INSERT EXEC fields on the statement.
-			 * This avoids duplicating the same 5-line block for each statement type.
-			 */
-			auto setInsertExecInfo = [&](InsertExecInfo *info) {
-				info->is_insert_exec = true;
-				info->target = pstrdup(tbl_name.c_str());
-				if (!tbl_schema.empty())
-					info->schema = pstrdup(tbl_schema.c_str());
-				if (!tbl_db.empty())
-					info->db_name = pstrdup(tbl_db.c_str());
-				if (!column_list.empty())
-					info->columns = pstrdup(column_list.c_str());
-			};
-
-			auto applyInsertExecInfo = [&](PLtsql_stmt *stmt) {
-				if (stmt->cmd_type == PLTSQL_STMT_EXEC)
-				{
-					PLtsql_stmt_exec *s = (PLtsql_stmt_exec *) stmt;
-					setInsertExecInfo(&s->insert_exec);
-				}
-				else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-				{
-					PLtsql_stmt_exec_batch *s = (PLtsql_stmt_exec_batch *) stmt;
-					setInsertExecInfo(&s->insert_exec);
-				}
-				else if (stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
-				{
-					PLtsql_stmt_exec_sp *s = (PLtsql_stmt_exec_sp *) stmt;
-					setInsertExecInfo(&s->insert_exec);
-				}
-				else
-					Assert(false); /* INSERT EXEC can only target EXEC, EXEC_BATCH, or EXEC_SP */
-			};
-
-			/* Set INSERT EXEC fields based on the actual statement type */
-			applyInsertExecInfo(base_stmt);
-
-			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
-			{
-				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
-				add_rewritten_query_fragment_to_mutator(&mutator);
-				mutator.run();
-			}
-			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-			{
-				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
-				/*
-				* We don't call markSelectFragment here — selectFragmentOffsets was
-				* recorded with ctx->parent as key, not ctxES. For dynamic SQL in
-				* INSERT EXEC, we rewrite the entire expression string.
-				*/
-				add_rewritten_query_fragment_to_mutator(&mutator);
-				mutator.run();
-			}
-
-			/*
-			* Note: PLTSQL_STMT_EXEC_SP (sp_executesql, sp_execute, sp_prepexec) does not
-			* need expression rewriting here — system SP arguments are explicit typed
-			* parameters, not general SQL expressions containing double-quoted identifiers.
-			*/
-
-			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
-			replaceGraftedStatement(ctx, base_stmt);
-
-			/* Clear the mutator since we're not using the execsql statement */
-			statementMutator.reset();
-			clear_rewritten_query_fragment();
+			handleInsertExec(ctx);
 			clear_query_hints();
 			clear_tables_info();
 			return;
@@ -6462,19 +6488,8 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 	stmt->cmd_type = PLTSQL_STMT_INSERT_BULK;
 	if (bulk_ctx->ddl_object())
 	{
-		if (bulk_ctx->ddl_object()->local_id())
-		{
-			table_name = ::getFullText(bulk_ctx->ddl_object()->local_id()).c_str();
-		}
-		else if (bulk_ctx->ddl_object()->full_object_name())
-		{
-			if (bulk_ctx->ddl_object()->full_object_name()->object_name)
-				table_name = stripQuoteFromId(bulk_ctx->ddl_object()->full_object_name()->object_name);
-			if (bulk_ctx->ddl_object()->full_object_name()->schema)
-				schema_name = stripQuoteFromId(bulk_ctx->ddl_object()->full_object_name()->schema);
-			if (bulk_ctx->ddl_object()->full_object_name()->database)
-				db_name = stripQuoteFromId(bulk_ctx->ddl_object()->full_object_name()->database);
-		}
+		extract_ddl_object_names(bulk_ctx->ddl_object(), table_name, schema_name, db_name);
+
 		if (!table_name.empty())
 		{
 			stmt->table_name = pstrdup(downcase_truncate_identifier(table_name.c_str(), table_name.length(), true));
@@ -6491,13 +6506,15 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 		/* create a list of columns to insert into */
 		if (!column_list.empty())
 		{
+			std::vector<std::string> col_names;
 			for (size_t i = 0; i < column_list.size(); i++)
 			{
 				std::string column_refs;
 				column_refs = ::stripQuoteFromId(column_list[i]->simple_column_name()->id());
 				if (!column_refs.empty())
-					stmt->column_refs = lappend(stmt->column_refs , pstrdup(downcase_truncate_identifier(column_refs.c_str(), column_refs.length(), true)));
+					col_names.push_back(column_refs);
 			}
+			stmt->column_refs = build_column_name_list(col_names);
 		}
 
 		if (!option_list.empty())

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1628,37 +1628,6 @@ public:
 	}
 
 	/*
-	 * Apply expression rewriting for INSERT EXEC statements.
-	 * Converts double-quoted strings to single-quoted strings
-	 * (e.g., "master" -> 'master') for PostgreSQL compatibility.
-	 * PLTSQL_STMT_EXEC_SP does not need rewriting — system SP arguments
-	 * are explicit typed parameters, not general SQL expressions.
-	*/
-	void applyInsertExecRewriting(PLtsql_stmt *base_stmt,
-                               TSqlParser::Execute_statementContext *ctxES)
-	{
-    	if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
-    	{
-        	PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-        	PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
-        	add_rewritten_query_fragment_to_mutator(&mutator);
-        	mutator.run();
-    	}
-		else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-		{
-			PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-			PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
-			/*
-			* We don't call markSelectFragment here — selectFragmentOffsets was
-			* recorded with ctx->parent as key, not ctxES. For dynamic SQL in
-			* INSERT EXEC, we rewrite the entire expression string.
-			*/
-			add_rewritten_query_fragment_to_mutator(&mutator);
-			mutator.run();
-		}
-	}
-
-	/*
 	 * Replace a grafted statement with a new one.
 	 * Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
 	 */
@@ -2124,7 +2093,7 @@ public:
 					first = false;
 					auto ids = col->id();
 					/* A column reference always has at least one identifier token per grammar */
-        			Assert(!ids.empty());
+					Assert(!ids.empty());
 					if (!ids.empty() && ids.back() != nullptr)
 						column_list += stripQuoteFromId(ids.back());
 				}
@@ -2154,27 +2123,54 @@ public:
 					info->columns = pstrdup(column_list.c_str());
 			};
 
+			auto applyInsertExecInfo = [&](PLtsql_stmt *stmt) {
+				if (stmt->cmd_type == PLTSQL_STMT_EXEC)
+				{
+					PLtsql_stmt_exec *s = (PLtsql_stmt_exec *) stmt;
+					setInsertExecInfo(&s->insert_exec);
+				}
+				else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+				{
+					PLtsql_stmt_exec_batch *s = (PLtsql_stmt_exec_batch *) stmt;
+					setInsertExecInfo(&s->insert_exec);
+				}
+				else if (stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
+				{
+					PLtsql_stmt_exec_sp *s = (PLtsql_stmt_exec_sp *) stmt;
+					setInsertExecInfo(&s->insert_exec);
+				}
+				else
+					Assert(false); /* INSERT EXEC can only target EXEC, EXEC_BATCH, or EXEC_SP */
+			};
+
 			/* Set INSERT EXEC fields based on the actual statement type */
+			applyInsertExecInfo(base_stmt);
+
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
-				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				setInsertExecInfo(&exec_stmt->insert_exec);
+				PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
+				add_rewritten_query_fragment_to_mutator(&mutator);
+				mutator.run();
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
-				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				setInsertExecInfo(&exec_batch_stmt->insert_exec);
-			}
-			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
-			{
-				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
-				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				setInsertExecInfo(&exec_sp_stmt->insert_exec);
+				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+				/*
+				* We don't call markSelectFragment here — selectFragmentOffsets was
+				* recorded with ctx->parent as key, not ctxES. For dynamic SQL in
+				* INSERT EXEC, we rewrite the entire expression string.
+				*/
+				add_rewritten_query_fragment_to_mutator(&mutator);
+				mutator.run();
 			}
 
-			applyInsertExecRewriting(base_stmt, ctxES);
+			/*
+			* Note: PLTSQL_STMT_EXEC_SP (sp_executesql, sp_execute, sp_prepexec) does not
+			* need expression rewriting here — system SP arguments are explicit typed
+			* parameters, not general SQL expressions containing double-quoted identifiers.
+			*/
 
 			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
 			replaceGraftedStatement(ctx, base_stmt);
@@ -2205,10 +2201,10 @@ public:
 			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
 			body = ctxES->execute_body();
 			Assert(body);
-
-			ctx_name = body->func_proc_name_server_database_schema();
-			if (ctx_name)
-			{
+			
+			ctx_name       = body->func_proc_name_server_database_schema();
+			if (ctx_name) 
+			{				
 				if (ctx_name->database)
 				{
 					db_name = stripQuoteFromId(ctx_name->database);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2210,7 +2210,7 @@ public:
 		 * Note : process_execsql_remove_unsupported_tokens() populates rewritten_query_fragment
 		 * which apply_exec_expression_rewriting() inside handleInsertExec() depends on.
 		 * Moving the check above it would break expression rewriting. 
-		*/
+		 */
 		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{
 			handleInsertExec(ctx);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2102,41 +2102,41 @@ public:
 						column_list += ", ";
 					first = false;
 					auto ids = col->id();
-					if (!ids.empty())
+					if (!ids.empty() && ids.back() != nullptr)
 						column_list += stripQuoteFromId(ids.back());
 				}
 			}
+
+			/*
+			 * Helper lambda to set INSERT EXEC fields on the statement.
+			 * This avoids duplicating the same 5-line block for each statement type.
+			 */
+			auto setInsertExecInfo = [&](InsertExecInfo *info) {
+				info->is_insert_exec = true;
+				if (!target_table.empty())
+					info->target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					info->columns = pstrdup(column_list.c_str());
+			};
 
 			/* Set INSERT EXEC fields based on the actual statement type */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
 				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				exec_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-				exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
 				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				exec_batch_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-				exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_batch_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
 			{
 				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
 				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				exec_sp_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_sp_stmt->insert_exec);
 			}
 
 			/*

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -392,55 +392,55 @@ stripQuoteFromId(std::string s)
 
 /*
  * extract_ddl_object_names - Extract table name, schema, and database
- * from a ddl_object parse context into output string references.
+ * from a ddl_object parse context. Names are downcased and truncated to match
+ * PostgreSQL identifier handling.
+ * Output pointers are set to NULL if the corresponding name is not present.
  * Returns true if a table name was found, false otherwise.
  */
 static bool
 extract_ddl_object_names(TSqlParser::Ddl_objectContext *ddl_object,
-                         std::string &table_name,
-                         std::string &schema_name,
-                         std::string &db_name)
+                         char **table_name,
+                         char **schema_name,
+                         char **db_name)
 {
-    if (!ddl_object)
-        return false;
+	*table_name = NULL;
+	*schema_name = NULL;
+	*db_name = NULL;
 
-    if (ddl_object->local_id())
-    {
-        table_name = ::getFullText(ddl_object->local_id());
-        return !table_name.empty();
-    }
-    else if (ddl_object->full_object_name())
-    {
-        if (ddl_object->full_object_name()->object_name)
-            table_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
-        if (ddl_object->full_object_name()->schema)
-            schema_name = stripQuoteFromId(ddl_object->full_object_name()->schema);
-        if (ddl_object->full_object_name()->database)
-            db_name = stripQuoteFromId(ddl_object->full_object_name()->database);
-        return !table_name.empty();
-    }
+	if (!ddl_object)
+		return false;
 
-    return false;
-}
+	if (ddl_object->local_id())
+	{
+		std::string tbl = ::getFullText(ddl_object->local_id());
+		if (!tbl.empty())
+			*table_name = downcase_truncate_identifier(tbl.c_str(), tbl.length(), true);
+		return (*table_name != NULL);
+	}
+	else if (ddl_object->full_object_name())
+	{
+		if (ddl_object->full_object_name()->object_name)
+		{
+			std::string tbl = stripQuoteFromId(ddl_object->full_object_name()->object_name);
+			if (!tbl.empty())
+				*table_name = downcase_truncate_identifier(tbl.c_str(), tbl.length(), true);
+		}
+		if (ddl_object->full_object_name()->schema)
+		{
+			std::string sch = stripQuoteFromId(ddl_object->full_object_name()->schema);
+			if (!sch.empty())
+				*schema_name = downcase_truncate_identifier(sch.c_str(), sch.length(), true);
+		}
+		if (ddl_object->full_object_name()->database)
+		{
+			std::string db = stripQuoteFromId(ddl_object->full_object_name()->database);
+			if (!db.empty())
+				*db_name = downcase_truncate_identifier(db.c_str(), db.length(), true);
+		}
+		return (*table_name != NULL);
+	}
 
-/*
- * build_column_name_list - Build a PostgreSQL List of column name strings
- * from a vector of raw column name strings. Each name is downcased and
- * truncated to match identifier handling elsewhere.
- */
-static List *
-build_column_name_list(const std::vector<std::string> &col_names)
-{
-    List *result = NIL;
-
-    for (const auto &col : col_names)
-    {
-        if (!col.empty())
-            result = lappend(result,
-                pstrdup(downcase_truncate_identifier(col.c_str(), col.length(), true)));
-    }
-
-    return result;
+	return false;
 }
 
 static int
@@ -809,50 +809,55 @@ add_rewritten_query_fragment_to_mutator(PLtsql_expr_query_mutator *mutator)
 static InsertExecInfo *
 get_insert_exec_info(TSqlParser::Dml_statementContext *ctx)
 {
-    InsertExecInfo *info = (InsertExecInfo *) palloc0(sizeof(InsertExecInfo));
-    std::string tbl_name, tbl_schema, tbl_db;
+	InsertExecInfo *info = (InsertExecInfo *) palloc0(sizeof(InsertExecInfo));
+	char *tbl_name = NULL;
+	char *tbl_schema = NULL;
+	char *tbl_db = NULL;
 
-    extract_ddl_object_names(ctx->insert_statement()->ddl_object(),
-                             tbl_name, tbl_schema, tbl_db);
+	extract_ddl_object_names(ctx->insert_statement()->ddl_object(),
+							 &tbl_name, &tbl_schema, &tbl_db);
 
-    /*
-     * Temp tables live in pg_temp, not user schemas. Strip any schema/db
-     * the user may have provided (e.g., dbo.#temp).
-     */
-    if (!tbl_name.empty() && tbl_name[0] == '#')
-    {
-        tbl_schema.clear();
-        tbl_db.clear();
-    }
+	/*
+	 * Temp tables live in pg_temp, not user schemas. Strip any schema/db
+	 * the user may have provided (e.g., dbo.#temp).
+	 */
+	if (tbl_name && tbl_name[0] == '#')
+	{
+		tbl_schema = NULL;
+		tbl_db = NULL;
+	}
 
-    if (tbl_name.empty())
-        throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
-            "INSERT EXEC requires a valid target table",
-            getLineAndPos(ctx->insert_statement()->ddl_object()));
+	if (!tbl_name)
+		throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+			"INSERT EXEC requires a valid target table",
+			getLineAndPos(ctx->insert_statement()->ddl_object()));
 
-    info->is_insert_exec = true;
-    info->target  = pstrdup(downcase_truncate_identifier(tbl_name.c_str(), tbl_name.length(), true));
-    info->schema  = tbl_schema.empty() ? NULL : pstrdup(downcase_truncate_identifier(tbl_schema.c_str(), tbl_schema.length(), true));
-    info->db_name = tbl_db.empty()     ? NULL : pstrdup(downcase_truncate_identifier(tbl_db.c_str(), tbl_db.length(), true));
+	info->is_insert_exec = true;
+	info->target  = tbl_name;
+	info->schema  = tbl_schema;
+	info->db_name = tbl_db;
 
-    /* Build column list */
-    List *column_list = NIL;
-    auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
-    if (column_list_ctx)
-    {
-        std::vector<std::string> col_names;
-        for (auto col : column_list_ctx->col)
-        {
-            auto ids = col->id();
-            Assert(!ids.empty());
-            if (!ids.empty() && ids.back() != nullptr)
-                col_names.push_back(stripQuoteFromId(ids.back()));
-        }
-        column_list = build_column_name_list(col_names);
-    }
-    info->columns = column_list;
+	/* Build column list */
+	List *column_list = NIL;
+	auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
+	if (column_list_ctx)
+	{
+		for (auto col : column_list_ctx->col)
+		{
+			auto ids = col->id();
+			Assert(!ids.empty());
+			if (!ids.empty() && ids.back() != nullptr)
+			{
+				std::string col_name = stripQuoteFromId(ids.back());
+				if (!col_name.empty())
+					column_list = lappend(column_list,
+						downcase_truncate_identifier(col_name.c_str(), col_name.length(), true));
+			}
+		}
+	}
+	info->columns = column_list;
 
-    return info;
+	return info;
 }
 
 /*
@@ -862,14 +867,14 @@ get_insert_exec_info(TSqlParser::Dml_statementContext *ctx)
 static void
 set_insert_exec_info(PLtsql_stmt *stmt, InsertExecInfo *info)
 {
-    if (stmt->cmd_type == PLTSQL_STMT_EXEC)
-        ((PLtsql_stmt_exec *) stmt)->insert_exec = *info;
-    else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-        ((PLtsql_stmt_exec_batch *) stmt)->insert_exec = *info;
-    else if (stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
-        ((PLtsql_stmt_exec_sp *) stmt)->insert_exec = *info;
-    else
-        Assert(false); /* INSERT EXEC can only target EXEC, EXEC_BATCH, or EXEC_SP */
+	if (stmt->cmd_type == PLTSQL_STMT_EXEC)
+		((PLtsql_stmt_exec *) stmt)->insert_exec = *info;
+	else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+		((PLtsql_stmt_exec_batch *) stmt)->insert_exec = *info;
+	else if (stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
+		((PLtsql_stmt_exec_sp *) stmt)->insert_exec = *info;
+	else
+		Assert(false); /* INSERT EXEC can only target EXEC, EXEC_BATCH, or EXEC_SP */
 }
 
 /*
@@ -884,25 +889,25 @@ set_insert_exec_info(PLtsql_stmt *stmt, InsertExecInfo *info)
 static void
 apply_exec_expression_rewriting(PLtsql_stmt *stmt, ParserRuleContext *baseCtx)
 {
-    if (stmt->cmd_type == PLTSQL_STMT_EXEC)
-    {
-        PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) stmt;
-        PLtsql_expr_query_mutator mutator(exec_stmt->expr, baseCtx);
-        add_rewritten_query_fragment_to_mutator(&mutator);
-        mutator.run();
-    }
-    else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-    {
-        PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) stmt;
-        PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, baseCtx);
-        /*
-         * We don't call markSelectFragment here — selectFragmentOffsets was
-         * recorded with ctx->parent as key, not baseCtx. For dynamic SQL in
-         * INSERT EXEC, we rewrite the entire expression string.
-         */
-        add_rewritten_query_fragment_to_mutator(&mutator);
-        mutator.run();
-    }
+	if (stmt->cmd_type == PLTSQL_STMT_EXEC)
+	{
+		PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) stmt;
+		PLtsql_expr_query_mutator mutator(exec_stmt->expr, baseCtx);
+		add_rewritten_query_fragment_to_mutator(&mutator);
+		mutator.run();
+	}
+	else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+	{
+		PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) stmt;
+		PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, baseCtx);
+		/*
+		 * We don't call markSelectFragment here — selectFragmentOffsets was
+		 * recorded with ctx->parent as key, not baseCtx. For dynamic SQL in
+		 * INSERT EXEC, we rewrite the entire expression string.
+		 */
+		add_rewritten_query_fragment_to_mutator(&mutator);
+		mutator.run();
+	}
 }
 
 static void
@@ -2163,7 +2168,7 @@ public:
 
 	void exitDml_statement(TSqlParser::Dml_statementContext *ctx) override
 	{
-        if (ctx->bulk_insert_statement())
+    	if (ctx->bulk_insert_statement())
         {
             clear_rewritten_query_fragment();
             return;
@@ -6475,9 +6480,9 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 	std::vector<TSqlParser::Insert_bulk_column_definitionContext *> column_list = bulk_ctx->insert_bulk_column_definition();
 	std::vector<TSqlParser::Bulk_insert_optionContext *> option_list = bulk_ctx->bulk_insert_option();
 
-	std::string table_name;
-	std::string schema_name;
-	std::string db_name;
+	char *table_name = NULL;
+	char *schema_name = NULL;
+	char *db_name = NULL;
 	stmt->column_refs = NIL;
 
 	if (!bulk_ctx)
@@ -6488,33 +6493,22 @@ makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx)
 	stmt->cmd_type = PLTSQL_STMT_INSERT_BULK;
 	if (bulk_ctx->ddl_object())
 	{
-		extract_ddl_object_names(bulk_ctx->ddl_object(), table_name, schema_name, db_name);
+		extract_ddl_object_names(bulk_ctx->ddl_object(), &table_name, &schema_name, &db_name);
 
-		if (!table_name.empty())
-		{
-			stmt->table_name = pstrdup(downcase_truncate_identifier(table_name.c_str(), table_name.length(), true));
-		}
-		if (!schema_name.empty())
-		{
-			stmt->schema_name = pstrdup(downcase_truncate_identifier(schema_name.c_str(), schema_name.length(), true));
-		}
-		if (!db_name.empty())
-		{
-			stmt->db_name = pstrdup(downcase_truncate_identifier(db_name.c_str(), db_name.length(), true));
-		}
+		stmt->table_name = table_name;
+		stmt->schema_name = schema_name;
+		stmt->db_name = db_name;
 
 		/* create a list of columns to insert into */
 		if (!column_list.empty())
 		{
-			std::vector<std::string> col_names;
 			for (size_t i = 0; i < column_list.size(); i++)
 			{
 				std::string column_refs;
 				column_refs = ::stripQuoteFromId(column_list[i]->simple_column_name()->id());
 				if (!column_refs.empty())
-					col_names.push_back(column_refs);
+					stmt->column_refs = lappend(stmt->column_refs , downcase_truncate_identifier(column_refs.c_str(), column_refs.length(), true));
 			}
-			stmt->column_refs = build_column_name_list(col_names);
 		}
 
 		if (!option_list.empty())

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -121,6 +121,7 @@ PLtsql_stmt *makeCfl(TSqlParser::Cfl_statementContext *ctx, tsqlBuilder &builder
 PLtsql_stmt *makeSQL(ParserRuleContext *ctx);
 std::vector<PLtsql_stmt *> makeAnother(TSqlParser::Another_statementContext *ctx, tsqlBuilder &builder);
 PLtsql_stmt *makeExecBodyBatch(TSqlParser::Execute_body_batchContext *ctx);
+PLtsql_stmt *makeExecuteStatement(TSqlParser::Execute_statementContext *ctx);
 PLtsql_stmt *makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type);
 PLtsql_stmt *makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx);
 PLtsql_stmt *makeDbccCheckidentStatement(TSqlParser::Dbcc_statementContext *ctx);
@@ -1626,6 +1627,36 @@ public:
 		setCode(container, list_delete_ptr(siblings, stmt));
 	}
 
+	// Replace a grafted statement with a new one
+	// Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	void replaceGraftedStatement(ParserRuleContext *ctx, PLtsql_stmt *new_stmt)
+	{
+		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
+		ParserRuleContext *container = peekContainer();
+
+		if (old_stmt && container)
+		{
+			List *siblings = getCode(container);
+
+			if (pltsql_enable_antlr_detailed_log)
+				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
+
+			// Remove old statement and add new one
+			siblings = list_delete_ptr(siblings, old_stmt);
+			siblings = lappend(siblings, new_stmt);
+			setCode(container, siblings);
+
+			// Update the fragment mapping
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+		else if (new_stmt)
+		{
+			// No old statement, just graft the new one
+			graft(new_stmt, container);
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+	}
+
 	//////////////////////////////////////////////////////////////////////////////
 	// Container statement management
 	//////////////////////////////////////////////////////////////////////////////
@@ -1949,32 +1980,195 @@ public:
 		process_execsql_remove_unsupported_tokens(ctx, statementMutator.get());
 
 		// record whether the stmt is an INSERT-EXEC stmt
-		stmt->insert_exec =
+		bool is_insert_exec =
 			ctx->insert_statement() &&
 			ctx->insert_statement()->insert_statement_value() &&
 			ctx->insert_statement()->insert_statement_value()->execute_statement();
 
-		if (stmt->insert_exec)
+		/*
+		 * New INSERT EXEC code path - gated behind GUC pltsql_enable_new_insert_exec.
+		 * When enabled, we create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
+		 * which allows the executor to handle INSERT EXEC with the new DestReceiver
+		 * and temp table approach. When disabled, fall through to legacy behavior.
+		 */
+		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{
-			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
-			TSqlParser::Execute_bodyContext *body = nullptr;
-
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
-			body = ctxES->execute_body();
-			Assert(body);
-			
-			ctx_name       = body->func_proc_name_server_database_schema();
-			if (ctx_name) 
-			{				
-				if (ctx_name->database)
+			/*
+			 * Check if we're inside a function - INSERT EXEC is not allowed in functions
+			 * unless the target is a table variable (local_id).
+			 */
+			if (is_compiling_create_function())
+			{
+				auto ddl_object = ctx->insert_statement()->ddl_object();
+				if (ddl_object && !ddl_object->local_id())
 				{
-					db_name = stripQuoteFromId(ctx_name->database);
-					is_cross_db = true;
+					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
+							"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}
-				if (ctx_name->schema)
-					schema_name = stripQuoteFromId(ctx_name->schema);
 			}
+
+			/*
+			 * The OUTPUT clause cannot be used in an INSERT...EXEC statement.
+			 * Check for OUTPUT clause and throw error if present.
+			 */
+			if (ctx->insert_statement()->output_clause())
+			{
+				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+					"The OUTPUT clause cannot be used in an INSERT...EXEC statement.",
+					getLineAndPos(ctx->insert_statement()->output_clause()));
+			}
+
+			/*
+			 * For INSERT EXEC, create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql.
+			 * This allows the executor to handle INSERT EXEC specially. makeExecuteStatement
+			 * returns PLtsql_stmt_exec for procedure calls, PLtsql_stmt_exec_batch for
+			 * dynamic SQL (EXEC(@var)), or PLtsql_stmt_exec_sp for system procedures.
+			 */
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+
+			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
+			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
+
+			/* Extract target table name and schema */
+			std::string target_table;
+			std::string target_schema;
+			auto ddl_object = ctx->insert_statement()->ddl_object();
+			if (ddl_object)
+			{
+				if (ddl_object->local_id())
+				{
+					/* Table variable like @tablevar - use as-is, no schema needed */
+					target_table = ::getFullText(ddl_object->local_id());
+					target_schema = "";  /* Table variables don't need schema */
+				}
+				else if (ddl_object->full_object_name())
+				{
+					/* Regular table or temp table - extract name and schema separately */
+					std::string tbl_name, tbl_schema, tbl_db;
+					if (ddl_object->full_object_name()->object_name)
+						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
+					if (ddl_object->full_object_name()->schema)
+						tbl_schema = stripQuoteFromId(ddl_object->full_object_name()->schema);
+					if (ddl_object->full_object_name()->database)
+						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
+
+					/*
+					 * Temp tables (starting with #) use pg_temp schema, so strip
+					 * any user-provided schema prefix like dbo.#temp.
+					 */
+					if (!tbl_name.empty() && tbl_name[0] == '#')
+					{
+						target_table = tbl_name;
+						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
+					}
+					/* Build table reference with explicit schema if provided */
+					else if (!tbl_db.empty())
+					{
+						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
+						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
+					}
+					else if (!tbl_schema.empty())
+					{
+						target_table = tbl_schema + "." + tbl_name;
+						target_schema = tbl_schema;
+					}
+					else
+					{
+						/*
+						 * No schema specified - don't hardcode dbo. Let the search path
+						 * resolve the table, which respects the user's default schema.
+						 */
+						target_table = tbl_name;
+						target_schema = "";
+					}
+				}
+			}
+
+			/* Extract column list */
+			std::string column_list;
+			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
+			if (column_list_ctx)
+			{
+				bool first = true;
+				for (auto col : column_list_ctx->col)
+				{
+					if (!first)
+						column_list += ", ";
+					first = false;
+					auto ids = col->id();
+					if (!ids.empty())
+						column_list += stripQuoteFromId(ids.back());
+				}
+			}
+
+			/* Set INSERT EXEC fields based on the actual statement type */
+			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+			{
+				/* Procedure call: EXEC proc_name */
+				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+				exec_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+			{
+				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
+				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+				exec_batch_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
+			{
+				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
+				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
+				exec_sp_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+			}
+
+			/*
+			 * Apply rewriting to the EXEC statement's expression.
+			 * This is needed to convert double-quoted strings to single-quoted strings
+			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
+			 * Without this, double-quoted strings would be interpreted as column references.
+			 */
+			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+			{
+				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+				PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
+				add_rewritten_query_fragment_to_mutator(&mutator);
+				mutator.run();
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+			{
+				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+				/*
+				 * For dynamic SQL, rewrite the entire expression - no need to limit
+				 * the rewriting range since the expression is the full SQL string.
+				 */
+				add_rewritten_query_fragment_to_mutator(&mutator);
+				mutator.run();
+			}
+
+			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
+			replaceGraftedStatement(ctx, base_stmt);
+
+			/* Clear the mutator since we're not using the execsql statement */
+			statementMutator.reset();
+			clear_rewritten_query_fragment();
+			return;
 		}
+
+		/* Record INSERT EXEC flag for legacy code path (when GUC is off) */
+		stmt->insert_exec = is_insert_exec;
 
 		// record whether stmt is cross-db
 		if (is_cross_db)
@@ -1999,7 +2193,8 @@ public:
 			if (ctx->insert_statement())
 			{
 				auto ddl_object = ctx->insert_statement()->ddl_object();
-				if (stmt->insert_exec && ddl_object && !ddl_object->local_id()) /* insert into non-local object */
+				/* INSERT EXEC in functions: when GUC is on, handled earlier; when off, check here */
+				if (stmt->insert_exec && ddl_object && !ddl_object->local_id())
 				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1628,6 +1628,37 @@ public:
 	}
 
 	/*
+	 * Apply expression rewriting for INSERT EXEC statements.
+	 * Converts double-quoted strings to single-quoted strings
+	 * (e.g., "master" -> 'master') for PostgreSQL compatibility.
+	 * PLTSQL_STMT_EXEC_SP does not need rewriting — system SP arguments
+	 * are explicit typed parameters, not general SQL expressions.
+	*/
+	void applyInsertExecRewriting(PLtsql_stmt *base_stmt,
+                               TSqlParser::Execute_statementContext *ctxES)
+	{
+    	if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+    	{
+        	PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+        	PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
+        	add_rewritten_query_fragment_to_mutator(&mutator);
+        	mutator.run();
+    	}
+		else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+		{
+			PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+			PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+			/*
+			* We don't call markSelectFragment here — selectFragmentOffsets was
+			* recorded with ctx->parent as key, not ctxES. For dynamic SQL in
+			* INSERT EXEC, we rewrite the entire expression string.
+			*/
+			add_rewritten_query_fragment_to_mutator(&mutator);
+			mutator.run();
+		}
+	}
+
+	/*
 	 * Replace a grafted statement with a new one.
 	 * Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
 	 */
@@ -1661,17 +1692,16 @@ public:
 			/* Update the fragment mapping */
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
-		else if (new_stmt && container)
+		else
 		{
-			/* No old statement, just graft the new one */
-			graft(new_stmt, container);
-			attachPLtsql_fragment(ctx, new_stmt);
+    		/*
+    		 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
+    		 * a PLtsql_stmt_execsql fragment before this function is called.
+    		* Reaching here means a broken parser state.
+    		*/
+    		Assert(false);
 		}
-		else if (new_stmt)
-		{
-			/* container is NULL - broken parser state, INSERT EXEC statement would be lost */
-			Assert(false);
-		}
+
 	}
 
 	//////////////////////////////////////////////////////////////////////////////
@@ -2050,20 +2080,18 @@ public:
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/* Extract target table name */
-			std::string target_table;
+			/* Extract target table name, schema, and database separately */
+			std::string tbl_name, tbl_schema, tbl_db;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is */
-					target_table = ::getFullText(ddl_object->local_id());
+					/* Table variable like @tablevar - no schema or db */
+					tbl_name = ::getFullText(ddl_object->local_id());
 				}
 				else if (ddl_object->full_object_name())
 				{
-					/* Regular table or temp table - extract name and schema separately */
-					std::string tbl_name, tbl_schema, tbl_db;
 					if (ddl_object->full_object_name()->object_name)
 						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
 					if (ddl_object->full_object_name()->schema)
@@ -2072,40 +2100,13 @@ public:
 						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
 
 					/*
-					 * Check if this is a temp table (starts with #).
-					 * In PostgreSQL, temp tables live in pg_temp schema, not user
-					 * schemas like dbo. We strip any schema prefix the user may have
-					 * provided (e.g., dbo.#temp) since it's not meaningful for temp tables.
-					 */
+					* Temp tables live in pg_temp, not user schemas. Strip any schema
+					* prefix the user may have provided (e.g., dbo.#temp).
+					*/
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
-						target_table = tbl_name;
-					}
-					/* Build table reference with explicit schema if provided */
-					else if (!tbl_db.empty())
-					{
-						/*
-						 * Three-part name: db..table or db.schema.table
-						 * When schema is empty (db..table), leave it empty and let the
-						 * executor resolve using the user's default schema, matching
-						 * T-SQL semantics.
-						 */
-						if (tbl_schema.empty())
-							target_table = tbl_db + ".." + tbl_name;
-						else
-							target_table = tbl_db + "." + tbl_schema + "." + tbl_name;
-					}
-					else if (!tbl_schema.empty())
-					{
-						target_table = tbl_schema + "." + tbl_name;
-					}
-					else
-					{
-						/*
-						 * No schema specified - don't hardcode dbo. Let the search path
-						 * resolve the table, which respects the user's default schema.
-						 */
-						target_table = tbl_name;
+						tbl_schema.clear();
+						tbl_db.clear();
 					}
 				}
 			}
@@ -2122,10 +2123,21 @@ public:
 						column_list += ", ";
 					first = false;
 					auto ids = col->id();
+					/* A column reference always has at least one identifier token per grammar */
+        			Assert(!ids.empty());
 					if (!ids.empty() && ids.back() != nullptr)
 						column_list += stripQuoteFromId(ids.back());
 				}
 			}
+
+			/*
+			 * target_table must be set for INSERT EXEC — if it's empty here,
+			 * the parse tree is malformed (ddl_object missing or has no object name).
+			 */
+			if (tbl_name.empty())
+				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+					"INSERT EXEC requires a valid target table",
+					getLineAndPos(ctx->insert_statement()->ddl_object()));
 
 			/*
 			 * Helper lambda to set INSERT EXEC fields on the statement.
@@ -2133,8 +2145,11 @@ public:
 			 */
 			auto setInsertExecInfo = [&](InsertExecInfo *info) {
 				info->is_insert_exec = true;
-				if (!target_table.empty())
-					info->target = pstrdup(target_table.c_str());
+				info->target = pstrdup(tbl_name.c_str());
+				if (!tbl_schema.empty())
+					info->schema = pstrdup(tbl_schema.c_str());
+				if (!tbl_db.empty())
+					info->db_name = pstrdup(tbl_db.c_str());
 				if (!column_list.empty())
 					info->columns = pstrdup(column_list.c_str());
 			};
@@ -2159,32 +2174,7 @@ public:
 				setInsertExecInfo(&exec_sp_stmt->insert_exec);
 			}
 
-			/*
-			 * Apply rewriting to the EXEC statement's expression.
-			 * This is needed to convert double-quoted strings to single-quoted strings
-			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
-			 * Without this, double-quoted strings would be interpreted as column references.
-			 */
-			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
-			{
-				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
-				add_rewritten_query_fragment_to_mutator(&mutator);
-				mutator.run();
-			}
-			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-			{
-				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
-				/*
-				 * Note: We don't call markSelectFragment here because the selectFragmentOffsets
-				 * was recorded with ctx->parent as the key in makeExecuteStatement, not ctxES.
-				 * For INSERT EXEC with dynamic SQL, we don't need to limit the rewriting range
-				 * since the expression is the entire dynamic SQL string.
-				 */
-				add_rewritten_query_fragment_to_mutator(&mutator);
-				mutator.run();
-			}
+			applyInsertExecRewriting(base_stmt, ctxES);
 
 			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
 			replaceGraftedStatement(ctx, base_stmt);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2167,8 +2167,38 @@ public:
 			return;
 		}
 
-		/* Record INSERT EXEC flag for legacy code path (when GUC is off) */
+		/*
+		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
+		 * This code is only needed when the new INSERT EXEC implementation is disabled.
+		 * When the GUC is true, we use PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
+		 * and the cross-database handling is done differently.
+		 * TODO: Remove this block when the new INSERT EXEC implementation is stable
+		 * and the GUC default is flipped to true.
+		 */
 		stmt->insert_exec = is_insert_exec;
+
+		/* Extract db_name and schema_name for cross-database INSERT EXEC (legacy path only) */
+		if (is_insert_exec && !pltsql_enable_new_insert_exec)
+		{
+			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
+			TSqlParser::Execute_bodyContext *body = nullptr;
+
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			body = ctxES->execute_body();
+			Assert(body);
+
+			ctx_name = body->func_proc_name_server_database_schema();
+			if (ctx_name)
+			{
+				if (ctx_name->database)
+				{
+					db_name = stripQuoteFromId(ctx_name->database);
+					is_cross_db = true;
+				}
+				if (ctx_name->schema)
+					schema_name = stripQuoteFromId(ctx_name->schema);
+			}
+		}
 
 		// record whether stmt is cross-db
 		if (is_cross_db)

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1634,11 +1634,7 @@ public:
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
 		ParserRuleContext *container = peekContainer();
 
-		/* Container must be valid to graft statements */
-		if (!container)
-			return;
-
-		if (old_stmt)
+		if (old_stmt && container)
 		{
 			List *siblings = getCode(container);
 
@@ -2007,7 +2003,7 @@ public:
 				if (ddl_object && !ddl_object->local_id())
 				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
-							"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
+						"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}
 			}
 
@@ -2023,33 +2019,36 @@ public:
 			}
 
 			/*
-			 * For INSERT EXEC, create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql.
-			 * This allows the executor to handle INSERT EXEC specially. makeExecuteStatement
-			 * returns PLtsql_stmt_exec for procedure calls, PLtsql_stmt_exec_batch for
-			 * dynamic SQL (EXEC(@var)), or PLtsql_stmt_exec_sp for system procedures.
+			 *Instead of creating a PLtsql_stmt_execsql for
+			 * "INSERT INTO t EXEC p", we create a PLtsql_stmt_exec for just "EXEC p"
+			 * and set the INSERT EXEC fields. This allows exec_stmt_exec to handle
+			 * the temp table lifecycle and avoids parser-level issues.
+			 *
+			 * Note: makeExecuteStatement returns either PLtsql_stmt_exec (for procedure calls)
+			 * or PLtsql_stmt_exec_batch (for dynamic SQL like EXEC(@variable)). We need to
+			 * handle both cases and set the INSERT EXEC fields on the correct struct.
 			 */
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
 
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/*
-			 * Extract target table components separately to prevent SQL injection.
-			 * Each component (db, schema, table) is stored individually so the executor
-			 * can properly quote them when building queries.
-			 */
-			std::string tbl_db, tbl_schema, tbl_name;
+			/* Extract target table name and schema */
+			std::string target_table;
+			std::string target_schema;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is */
-					tbl_name = ::getFullText(ddl_object->local_id());
+					/* Table variable like @tablevar - use as-is, no schema needed */
+					target_table = ::getFullText(ddl_object->local_id());
+					target_schema = "";  /* Table variables don't need schema */
 				}
 				else if (ddl_object->full_object_name())
 				{
-					/* Regular table or temp table - extract components separately */
+					/* Regular table or temp table - extract name and schema separately */
+					std::string tbl_name, tbl_schema, tbl_db;
 					if (ddl_object->full_object_name()->object_name)
 						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
 					if (ddl_object->full_object_name()->schema)
@@ -2058,60 +2057,86 @@ public:
 						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
 
 					/*
-					 * Temp tables (starting with #) use pg_temp schema, so clear
-					 * any user-provided schema prefix like dbo.#temp.
+					 * Check if this is a temp table (starts with #).
+					 * In PostgreSQL, temp tables live in pg_temp schema, not user
+					 * schemas like dbo. We strip any schema prefix the user may have
+					 * provided (e.g., dbo.#temp) since it's not meaningful for temp tables.
 					 */
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
-						tbl_schema.clear();
-						tbl_db.clear();
+						target_table = tbl_name;
+						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
+					}
+					/* Build table reference with explicit schema if provided */
+					else if (!tbl_db.empty())
+					{
+						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
+						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
+					}
+					else if (!tbl_schema.empty())
+					{
+						target_table = tbl_schema + "." + tbl_name;
+						target_schema = tbl_schema;
+					}
+					else
+					{
+						/*
+						 * No schema specified - don't hardcode dbo. Let the search path
+						 * resolve the table, which respects the user's default schema.
+						 */
+						target_table = tbl_name;
+						target_schema = "";
 					}
 				}
 			}
 
-			/* Extract column list as a List of column name strings */
-			List *column_list = NIL;
+			/* Extract column list */
+			std::string column_list;
 			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
 			if (column_list_ctx)
 			{
+				bool first = true;
 				for (auto col : column_list_ctx->col)
 				{
+					if (!first)
+						column_list += ", ";
+					first = false;
 					auto ids = col->id();
-					if (!ids.empty() && ids.back() != nullptr)
-					{
-						std::string col_name = stripQuoteFromId(ids.back());
-						column_list = lappend(column_list, pstrdup(col_name.c_str()));
-					}
+					if (!ids.empty())
+						column_list += stripQuoteFromId(ids.back());
 				}
 			}
-
-			/*
-			 * Helper lambda to set InsertExecInfo fields.
-			 * This avoids code duplication across the three statement types.
-			 */
-			auto setInsertExecInfo = [&](InsertExecInfo *info) {
-				info->is_insert_exec = true;
-				info->target_db = tbl_db.empty() ? NULL : pstrdup(tbl_db.c_str());
-				info->target_schema = tbl_schema.empty() ? NULL : pstrdup(tbl_schema.c_str());
-				info->target_table = tbl_name.empty() ? NULL : pstrdup(tbl_name.c_str());
-				info->columns = column_list;
-			};
 
 			/* Set INSERT EXEC fields based on the actual statement type */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
+				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				setInsertExecInfo(&exec_stmt->insert_exec);
+				exec_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+				exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
+				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				setInsertExecInfo(&exec_batch_stmt->insert_exec);
+				exec_batch_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+				exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
 			{
+				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
 				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				setInsertExecInfo(&exec_sp_stmt->insert_exec);
+				exec_sp_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
 			}
 
 			/*
@@ -2119,10 +2144,6 @@ public:
 			 * This is needed to convert double-quoted strings to single-quoted strings
 			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
 			 * Without this, double-quoted strings would be interpreted as column references.
-			 *
-			 * Note: PLTSQL_STMT_EXEC_SP (sp_executesql, etc.) does not need rewriting here
-			 * because its SQL string parameter is already handled as a string literal, not
-			 * as an expression that could contain double-quoted identifiers.
 			 */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
@@ -2135,6 +2156,12 @@ public:
 			{
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
 				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+				/*
+				 * Note: We don't call markSelectFragment here because the selectFragmentOffsets
+				 * was recorded with ctx->parent as the key in makeExecuteStatement, not ctxES.
+				 * For INSERT EXEC with dynamic SQL, we don't need to limit the rewriting range
+				 * since the expression is the entire dynamic SQL string.
+				 */
 				add_rewritten_query_fragment_to_mutator(&mutator);
 				mutator.run();
 			}
@@ -2147,7 +2174,6 @@ public:
 			clear_rewritten_query_fragment();
 			return;
 		}
-
 		/*
 		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
 		 * This code is only needed when the new INSERT EXEC implementation is disabled.
@@ -2204,8 +2230,7 @@ public:
 			if (ctx->insert_statement())
 			{
 				auto ddl_object = ctx->insert_statement()->ddl_object();
-				/* INSERT EXEC in functions: when GUC is on, handled earlier; when off, check here */
-				if (stmt->insert_exec && ddl_object && !ddl_object->local_id())
+				if (stmt->insert_exec && ddl_object && !ddl_object->local_id()) /* insert into non-local object */
 				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1659,11 +1659,16 @@ public:
 			// Update the fragment mapping
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
-		else if (new_stmt && container)
+		else if (new_stmt)
 		{
-			// No old statement, just graft the new one
-			graft(new_stmt, container);
-			attachPLtsql_fragment(ctx, new_stmt);
+			/* Parser state error if container is NULL - INSERT EXEC statement would be lost */
+			Assert(container != NULL);
+			if (container)
+			{
+				// No old statement, just graft the new one
+				graft(new_stmt, container);
+				attachPLtsql_fragment(ctx, new_stmt);
+			}
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2218,7 +2218,7 @@ public:
 		stmt->insert_exec = is_insert_exec;
 
 		/* Extract db_name and schema_name for cross-database INSERT EXEC (legacy path only) */
-		if (is_insert_exec && !pltsql_enable_new_insert_exec)
+		if (is_insert_exec)
 		{
 			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
 			TSqlParser::Execute_bodyContext *body = nullptr;

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1797,13 +1797,13 @@ public:
 		ParserRuleContext *container = peekContainer();
 
 		/*
-    	 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
-    	 * a PLtsql_stmt_execsql fragment before this function is called.
-    	 * Reaching here means a broken parser state.
-    	*/
-    	Assert(old_stmt != NULL && container != NULL);
+		 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
+		 * a PLtsql_stmt_execsql fragment before this function is called.
+		 * Reaching here means a broken parser state.
+		*/
+		Assert(old_stmt != NULL && container != NULL);
 		if (!old_stmt || !container)
-    		elog(ERROR, "INSERT EXEC: internal parser state error in replaceGraftedStatement");
+			elog(ERROR, "INSERT EXEC: internal parser state error in replaceGraftedStatement");
 
 		List *siblings = getCode(container);
 		ListCell *lc;
@@ -2206,9 +2206,9 @@ public:
 		 * When enabled, we create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
 		 * which allows the executor to handle INSERT EXEC with the new DestReceiver
 		 * and temp table approach. When disabled, fall through to legacy behavior.
-		 
+		 *
 		 * Note: process_execsql_remove_unsupported_tokens() above populates
- 		 * rewritten_query_fragment which handleInsertExec() depends on.
+		 * rewritten_query_fragment which handleInsertExec() depends on.
 		*/
 		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -399,9 +399,9 @@ stripQuoteFromId(std::string s)
  */
 static bool
 extract_ddl_object_names(TSqlParser::Ddl_objectContext *ddl_object,
-                         char **table_name,
-                         char **schema_name,
-                         char **db_name)
+						 char **table_name,
+						 char **schema_name,
+						 char **db_name)
 {
 	*table_name = NULL;
 	*schema_name = NULL;
@@ -2175,11 +2175,11 @@ public:
 
 	void exitDml_statement(TSqlParser::Dml_statementContext *ctx) override
 	{
-    	if (ctx->bulk_insert_statement())
-        {
-            clear_rewritten_query_fragment();
-            return;
-        }
+		if (ctx->bulk_insert_statement())
+		{
+			clear_rewritten_query_fragment();
+			return;
+		}
 		PLtsql_stmt_execsql *stmt = (PLtsql_stmt_execsql *) getPLtsql_fragment(ctx);
 		Assert(stmt);
 		Assert(stmt->sqlstmt = statementMutator->expr);
@@ -2207,8 +2207,9 @@ public:
 		 * which allows the executor to handle INSERT EXEC with the new DestReceiver
 		 * and temp table approach. When disabled, fall through to legacy behavior.
 		 *
-		 * Note: process_execsql_remove_unsupported_tokens() above populates
-		 * rewritten_query_fragment which handleInsertExec() depends on.
+		 * Note : process_execsql_remove_unsupported_tokens() populates rewritten_query_fragment
+		 * which apply_exec_expression_rewriting() inside handleInsertExec() depends on.
+		 * Moving the check above it would break expression rewriting. 
 		*/
 		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1634,7 +1634,11 @@ public:
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
 		ParserRuleContext *container = peekContainer();
 
-		if (old_stmt && container)
+		/* Container must be valid to graft statements */
+		if (!container)
+			return;
+
+		if (old_stmt)
 		{
 			List *siblings = getCode(container);
 
@@ -2029,22 +2033,23 @@ public:
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/* Extract target table name and schema */
-			std::string target_table;
-			std::string target_schema;
+			/*
+			 * Extract target table components separately to prevent SQL injection.
+			 * Each component (db, schema, table) is stored individually so the executor
+			 * can properly quote them when building queries.
+			 */
+			std::string tbl_db, tbl_schema, tbl_name;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is, no schema needed */
-					target_table = ::getFullText(ddl_object->local_id());
-					target_schema = "";  /* Table variables don't need schema */
+					/* Table variable like @tablevar - use as-is */
+					tbl_name = ::getFullText(ddl_object->local_id());
 				}
 				else if (ddl_object->full_object_name())
 				{
-					/* Regular table or temp table - extract name and schema separately */
-					std::string tbl_name, tbl_schema, tbl_db;
+					/* Regular table or temp table - extract components separately */
 					if (ddl_object->full_object_name()->object_name)
 						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
 					if (ddl_object->full_object_name()->schema)
@@ -2053,84 +2058,60 @@ public:
 						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
 
 					/*
-					 * Temp tables (starting with #) use pg_temp schema, so strip
+					 * Temp tables (starting with #) use pg_temp schema, so clear
 					 * any user-provided schema prefix like dbo.#temp.
 					 */
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
-						target_table = tbl_name;
-						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
-					}
-					/* Build table reference with explicit schema if provided */
-					else if (!tbl_db.empty())
-					{
-						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
-						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
-					}
-					else if (!tbl_schema.empty())
-					{
-						target_table = tbl_schema + "." + tbl_name;
-						target_schema = tbl_schema;
-					}
-					else
-					{
-						/*
-						 * No schema specified - don't hardcode dbo. Let the search path
-						 * resolve the table, which respects the user's default schema.
-						 */
-						target_table = tbl_name;
-						target_schema = "";
+						tbl_schema.clear();
+						tbl_db.clear();
 					}
 				}
 			}
 
-			/* Extract column list */
-			std::string column_list;
+			/* Extract column list as a List of column name strings */
+			List *column_list = NIL;
 			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
 			if (column_list_ctx)
 			{
-				bool first = true;
 				for (auto col : column_list_ctx->col)
 				{
-					if (!first)
-						column_list += ", ";
-					first = false;
 					auto ids = col->id();
-					if (!ids.empty())
-						column_list += stripQuoteFromId(ids.back());
+					if (!ids.empty() && ids.back() != nullptr)
+					{
+						std::string col_name = stripQuoteFromId(ids.back());
+						column_list = lappend(column_list, pstrdup(col_name.c_str()));
+					}
 				}
 			}
+
+			/*
+			 * Helper lambda to set InsertExecInfo fields.
+			 * This avoids code duplication across the three statement types.
+			 */
+			auto setInsertExecInfo = [&](InsertExecInfo *info) {
+				info->is_insert_exec = true;
+				info->target_db = tbl_db.empty() ? NULL : pstrdup(tbl_db.c_str());
+				info->target_schema = tbl_schema.empty() ? NULL : pstrdup(tbl_schema.c_str());
+				info->target_table = tbl_name.empty() ? NULL : pstrdup(tbl_name.c_str());
+				info->columns = column_list;
+			};
 
 			/* Set INSERT EXEC fields based on the actual statement type */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
-				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				exec_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
-				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				exec_batch_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_batch_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
 			{
-				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
 				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				exec_sp_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_sp_stmt->insert_exec);
 			}
 
 			/*
@@ -2138,6 +2119,10 @@ public:
 			 * This is needed to convert double-quoted strings to single-quoted strings
 			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
 			 * Without this, double-quoted strings would be interpreted as column references.
+			 *
+			 * Note: PLTSQL_STMT_EXEC_SP (sp_executesql, etc.) does not need rewriting here
+			 * because its SQL string parameter is already handled as a string literal, not
+			 * as an expression that could contain double-quoted identifiers.
 			 */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
@@ -2150,10 +2135,6 @@ public:
 			{
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
 				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
-				/*
-				 * For dynamic SQL, rewrite the entire expression - no need to limit
-				 * the rewriting range since the expression is the full SQL string.
-				 */
 				add_rewritten_query_fragment_to_mutator(&mutator);
 				mutator.run();
 			}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1637,19 +1637,29 @@ public:
 		if (old_stmt && container)
 		{
 			List *siblings = getCode(container);
+			ListCell *lc;
+			int pos = 0;
 
 			if (pltsql_enable_antlr_detailed_log)
 				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
 
-			// Remove old statement and add new one
+			// Find the position of the old statement
+			foreach(lc, siblings)
+			{
+				if (lfirst(lc) == old_stmt)
+					break;
+				pos++;
+			}
+
+			// Remove old statement and insert new one at the same position
 			siblings = list_delete_ptr(siblings, old_stmt);
-			siblings = lappend(siblings, new_stmt);
+			siblings = list_insert_nth(siblings, pos, new_stmt);
 			setCode(container, siblings);
 
 			// Update the fragment mapping
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
-		else if (new_stmt)
+		else if (new_stmt && container)
 		{
 			// No old statement, just graft the new one
 			graft(new_stmt, container);
@@ -2019,7 +2029,7 @@ public:
 			}
 
 			/*
-			 *Instead of creating a PLtsql_stmt_execsql for
+			 * Instead of creating a PLtsql_stmt_execsql for
 			 * "INSERT INTO t EXEC p", we create a PLtsql_stmt_exec for just "EXEC p"
 			 * and set the INSERT EXEC fields. This allows exec_stmt_exec to handle
 			 * the temp table lifecycle and avoids parser-level issues.
@@ -2028,22 +2038,20 @@ public:
 			 * or PLtsql_stmt_exec_batch (for dynamic SQL like EXEC(@variable)). We need to
 			 * handle both cases and set the INSERT EXEC fields on the correct struct.
 			 */
-
 			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/* Extract target table name and schema */
+			/* Extract target table name */
 			std::string target_table;
-			std::string target_schema;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is, no schema needed */
+					/* Table variable like @tablevar - use as-is */
 					target_table = ::getFullText(ddl_object->local_id());
-					target_schema = "";  /* Table variables don't need schema */
 				}
 				else if (ddl_object->full_object_name())
 				{
@@ -2065,18 +2073,24 @@ public:
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
 						target_table = tbl_name;
-						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
 					}
 					/* Build table reference with explicit schema if provided */
 					else if (!tbl_db.empty())
 					{
-						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
-						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
+						/*
+						 * Three-part name: db..table or db.schema.table
+						 * When schema is empty (db..table), leave it empty and let the
+						 * executor resolve using the user's default schema, matching
+						 * T-SQL semantics.
+						 */
+						if (tbl_schema.empty())
+							target_table = tbl_db + ".." + tbl_name;
+						else
+							target_table = tbl_db + "." + tbl_schema + "." + tbl_name;
 					}
 					else if (!tbl_schema.empty())
 					{
 						target_table = tbl_schema + "." + tbl_name;
-						target_schema = tbl_schema;
 					}
 					else
 					{
@@ -2085,7 +2099,6 @@ public:
 						 * resolve the table, which respects the user's default schema.
 						 */
 						target_table = tbl_name;
-						target_schema = "";
 					}
 				}
 			}
@@ -2172,6 +2185,8 @@ public:
 			/* Clear the mutator since we're not using the execsql statement */
 			statementMutator.reset();
 			clear_rewritten_query_fragment();
+			clear_query_hints();
+			clear_tables_info();
 			return;
 		}
 		/*

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1627,8 +1627,10 @@ public:
 		setCode(container, list_delete_ptr(siblings, stmt));
 	}
 
-	// Replace a grafted statement with a new one
-	// Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	/*
+	 * Replace a grafted statement with a new one.
+	 * Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	 */
 	void replaceGraftedStatement(ParserRuleContext *ctx, PLtsql_stmt *new_stmt)
 	{
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
@@ -1643,7 +1645,7 @@ public:
 			if (pltsql_enable_antlr_detailed_log)
 				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
 
-			// Find the position of the old statement
+			/* Find the position of the old statement */
 			foreach(lc, siblings)
 			{
 				if (lfirst(lc) == old_stmt)
@@ -1651,24 +1653,24 @@ public:
 				pos++;
 			}
 
-			// Remove old statement and insert new one at the same position
+			/* Remove old statement and insert new one at the same position */
 			siblings = list_delete_ptr(siblings, old_stmt);
 			siblings = list_insert_nth(siblings, pos, new_stmt);
 			setCode(container, siblings);
 
-			// Update the fragment mapping
+			/* Update the fragment mapping */
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+		else if (new_stmt && container)
+		{
+			/* No old statement, just graft the new one */
+			graft(new_stmt, container);
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
 		else if (new_stmt)
 		{
-			/* Parser state error if container is NULL - INSERT EXEC statement would be lost */
-			Assert(container != NULL);
-			if (container)
-			{
-				// No old statement, just graft the new one
-				graft(new_stmt, container);
-				attachPLtsql_fragment(ctx, new_stmt);
-			}
+			/* container is NULL - broken parser state, INSERT EXEC statement would be lost */
+			Assert(false);
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -823,14 +823,14 @@ get_insert_exec_info(TSqlParser::Dml_statementContext *ctx)
 	 */
 	if (tbl_name && tbl_name[0] == '#')
 	{
-		tbl_schema = NULL;
-		tbl_db = NULL;
+		if (tbl_schema) { pfree(tbl_schema); tbl_schema = NULL; }
+		if (tbl_db)     { pfree(tbl_db);     tbl_db = NULL; }
 	}
 
 	if (!tbl_name)
 		throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
 			"INSERT EXEC requires a valid target table",
-			getLineAndPos(ctx->insert_statement()->ddl_object()));
+			getLineAndPos(ctx->insert_statement()));
 
 	info->target  = tbl_name;
 	info->schema  = tbl_schema;
@@ -1802,6 +1802,8 @@ public:
     	 * Reaching here means a broken parser state.
     	*/
     	Assert(old_stmt != NULL && container != NULL);
+		if (!old_stmt || !container)
+    		elog(ERROR, "INSERT EXEC: internal parser state error in replaceGraftedStatement");
 
 		List *siblings = getCode(container);
 		ListCell *lc;
@@ -1811,12 +1813,18 @@ public:
 			std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
 
 		/* Find the position of the old statement */
+		bool found = false;
 		foreach(lc, siblings)
 		{
-			if (lfirst(lc) == old_stmt)
-				break;
+			if (lfirst(lc) == old_stmt) 
+			{ 
+				found = true; 
+				break; 
+			}
 			pos++;
 		}
+		if (!found)
+			elog(ERROR, "INSERT EXEC: grafted statement not found in container");
 
 		/* Remove old statement and insert new one at the same position */
 		siblings = list_delete_ptr(siblings, old_stmt);
@@ -2198,7 +2206,10 @@ public:
 		 * When enabled, we create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
 		 * which allows the executor to handle INSERT EXEC with the new DestReceiver
 		 * and temp table approach. When disabled, fall through to legacy behavior.
-		 */
+		 
+		 * Note: process_execsql_remove_unsupported_tokens() above populates
+ 		 * rewritten_query_fragment which handleInsertExec() depends on.
+		*/
 		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{
 			handleInsertExec(ctx);


### PR DESCRIPTION
### Description

**Background: INSERT...EXEC Redesign**

The current INSERT...EXEC implementation has limitations with transaction handling, error recovery, and TRY-CATCH compatibility. We're redesigning it using a **temp table buffering approach**:
1. Procedure output is captured into a temporary buffer table via a custom DestReceiver
2. After procedure execution completes, buffered rows are flushed to the target table
3. This enables proper TRY-CATCH error handling and transaction semantics matching SQL Server

**PR Series Overview:**
| PR | Focus | Description |
|----|-------|-------------|
| PR0 | GUC | Feature flag to gate the new code path |
| **PR1** | **Parser** | **Parse INSERT...EXEC and extract target table info** |
| PR2 | Executor | Core state management and schema detection |
| PR3 | DestReceiver | Capture procedure output to temp table |
| PR4 | Temp Table | Create/drop temp buffer table with correct schema |
| PR5 | Flush | Transfer buffered data to target table |
| PR6 | Integration | Wire everything together with tests |

**PR Chain:** [← PR0](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4780) | [PR2 →](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4782)

**This PR:**

Adds parser support for INSERT...EXEC statements. When the `enable_new_insert_exec` GUC is enabled, the parser creates a `PLtsql_stmt_exec` (or `PLtsql_stmt_exec_batch`/`PLtsql_stmt_exec_sp`) with INSERT EXEC metadata attached, instead of the default `PLtsql_stmt_execsql`.

**Changes:**
- Add `InsertExecInfo` struct to `pltsql-2.h` with `target`, `columns` fields
- Add `InsertExecInfo` to `PLtsql_stmt_exec`, `PLtsql_stmt_exec_sp`, `PLtsql_stmt_exec_batch`
- Add `replaceGraftedStatement()` method to replace default `PLtsql_stmt_execsql` with appropriate EXEC statement
- Gate new code path behind `babelfishpg_tsql.enable_new_insert_exec` GUC (default: false)

### Issues Resolved
PR1 of Task: [BABEL-5522](https://jira.rds.a2z.com/browse/BABEL-5522)

### Test Scenarios Covered
* **Use case based -** N/A (new code path disabled by default; existing INSERT EXEC tests pass with legacy path)
* **Boundary conditions -** N/A
* **Arbitrary inputs -** N/A
* **Negative test cases -** N/A
* **Minor version upgrade tests -** N/A
* **Major version upgrade tests -** N/A
* **Performance tests -** N/A
* **Tooling impact -** None
* **Client tests -** Existing JDBC tests pass (legacy path unchanged)

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.
