### PR TITLE
[BABEL] Insert Exec Redesign PR3 destreceiver

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -16,23 +16,20 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_attribute.h"
 #include "commands/defrem.h"
+#include "executor/executor.h"
+#include "executor/tuptable.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
-#include "executor/tuptable.h"
 #include "nodes/parsenodes.h"
 #include "parser/parse_coerce.h"
+#include "parser/scansup.h"
 #include "tcop/dest.h"
 #include "utils/builtins.h"
-
-#include "executor/executor.h"
-#include "parser/scansup.h"
+#include "utils/lsyscache.h"
 
 #include "catalog.h"
 #include "multidb.h"
 #include "session.h"
-
-#include "utils/builtins.h"
-#include "utils/lsyscache.h"
 
 extern int execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockArgs *args, List *params);
 
@@ -43,7 +40,6 @@ typedef struct
 {
 	DestReceiver pub;			/* public fields */
 	Relation	temp_rel;		/* open relation, closed in cleanup */
-	TupleDesc	typeinfo;		/* tuple descriptor from startup */
 	/* Projection infrastructure — coerce_to_target_type is a no-op when types already match */
 	ExprContext *econtext;		/* expression context for projection */
 	ProjectionInfo *proj_info;	/* projection info for coercion */
@@ -329,13 +325,13 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	int			i;
 	List	   *target_list = NIL;
 
-	/* store the tuple descriptor for later use */
-	myState->typeinfo = typeinfo;
-
 	/*
 	 * Validate column count
 	 */
 	result_natts = typeinfo->natts;
+
+	if (!OidIsValid(insert_exec_ctx.temp_table_oid))
+		elog(ERROR, "INSERT EXEC failed due to missing temp table OID");
 
 	/* Open temp table to get its tuple descriptor */
 	myState->temp_rel = table_open(insert_exec_ctx.temp_table_oid, RowExclusiveLock);
@@ -420,6 +416,10 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 {
 	DR_insertexec *myState = (DR_insertexec *) self;
 	TupleTableSlot *insert_slot;
+
+	Assert(myState->temp_rel != NULL);
+	Assert(myState->proj_info != NULL);
+	Assert(myState->econtext != NULL);
 
 	/* Reset per-tuple memory context for expression evaluation */
 	ResetExprContext(myState->econtext);

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -2,7 +2,8 @@
  * pl_insert_exec.c
  *	INSERT EXECUTE implementation for Babelfish PL/tsql
  *	It implements:
- *		- Temp table lifecycle: creation, flush, and drop
+ *	- Temp table lifecycle: creation, flush, and drop
+ *	- Dest Receiver callback functions implementation
  *-------------------------------------------------------------------------
  */
 
@@ -11,22 +12,47 @@
 #include "pltsql-2.h"
 
 #include "access/table.h"
-#include "access/xact.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_attribute.h"
-#include "commands/defrem.h"
-#include "miscadmin.h"
 #include "nodes/makefuncs.h"
+#include "executor/tuptable.h"
+#include "nodes/parsenodes.h"
+#include "parser/parse_coerce.h"
+#include "tcop/dest.h"
+#include "utils/builtins.h"
+
+#include "executor/executor.h"
 #include "parser/scansup.h"
 
 #include "catalog.h"
 #include "multidb.h"
 #include "session.h"
 
-#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 
 extern int execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockArgs *args, List *params);
+
+/*
+ * DestReceiver struct for INSERT EXEC - captures procedure output into a temp table.
+ */
+typedef struct
+{
+	DestReceiver pub;			/* public fields */
+	Oid			temp_table_oid;	/* OID of temp table to insert into */
+	Relation	temp_rel;		/* open relation, closed in cleanup */
+	TupleDesc	typeinfo;		/* tuple descriptor from startup */
+	/* Coercion infrastructure using ExecProject */
+	ExprContext *econtext;		/* expression context for projection */
+	ProjectionInfo *proj_info;	/* projection info for type coercion (NULL if no coercion needed) */
+	TupleTableSlot *proj_slot;	/* result slot for projection */
+	bool		needs_coercion;	/* true if any column needs coercion */
+} DR_insertexec;
+
+/* Forward declarations for DestReceiver callbacks */
+static void insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo);
+static bool insertexec_receive(TupleTableSlot *slot, DestReceiver *self);
+static void insertexec_shutdown(DestReceiver *self);
+static void insertexec_destroy(DestReceiver *self);
 
 /*
  * Global INSERT EXEC context - defined in pltsql.h, declared here.
@@ -266,4 +292,221 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
 	/* Route through execute_batch to handle triggers and errors properly. */
 	execute_batch(estate, flush_query.data, NULL, NULL);
 	pfree(flush_query.data);
+}
+
+/*
+ * Create a DestReceiver for INSERT EXEC that writes to a temp table.
+ */
+DestReceiver *
+CreateInsertExecDestReceiver(Oid temp_table_oid)
+{
+	DR_insertexec *self = (DR_insertexec *) palloc0(sizeof(DR_insertexec));
+
+	self->pub.receiveSlot = insertexec_receive;
+	self->pub.rStartup = insertexec_startup;
+	self->pub.rShutdown = insertexec_shutdown;
+	self->pub.rDestroy = insertexec_destroy;
+	self->temp_table_oid = temp_table_oid;
+
+	return (DestReceiver *) self;
+}
+
+/*
+ * insertexec_startup - executor startup for INSERT EXEC receiver
+ *
+ * Validates column count and builds coercion expressions for type 
+ * conversion using PostgreSQL's ExecBuildProjectionInfo/ExecProject.
+ */
+static void
+insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+	TupleDesc	temp_tupdesc;
+	int			result_natts;
+	int			temp_natts;
+	int			i;
+	List	   *target_list = NIL;
+
+	/* store the tuple descriptor for later use */
+	myState->typeinfo = typeinfo;
+
+	/*
+	 * Validate column count
+	 */
+	result_natts = typeinfo->natts;
+
+	/* Open temp table to get its tuple descriptor */
+	myState->temp_rel = table_open(myState->temp_table_oid, RowExclusiveLock);
+	temp_tupdesc = RelationGetDescr(myState->temp_rel);
+	temp_natts = temp_tupdesc->natts;
+
+	if (result_natts != temp_natts)
+	{
+		table_close(myState->temp_rel, RowExclusiveLock);
+		myState->temp_rel = NULL;
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("column name or number of supplied values does not match table definition")));
+	}
+
+	myState->needs_coercion = false;
+
+	for (i = 0; i < temp_natts; i++)
+	{
+		Form_pg_attribute src_att = TupleDescAttr(typeinfo, i);
+		Form_pg_attribute tgt_att = TupleDescAttr(temp_tupdesc, i);
+		Var		   *var;
+		Node	   *expr;
+		TargetEntry *tle;
+
+		/* Create Var node referencing input tuple column (OUTER_VAR for ecxt_outertuple) */
+		var = makeVar(OUTER_VAR,
+					  i + 1,				/* attnum is 1-based */
+					  src_att->atttypid,
+					  src_att->atttypmod,
+					  src_att->attcollation,
+					  0);					/* varlevelsup */
+
+		expr = (Node *) var;
+
+		/* Check if coercion is needed for this column */
+		if (src_att->atttypid != tgt_att->atttypid ||
+			(src_att->atttypmod != tgt_att->atttypmod && tgt_att->atttypmod != -1))
+		{
+			Node	   *cast_expr;
+
+			myState->needs_coercion = true;
+
+			/* Build coercion expression using ASSIGNMENT coercion */
+			cast_expr = coerce_to_target_type(NULL,
+											  expr,
+											  src_att->atttypid,
+											  tgt_att->atttypid,
+											  tgt_att->atttypmod,
+											  COERCION_ASSIGNMENT,
+											  COERCE_IMPLICIT_CAST,
+											  -1);
+
+			if (cast_expr == NULL)
+			{
+				table_close(myState->temp_rel, RowExclusiveLock);
+				myState->temp_rel = NULL;
+				ereport(ERROR,
+						(errcode(ERRCODE_CANNOT_COERCE),
+						 errmsg("cannot convert type %s to %s",
+								format_type_be(src_att->atttypid),
+								format_type_be(tgt_att->atttypid))));
+			}
+
+			expr = cast_expr;
+		}
+
+		/* Create TargetEntry for this column */
+		tle = makeTargetEntry((Expr *) expr,
+							  i + 1,		/* resno is 1-based */
+							  NULL,			/* resname */
+							  false);		/* resjunk */
+		target_list = lappend(target_list, tle);
+	}
+
+	/* Create expression context and projection info if coercion needed */
+	if (myState->needs_coercion)
+	{
+		TupleDesc	proj_tupdesc;
+
+		myState->econtext = CreateStandaloneExprContext();
+
+		/* Create a copy of the temp table's tuple descriptor for the result slot */
+		proj_tupdesc = CreateTupleDescCopy(temp_tupdesc);
+
+		/* Create the result slot for projection */
+		myState->proj_slot = MakeSingleTupleTableSlot(proj_tupdesc, &TTSOpsVirtual);
+
+		/* Build the projection info */
+		myState->proj_info = ExecBuildProjectionInfo(target_list,
+													 myState->econtext,
+													 myState->proj_slot,
+													 NULL,		/* no parent PlanState */
+													 typeinfo);	/* input descriptor */
+	}
+
+	/* temp_rel stays open - closed in cleanup function */
+}
+
+/*
+ * insertexec_receive - receive each tuple and insert into temp table
+ */
+static bool
+insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+	CommandId	cid;
+	TupleTableSlot *insert_slot;
+
+	cid = GetCurrentCommandId(true);
+
+	if (myState->needs_coercion)
+	{
+		ExprContext *econtext = myState->econtext;
+
+		/* Reset per-tuple memory context for expression evaluation */
+		ResetExprContext(econtext);
+
+		/*
+		 * Set up the input slot for projection.
+		 */
+		econtext->ecxt_outertuple = slot;
+
+		/* Project tuple with type coercion */
+		insert_slot = ExecProject(myState->proj_info);
+
+		/* Insert the projected tuple */
+		table_tuple_insert(myState->temp_rel, insert_slot, cid, 0, NULL);
+	}
+	else
+		/* No coercion needed - insert directly */
+		table_tuple_insert(myState->temp_rel, slot, cid, 0, NULL);
+
+	return true;
+}
+
+/*
+ * insertexec_shutdown - executor end for INSERT EXEC receiver
+ *
+ * Clean up the expression context and projection slot used for type coercion.
+ */
+static void
+insertexec_shutdown(DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+
+	/* Close the temp table held since startup */
+	if (myState->temp_rel != NULL)
+	{
+		table_close(myState->temp_rel, RowExclusiveLock);
+		myState->temp_rel = NULL;
+	}
+
+	/* Free the projection slot if we created one */
+	if (myState->proj_slot != NULL)
+	{
+		ExecDropSingleTupleTableSlot(myState->proj_slot);
+		myState->proj_slot = NULL;
+	}
+
+	/* Free the expression context if we created one */
+	if (myState->econtext != NULL)
+	{
+		FreeExprContext(myState->econtext, true);
+		myState->econtext = NULL;
+	}
+}
+
+/*
+ * insertexec_destroy - release DestReceiver object
+ */
+static void
+insertexec_destroy(DestReceiver *self)
+{
+	pfree(self);
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -12,8 +12,11 @@
 #include "pltsql-2.h"
 
 #include "access/table.h"
+#include "access/xact.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_attribute.h"
+#include "commands/defrem.h"
+#include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "executor/tuptable.h"
 #include "nodes/parsenodes.h"
@@ -28,6 +31,7 @@
 #include "multidb.h"
 #include "session.h"
 
+#include "utils/builtins.h"
 #include "utils/lsyscache.h"
 
 extern int execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockArgs *args, List *params);
@@ -38,14 +42,12 @@ extern int execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockA
 typedef struct
 {
 	DestReceiver pub;			/* public fields */
-	Oid			temp_table_oid;	/* OID of temp table to insert into */
 	Relation	temp_rel;		/* open relation, closed in cleanup */
 	TupleDesc	typeinfo;		/* tuple descriptor from startup */
-	/* Coercion infrastructure using ExecProject */
+	/* Projection infrastructure — coerce_to_target_type is a no-op when types already match */
 	ExprContext *econtext;		/* expression context for projection */
-	ProjectionInfo *proj_info;	/* projection info for type coercion (NULL if no coercion needed) */
+	ProjectionInfo *proj_info;	/* projection info for coercion */
 	TupleTableSlot *proj_slot;	/* result slot for projection */
-	bool		needs_coercion;	/* true if any column needs coercion */
 } DR_insertexec;
 
 /* Forward declarations for DestReceiver callbacks */
@@ -298,15 +300,14 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate,
  * Create a DestReceiver for INSERT EXEC that writes to a temp table.
  */
 DestReceiver *
-CreateInsertExecDestReceiver(Oid temp_table_oid)
+CreateInsertExecDestReceiver(void)
 {
-	DR_insertexec *self = (DR_insertexec *) palloc0(sizeof(DR_insertexec));
+	DR_insertexec *self = palloc0_object(DR_insertexec);
 
 	self->pub.receiveSlot = insertexec_receive;
 	self->pub.rStartup = insertexec_startup;
 	self->pub.rShutdown = insertexec_shutdown;
 	self->pub.rDestroy = insertexec_destroy;
-	self->temp_table_oid = temp_table_oid;
 
 	return (DestReceiver *) self;
 }
@@ -336,20 +337,15 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	result_natts = typeinfo->natts;
 
 	/* Open temp table to get its tuple descriptor */
-	myState->temp_rel = table_open(myState->temp_table_oid, RowExclusiveLock);
+	myState->temp_rel = table_open(insert_exec_ctx.temp_table_oid, RowExclusiveLock);
 	temp_tupdesc = RelationGetDescr(myState->temp_rel);
 	temp_natts = temp_tupdesc->natts;
 
 	if (result_natts != temp_natts)
-	{
-		table_close(myState->temp_rel, RowExclusiveLock);
-		myState->temp_rel = NULL;
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
 				 errmsg("column name or number of supplied values does not match table definition")));
-	}
 
-	myState->needs_coercion = false;
 
 	for (i = 0; i < temp_natts; i++)
 	{
@@ -367,39 +363,26 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 					  src_att->attcollation,
 					  0);					/* varlevelsup */
 
-		expr = (Node *) var;
+		/*
+		 * coerce_to_target_type returns the Var unchanged when types match,
+		 * so we call it unconditionally.
+		 */
+		expr = coerce_to_target_type(NULL,
+									 (Node *) var,
+									 src_att->atttypid,
+									 tgt_att->atttypid,
+									 tgt_att->atttypmod,
+									 COERCION_ASSIGNMENT,
+									 COERCE_IMPLICIT_CAST,
+									 -1);
 
-		/* Check if coercion is needed for this column */
-		if (src_att->atttypid != tgt_att->atttypid ||
-			(src_att->atttypmod != tgt_att->atttypmod && tgt_att->atttypmod != -1))
-		{
-			Node	   *cast_expr;
+		if (expr == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_CANNOT_COERCE),
+					 errmsg("cannot convert type %s to %s",
+							format_type_be(src_att->atttypid),
+							format_type_be(tgt_att->atttypid))));
 
-			myState->needs_coercion = true;
-
-			/* Build coercion expression using ASSIGNMENT coercion */
-			cast_expr = coerce_to_target_type(NULL,
-											  expr,
-											  src_att->atttypid,
-											  tgt_att->atttypid,
-											  tgt_att->atttypmod,
-											  COERCION_ASSIGNMENT,
-											  COERCE_IMPLICIT_CAST,
-											  -1);
-
-			if (cast_expr == NULL)
-			{
-				table_close(myState->temp_rel, RowExclusiveLock);
-				myState->temp_rel = NULL;
-				ereport(ERROR,
-						(errcode(ERRCODE_CANNOT_COERCE),
-						 errmsg("cannot convert type %s to %s",
-								format_type_be(src_att->atttypid),
-								format_type_be(tgt_att->atttypid))));
-			}
-
-			expr = cast_expr;
-		}
 
 		/* Create TargetEntry for this column */
 		tle = makeTargetEntry((Expr *) expr,
@@ -409,26 +392,18 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 		target_list = lappend(target_list, tle);
 	}
 
-	/* Create expression context and projection info if coercion needed */
-	if (myState->needs_coercion)
-	{
-		TupleDesc	proj_tupdesc;
+	/* Create expression context and projection info */
+	myState->econtext = CreateStandaloneExprContext();
 
-		myState->econtext = CreateStandaloneExprContext();
+	/* Pass temp_tupdesc directly - valid while temp_rel is held open */
+	myState->proj_slot = MakeSingleTupleTableSlot(temp_tupdesc, &TTSOpsVirtual);
 
-		/* Create a copy of the temp table's tuple descriptor for the result slot */
-		proj_tupdesc = CreateTupleDescCopy(temp_tupdesc);
-
-		/* Create the result slot for projection */
-		myState->proj_slot = MakeSingleTupleTableSlot(proj_tupdesc, &TTSOpsVirtual);
-
-		/* Build the projection info */
-		myState->proj_info = ExecBuildProjectionInfo(target_list,
-													 myState->econtext,
-													 myState->proj_slot,
-													 NULL,		/* no parent PlanState */
-													 typeinfo);	/* input descriptor */
-	}
+	/* Build the projection info */
+	myState->proj_info = ExecBuildProjectionInfo(target_list,
+												 myState->econtext,
+												 myState->proj_slot,
+												 NULL,		/* no parent PlanState */
+												 typeinfo);	/* input descriptor */
 
 	/* temp_rel stays open - closed in cleanup function */
 }
@@ -445,27 +420,17 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 
 	cid = GetCurrentCommandId(true);
 
-	if (myState->needs_coercion)
-	{
-		ExprContext *econtext = myState->econtext;
+	/* Reset per-tuple memory context for expression evaluation */
+	ResetExprContext(myState->econtext);
 
-		/* Reset per-tuple memory context for expression evaluation */
-		ResetExprContext(econtext);
+	/* Set up the input slot for projection */
+	myState->econtext->ecxt_outertuple = slot;
 
-		/*
-		 * Set up the input slot for projection.
-		 */
-		econtext->ecxt_outertuple = slot;
+	/* Project tuple with type coercion */
+	insert_slot = ExecProject(myState->proj_info);
 
-		/* Project tuple with type coercion */
-		insert_slot = ExecProject(myState->proj_info);
-
-		/* Insert the projected tuple */
-		table_tuple_insert(myState->temp_rel, insert_slot, cid, 0, NULL);
-	}
-	else
-		/* No coercion needed - insert directly */
-		table_tuple_insert(myState->temp_rel, slot, cid, 0, NULL);
+	/* Insert the projected tuple */
+	table_tuple_insert(myState->temp_rel, insert_slot, cid, 0, NULL);
 
 	return true;
 }
@@ -480,26 +445,17 @@ insertexec_shutdown(DestReceiver *self)
 {
 	DR_insertexec *myState = (DR_insertexec *) self;
 
-	/* Close the temp table held since startup */
-	if (myState->temp_rel != NULL)
-	{
-		table_close(myState->temp_rel, RowExclusiveLock);
-		myState->temp_rel = NULL;
-	}
+	Assert(myState->temp_rel != NULL);
+	table_close(myState->temp_rel, RowExclusiveLock);
+	myState->temp_rel = NULL;
 
-	/* Free the projection slot if we created one */
-	if (myState->proj_slot != NULL)
-	{
-		ExecDropSingleTupleTableSlot(myState->proj_slot);
-		myState->proj_slot = NULL;
-	}
+	Assert(myState->proj_slot != NULL);
+	ExecDropSingleTupleTableSlot(myState->proj_slot);
+	myState->proj_slot = NULL;
 
-	/* Free the expression context if we created one */
-	if (myState->econtext != NULL)
-	{
-		FreeExprContext(myState->econtext, true);
-		myState->econtext = NULL;
-	}
+	Assert(myState->econtext != NULL);
+	FreeExprContext(myState->econtext, true);
+	myState->econtext = NULL;
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -48,6 +48,7 @@ typedef struct
 	ExprContext *econtext;		/* expression context for projection */
 	ProjectionInfo *proj_info;	/* projection info for coercion */
 	TupleTableSlot *proj_slot;	/* result slot for projection */
+	CommandId	cid;			/* command ID obtained once in startup, shared across all tuples */
 } DR_insertexec;
 
 /* Forward declarations for DestReceiver callbacks */
@@ -405,6 +406,9 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 												 NULL,		/* no parent PlanState */
 												 typeinfo);	/* input descriptor */
 
+	/* Obtain command ID once - all tuples share the same cid for MVCC consistency */
+	myState->cid = GetCurrentCommandId(true);
+
 	/* temp_rel stays open - closed in cleanup function */
 }
 
@@ -415,10 +419,7 @@ static bool
 insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 {
 	DR_insertexec *myState = (DR_insertexec *) self;
-	CommandId	cid;
 	TupleTableSlot *insert_slot;
-
-	cid = GetCurrentCommandId(true);
 
 	/* Reset per-tuple memory context for expression evaluation */
 	ResetExprContext(myState->econtext);
@@ -430,7 +431,7 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 	insert_slot = ExecProject(myState->proj_info);
 
 	/* Insert the projected tuple */
-	table_tuple_insert(myState->temp_rel, insert_slot, cid, 0, NULL);
+	table_tuple_insert(myState->temp_rel, insert_slot, myState->cid, 0, NULL);
 
 	return true;
 }

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2534,7 +2534,7 @@ extern InsertExecContext insert_exec_ctx;
 extern Oid create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in);
 extern void flush_insert_exec_temp_table(PLtsql_execstate *estate,
 										 const char *column_list);
-extern DestReceiver *CreateInsertExecDestReceiver(Oid temp_table_oid);
+extern DestReceiver *CreateInsertExecDestReceiver(void);
 
 #define NUM_DB_OBJECTS 11
 

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2534,6 +2534,7 @@ extern InsertExecContext insert_exec_ctx;
 extern Oid create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in);
 extern void flush_insert_exec_temp_table(PLtsql_execstate *estate,
 										 const char *column_list);
+extern DestReceiver *CreateInsertExecDestReceiver(Oid temp_table_oid);
 
 #define NUM_DB_OBJECTS 11
 


### PR DESCRIPTION
### Description

**Background: INSERT...EXEC Redesign**

The current INSERT...EXEC implementation has limitations with transaction handling, error recovery, and TRY-CATCH compatibility. We're redesigning it using a **temp table buffering approach**:
1. Procedure output is captured into a temporary buffer table via a custom DestReceiver
2. After procedure execution completes, buffered rows are flushed to the target table
3. This enables proper TRY-CATCH error handling and transaction semantics matching SQL Server

**PR Series Overview:**
| PR | Focus | Description |
|----|-------|-------------|
| PR0 | GUC | Feature flag to gate the new code path |
| PR1 | Parser | Parse INSERT...EXEC and extract target table info |
| PR2 | Executor | Core state management and schema detection |
| **PR3** | **DestReceiver** | **Capture procedure output to temp table** |
| PR4 | Integration | Wire everything together with tests |

**PR Chain:** [← PR2](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4782)

**This PR:**

Implements a custom DestReceiver that captures procedure output tuples and inserts them into a session-local temp table for later flush to the target table. 

**Changes:**
- Add `DR_insertexec` struct with coercion infrastructure (ExprContext, ProjectionInfo)
- Implement `insertexec_startup()` - validates column count matches temp table, builds type coercion expressions
- Implement `insertexec_receive()` - receives tuples and inserts into temp table with optional type coercion
- Implement `insertexec_shutdown()` / `insertexec_destroy()` - cleanup resources

**Design Notes:**
- Column count validation happens at startup (before any rows are processed) to match SQL Server behavior
- Type coercion uses PostgreSQL's `ExecProject` for implicit type conversion
- Per-tuple table open/close is intentional for subtransaction safety (TRY-CATCH rollback)

### Issues Resolved
PR3 of Task: [BABEL-5522](https://jira.rds.a2z.com/browse/BABEL-5522)

### Test Scenarios Covered
* **Use case based -** Tested via full feature integration in PR6
* **Boundary conditions -** Column count validation at startup
* **Arbitrary inputs -** N/A
* **Negative test cases -** Column mismatch raises error before any rows are inserted
* **Minor version upgrade tests -** N/A
* **Major version upgrade tests -** N/A
* **Performance tests -** N/A
* **Tooling impact -** N/A
* **Client tests -** N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.