### PR TITLE
[BABEL] Insert Exec PR2 temp table

### DIFF
--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -80,6 +80,7 @@ OBJS += src/fts_parser.o
 OBJS += src/pltsql_partition.o
 OBJS += src/bbf_parallel_query.o
 OBJS += src/temp_table.o
+OBJS += src/pl_insert_exec.o
 
 export ANTLR4_JAVA_BIN=java
 export ANTLR4_RUNTIME_LIB=-lantlr4-runtime

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3647,9 +3647,14 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 		change_object_owner_if_db_owner();
 
 	/*
-	 * Detect schema changes to the INSERT EXEC target table.
-	 * If the executed procedure alters the target table, we need to fail
-	 * the INSERT EXEC to prevent data corruption from schema mismatch.
+	 * Detect schema changes to the INSERT EXEC target table and record them
+	 * via a flag rather than failing directly. This hook fires inside the DDL
+	 * execution context, not inside INSERT EXEC. Raising an error
+	 * here would propagate through the DDL stack and could be caught by a
+	 * TRY/CATCH block in the executing procedure, silently suppressing it.
+	 * The flag is checked at flush time in flush_insert_exec_temp_table, which
+	 * runs outside the procedure's execution context where the error cannot
+	 * be suppressed.
 	 */
 	if ((access == OAT_POST_ALTER || access == OAT_DROP) && classId == RelationRelationId)
 	{

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3651,7 +3651,7 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 	 * If the executed procedure alters the target table, we need to fail
 	 * the INSERT EXEC to prevent data corruption from schema mismatch.
 	 */
-	if (access == OAT_POST_ALTER && classId == RelationRelationId)
+	if ((access == OAT_POST_ALTER || access == OAT_DROP) && classId == RelationRelationId)
 	{
 		if (OidIsValid(insert_exec_ctx.target_rel_oid) && objectId == insert_exec_ctx.target_rel_oid)
 			insert_exec_ctx.is_target_relation_modified = true;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3645,6 +3645,19 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 
 	if (access == OAT_POST_CREATE)
 		change_object_owner_if_db_owner();
+
+	/*
+	 * Detect schema changes to the INSERT EXEC target table.
+	 * If the executed procedure alters the target table, we need to fail
+	 * the INSERT EXEC to prevent data corruption from schema mismatch.
+	 */
+	if (access == OAT_POST_ALTER && classId == RelationRelationId)
+	{
+		if (OidIsValid(insert_exec_ctx.target_rel_oid) && objectId == insert_exec_ctx.target_rel_oid)
+		{
+			insert_exec_ctx.is_target_relation_modified = true;
+		}
+	}
 }
 
 static void

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -3654,9 +3654,7 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 	if (access == OAT_POST_ALTER && classId == RelationRelationId)
 	{
 		if (OidIsValid(insert_exec_ctx.target_rel_oid) && objectId == insert_exec_ctx.target_rel_oid)
-		{
 			insert_exec_ctx.is_target_relation_modified = true;
-		}
 	}
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -444,7 +444,7 @@ static pltsql_CastHashEntry *get_cast_hashentry(PLtsql_execstate *estate,
 static void exec_init_tuple_store(PLtsql_execstate *estate);
 static void exec_set_found(PLtsql_execstate *estate, bool state);
 static void exec_set_fetch_status(PLtsql_execstate *estate, int status);
-static void exec_set_rowcount(uint64 rowno);
+void exec_set_rowcount(uint64 rowno);
 static void exec_set_error(PLtsql_execstate *estate, int error, int pg_error, bool error_mapping_failed);
 static void pltsql_create_econtext(PLtsql_execstate *estate);
 static void pltsql_commit_not_required_impl_txn(PLtsql_execstate *estate);
@@ -9693,7 +9693,7 @@ exec_set_fetch_status(PLtsql_execstate *estate, int status)
 	fetch_status_var = status;
 }
 
-static void
+void
 exec_set_rowcount(uint64 rowno)
 {
 	rowcount_var = rowno;

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -444,7 +444,7 @@ static pltsql_CastHashEntry *get_cast_hashentry(PLtsql_execstate *estate,
 static void exec_init_tuple_store(PLtsql_execstate *estate);
 static void exec_set_found(PLtsql_execstate *estate, bool state);
 static void exec_set_fetch_status(PLtsql_execstate *estate, int status);
-void exec_set_rowcount(uint64 rowno);
+static void exec_set_rowcount(uint64 rowno);
 static void exec_set_error(PLtsql_execstate *estate, int error, int pg_error, bool error_mapping_failed);
 static void pltsql_create_econtext(PLtsql_execstate *estate);
 static void pltsql_commit_not_required_impl_txn(PLtsql_execstate *estate);
@@ -9693,7 +9693,7 @@ exec_set_fetch_status(PLtsql_execstate *estate, int status)
 	fetch_status_var = status;
 }
 
-void
+static void
 exec_set_rowcount(uint64 rowno)
 {
 	rowcount_var = rowno;

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -2,15 +2,8 @@
  *
  * pl_insert_exec.c
  *	  INSERT EXECUTE implementation for Babelfish PL/tsql
- *
- * This file contains all logic for the INSERT INTO <target> EXEC <proc>
- * statement redesign. It implements:
- *   - InsertExecContext: global state tracking for an active INSERT EXEC
- *   - DestReceiver (DR_insertexec): captures procedure output into a
- *     session-local temp table
- *   - Temp table lifecycle: creation, schema inference, flush, and drop
- *   - Context management accessors used across pl_exec.c, hooks.c, and
- *     the TDS layer
+It implements:
+ *	- Temp table lifecycle: creation, flush, and drop
  *
  *-------------------------------------------------------------------------
  */
@@ -35,8 +28,7 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 
-/* Forward declaration for exec_set_rowcount - defined in pl_exec.c */
-extern void exec_set_rowcount(uint64 rowno);
+extern int execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockArgs *args, List *params);
 
 /*
  * Global INSERT EXEC context - defined in pltsql.h, declared here.
@@ -66,7 +58,7 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 	/* Resolve the relation OID using RangeVar - works for both regular and temp tables */
 	rv = makeRangeVar(physical_schema ? pstrdup(physical_schema) : NULL,
 					  pstrdup(lower_table_name), -1);
-	relid = RangeVarGetRelid(rv, AccessShareLock, false);
+	relid = RangeVarGetRelid(rv, NoLock, false);
 
 	pfree(lower_table_name);
 
@@ -147,9 +139,6 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	temp_table_name = ChooseRelationName("__insert_exec_buf", NULL, NULL,
 										 temp_nsp_oid, false);
 
-	if (temp_table_name == NULL)
-		elog(ERROR, "INSERT-EXEC: failed to generate temp table name for buffering");
-
 	/*
 	 * Parse schema and table name from target_table.
 	 * For temp tables (starting with #) and table variables (@),
@@ -172,25 +161,16 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	 * non-computed column names.
 	 */
 	if (column_list != NULL)
-	{
 		select_cols = column_list;
-	}
 	else
-	{
-		cols_to_free = get_insertable_column_list(target_table, physical_schema);
-		select_cols = cols_to_free;
-	}
+		select_cols = cols_to_free = get_insertable_column_list(target_table, physical_schema);
+
 
 	/*
 	 * Build a fully qualified reference for the source table.
 	 * For temp tables and table variables, use the name directly.
 	 */
-	if (physical_schema != NULL)
-		qualified_target = psprintf("%s.%s",
-									quote_identifier(physical_schema),
-									quote_identifier(target_table));
-	else
-		qualified_target = pstrdup(quote_identifier(target_table));
+	qualified_target = quote_qualified_identifier(physical_schema, target_table);
 
 	/*
 	 * Create the temp buffer table by selecting the desired columns
@@ -235,85 +215,38 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 void
 flush_insert_exec_temp_table(PLtsql_execstate *estate,
 							 const char *target_table,
-							 const char *column_list)
+							 const char *column_list_str)
 {
 	char			*temp_table_name;
 	StringInfoData	flush_query;
-	int				rc;
 	Oid				temp_oid = insert_exec_ctx.temp_table_oid;
 
 	if (!OidIsValid(temp_oid) || target_table == NULL)
-	{
 		return;
-	}
 
 	/*
 	 * Verify target table schema hasn't changed since INSERT EXEC started.
 	 */
 	if (insert_exec_ctx.is_target_relation_modified)
-	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table.")));
-	}
 
 	/* Get the temp table name from its OID */
 	temp_table_name = get_rel_name(temp_oid);
 	if (temp_table_name == NULL)
-	{
 		elog(ERROR, "INSERT-EXEC: Could not find temp table with OID %u", temp_oid);
-	}
 
 	initStringInfo(&flush_query);
 
-	if (column_list != NULL)
-	{
-		/*
-		 * User specified columns - use them directly.
-		 * The temp table was created with columns in the same order as the
-		 * user's column list, so SELECT * gives values in the correct order.
-		 */
-		appendStringInfo(&flush_query,
-			"INSERT INTO %s (%s) SELECT * FROM %s",
-			quote_identifier(target_table),
-			column_list,
-			quote_identifier(temp_table_name));
-	}
-	else
-	{
-		appendStringInfo(&flush_query,
-			"INSERT INTO %s SELECT * FROM %s",
-			quote_identifier(target_table),
-			quote_identifier(temp_table_name));
-	}
+	appendStringInfo(&flush_query,
+      "INSERT INTO %s%s SELECT * FROM %s",
+      quote_identifier(target_table),
+      column_list_str ? column_list_str : "",
+      quote_identifier(temp_table_name));
 
-	/*
-	 * We route through exec_stmt_execsql to reuse the standard SQL execution
-	 * path which handles triggers, rowcount, and FOUND properly.
+	/* We route through execute_batch so the flush INSERT goes through
+	 * the exec_stmt_execsql, which handles triggers, errors, rowcount and FOUND properly.
 	 */
-	PG_TRY();
-	{
-		/* Execute the flush INSERT using SPI */
-		rc = SPI_execute(flush_query.data, false, 0);
-
-		/*
-   		 * SPI_execute returns SPI_OK_INSERT_RETURNING (not SPI_OK_INSERT) when
-   		 * the target table has IDENTITY INSERT ON. Accept both.
-   		 */
-		if (rc != SPI_OK_INSERT && rc != SPI_OK_INSERT_RETURNING)
-			elog(ERROR, "INSERT-EXEC: Failed to flush temp table to target");
-
-		/* Update rowcount for T-SQL compatibility */
-		estate->eval_processed = SPI_processed;
-		exec_set_rowcount(SPI_processed);
-	}
-	PG_CATCH();
-	{
-
-		pfree(flush_query.data);
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
-
-	pfree(flush_query.data);
+	execute_batch(estate, flush_query.data, NULL, NULL);
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -56,7 +56,7 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 	/* Resolve the relation OID using RangeVar - works for both regular and temp tables */
 	rv = makeRangeVar(physical_schema ? pstrdup(physical_schema) : NULL,
 					  pstrdup(lower_table_name), -1);
-	relid = RangeVarGetRelid(rv, AccessShareLock, true);
+	relid = RangeVarGetRelid(rv, NoLock, true);
 
 	pfree(lower_table_name);
 
@@ -65,7 +65,7 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 			table_name);
 
 	/* Open the relation */
-	rel = table_open(relid, NoLock);
+	rel = table_open(relid, AccessShareLock);
 	tupdesc = RelationGetDescr(rel);
 
 	/* Iterate over columns and build the list */
@@ -265,4 +265,5 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 
 	/* Route through execute_batch to handle triggers and errors properly. */
 	execute_batch(estate, flush_query.data, NULL, NULL);
+	pfree(flush_query.data);
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1,10 +1,8 @@
 /*-------------------------------------------------------------------------
- *
  * pl_insert_exec.c
- *	  INSERT EXECUTE implementation for Babelfish PL/tsql
-It implements:
- *	- Temp table lifecycle: creation, flush, and drop
- *
+ *	INSERT EXECUTE implementation for Babelfish PL/tsql
+ *	It implements:
+ *		- Temp table lifecycle: creation, flush, and drop
  *-------------------------------------------------------------------------
  */
 
@@ -48,8 +46,8 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 	TupleDesc	tupdesc;
 	int			i;
 	bool		first_col = true;
-	char	   *lower_table_name;
-	RangeVar   *rv;
+	char		*lower_table_name;
+	RangeVar	*rv;
 
 	initStringInfo(&col_list);
 
@@ -58,7 +56,7 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 	/* Resolve the relation OID using RangeVar - works for both regular and temp tables */
 	rv = makeRangeVar(physical_schema ? pstrdup(physical_schema) : NULL,
 					  pstrdup(lower_table_name), -1);
-	relid = RangeVarGetRelid(rv, NoLock, false);
+	relid = RangeVarGetRelid(rv, AccessShareLock, true);
 
 	pfree(lower_table_name);
 
@@ -67,7 +65,7 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 			table_name);
 
 	/* Open the relation */
-	rel = table_open(relid, AccessShareLock);
+	rel = table_open(relid, NoLock);
 	tupdesc = RelationGetDescr(rel);
 
 	/* Iterate over columns and build the list */
@@ -140,18 +138,25 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 										 temp_nsp_oid, false);
 
 	/*
-	 * Parse schema and table name from target_table.
-	 * For temp tables (starting with #) and table variables (@),
-	 * no schema resolution is needed.
-	 */
-	if (!(target_table[0] == '#' || target_table[0] == '@'))
+	* Resolve the physical schema for the target table reference.
+	*
+	* Three cases per T-SQL semantics:
+	*	1. Temp table (#) — always in pg_temp
+	*	2. Schema explicitly specified — resolve to physical schema name
+	*	3. No schema specified — leave NULL, let search_path handle resolution
+	*/
+	if (target_table[0] == '#')
+		physical_schema = pstrdup("pg_temp");
+	else if (schema_name_in != NULL)
 	{
-		const char *sname = (schema_name_in != NULL) ? schema_name_in : "dbo";
-		physical_schema = get_physical_schema_name(get_cur_db_name(), sname);
+		/* User specified schema — resolve to physical name */
+		physical_schema = get_physical_schema_name(get_cur_db_name(), schema_name_in);
 		if (physical_schema == NULL)
 			elog(ERROR, "INSERT-EXEC: Failed to resolve schema for target table: %s",
 				target_table);
 	}
+	/* else: no schema specified, not a temp table — physical_schema stays NULL,
+	* search_path will resolve the target correctly */
 
 	/*
 	 * Determine the column list to SELECT.
@@ -170,7 +175,10 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	 * Build a fully qualified reference for the source table.
 	 * For temp tables and table variables, use the name directly.
 	 */
-	qualified_target = quote_qualified_identifier(physical_schema, target_table);
+	/* Use qualified reference only when schema is known */
+	qualified_target = (physical_schema != NULL)
+		? quote_qualified_identifier(physical_schema, target_table)
+		: pstrdup(quote_identifier(target_table));
 
 	/*
 	 * Create the temp buffer table by selecting the desired columns
@@ -214,15 +222,19 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
  */
 void
 flush_insert_exec_temp_table(PLtsql_execstate *estate,
-							 const char *target_table,
 							 const char *column_list_str)
 {
 	char			*temp_table_name;
+	char			*relname;
+	char			*nspname;
 	StringInfoData	flush_query;
 	Oid				temp_oid = insert_exec_ctx.temp_table_oid;
 
-	if (!OidIsValid(temp_oid) || target_table == NULL)
-		return;
+	if (!OidIsValid(temp_oid) || !OidIsValid(insert_exec_ctx.target_rel_oid))
+    	return;
+
+	relname = get_rel_name(insert_exec_ctx.target_rel_oid);
+	nspname = get_namespace_name(get_rel_namespace(insert_exec_ctx.target_rel_oid));
 
 	/*
 	 * Verify target table schema hasn't changed since INSERT EXEC started.
@@ -230,7 +242,7 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 	if (insert_exec_ctx.is_target_relation_modified)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table.")));
+				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table")));
 
 	/* Get the temp table name from its OID */
 	temp_table_name = get_rel_name(temp_oid);
@@ -240,13 +252,11 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 	initStringInfo(&flush_query);
 
 	appendStringInfo(&flush_query,
-      "INSERT INTO %s%s SELECT * FROM %s",
-      quote_identifier(target_table),
-      column_list_str ? column_list_str : "",
-      quote_identifier(temp_table_name));
+		"INSERT INTO %s%s SELECT * FROM %s",
+		quote_qualified_identifier(nspname, relname),
+		column_list_str ? column_list_str : "",
+		quote_identifier(temp_table_name));
 
-	/* We route through execute_batch so the flush INSERT goes through
-	 * the exec_stmt_execsql, which handles triggers, errors, rowcount and FOUND properly.
-	 */
+	/* Route through execute_batch to handle triggers and errors properly. */
 	execute_batch(estate, flush_query.data, NULL, NULL);
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -138,13 +138,13 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 										 temp_nsp_oid, false);
 
 	/*
-	* Resolve the physical schema for the target table reference.
-	*
-	* Three cases per T-SQL semantics:
-	*	1. Temp table (#) — always in pg_temp
-	*	2. Schema explicitly specified — resolve to physical schema name
-	*	3. No schema specified — leave NULL, let search_path handle resolution
-	*/
+	 * Resolve the physical schema for the target table reference.
+	 *
+	 * Three cases per T-SQL semantics:
+	 *	1. Temp table (#) — always in pg_temp
+	 *	2. Schema explicitly specified — resolve to physical schema name
+	 *	3. No schema specified — leave NULL, let search_path handle resolution
+	 */
 	if (target_table[0] == '#')
 		physical_schema = pstrdup("pg_temp");
 	else if (schema_name_in != NULL)
@@ -155,8 +155,10 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 			elog(ERROR, "INSERT-EXEC: Failed to resolve schema for target table: %s",
 				target_table);
 	}
-	/* else: no schema specified, not a temp table — physical_schema stays NULL,
-	* search_path will resolve the target correctly */
+	/* 
+	 * else: no schema specified, not a temp table — physical_schema stays NULL,
+	 * search_path will resolve the target correctly
+	 */
 
 	/*
 	 * Determine the column list to SELECT.
@@ -173,12 +175,8 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 
 	/*
 	 * Build a fully qualified reference for the source table.
-	 * For temp tables and table variables, use the name directly.
 	 */
-	/* Use qualified reference only when schema is known */
-	qualified_target = (physical_schema != NULL)
-		? quote_qualified_identifier(physical_schema, target_table)
-		: pstrdup(quote_identifier(target_table));
+	qualified_target = quote_qualified_identifier(physical_schema, target_table);
 
 	/*
 	 * Create the temp buffer table by selecting the desired columns
@@ -224,14 +222,15 @@ void
 flush_insert_exec_temp_table(PLtsql_execstate *estate,
 							 const char *column_list_str)
 {
-	char			*temp_table_name;
+	char			*temp_name;
 	char			*relname;
 	char			*nspname;
+	Relation		temp_rel;
 	StringInfoData	flush_query;
 	Oid				temp_oid = insert_exec_ctx.temp_table_oid;
 
 	if (!OidIsValid(temp_oid) || !OidIsValid(insert_exec_ctx.target_rel_oid))
-    	return;
+		return;
 
 	relname = get_rel_name(insert_exec_ctx.target_rel_oid);
 	nspname = get_namespace_name(get_rel_namespace(insert_exec_ctx.target_rel_oid));
@@ -245,9 +244,10 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table")));
 
 	/* Get the temp table name from its OID */
-	temp_table_name = get_rel_name(temp_oid);
-	if (temp_table_name == NULL)
-		elog(ERROR, "INSERT-EXEC: Could not find temp table with OID %u", temp_oid);
+	temp_rel = table_open(temp_oid, NoLock);
+	temp_name = quote_qualified_identifier(get_namespace_name(RelationGetNamespace(temp_rel)),
+										  RelationGetRelationName(temp_rel));
+	table_close(temp_rel, NoLock);
 
 	initStringInfo(&flush_query);
 
@@ -255,7 +255,7 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 		"INSERT INTO %s%s SELECT * FROM %s",
 		quote_qualified_identifier(nspname, relname),
 		column_list_str ? column_list_str : "",
-		quote_identifier(temp_table_name));
+		temp_name);
 
 	/* Route through execute_batch to handle triggers and errors properly. */
 	execute_batch(estate, flush_query.data, NULL, NULL);

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -61,7 +61,7 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 	pfree(lower_table_name);
 
 	if (!OidIsValid(relid))
-		elog(ERROR, "could not find relation for INSERT EXEC target table: %s",
+		elog(ERROR, "INSERT EXEC failed due to missing relation for target table \"%s\"",
 			table_name);
 
 	/* Open the relation */
@@ -92,13 +92,14 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 		first_col = false;
 	}
 
+	/* release the lock acquired by RangeVarGetRelid */
 	table_close(rel, AccessShareLock);
 
 	/* Error if no insertable columns found */
 	if (first_col)
 	{
 		pfree(col_list.data);
-		elog(ERROR, "no insertable columns found for INSERT EXEC target table: %s",
+		elog(ERROR, "INSERT EXEC failed due to no insertable columns in target table \"%s\"",
 			table_name);
 	}
 
@@ -109,10 +110,11 @@ get_insertable_column_list(const char *table_name, const char *physical_schema)
 /*
  * Create a temp table for INSERT EXEC buffering.
  *
- * Creates a PostgreSQL temp table with schema matching
- * the target table. Uses ChooseRelationName to generate a unique name.
- * For regular tables, queries pg_attribute to get column definitions
- * (avoids needing SELECT permission for ownership chaining).
+ * Creates a PostgreSQL temp table with schema matching the target table.
+ * Uses ChooseRelationName to generate a unique name and ON COMMIT DROP
+ * for automatic cleanup. Column types are inferred from the target table
+ * via SELECT ... WITH NO DATA. The caller must have SELECT permission on
+ * the target table for this to succeed.
  */
 Oid
 create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in)
@@ -132,7 +134,7 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	 */
 	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
 	if (!OidIsValid(temp_nsp_oid))
-		elog(ERROR, "INSERT-EXEC: pg_temp namespace not found");
+		elog(ERROR, "INSERT EXEC failed due to missing pg_temp namespace");
 
 	temp_table_name = ChooseRelationName("__insert_exec_buf", NULL, NULL,
 										 temp_nsp_oid, false);
@@ -152,7 +154,7 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 		/* User specified schema — resolve to physical name */
 		physical_schema = get_physical_schema_name(get_cur_db_name(), schema_name_in);
 		if (physical_schema == NULL)
-			elog(ERROR, "INSERT-EXEC: Failed to resolve schema for target table: %s",
+			elog(ERROR, "INSERT EXEC failed due to unresolvable schema for target table \"%s\"",
 				target_table);
 	}
 	/* 
@@ -198,7 +200,7 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 
 	rc = SPI_execute(create_stmt.data, false, 0);
 	if (rc != SPI_OK_UTILITY)
-		elog(ERROR, "failed to create INSERT EXEC temp table: %s",
+		elog(ERROR, "INSERT EXEC failed due to temp table creation error: %s",
 			 SPI_result_code_string(rc));
 
 	pfree(create_stmt.data);
@@ -206,7 +208,7 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	/* Get the OID of the created temp table */
 	temp_table_oid = RelnameGetRelid(temp_table_name);
 	if (!OidIsValid(temp_table_oid))
-		elog(ERROR, "could not find INSERT EXEC temp table %s", temp_table_name);
+		elog(ERROR, "INSERT EXEC failed due to missing temp table \"%s\"", temp_table_name);
 
 	return temp_table_oid;
 }
@@ -236,6 +238,10 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 	nspname = get_namespace_name(get_rel_namespace(insert_exec_ctx.target_rel_oid));
 
 	/*
+	 * TODO: Reset insert_exec_ctx here before erroring to prevent stale state
+	 * from affecting subsequent INSERT EXEC operations in the same session.
+	 * Cleanup will be added in the wiring PR alongside reset_insert_exec_context().
+	 *
 	 * Verify target table schema hasn't changed since INSERT EXEC started.
 	 */
 	if (insert_exec_ctx.is_target_relation_modified)

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1,0 +1,319 @@
+/*-------------------------------------------------------------------------
+ *
+ * pl_insert_exec.c
+ *	  INSERT EXECUTE implementation for Babelfish PL/tsql
+ *
+ * This file contains all logic for the INSERT INTO <target> EXEC <proc>
+ * statement redesign. It implements:
+ *   - InsertExecContext: global state tracking for an active INSERT EXEC
+ *   - DestReceiver (DR_insertexec): captures procedure output into a
+ *     session-local temp table
+ *   - Temp table lifecycle: creation, schema inference, flush, and drop
+ *   - Context management accessors used across pl_exec.c, hooks.c, and
+ *     the TDS layer
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/* Include pltsql.h first to define types used by pltsql-2.h */
+#include "pltsql.h"
+#include "pltsql-2.h"
+
+#include "access/table.h"
+#include "access/xact.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_attribute.h"
+#include "commands/defrem.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "parser/scansup.h"
+
+#include "catalog.h"
+#include "multidb.h"
+#include "session.h"
+
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+
+/* Forward declaration for exec_set_rowcount - defined in pl_exec.c */
+extern void exec_set_rowcount(uint64 rowno);
+
+/*
+ * Global INSERT EXEC context - defined in pltsql.h, declared here.
+ */
+InsertExecContext insert_exec_ctx;
+
+/*
+ * Get a comma-separated list of non-IDENTITY, non-computed column names
+ * for a table by opening the relation and iterating over its tuple descriptor.
+ */
+static char *
+get_insertable_column_list(const char *table_name, const char *physical_schema)
+{
+	StringInfoData col_list;
+	Oid			relid;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	int			i;
+	bool		first_col = true;
+	char	   *lower_table_name;
+	RangeVar   *rv;
+
+	initStringInfo(&col_list);
+
+	lower_table_name = downcase_identifier(table_name, strlen(table_name), false, false);
+
+	/* Resolve the relation OID using RangeVar - works for both regular and temp tables */
+	rv = makeRangeVar(physical_schema ? pstrdup(physical_schema) : NULL,
+					  pstrdup(lower_table_name), -1);
+	relid = RangeVarGetRelid(rv, AccessShareLock, false);
+
+	pfree(lower_table_name);
+
+	if (!OidIsValid(relid))
+		elog(ERROR, "could not find relation for INSERT EXEC target table: %s",
+			table_name);
+
+	/* Open the relation */
+	rel = table_open(relid, AccessShareLock);
+	tupdesc = RelationGetDescr(rel);
+
+	/* Iterate over columns and build the list */
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+		/* Skip dropped columns */
+		if (attr->attisdropped)
+			continue;
+
+		/* Skip identity columns */
+		if (attr->attidentity != '\0')
+			continue;
+
+		/* Skip generated/computed columns */
+		if (attr->attgenerated != '\0')
+			continue;
+
+		/* Add column name to the list */
+		if (!first_col)
+			appendStringInfoString(&col_list, ", ");
+		appendStringInfoString(&col_list, quote_identifier(NameStr(attr->attname)));
+		first_col = false;
+	}
+
+	table_close(rel, AccessShareLock);
+
+	/* Error if no insertable columns found */
+	if (first_col)
+	{
+		pfree(col_list.data);
+		elog(ERROR, "no insertable columns found for INSERT EXEC target table: %s",
+			table_name);
+	}
+
+	return col_list.data;
+}
+
+
+/*
+ * Create a temp table for INSERT EXEC buffering.
+ *
+ * Creates a PostgreSQL temp table with schema matching
+ * the target table. Uses ChooseRelationName to generate a unique name.
+ * For regular tables, queries pg_attribute to get column definitions
+ * (avoids needing SELECT permission for ownership chaining).
+ */
+Oid
+create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in)
+{
+	StringInfoData create_stmt;
+	int			rc;
+	Oid			temp_table_oid;
+	char		*temp_table_name;
+	char		*physical_schema = NULL;
+	Oid			temp_nsp_oid;
+	const char	*select_cols;
+	char		*cols_to_free = NULL;
+	char		*qualified_target;
+
+	/*
+	 * Generate a unique temp table name using ChooseRelationName.
+	 */
+	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
+	if (!OidIsValid(temp_nsp_oid))
+		elog(ERROR, "INSERT-EXEC: pg_temp namespace not found");
+
+	temp_table_name = ChooseRelationName("__insert_exec_buf", NULL, NULL,
+										 temp_nsp_oid, false);
+
+	if (temp_table_name == NULL)
+		elog(ERROR, "INSERT-EXEC: failed to generate temp table name for buffering");
+
+	/*
+	 * Parse schema and table name from target_table.
+	 * For temp tables (starting with #) and table variables (@),
+	 * no schema resolution is needed.
+	 */
+	if (!(target_table[0] == '#' || target_table[0] == '@'))
+	{
+		const char *sname = (schema_name_in != NULL) ? schema_name_in : "dbo";
+		physical_schema = get_physical_schema_name(get_cur_db_name(), sname);
+		if (physical_schema == NULL)
+			elog(ERROR, "INSERT-EXEC: Failed to resolve schema for target table: %s",
+				target_table);
+	}
+
+	/*
+	 * Determine the column list to SELECT.
+	 *
+	 * If the user specified columns, use them directly.
+	 * Otherwise, query the relation to get all non-IDENTITY,
+	 * non-computed column names.
+	 */
+	if (column_list != NULL)
+	{
+		select_cols = column_list;
+	}
+	else
+	{
+		cols_to_free = get_insertable_column_list(target_table, physical_schema);
+		select_cols = cols_to_free;
+	}
+
+	/*
+	 * Build a fully qualified reference for the source table.
+	 * For temp tables and table variables, use the name directly.
+	 */
+	if (physical_schema != NULL)
+		qualified_target = psprintf("%s.%s",
+									quote_identifier(physical_schema),
+									quote_identifier(target_table));
+	else
+		qualified_target = pstrdup(quote_identifier(target_table));
+
+	/*
+	 * Create the temp buffer table by selecting the desired columns
+	 * with no rows. PostgreSQL infers column types from the SELECT.
+	 * ON COMMIT DROP ensures automatic cleanup at transaction end.
+	 */
+	initStringInfo(&create_stmt);
+	appendStringInfo(&create_stmt,
+		"CREATE TEMP TABLE %s ON COMMIT DROP AS SELECT %s FROM %s WITH NO DATA",
+		quote_identifier(temp_table_name), select_cols, qualified_target);
+
+	if (cols_to_free)
+		pfree(cols_to_free);
+	pfree(qualified_target);
+
+	/* Clean up parsed names */
+	if (physical_schema)
+		pfree(physical_schema);
+
+	rc = SPI_execute(create_stmt.data, false, 0);
+	if (rc != SPI_OK_UTILITY)
+		elog(ERROR, "failed to create INSERT EXEC temp table: %s",
+			 SPI_result_code_string(rc));
+
+	pfree(create_stmt.data);
+
+	/* Get the OID of the created temp table */
+	temp_table_oid = RelnameGetRelid(temp_table_name);
+	if (!OidIsValid(temp_table_oid))
+		elog(ERROR, "could not find INSERT EXEC temp table %s", temp_table_name);
+
+	return temp_table_oid;
+}
+
+/*
+ * Flush data from temp table to target table.
+ *
+ * Executes INSERT INTO target SELECT * FROM temp_table.
+ * Uses SPI_execute for the flush INSERT.
+ * The flush is called while still inside the procedure's execution context.
+ */
+void
+flush_insert_exec_temp_table(PLtsql_execstate *estate,
+							 const char *target_table,
+							 const char *column_list)
+{
+	char			*temp_table_name;
+	StringInfoData	flush_query;
+	int				rc;
+	Oid				temp_oid = insert_exec_ctx.temp_table_oid;
+
+	if (!OidIsValid(temp_oid) || target_table == NULL)
+	{
+		return;
+	}
+
+	/*
+	 * Verify target table schema hasn't changed since INSERT EXEC started.
+	 */
+	if (insert_exec_ctx.is_target_relation_modified)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table.")));
+	}
+
+	/* Get the temp table name from its OID */
+	temp_table_name = get_rel_name(temp_oid);
+	if (temp_table_name == NULL)
+	{
+		elog(ERROR, "INSERT-EXEC: Could not find temp table with OID %u", temp_oid);
+	}
+
+	initStringInfo(&flush_query);
+
+	if (column_list != NULL)
+	{
+		/*
+		 * User specified columns - use them directly.
+		 * The temp table was created with columns in the same order as the
+		 * user's column list, so SELECT * gives values in the correct order.
+		 */
+		appendStringInfo(&flush_query,
+			"INSERT INTO %s (%s) SELECT * FROM %s",
+			quote_identifier(target_table),
+			column_list,
+			quote_identifier(temp_table_name));
+	}
+	else
+	{
+		appendStringInfo(&flush_query,
+			"INSERT INTO %s SELECT * FROM %s",
+			quote_identifier(target_table),
+			quote_identifier(temp_table_name));
+	}
+
+	/*
+	 * We route through exec_stmt_execsql to reuse the standard SQL execution
+	 * path which handles triggers, rowcount, and FOUND properly.
+	 */
+	PG_TRY();
+	{
+		/* Execute the flush INSERT using SPI */
+		rc = SPI_execute(flush_query.data, false, 0);
+
+		/*
+   		 * SPI_execute returns SPI_OK_INSERT_RETURNING (not SPI_OK_INSERT) when
+   		 * the target table has IDENTITY INSERT ON. Accept both.
+   		 */
+		if (rc != SPI_OK_INSERT && rc != SPI_OK_INSERT_RETURNING)
+			elog(ERROR, "INSERT-EXEC: Failed to flush temp table to target");
+
+		/* Update rowcount for T-SQL compatibility */
+		estate->eval_processed = SPI_processed;
+		exec_set_rowcount(SPI_processed);
+	}
+	PG_CATCH();
+	{
+
+		pfree(flush_query.data);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	pfree(flush_query.data);
+}

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2519,6 +2519,23 @@ extern bool 	is_numeric_datatype(Oid typid);
  */
 extern char *tsql_format_type_extended(Oid type_oid, int32 typemod, bits16 flags);
 
+/*
+ * INSERT EXEC functions (pl_insert_exec.c)
+ */
+typedef struct InsertExecContext
+{
+	Oid			temp_table_oid;			/* OID of temp table for buffering */
+	Oid			target_rel_oid;			/* OID of target table - lock held to detect schema changes */
+	bool		is_target_relation_modified;	/* Set by bbf_object_access_hook when target table is altered */
+} InsertExecContext;
+
+extern InsertExecContext insert_exec_ctx;
+
+extern Oid create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in);
+extern void flush_insert_exec_temp_table(PLtsql_execstate *estate,
+										 const char *target_table,
+										 const char *column_list);
+
 #define NUM_DB_OBJECTS 11
 
 extern const char *shipped_objects_not_in_sys_db[NUM_DB_OBJECTS][2];

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2533,7 +2533,6 @@ extern InsertExecContext insert_exec_ctx;
 
 extern Oid create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in);
 extern void flush_insert_exec_temp_table(PLtsql_execstate *estate,
-										 const char *target_table,
 										 const char *column_list);
 
 #define NUM_DB_OBJECTS 11


### PR DESCRIPTION
### Description

**Background: INSERT...EXEC Redesign**

The current INSERT...EXEC implementation has limitations with transaction handling, error recovery, and TRY-CATCH compatibility. We're redesigning it using a **temp table buffering approach**:
1. Procedure output is captured into a temporary buffer table via a custom DestReceiver
2. After procedure execution completes, buffered rows are flushed to the target table
3. This enables proper TRY-CATCH error handling and transaction semantics matching SQL Server

**PR Series Overview:**
| PR | Focus | Description |
|----|-------|-------------|
| PR0 | GUC | Feature flag to gate the new code path |
| PR1 | Parser | Parse INSERT...EXEC and extract target table info |
| **PR2** | **Temp Table** | **Temp table creation, drop and flush** |
| PR3 | DestReceiver | Capture procedure output to temp table |
| PR4 | Integration | Wire everything together with tests |

**PR Chain:** [← PR1](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4781) | [PR3 →](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4783)

**This PR:**

Adds the core state management infrastructure for INSERT EXEC. A new `pl_insert_exec.c` file provides creation of temp table, drop temp table and flush temp table.

**Changes:**
- New `pl_insert_exec.c` file containing:
  - Temp table creation logic.
  - Temp table drop logic.
  - Temp table flush logic.
- Function declarations added to `pltsql.h`
- Build configuration updated in `Makefile`

### Issues Resolved
PR2 of Task: [BABEL-5522](https://jira.rds.a2z.com/browse/BABEL-5522)

### Test Scenarios Covered
* **Use case based -** No new tests in this PR; existing tests pass (GUC is off by default, so legacy path is used)
* **Boundary conditions -** N/A (infrastructure PR)
* **Arbitrary inputs -** N/A
* **Negative test cases -** N/A (tests will be added in PR6 when feature is complete)
* **Minor version upgrade tests -** N/A
* **Major version upgrade tests -** N/A
* **Performance tests -** N/A
* **Tooling impact -** None
* **Client tests -** N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.