### PR TITLE
[BABEL] Insert Exec PR5 Flush

### DIFF
--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -80,6 +80,7 @@ OBJS += src/fts_parser.o
 OBJS += src/pltsql_partition.o
 OBJS += src/bbf_parallel_query.o
 OBJS += src/temp_table.o
+OBJS += src/pl_insert_exec.o
 
 export ANTLR4_JAVA_BIN=java
 export ANTLR4_RUNTIME_LIB=-lantlr4-runtime

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -956,8 +956,8 @@ define_custom_variables(void)
 							 NULL,
 							 &pltsql_enable_new_insert_exec,
 							 false,
-							 PGC_USERSET,
-							 GUC_NOT_IN_SAMPLE,
+							 PGC_SUSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("babelfishpg_tsql.noexec",

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -59,6 +59,7 @@ bool		pltsql_disable_batch_auto_commit = false;
 bool		pltsql_disable_internal_savepoint = false;
 bool		pltsql_disable_txn_in_triggers = false;
 bool		pltsql_recursive_triggers = false;
+bool		pltsql_enable_new_insert_exec = false;
 bool		pltsql_noexec = false;
 bool		pltsql_showplan_all = false;
 bool		pltsql_showplan_text = false;
@@ -948,6 +949,15 @@ define_custom_variables(void)
 							 false,
 							 PGC_USERSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_new_insert_exec",
+							 gettext_noop("Enables INSERT...EXEC redesign code path"),
+							 NULL,
+							 &pltsql_enable_new_insert_exec,
+							 false,
+							 PGC_USERSET,
+							 GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("babelfishpg_tsql.noexec",

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -24,6 +24,7 @@ extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;
 extern bool pltsql_weak_view_binding;
 extern bool pltsql_no_browsetable;
+extern bool pltsql_enable_new_insert_exec;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -322,7 +322,7 @@ static int	exec_stmt_raise(PLtsql_execstate *estate,
 							PLtsql_stmt_raise *stmt);
 static int	exec_stmt_assert(PLtsql_execstate *estate,
 							 PLtsql_stmt_assert *stmt);
-static int	exec_stmt_execsql(PLtsql_execstate *estate,
+int	exec_stmt_execsql(PLtsql_execstate *estate,
 							  PLtsql_stmt_execsql *stmt);
 static void updateColumnUpdatedList(Query *query);
 static int	exec_stmt_dynexecute(PLtsql_execstate *estate,
@@ -4474,7 +4474,7 @@ execute_txn_command(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt)
  * is recreated when needed for cases like commit/
  * rollbck/rollback to savepoint
  */
-static void
+void
 commit_stmt(PLtsql_execstate *estate, bool txnStarted)
 {
 	SimpleEcontextStackEntry *topEntry = simple_econtext_stack;
@@ -4805,7 +4805,7 @@ setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_s
  * needs to use that, fix those callers to push/pop stmt_mcontext.
  * ----------
  */
-static int
+int
 exec_stmt_execsql(PLtsql_execstate *estate,
 				  PLtsql_stmt_execsql *stmt)
 {

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -50,6 +50,7 @@
 #include "session.h"
 #include "parser/scansup.h"
 #include "parser/parse_oper.h"
+#include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/varlena.h"
 
@@ -74,13 +75,17 @@ typedef struct InsertExecSchemaSignature
 /*
  * Global context for INSERT EXEC - bundled into a single struct for cleaner code.
  * This context is needed for nested procedure calls during INSERT EXEC.
+ *
+ * Note: target_table and column_list use a legacy string interface. The parser
+ * stores these as separate components in InsertExecInfo; the executor will use
+ * those fields with quote_identifier() for SQL safety.
  */
 typedef struct InsertExecContext
 {
 	Oid			temp_table_oid;			/* OID of temp table for buffering */
 	char	   *temp_table_name;		/* Name of temp table for buffering (dynamically chosen) */
-	char	   *target_table;			/* Target table name */
-	char	   *column_list;			/* Column list for INSERT */
+	char	   *target_table;			/* Target table name (legacy interface) */
+	char	   *column_list;			/* Column list for INSERT (legacy interface, see note above) */
 	bool		flush_in_progress;		/* True during flush phase to block commit_stmt */
 	int			call_stack_depth;		/* Call stack depth when INSERT EXEC was started */
 	bool		had_error;				/* True if INSERT EXEC had an error */
@@ -113,6 +118,10 @@ static InsertExecContext insert_exec_ctx = {
 /*
  * Parse tsql table name (1-part, 2-part, or 3-part) into schema and table.
  * Returns true on success. Caller must pfree the output strings.
+ *
+ * Note: Uses simple strrchr splitting - doesn't handle bracket-quoted identifiers
+ * or cross-database names. The parser already handles these cases and stores
+ * components separately in InsertExecInfo. Unqualified names default to "dbo".
  */
 bool
 parse_insert_exec_table_name(const char *target_table,
@@ -126,6 +135,7 @@ parse_insert_exec_table_name(const char *target_table,
 	char	   *second_dot;
 	char	   *schema_name = NULL;
 	char	   *table_name = NULL;
+	const char *cur_db;
 
 	if (target_table == NULL)
 		return false;
@@ -143,7 +153,11 @@ parse_insert_exec_table_name(const char *target_table,
 		second_dot = strrchr(target_copy, '.');
 		if (second_dot != NULL)
 		{
-			/* db.schema.table - schema is after the second dot */
+			/*
+			 * db.schema.table - schema is after the second dot.
+			 * Note: database part is ignored - we always resolve against
+			 * the current database. Cross-database INSERT EXEC is not supported.
+			 */
 			schema_name = pstrdup(second_dot + 1);
 		}
 		else
@@ -155,9 +169,9 @@ parse_insert_exec_table_name(const char *target_table,
 	else
 	{
 		/*
-		 * Just table name, no schema specified - default to dbo for now.
-		 * TODO: Ideally we should respect the user's default schema,
-		 * but that requires changes to how ownership chaining works.
+		 * Just table name, no schema specified - default to dbo.
+		 * This matches T-SQL behavior where dbo is the default schema
+		 * for unqualified object references.
 		 */
 		table_name = pstrdup(target_copy);
 		schema_name = pstrdup("dbo");
@@ -169,7 +183,11 @@ parse_insert_exec_table_name(const char *target_table,
 
 	if (get_physical && physical_schema_out != NULL)
 	{
-		*physical_schema_out = get_physical_schema_name(get_cur_db_name(), schema_name);
+		cur_db = get_cur_db_name();
+		if (cur_db != NULL)
+			*physical_schema_out = get_physical_schema_name((char *) cur_db, schema_name);
+		else
+			*physical_schema_out = NULL;
 	}
 	else if (physical_schema_out != NULL)
 	{
@@ -331,10 +349,9 @@ pltsql_insert_exec_clear_error_flag(void)
 void
 pltsql_insert_exec_set_implicit_txn_flag(void)
 {
-	elog(DEBUG4, "TSQL TXN Setting implicit txn flag for INSERT EXEC (was %d, setting to true)",
+	elog(DEBUG4, "TSQL TXN INSERT EXEC implicit txn flag: %d -> true",
 		 insert_exec_ctx.started_implicit_txn);
 	insert_exec_ctx.started_implicit_txn = true;
-	elog(DEBUG4, "TSQL TXN After setting implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
 }
 
 /*
@@ -344,7 +361,6 @@ pltsql_insert_exec_set_implicit_txn_flag(void)
 bool
 pltsql_insert_exec_started_implicit_txn(void)
 {
-	elog(DEBUG4, "TSQL TXN Checking implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
 	return insert_exec_ctx.started_implicit_txn;
 }
 
@@ -355,7 +371,8 @@ pltsql_insert_exec_started_implicit_txn(void)
 void
 pltsql_insert_exec_clear_implicit_txn_flag(void)
 {
-	elog(DEBUG4, "TSQL TXN Clearing implicit txn flag (was %d)", insert_exec_ctx.started_implicit_txn);
+	elog(DEBUG4, "TSQL TXN INSERT EXEC implicit txn flag: %d -> false",
+		 insert_exec_ctx.started_implicit_txn);
 	insert_exec_ctx.started_implicit_txn = false;
 }
 
@@ -383,8 +400,23 @@ pltsql_insert_exec_check_pending_drop(void)
 		StringInfoData drop_stmt;
 		int			rc;
 
+		/*
+		 * Defensive check: temp table names are internally generated with a known
+		 * prefix. If this doesn't match, something is wrong - skip the drop.
+		 */
+		if (strncmp(insert_exec_ctx.temp_table_name, "#__insert_exec_buf_", 19) != 0)
+		{
+			elog(WARNING, "unexpected INSERT EXEC temp table name format: %s",
+				 insert_exec_ctx.temp_table_name);
+			pfree(insert_exec_ctx.temp_table_name);
+			insert_exec_ctx.temp_table_name = NULL;
+			insert_exec_ctx.pending_drop = false;
+			return;
+		}
+
 		initStringInfo(&drop_stmt);
-		appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s", insert_exec_ctx.temp_table_name);
+		appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s",
+						 quote_identifier(insert_exec_ctx.temp_table_name));
 
 		rc = SPI_execute(drop_stmt.data, false, 0);
 		if (rc != SPI_OK_UTILITY)
@@ -403,6 +435,9 @@ pltsql_insert_exec_check_pending_drop(void)
  * We record column count and types at INSERT EXEC start, then verify they
  * haven't changed before flushing. Regular tables get RowExclusiveLock to
  * block concurrent DDL; temp tables only get schema captured (session-local).
+ *
+ * For regular tables, we check INSERT permission early to fail fast rather
+ * than executing the procedure and buffering data only to fail at flush.
  */
 void
 pltsql_insert_exec_open_target_table(const char *target_table)
@@ -465,6 +500,16 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 		}
 
 		/*
+		 * Check INSERT permission on the target table early. This prevents
+		 * executing the procedure and buffering data only to fail at flush.
+		 * Note: ownership chaining may allow the INSERT at flush time even
+		 * if this check fails, but failing early is safer and matches SQL
+		 * Server behavior for most cases.
+		 */
+		if (pg_class_aclcheck(relid, GetUserId(), ACL_INSERT) != ACLCHECK_OK)
+			aclcheck_error(ACLCHECK_NO_PRIV, OBJECT_TABLE, target_table);
+
+		/*
 		 * Acquire RowExclusiveLock on the target table.
 		 * This lock will be held until the end of the transaction.
 		 * It blocks concurrent sessions from modifying the table.
@@ -476,6 +521,10 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 		}
 		PG_CATCH();
 		{
+			/*
+			 * If we can't lock, skip schema capture. Permission was already
+			 * checked above, so this is likely a lock timeout or similar.
+			 */
 			MemoryContextSwitchTo(oldcontext);
 			FlushErrorState();
 			return;
@@ -496,6 +545,10 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 	}
 	PG_CATCH();
 	{
+		/*
+		 * Best-effort: if we can't open the table, skip schema capture.
+		 * The flush operation will report the proper error.
+		 */
 		MemoryContextSwitchTo(oldcontext);
 		FlushErrorState();
 		insert_exec_ctx.target_rel_oid = InvalidOid;
@@ -504,6 +557,18 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 	PG_END_TRY();
 
 	tupdesc = RelationGetDescr(rel);
+
+	/*
+	 * Defensive check: ensure natts is valid before allocating arrays.
+	 * PostgreSQL caps this at MaxTupleAttributeNumber (1664), but check
+	 * anyway to guard against corrupt catalogs or buggy extensions.
+	 */
+	if (tupdesc->natts < 0 || tupdesc->natts > MaxTupleAttributeNumber)
+	{
+		table_close(rel, NoLock);
+		elog(WARNING, "invalid target table attribute count: %d", tupdesc->natts);
+		return;
+	}
 
 	/* Allocate schema signature in TopMemoryContext so it survives error handling */
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
@@ -749,7 +814,11 @@ pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
 	temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
 	Assert(OidIsValid(temp_table_oid));
 
-	/* Parse the query string - if parsing fails, defer to normal execution */
+	/*
+	 * Parse the query string. For syntax errors, defer to normal execution
+	 * which will report the error properly. For other errors (e.g., OOM),
+	 * re-throw since they indicate a serious problem.
+	 */
 	oldcontext = CurrentMemoryContext;
 	PG_TRY();
 	{
@@ -757,9 +826,23 @@ pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
 	}
 	PG_CATCH();
 	{
+		ErrorData  *edata;
+
 		MemoryContextSwitchTo(oldcontext);
+		edata = CopyErrorData();
 		FlushErrorState();
-		return true;  /* Parse error - normal path will report it */
+
+		/*
+		 * Only swallow syntax errors - these will be reported properly by
+		 * the normal execution path. Re-throw other errors like OOM.
+		 */
+		if (edata->sqlerrcode != ERRCODE_SYNTAX_ERROR &&
+			edata->sqlerrcode != ERRCODE_FEATURE_NOT_SUPPORTED)
+		{
+			ReThrowError(edata);
+		}
+		FreeErrorData(edata);
+		return true;  /* Syntax error - normal path will report it */
 	}
 	PG_END_TRY();
 

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1445,7 +1445,7 @@ insertexec_destroy(DestReceiver *self)
 /*
  * Create a temp table for INSERT EXEC buffering.
  *
- * Creates a PostgreSQL temp table (not Babelfish #temp) with schema matching
+ * Creates a PostgreSQL temp table with schema matching
  * the target table. Uses a unique name pattern __insert_exec_buf_PID_N to avoid
  * conflicts. For regular tables, queries pg_attribute to get column definitions
  * (avoids needing SELECT permission for ownership chaining).
@@ -1467,9 +1467,7 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 
 	/*
 	 * Generate a unique temp table name using backend PID and a suffix.
-	 * We use PostgreSQL temp tables (not Babelfish temp tables with # prefix)
-	 * because they are more stable and don't have ENR-related issues.
-	 */
+	*/
 	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
 
 	for (;;)
@@ -1490,8 +1488,10 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 		if (!OidIsValid(existing_relid))
 			break;  /* Name is available */
 
+		/* Name is taken, try the next suffix */
 		suffix++;
 
+		/* Safety check to prevent infinite loop */
 		if (suffix > 10000)
 			elog(ERROR, "INSERT-EXEC: Could not find available temp table name after 10000 attempts");
 	}
@@ -1508,22 +1508,24 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	 * issues where get_relname_relid didn't find the table but it exists.
 	 */
 	initStringInfo(&create_stmt);
-	appendStringInfo(&create_stmt, "DROP TABLE IF EXISTS %s",
-					 quote_identifier(temp_table_name));
+	appendStringInfo(&create_stmt, "DROP TABLE IF EXISTS %s", temp_table_name);
 	rc = SPI_execute(create_stmt.data, false, 0);
 	if (rc != SPI_OK_UTILITY)
 		elog(WARNING, "failed to drop existing INSERT EXEC temp table: %s",
 			 SPI_result_code_string(rc));
 	pfree(create_stmt.data);
 
+	/* Reset the pending drop flag */
 	insert_exec_ctx.pending_drop = false;
 
 	/*
 	 * Parse schema and table name from target_table.
+	 * Format can be: "table", "schema.table", or "db.schema.table"
 	 * For temp tables (starting with #), we don't need schema parsing.
 	 */
 	if (target_table[0] == '#' || target_table[0] == '@')
 	{
+		/* Temp table or table variable - no schema needed */
 		table_name = pstrdup(target_table);
 		schema_name = NULL;
 		physical_schema = NULL;
@@ -1554,18 +1556,20 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 			 */
 			appendStringInfo(&create_stmt,
 				"SELECT %s INTO %s FROM %s WHERE 1=0",
-				column_list,
-				quote_identifier(temp_table_name),
-				quote_identifier(target_table));
+				column_list, temp_table_name, target_table);
 		}
 		else
 		{
+			/*
+			 * Regular table - query pg_attribute for column definitions.
+			 * Parse the column_list to get individual column names, then
+			 * query their types from pg_attribute.
+			 */
 			StringInfoData col_defs;
 			bool		first_col = true;
 			int			proc_count;
-			int			i;
-			RangeVar   *target_rv;
-			Oid			target_relid;
+			uint64		i;
+			char	   *pg_table_ref;
 			char	   *col_list_copy;
 			char	   *col_name;
 			char	   *saveptr;
@@ -1575,19 +1579,15 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 			initStringInfo(&col_defs);
 			initStringInfo(&col_names_sql);
 
-			/*
-			 * Resolve target table OID to avoid SQL injection via regclass.
-			 * Using OID directly is safer than string interpolation.
-			 */
-			target_rv = makeRangeVar(physical_schema, table_name, -1);
-			target_relid = RangeVarGetRelid(target_rv, AccessShareLock, false);
+			pg_table_ref = psprintf("%s.%s", physical_schema, table_name);
 
 			/*
-			 * Parse column_list to build SQL IN clause. Lowercase column names
-			 * to match pg_attribute storage.
+			 * Parse the column_list to build a SQL IN clause.
+			 * column_list is like "c, a" - we need to convert to ('c', 'a')
 			 *
-			 * Note: strtok_r splits on both comma and space, so quoted identifiers
-			 * with embedded spaces in the column list are not supported.
+			 * IMPORTANT: We lowercase the column names because pg_attribute stores
+			 * column names in lowercase (for unquoted identifiers), and we compare
+			 * using lower(a.attname) IN (...). Both sides must be lowercase.
 			 */
 			col_list_copy = pstrdup(column_list);
 			first_col = true;
@@ -1595,6 +1595,7 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 			col_name = strtok_r(col_list_copy, ", ", &saveptr);
 			while (col_name != NULL)
 			{
+				/* Skip leading/trailing whitespace */
 				while (*col_name == ' ' || *col_name == '\t')
 					col_name++;
 				if (*col_name != '\0')
@@ -1602,8 +1603,9 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 					char *lower_col_name;
 					if (!first_col)
 						appendStringInfoString(&col_names_sql, ", ");
+					/* Lowercase the column name to match pg_attribute storage */
 					lower_col_name = downcase_identifier(col_name, strlen(col_name), false, false);
-					appendStringInfoString(&col_names_sql, quote_literal_cstr(lower_col_name));
+					appendStringInfo(&col_names_sql, "'%s'", lower_col_name);
 					pfree(lower_col_name);
 					first_col = false;
 				}
@@ -1612,16 +1614,21 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 			appendStringInfoChar(&col_names_sql, ')');
 			pfree(col_list_copy);
 
+			/*
+			 * Query to get column definitions for the specified columns.
+			 * We use CASE to preserve the order from the column_list.
+			 */
 			appendStringInfo(&col_query,
 				"SELECT a.attname, format_type(a.atttypid, a.atttypmod) as coltype "
 				"FROM pg_attribute a "
-				"WHERE a.attrelid = %u "
+				"WHERE a.attrelid = '%s'::regclass "
 				"AND a.attnum > 0 "
 				"AND NOT a.attisdropped "
 				"AND lower(a.attname) IN %s "
 				"ORDER BY a.attnum",
-				target_relid, col_names_sql.data);
+				pg_table_ref, col_names_sql.data);
 
+			pfree(pg_table_ref);
 			pfree(col_names_sql.data);
 
 			rc = SPI_execute(col_query.data, false, 0);
@@ -1633,163 +1640,250 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 					 SPI_result_code_string(rc));
 			}
 
-			proc_count = (int) SPI_processed;
+			proc_count = SPI_processed;
+
 			if (proc_count == 0)
 			{
 				pfree(col_query.data);
 				pfree(col_defs.data);
-				elog(ERROR, "INSERT-EXEC: No matching columns found in target table");
+				elog(ERROR, "no columns found for INSERT EXEC temp table");
 			}
-
-			first_col = true;
-			for (i = 0; i < proc_count; i++)
+			else
 			{
-				HeapTuple	tuple = SPI_tuptable->vals[i];
-				TupleDesc	tupdesc = SPI_tuptable->tupdesc;
-				char	   *attname = SPI_getvalue(tuple, tupdesc, 1);
-				char	   *coltype = SPI_getvalue(tuple, tupdesc, 2);
-
-				/* Defensive: SPI_getvalue returns NULL for SQL NULL */
-				if (attname == NULL || coltype == NULL)
+				/* Build column definitions from query results */
+				first_col = true;
+				for (i = 0; i < proc_count; i++)
 				{
-					if (attname) pfree(attname);
-					if (coltype) pfree(coltype);
-					pfree(col_query.data);
-					pfree(col_defs.data);
-					elog(ERROR, "INSERT-EXEC: NULL column name or type from pg_attribute");
+					char *colname = SPI_getvalue(SPI_tuptable->vals[i],
+												 SPI_tuptable->tupdesc, 1);
+					char *coltype_raw = SPI_getvalue(SPI_tuptable->vals[i],
+												 SPI_tuptable->tupdesc, 2);
+					if (colname != NULL && coltype_raw != NULL)
+					{
+						char *coltype = clean_format_type_string(coltype_raw);
+						if (!first_col)
+							appendStringInfoString(&col_defs, ", ");
+						appendStringInfo(&col_defs, "%s %s", colname, coltype);
+						first_col = false;
+						pfree(coltype);
+					}
 				}
 
-				if (!first_col)
-					appendStringInfoString(&col_defs, ", ");
-				appendStringInfo(&col_defs, "%s %s", quote_identifier(attname), coltype);
-				first_col = false;
+				SPI_freetuptable(SPI_tuptable);
+				pfree(col_query.data);
 
-				pfree(attname);
-				pfree(coltype);
+				/* Create temp table with explicit column definitions */
+				appendStringInfo(&create_stmt,
+					"CREATE TEMP TABLE %s (%s)",
+					temp_table_name, col_defs.data);
+
+				pfree(col_defs.data);
 			}
-
-			appendStringInfo(&create_stmt, "CREATE TEMP TABLE %s (%s)",
-							 quote_identifier(temp_table_name), col_defs.data);
-
-			pfree(col_query.data);
-			pfree(col_defs.data);
 		}
 	}
 	else
 	{
 		/*
-		 * No column list - create temp table with all columns from target.
-		 * For temp tables, use SELECT INTO. For regular tables, query pg_attribute.
-		 */
+ 		 * Create temp table excluding IDENTITY and computed columns.
+ 		 * Temp tables (#) and table variables (@) use SELECT INTO (owned by current user).
+ 		 * Regular tables query pg_attribute to avoid needing SELECT permission.
+ 		*/
+
 		if (physical_schema == NULL)
 		{
 			/*
-			 * Temp table or table variable target - use SELECT INTO.
-			 * Quote identifiers to prevent SQL injection.
+			 * Temp table or table variable - use SELECT * INTO to copy structure.
+			 * This is simpler and more reliable for temp tables.
+			 * We need to exclude IDENTITY and computed columns, so we query
+			 * for non-identity column names first, then use those in SELECT.
 			 */
-			appendStringInfo(&create_stmt,
-				"SELECT * INTO %s FROM %s WHERE 1=0",
-				quote_identifier(temp_table_name),
-				quote_identifier(target_table));
+			StringInfoData non_identity_cols;
+			bool		first_col = true;
+			int			proc_count;
+			uint64		i;
+
+			initStringInfo(&col_query);
+			initStringInfo(&non_identity_cols);
+
+			/*
+			 * Query to get non-IDENTITY, non-computed column names.
+			 * Use pg_class join to find the temp table.
+			 */
+			appendStringInfo(&col_query,
+				"SELECT a.attname "
+				"FROM pg_attribute a "
+				"JOIN pg_class c ON a.attrelid = c.oid "
+				"WHERE c.relname = '%s' "
+				"AND a.attnum > 0 "
+				"AND NOT a.attisdropped "
+				"AND a.attidentity = '' "
+				"AND a.attgenerated = '' "
+				"ORDER BY a.attnum",
+				table_name);
+
+			rc = SPI_execute(col_query.data, false, 0);
+			if (rc != SPI_OK_SELECT)
+			{
+				pfree(col_query.data);
+				pfree(non_identity_cols.data);
+				/* Fall back to CREATE TEMP TABLE AS SELECT */
+				appendStringInfo(&create_stmt,
+					"CREATE TEMP TABLE %s AS SELECT * FROM %s WHERE 1=0",
+					temp_table_name, target_table);
+			}
+			else
+			{
+				proc_count = SPI_processed;
+
+				if (proc_count == 0)
+				{
+					/* No columns found, fall back to CREATE TEMP TABLE AS SELECT */
+					pfree(col_query.data);
+					pfree(non_identity_cols.data);
+					appendStringInfo(&create_stmt,
+						"CREATE TEMP TABLE %s AS SELECT * FROM %s WHERE 1=0",
+						temp_table_name, target_table);
+				}
+				else
+				{
+					/* Build column list from query results */
+					for (i = 0; i < proc_count; i++)
+					{
+						char *colname = SPI_getvalue(SPI_tuptable->vals[i],
+													 SPI_tuptable->tupdesc, 1);
+						if (colname != NULL)
+						{
+							if (!first_col)
+								appendStringInfoString(&non_identity_cols, ", ");
+							appendStringInfoString(&non_identity_cols, colname);
+							first_col = false;
+						}
+					}
+
+					SPI_freetuptable(SPI_tuptable);
+					pfree(col_query.data);
+
+					appendStringInfo(&create_stmt,
+						"CREATE TEMP TABLE %s AS SELECT %s FROM %s WHERE 1=0",
+						temp_table_name, non_identity_cols.data, target_table);
+
+					pfree(non_identity_cols.data);
+				}
+			}
 		}
 		else
 		{
+			/*
+			 * Regular table - query pg_attribute for column definitions.
+			 * This avoids needing SELECT permission on the target table.
+			 */
 			StringInfoData col_defs;
 			bool		first_col = true;
 			int			proc_count;
-			int			i;
-			RangeVar   *target_rv;
-			Oid			target_relid;
+			uint64		i;
+			char	   *pg_table_ref;
 
 			initStringInfo(&col_query);
 			initStringInfo(&col_defs);
 
-			/*
-			 * Resolve target table OID to avoid SQL injection via regclass.
-			 * Using OID directly is safer than string interpolation.
-			 */
-			target_rv = makeRangeVar(physical_schema, table_name, -1);
-			target_relid = RangeVarGetRelid(target_rv, AccessShareLock, false);
+			pg_table_ref = psprintf("%s.%s", physical_schema, table_name);
 
+			/*
+			 * Query to get non-IDENTITY, non-computed column definitions.
+			 * attidentity = '' means not an identity column
+			 * attgenerated = '' means not a generated/computed column
+			 *
+			 * Use regclass cast to properly resolve the table.
+			 */
 			appendStringInfo(&col_query,
 				"SELECT a.attname, format_type(a.atttypid, a.atttypmod) as coltype "
 				"FROM pg_attribute a "
-				"WHERE a.attrelid = %u "
+				"WHERE a.attrelid = '%s'::regclass "
 				"AND a.attnum > 0 "
 				"AND NOT a.attisdropped "
+				"AND a.attidentity = '' "
+				"AND a.attgenerated = '' "
 				"ORDER BY a.attnum",
-				target_relid);
+				pg_table_ref);
+
+			pfree(pg_table_ref);
 
 			rc = SPI_execute(col_query.data, false, 0);
 			if (rc != SPI_OK_SELECT)
 			{
 				pfree(col_query.data);
 				pfree(col_defs.data);
-				elog(ERROR, "failed to query target table columns for INSERT EXEC: %s",
+				elog(ERROR, "failed to query target table columns: %s",
 					 SPI_result_code_string(rc));
 			}
 
-			proc_count = (int) SPI_processed;
+			proc_count = SPI_processed;
+
 			if (proc_count == 0)
 			{
+				/* No non-identity columns found - this shouldn't happen normally */
 				pfree(col_query.data);
 				pfree(col_defs.data);
-				elog(ERROR, "INSERT-EXEC: Target table has no columns");
+				elog(ERROR, "no columns found for INSERT EXEC temp table");
 			}
-
-			first_col = true;
-			for (i = 0; i < proc_count; i++)
+			else
 			{
-				HeapTuple	tuple = SPI_tuptable->vals[i];
-				TupleDesc	tupdesc = SPI_tuptable->tupdesc;
-				char	   *attname = SPI_getvalue(tuple, tupdesc, 1);
-				char	   *coltype = SPI_getvalue(tuple, tupdesc, 2);
-
-				/* Defensive: SPI_getvalue returns NULL for SQL NULL */
-				if (attname == NULL || coltype == NULL)
+				/* Build column definitions from query results */
+				for (i = 0; i < proc_count; i++)
 				{
-					if (attname) pfree(attname);
-					if (coltype) pfree(coltype);
-					pfree(col_query.data);
-					pfree(col_defs.data);
-					elog(ERROR, "INSERT-EXEC: NULL column name or type from pg_attribute");
+					char *colname = SPI_getvalue(SPI_tuptable->vals[i],
+												 SPI_tuptable->tupdesc, 1);
+					char *coltype_raw = SPI_getvalue(SPI_tuptable->vals[i],
+												 SPI_tuptable->tupdesc, 2);
+					if (colname != NULL && coltype_raw != NULL)
+					{
+						char *coltype = clean_format_type_string(coltype_raw);
+						if (!first_col)
+							appendStringInfoString(&col_defs, ", ");
+						appendStringInfo(&col_defs, "%s %s", colname, coltype);
+						first_col = false;
+						pfree(coltype);
+					}
 				}
 
-				if (!first_col)
-					appendStringInfoString(&col_defs, ", ");
-				appendStringInfo(&col_defs, "%s %s", quote_identifier(attname), coltype);
-				first_col = false;
+				SPI_freetuptable(SPI_tuptable);
+				pfree(col_query.data);
 
-				pfree(attname);
-				pfree(coltype);
+				/* Create temp table with explicit column definitions */
+				appendStringInfo(&create_stmt,
+					"CREATE TEMP TABLE %s (%s)",
+					temp_table_name, col_defs.data);
+
+				pfree(col_defs.data);
 			}
-
-			appendStringInfo(&create_stmt, "CREATE TEMP TABLE %s (%s)",
-							 quote_identifier(temp_table_name), col_defs.data);
-
-			pfree(col_query.data);
-			pfree(col_defs.data);
 		}
 	}
 
-	if (schema_name) pfree(schema_name);
-	if (table_name) pfree(table_name);
-	if (physical_schema) pfree(physical_schema);
+	/* Clean up parsed names */
+	if (table_name)
+		pfree(table_name);
+	if (schema_name)
+		pfree(schema_name);
+	if (physical_schema)
+		pfree(physical_schema);
 
+	/*
+	 * Execute the statement to create temp table.
+	 * We use CREATE TEMP TABLE AS SELECT which returns SPI_OK_SELINTO.
+	 * For regular tables with explicit column definitions, we use
+	 * CREATE TEMP TABLE which returns SPI_OK_UTILITY.
+	 */
 	rc = SPI_execute(create_stmt.data, false, 0);
+	if (rc != SPI_OK_UTILITY && rc != SPI_OK_SELINTO)
+		elog(ERROR, "failed to create INSERT EXEC temp table: %s",
+			 SPI_result_code_string(rc));
+
 	pfree(create_stmt.data);
 
-	if (rc != SPI_OK_UTILITY && rc != SPI_OK_SELINTO)
-		elog(ERROR, "failed to create INSERT EXEC temp table: %s", SPI_result_code_string(rc));
-
-	/* Get the OID of the newly created temp table */
-	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
-	if (!OidIsValid(temp_nsp_oid))
-		elog(ERROR, "INSERT-EXEC: pg_temp namespace not found after creating temp table");
-
-	temp_table_oid = get_relname_relid(temp_table_name, temp_nsp_oid);
+	/* Get the OID of the created temp table */
+	temp_table_oid = RelnameGetRelid(temp_table_name);
 	if (!OidIsValid(temp_table_oid))
-		elog(ERROR, "INSERT-EXEC: Could not find temp table %s after creation", temp_table_name);
+		elog(ERROR, "could not find INSERT EXEC temp table %s", temp_table_name);
 
 	return temp_table_oid;
 }
@@ -1804,9 +1898,7 @@ drop_insert_exec_temp_table(Oid temp_table_oid)
 	StringInfoData drop_stmt;
 	int			rc;
 
-	/* Parameter kept for interface consistency; we drop by name from context */
-	(void) temp_table_oid;
-
+	/* Use the stored temp table name from the context */
 	if (insert_exec_ctx.temp_table_name == NULL)
 	{
 		elog(DEBUG1, "INSERT-EXEC: No temp table name stored, cannot drop");
@@ -1814,8 +1906,7 @@ drop_insert_exec_temp_table(Oid temp_table_oid)
 	}
 
 	initStringInfo(&drop_stmt);
-	appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s",
-					 quote_identifier(insert_exec_ctx.temp_table_name));
+	appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s", insert_exec_ctx.temp_table_name);
 
 	rc = SPI_execute(drop_stmt.data, false, 0);
 	if (rc != SPI_OK_UTILITY)
@@ -1824,6 +1915,7 @@ drop_insert_exec_temp_table(Oid temp_table_oid)
 
 	pfree(drop_stmt.data);
 
+	/* Clear the stored temp table name and OID */
 	pfree(insert_exec_ctx.temp_table_name);
 	insert_exec_ctx.temp_table_name = NULL;
 	insert_exec_ctx.temp_table_oid = InvalidOid;

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1168,7 +1168,7 @@ CreateInsertExecDestReceiver(Oid temp_table_oid)
 	self->pub.rStartup = insertexec_startup;
 	self->pub.rShutdown = insertexec_shutdown;
 	self->pub.rDestroy = insertexec_destroy;
-	self->pub.mydest = DestNone;  /* no standard dest type fits; avoids miscast risks */
+	self->pub.mydest = DestTransientRel;  /* reuse existing dest type */
 	self->temp_table_oid = temp_table_oid;
 
 	return (DestReceiver *) self;
@@ -1177,10 +1177,13 @@ CreateInsertExecDestReceiver(Oid temp_table_oid)
 /*
  * insertexec_startup --- executor startup for INSERT EXEC receiver
  *
- * Validates column count matches temp table and builds coercion expressions
- * for type conversion. We open/close the relation per-tuple in insertexec_receive
- * to avoid holding stale handles across subtransaction boundaries.
+ * Relation is opened/closed per-tuple in insertexec_receive to avoid
+ * invalid handles after subtransaction rollbacks (e.g., TRY/CATCH).
+ *
+ * Validates column count matches the temp table and builds coercion
+ * expressions for type conversion using PostgreSQL's ExecInitExpr/ExecEvalExpr.
  */
+
 static void
 insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 {
@@ -1192,15 +1195,20 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	int			i;
 	List	   *target_list = NIL;
 
-	/* Store the tuple descriptor for later use */
+	/* Just store the tuple descriptor for later use */
 	myState->typeinfo = typeinfo;
 	myState->rows_inserted = 0;
 	myState->proj_info = NULL;
 	myState->proj_slot = NULL;
 
-	/* Validate column count matches temp table */
+	/*
+	 * Validate column count: the number of columns in the result set
+	 * must match the number of columns in the temp table.
+	 * "Column name or number of supplied values does not match table definition."
+	 */
 	result_natts = typeinfo->natts;
 
+	/* Open temp table to get its tuple descriptor */
 	temp_rel = table_open(myState->temp_table_oid, AccessShareLock);
 	temp_tupdesc = RelationGetDescr(temp_rel);
 	temp_natts = temp_tupdesc->natts;
@@ -1208,11 +1216,12 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	if (result_natts != temp_natts)
 	{
 		table_close(temp_rel, AccessShareLock);
-		/*
-		 * Set error flag BEFORE throwing so flush is skipped even if TRY-CATCH
-		 * catches it. Column mismatch errors roll back all rows, unlike data-level
-		 * errors (e.g., division by zero) which only affect the current row.
-		 */
+	/*
+ 	 * Set error flag BEFORE throwing to skip flush and re-throw even if
+ 	 * TRY-CATCH catches it. Column mismatch errors roll back all rows,
+ 	 * unlike data errors (e.g., divide by zero) which only affect current row.
+ 	*/
+
 		pltsql_insert_exec_set_error_flag();
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
@@ -1233,15 +1242,15 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 
 		/* Create Var node referencing input tuple column (OUTER_VAR for ecxt_outertuple) */
 		var = makeVar(OUTER_VAR,
-					  i + 1,			/* attnum is 1-based */
+					  i + 1,				/* attnum is 1-based */
 					  src_att->atttypid,
 					  src_att->atttypmod,
 					  src_att->attcollation,
-					  0);				/* varlevelsup */
+					  0);					/* varlevelsup */
 
 		expr = (Node *) var;
 
-		/* Check if coercion is needed */
+		/* Check if coercion is needed for this column */
 		if (src_att->atttypid != tgt_att->atttypid ||
 			(src_att->atttypmod != tgt_att->atttypmod && tgt_att->atttypmod != -1))
 		{
@@ -1310,8 +1319,14 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 		TupleDesc	proj_tupdesc;
 
 		myState->econtext = CreateStandaloneExprContext();
+
+		/* Create a copy of the temp table's tuple descriptor for the result slot */
 		proj_tupdesc = CreateTupleDescCopy(temp_tupdesc);
+
+		/* Create the result slot for projection */
 		myState->proj_slot = MakeSingleTupleTableSlot(proj_tupdesc, &TTSOpsVirtual);
+
+		/* Build the projection info */
 		myState->proj_info = ExecBuildProjectionInfo(target_list,
 													 myState->econtext,
 													 myState->proj_slot,
@@ -1322,23 +1337,17 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	table_close(temp_rel, AccessShareLock);
 
 	/*
-	 * Pre-assign transaction ID before parallel mode starts. This is critical
-	 * for parallel query: insertexec_receive calls table_tuple_insert which
-	 * needs a transaction ID, but AssignTransactionId fails during parallel mode.
-	 */
-	(void) GetCurrentTransactionId();
+ 	 * Pre-assign XID before parallel mode starts. table_tuple_insert() calls
+ 	 * GetCurrentTransactionId() which fails in parallel mode if no XID exists.
+ 	 * rStartup runs before EnterParallelMode, so assigning here avoids the error.
+ 	*/
+
+	(void) GetCurrentTransactionId();  /* Ensure XID is assigned before parallel mode */
 }
 
 /*
  * insertexec_receive --- receive one tuple and insert into temp table
- *
- * Opens/closes the relation for each tuple to avoid holding stale handles
- * across subtransaction boundaries (e.g., inner TRY/CATCH blocks).
- *
- * Note: Each open acquires RowExclusiveLock but we don't release it (NoLock
- * on close), accumulating lock refs. For temp tables this is fine - no shared
- * memory contention - but could be optimized to open once in startup if needed.
- */
+*/
 static bool
 insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 {
@@ -1355,21 +1364,41 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 	{
 		ExprContext *econtext = myState->econtext;
 
+		/* Reset per-tuple memory context for expression evaluation */
 		ResetExprContext(econtext);
+
+		/*
+		 * Set up the input slot for projection.
+		 * ExecProject will read from ecxt_outertuple (we used OUTER_VAR in the Var nodes).
+		 */
 		econtext->ecxt_outertuple = slot;
 
 		/* Project tuple with type coercion */
 		insert_slot = ExecProject(myState->proj_info);
 
-		table_tuple_insert(temp_rel, insert_slot, cid, 0, NULL);
+		/* Insert the projected tuple */
+		table_tuple_insert(temp_rel,
+						   insert_slot,
+						   cid,
+						   0,
+						   NULL);
 	}
 	else
 	{
-		/* No coercion needed - insert directly */
-		table_tuple_insert(temp_rel, slot, cid, 0, NULL);
+		/*
+		 * No coercion needed - insert directly.
+		 * table_tuple_insert handles slot type conversion if needed.
+		 */
+		table_tuple_insert(temp_rel,
+						   slot,
+						   cid,
+						   0,  /* no special options - preserve MVCC */
+						   NULL);  /* no bulk insert state */
 	}
 
+	/* Close relation immediately - don't hold across subtransaction boundaries */
 	table_close(temp_rel, NoLock);
+
 	myState->rows_inserted++;
 
 	return true;
@@ -1377,18 +1406,22 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 
 /*
  * insertexec_shutdown --- executor end for INSERT EXEC receiver
+ *
+ * Clean up the expression context and projection slot used for type coercion.
  */
 static void
 insertexec_shutdown(DestReceiver *self)
 {
 	DR_insertexec *myState = (DR_insertexec *) self;
 
+	/* Free the projection slot if we created one */
 	if (myState->proj_slot != NULL)
 	{
 		ExecDropSingleTupleTableSlot(myState->proj_slot);
 		myState->proj_slot = NULL;
 	}
 
+	/* Free the expression context if we created one */
 	if (myState->econtext != NULL)
 	{
 		FreeExprContext(myState->econtext, true);
@@ -1404,11 +1437,9 @@ insertexec_destroy(DestReceiver *self)
 {
 	DR_insertexec *myState = (DR_insertexec *) self;
 
-	/* Defensive: ensure resources are freed even if shutdown was skipped */
-	if (myState->proj_slot != NULL || myState->econtext != NULL)
-		insertexec_shutdown(self);
+	/* proj_info is allocated in the expression context, no need to free separately */
+	myState->proj_info = NULL;
 
-	myState->proj_info = NULL;  /* allocated in expression context */
 	pfree(self);
 }
 

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -181,75 +181,6 @@ static InsertExecContext insert_exec_ctx = {
 };
 
 /*
- * Parse a T-SQL table name (1-part, 2-part, or 3-part) into schema and table.
- * Returns true on success. Caller must pfree the output strings.
- */
-bool
-parse_insert_exec_table_name(const char *target_table,
-							 char **schema_name_out,
-							 char **table_name_out,
-							 char **physical_schema_out,
-							 bool get_physical)
-{
-	char	   *target_copy;
-	char	   *dot_pos;
-	char	   *second_dot;
-	char	   *schema_name = NULL;
-	char	   *table_name = NULL;
-
-	if (target_table == NULL)
-		return false;
-
-	target_copy = pstrdup(target_table);
-
-	/* Find the last dot to separate schema from table */
-	dot_pos = strrchr(target_copy, '.');
-	if (dot_pos != NULL)
-	{
-		*dot_pos = '\0';
-		table_name = pstrdup(dot_pos + 1);
-
-		/* Check if there's another dot (db.schema.table) */
-		second_dot = strrchr(target_copy, '.');
-		if (second_dot != NULL)
-		{
-			/* db.schema.table - schema is after the second dot */
-			schema_name = pstrdup(second_dot + 1);
-		}
-		else
-		{
-			/* schema.table */
-			schema_name = pstrdup(target_copy);
-		}
-	}
-	else
-	{
-		/*
-		 * Just table name, no schema specified - default to dbo for now.
-		 * TODO: Ideally we should respect the user's default schema,
-		 * but that requires changes to how ownership chaining works.
-		 */
-		table_name = pstrdup(target_copy);
-		schema_name = pstrdup("dbo");
-	}
-	pfree(target_copy);
-
-	*schema_name_out = schema_name;
-	*table_name_out = table_name;
-
-	if (get_physical && physical_schema_out != NULL)
-	{
-		*physical_schema_out = get_physical_schema_name(get_cur_db_name(), schema_name);
-	}
-	else if (physical_schema_out != NULL)
-	{
-		*physical_schema_out = NULL;
-	}
-
-	return true;
-}
-
-/*
  * Set the global INSERT EXEC context with target table info.
  * Called from ANTLR parser when INSERT EXEC is detected.
  * This is called BEFORE temp table creation - just stores the target info.
@@ -1571,11 +1502,14 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	}
 	else
 	{
-		if (!parse_insert_exec_table_name(target_table, &schema_name, &table_name,
-										  &physical_schema, true))
-		{
-			elog(ERROR, "INSERT-EXEC: Failed to parse target table name: %s", target_table);
-		}
+		table_name = pstrdup(target_table);
+		if (schema_name_in != NULL)
+			schema_name = pstrdup(schema_name_in);
+		else
+			schema_name = pstrdup("dbo");
+		physical_schema = get_physical_schema_name(get_cur_db_name(), schema_name);
+		if (physical_schema == NULL)
+			elog(ERROR, "INSERT-EXEC: Failed to resolve schema for target table: %s", target_table);
 	}
 
 	initStringInfo(&create_stmt);
@@ -2237,10 +2171,10 @@ insert_exec_setup(PLtsql_execstate *estate,
 	pltsql_set_insert_exec_context_info(target_table, column_list);
 
 	/* Hold target table open to detect schema alterations during execution */
-	pltsql_insert_exec_open_target_table(target_table);
+	pltsql_insert_exec_open_target_table(target_table, schema_name, db_name);
 
 	/* Create temp table based on target table structure */
-	temp_table_oid = create_insert_exec_temp_table(target_table, column_list);
+	temp_table_oid = create_insert_exec_temp_table(target_table, column_list, schema_name);
 
 	/* Set global context so DestReceiver knows where to write */
 	pltsql_set_insert_exec_context(temp_table_oid);

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1,0 +1,1177 @@
+/*-------------------------------------------------------------------------
+ *
+ * pl_insert_exec.c
+ *	  INSERT EXECUTE implementation for Babelfish PL/tsql
+ *
+ * This file contains all logic for the INSERT INTO <target> EXEC <proc>
+ * statement redesign. It implements:
+ *   - InsertExecContext: global state tracking for an active INSERT EXEC
+ *   - DestReceiver (DR_insertexec): captures procedure output into a
+ *     session-local temp table
+ *   - Temp table lifecycle: creation, schema inference, flush, and drop
+ *   - Context management accessors used across pl_exec.c, hooks.c, and
+ *     the TDS layer
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/* Include pltsql.h first to define types used by pltsql-2.h */
+#include "pltsql.h"
+#include "pltsql-2.h"
+
+#include "funcapi.h"
+
+#include "access/parallel.h"
+#include "access/table.h"
+#include "parser/parser.h"
+#include "access/tableam.h"
+#include "access/attmap.h"
+#include "access/xact.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_attribute.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
+#include "executor/executor.h"
+#include "executor/tstoreReceiver.h"
+#include "executor/tuptable.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "optimizer/optimizer.h"
+#include "parser/parse_coerce.h"
+#include "tcop/dest.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "storage/lmgr.h"
+
+#include "catalog.h"
+#include "multidb.h"
+#include "pltsql_permissions.h"
+#include "session.h"
+#include "parser/scansup.h"
+#include "parser/parse_oper.h"
+#include "utils/builtins.h"
+#include "utils/varlena.h"
+
+/* Forward declaration for exec_stmt_execsql from pl_exec.c */
+extern int exec_stmt_execsql(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
+
+/*
+ * DestReceiver that writes tuples to a temp table for INSERT EXEC buffering.
+ */
+
+/*
+ * Schema signature (column count and types) captured at INSERT EXEC start,
+ * used to detect ALTER TABLE operations before flushing to the target.
+ */
+typedef struct InsertExecSchemaSignature
+{
+	int			natts;			/* Number of columns */
+	Oid		   *atttypids;		/* Array of column type OIDs */
+	int32	   *atttypmods;		/* Array of column type modifiers */
+} InsertExecSchemaSignature;
+
+/*
+ * Global context for INSERT EXEC - bundled into a single struct for cleaner code.
+ * This context is needed for nested procedure calls during INSERT EXEC.
+ */
+typedef struct InsertExecContext
+{
+	Oid			temp_table_oid;			/* OID of temp table for buffering */
+	char	   *temp_table_name;		/* Name of temp table for buffering (dynamically chosen) */
+	char	   *target_table;			/* Target table name */
+	char	   *column_list;			/* Column list for INSERT */
+	bool		flush_in_progress;		/* True during flush phase to block commit_stmt */
+	int			call_stack_depth;		/* Call stack depth when INSERT EXEC was started */
+	bool		had_error;				/* True if INSERT EXEC had an error */
+	bool		pending_drop;			/* True if temp table needs to be dropped when SPI is available */
+	Oid			target_rel_oid;			/* OID of target table - lock held to detect schema changes */
+	InsertExecSchemaSignature *schema_sig;	/* Schema signature for detecting changes */
+	uint64		execution_id;			/* Unique ID for this INSERT EXEC execution */
+	bool		started_implicit_txn;	/* True if INSERT EXEC started an implicit transaction */
+} InsertExecContext;
+
+/* Counter for generating unique execution IDs */
+static uint64 insert_exec_execution_counter = 0;
+
+/* Initialize the global INSERT EXEC context */
+static InsertExecContext insert_exec_ctx = {
+	.temp_table_oid = InvalidOid,
+	.temp_table_name = NULL,
+	.target_table = NULL,
+	.column_list = NULL,
+	.flush_in_progress = false,
+	.call_stack_depth = 0,
+	.had_error = false,
+	.pending_drop = false,
+	.target_rel_oid = InvalidOid,
+	.schema_sig = NULL,
+	.execution_id = 0,
+	.started_implicit_txn = false
+};
+
+/*
+ * Parse tsql table name (1-part, 2-part, or 3-part) into schema and table.
+ * Returns true on success. Caller must pfree the output strings.
+ */
+bool
+parse_insert_exec_table_name(const char *target_table,
+							 char **schema_name_out,
+							 char **table_name_out,
+							 char **physical_schema_out,
+							 bool get_physical)
+{
+	char	   *target_copy;
+	char	   *dot_pos;
+	char	   *second_dot;
+	char	   *schema_name = NULL;
+	char	   *table_name = NULL;
+
+	if (target_table == NULL)
+		return false;
+
+	target_copy = pstrdup(target_table);
+
+	/* Find the last dot to separate schema from table */
+	dot_pos = strrchr(target_copy, '.');
+	if (dot_pos != NULL)
+	{
+		*dot_pos = '\0';
+		table_name = pstrdup(dot_pos + 1);
+
+		/* Check if there's another dot (db.schema.table) */
+		second_dot = strrchr(target_copy, '.');
+		if (second_dot != NULL)
+		{
+			/* db.schema.table - schema is after the second dot */
+			schema_name = pstrdup(second_dot + 1);
+		}
+		else
+		{
+			/* schema.table */
+			schema_name = pstrdup(target_copy);
+		}
+	}
+	else
+	{
+		/*
+		 * Just table name, no schema specified - default to dbo for now.
+		 * TODO: Ideally we should respect the user's default schema,
+		 * but that requires changes to how ownership chaining works.
+		 */
+		table_name = pstrdup(target_copy);
+		schema_name = pstrdup("dbo");
+	}
+	pfree(target_copy);
+
+	*schema_name_out = schema_name;
+	*table_name_out = table_name;
+
+	if (get_physical && physical_schema_out != NULL)
+	{
+		*physical_schema_out = get_physical_schema_name(get_cur_db_name(), schema_name);
+	}
+	else if (physical_schema_out != NULL)
+	{
+		*physical_schema_out = NULL;
+	}
+
+	return true;
+}
+
+/*
+ * Set the global INSERT EXEC context with target table info.
+ * Called from ANTLR parser when INSERT EXEC is detected.
+ * This is called BEFORE temp table creation - just stores the target info.
+ *
+ * IMPORTANT: We allocate in TopMemoryContext so the strings survive
+ * error handling (PG_CATCH blocks). The current memory context may be
+ * reset during error processing, which would corrupt these pointers.
+ */
+void
+pltsql_set_insert_exec_context_info(const char *target_table, const char *column_list)
+{
+	MemoryContext oldcontext;
+	PLExecStateCallStack *cur;
+	int depth = 0;
+
+	/* Clear any previous context */
+	if (insert_exec_ctx.target_table)
+	{
+		pfree(insert_exec_ctx.target_table);
+		insert_exec_ctx.target_table = NULL;
+	}
+	if (insert_exec_ctx.column_list)
+	{
+		pfree(insert_exec_ctx.column_list);
+		insert_exec_ctx.column_list = NULL;
+	}
+
+	/* Allocate in TopMemoryContext so strings survive error handling */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	insert_exec_ctx.target_table = target_table ? pstrdup(target_table) : NULL;
+	insert_exec_ctx.column_list = column_list ? pstrdup(column_list) : NULL;
+	MemoryContextSwitchTo(oldcontext);
+
+	/* Record the call stack depth when INSERT EXEC was started */
+	cur = exec_state_call_stack;
+	while (cur != NULL)
+	{
+		depth++;
+		cur = cur->next;
+	}
+	/*
+	 * Record the call stack depth when INSERT EXEC was started.
+	 * This is used to detect stale INSERT EXEC context.
+	 */
+	insert_exec_ctx.call_stack_depth = depth;
+
+	/*
+	 * Store a unique execution ID for this INSERT EXEC. This is used to detect
+	 * if the INSERT EXEC context is stale (from a previous execution).
+	 */
+	insert_exec_ctx.execution_id = ++insert_exec_execution_counter;
+}
+
+/*
+ * Set the global INSERT EXEC context with temp table OID.
+ * Called when temp table is created in exec_stmt_exec.
+ */
+void
+pltsql_set_insert_exec_context(Oid temp_table_oid)
+{
+	insert_exec_ctx.temp_table_oid = temp_table_oid;
+}
+
+/*
+ * Clear the global INSERT EXEC context.
+ * Called when exiting INSERT EXEC context normally.
+ * Note: Does not clear had_error or started_implicit_txn flags, which are
+ * needed for post-cleanup transaction count mismatch checks.
+ */
+void
+pltsql_clear_insert_exec_context(void)
+{
+	insert_exec_ctx.temp_table_oid = InvalidOid;
+	insert_exec_ctx.call_stack_depth = 0;
+	insert_exec_ctx.execution_id = 0;
+	insert_exec_ctx.flush_in_progress = false;
+	insert_exec_ctx.pending_drop = false;
+	if (insert_exec_ctx.target_table)
+	{
+		pfree(insert_exec_ctx.target_table);
+		insert_exec_ctx.target_table = NULL;
+	}
+	if (insert_exec_ctx.column_list)
+	{
+		pfree(insert_exec_ctx.column_list);
+		insert_exec_ctx.column_list = NULL;
+	}
+	if (insert_exec_ctx.temp_table_name)
+	{
+		pfree(insert_exec_ctx.temp_table_name);
+		insert_exec_ctx.temp_table_name = NULL;
+	}
+}
+
+/*
+ * Full reset of INSERT EXEC context for safety net cleanup paths.
+ * Called when stale context is detected (e.g., empty call stack, batch end).
+ * Unlike pltsql_clear_insert_exec_context(), this also clears the error and
+ * implicit transaction flags, and releases target table resources.
+ */
+void
+pltsql_insert_exec_reset_all(void)
+{
+	/* Release target table lock and free schema signature */
+	pltsql_insert_exec_close_target_table();
+
+	/* Clear all context fields including flags */
+	pltsql_clear_insert_exec_context();
+	insert_exec_ctx.had_error = false;
+	insert_exec_ctx.started_implicit_txn = false;
+}
+
+/*
+ * Set the INSERT EXEC error flag.
+ * Called when an error occurs during INSERT EXEC.
+ * This flag is used to skip the transaction count mismatch check.
+ */
+void
+pltsql_insert_exec_set_error_flag(void)
+{
+	insert_exec_ctx.had_error = true;
+}
+
+/*
+ * Check if INSERT EXEC had an error.
+ * Used to skip the transaction count mismatch check.
+ */
+bool
+pltsql_insert_exec_had_error(void)
+{
+	return insert_exec_ctx.had_error;
+}
+
+/*
+ * Clear the INSERT EXEC error flag.
+ * Called after the error has been handled.
+ */
+void
+pltsql_insert_exec_clear_error_flag(void)
+{
+	insert_exec_ctx.had_error = false;
+}
+
+/*
+ * Set the flag indicating INSERT EXEC started an implicit transaction.
+ * This flag persists even after the INSERT EXEC context is cleared,
+ * so it can be used to skip the transaction count mismatch check.
+ */
+void
+pltsql_insert_exec_set_implicit_txn_flag(void)
+{
+	elog(DEBUG4, "TSQL TXN Setting implicit txn flag for INSERT EXEC (was %d, setting to true)",
+		 insert_exec_ctx.started_implicit_txn);
+	insert_exec_ctx.started_implicit_txn = true;
+	elog(DEBUG4, "TSQL TXN After setting implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
+}
+
+/*
+ * Check if INSERT EXEC started an implicit transaction.
+ * Used to skip the transaction count mismatch check.
+ */
+bool
+pltsql_insert_exec_started_implicit_txn(void)
+{
+	elog(DEBUG4, "TSQL TXN Checking implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
+	return insert_exec_ctx.started_implicit_txn;
+}
+
+/*
+ * Clear the flag indicating INSERT EXEC started an implicit transaction.
+ * Called after the transaction count mismatch check has been skipped.
+ */
+void
+pltsql_insert_exec_clear_implicit_txn_flag(void)
+{
+	elog(DEBUG4, "TSQL TXN Clearing implicit txn flag (was %d)", insert_exec_ctx.started_implicit_txn);
+	insert_exec_ctx.started_implicit_txn = false;
+}
+
+/*
+ * Set the pending drop flag.
+ * Called when an error occurs and we can't drop the temp table immediately.
+ */
+void
+pltsql_insert_exec_set_pending_drop(void)
+{
+	insert_exec_ctx.pending_drop = true;
+}
+
+/*
+ * Check and drop the pending temp table if needed.
+ * Called at the start of each INSERT EXEC to clean up any leftover temp table.
+ * This handles the case where a previous INSERT EXEC failed and couldn't
+ * drop its temp table because SPI wasn't available in the error context.
+ */
+void
+pltsql_insert_exec_check_pending_drop(void)
+{
+	if (insert_exec_ctx.pending_drop && insert_exec_ctx.temp_table_name != NULL)
+	{
+		StringInfoData drop_stmt;
+		int			rc;
+
+		initStringInfo(&drop_stmt);
+		appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s", insert_exec_ctx.temp_table_name);
+
+		rc = SPI_execute(drop_stmt.data, false, 0);
+		if (rc != SPI_OK_UTILITY)
+			elog(WARNING, "failed to drop pending INSERT EXEC temp table %s: %s",
+				 insert_exec_ctx.temp_table_name, SPI_result_code_string(rc));
+
+		pfree(drop_stmt.data);
+		pfree(insert_exec_ctx.temp_table_name);
+		insert_exec_ctx.temp_table_name = NULL;
+		insert_exec_ctx.pending_drop = false;
+	}
+}
+
+/*
+ * Capture schema signature and lock target table for schema change detection.
+ * We record column count and types at INSERT EXEC start, then verify they
+ * haven't changed before flushing. Regular tables get RowExclusiveLock to
+ * block concurrent DDL; temp tables only get schema captured (session-local).
+ */
+void
+pltsql_insert_exec_open_target_table(const char *target_table)
+{
+	RangeVar   *rv;
+	Oid			relid;
+	char	   *schema_name = NULL;
+	char	   *table_name = NULL;
+	char	   *physical_schema = NULL;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	int			i;
+	MemoryContext oldcontext;
+	bool		is_temp_table;
+
+	if (target_table == NULL)
+		return;
+
+	is_temp_table = (target_table[0] == '#' || target_table[0] == '@');
+
+	if (is_temp_table)
+	{
+		/*
+		 * Temp table or table variable - resolve using RangeVarGetRelid.
+		 * We don't need to lock because they're session-local.
+		 */
+		rv = makeRangeVar(NULL, pstrdup(target_table), -1);
+		relid = RangeVarGetRelid(rv, NoLock, true);
+
+		if (!OidIsValid(relid))
+			return;
+
+		/* Store the OID for schema verification (no lock for temp tables) */
+		insert_exec_ctx.target_rel_oid = relid;
+	}
+	else
+	{
+		/* Regular table - parse schema and table name */
+		if (!parse_insert_exec_table_name(target_table, &schema_name, &table_name,
+										  &physical_schema, true))
+		{
+			return;
+		}
+
+		/* Create RangeVar and get the relation OID */
+		rv = makeRangeVar(physical_schema, table_name, -1);
+		relid = RangeVarGetRelid(rv, NoLock, true);
+
+		if (schema_name)
+			pfree(schema_name);
+		if (table_name)
+			pfree(table_name);
+		if (physical_schema)
+			pfree(physical_schema);
+
+		if (!OidIsValid(relid))
+		{
+			/* Table doesn't exist - will be caught later during flush */
+			return;
+		}
+
+		/*
+		 * Acquire RowExclusiveLock on the target table.
+		 * This lock will be held until the end of the transaction.
+		 * It blocks concurrent sessions from modifying the table.
+		 */
+		oldcontext = CurrentMemoryContext;
+		PG_TRY();
+		{
+			LockRelationOid(relid, RowExclusiveLock);
+		}
+		PG_CATCH();
+		{
+			MemoryContextSwitchTo(oldcontext);
+			FlushErrorState();
+			return;
+		}
+		PG_END_TRY();
+
+		insert_exec_ctx.target_rel_oid = relid;
+	}
+
+	/*
+	 * Capture the schema signature of the target table.
+	 * This is used to detect DROP/ALTER at flush time.
+	 */
+	oldcontext = CurrentMemoryContext;
+	PG_TRY();
+	{
+		rel = table_open(relid, NoLock);
+	}
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(oldcontext);
+		FlushErrorState();
+		insert_exec_ctx.target_rel_oid = InvalidOid;
+		return;
+	}
+	PG_END_TRY();
+
+	tupdesc = RelationGetDescr(rel);
+
+	/* Allocate schema signature in TopMemoryContext so it survives error handling */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+
+	/* Free any previous schema signature */
+	if (insert_exec_ctx.schema_sig != NULL)
+	{
+		if (insert_exec_ctx.schema_sig->atttypids)
+			pfree(insert_exec_ctx.schema_sig->atttypids);
+		if (insert_exec_ctx.schema_sig->atttypmods)
+			pfree(insert_exec_ctx.schema_sig->atttypmods);
+		pfree(insert_exec_ctx.schema_sig);
+		insert_exec_ctx.schema_sig = NULL;
+	}
+
+	insert_exec_ctx.schema_sig = palloc0(sizeof(InsertExecSchemaSignature));
+	insert_exec_ctx.schema_sig->natts = tupdesc->natts;
+	insert_exec_ctx.schema_sig->atttypids = palloc0(tupdesc->natts * sizeof(Oid));
+	insert_exec_ctx.schema_sig->atttypmods = palloc0(tupdesc->natts * sizeof(int32));
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+		insert_exec_ctx.schema_sig->atttypids[i] = attr->atttypid;
+		insert_exec_ctx.schema_sig->atttypmods[i] = attr->atttypmod;
+	}
+
+	MemoryContextSwitchTo(oldcontext);
+
+	table_close(rel, NoLock);  /* Keep the lock (if any) */
+}
+
+/*
+ * Close the target table that was held open during INSERT EXEC.
+ * Called after the flush completes or on error cleanup.
+ *
+ * For regular tables: Release the RowExclusiveLock we acquired.
+ * For temp tables: Just clear the OID (no lock was acquired).
+ */
+void
+pltsql_insert_exec_close_target_table(void)
+{
+	if (OidIsValid(insert_exec_ctx.target_rel_oid))
+	{
+		const char *target = pltsql_get_insert_exec_target_table();
+		bool is_temp_table = (target != NULL && (target[0] == '#' || target[0] == '@'));
+
+		/*
+		 * Only release the lock for regular tables (not temp tables).
+		 * Temp tables don't have locks to release.
+		 */
+		if (!is_temp_table && !IsAbortedTransactionBlockState())
+		{
+			MemoryContext oldcontext = CurrentMemoryContext;
+			PG_TRY();
+			{
+				UnlockRelationOid(insert_exec_ctx.target_rel_oid, RowExclusiveLock);
+			}
+			PG_CATCH();
+			{
+				MemoryContextSwitchTo(oldcontext);
+				FlushErrorState();
+				/* Ignore unlock failures - table may have been dropped */
+			}
+			PG_END_TRY();
+		}
+		insert_exec_ctx.target_rel_oid = InvalidOid;
+	}
+
+	/* Free the schema signature */
+	if (insert_exec_ctx.schema_sig != NULL)
+	{
+		if (insert_exec_ctx.schema_sig->atttypids)
+			pfree(insert_exec_ctx.schema_sig->atttypids);
+		if (insert_exec_ctx.schema_sig->atttypmods)
+			pfree(insert_exec_ctx.schema_sig->atttypmods);
+		pfree(insert_exec_ctx.schema_sig);
+		insert_exec_ctx.schema_sig = NULL;
+	}
+}
+
+/*
+ * Verify that the target table schema hasn't changed since INSERT EXEC started.
+ * Returns true if schema is unchanged, false if it has changed.
+ *
+ * This is called before flushing data to the target table to detect if the
+ * executed procedure altered the target table's schema.
+ */
+bool
+pltsql_insert_exec_verify_schema(void)
+{
+	Relation	rel;
+	TupleDesc	tupdesc;
+	int			i;
+	bool		schema_changed = false;
+	MemoryContext oldcontext;
+
+	/* If no schema signature was captured, skip the check */
+	if (insert_exec_ctx.schema_sig == NULL || !OidIsValid(insert_exec_ctx.target_rel_oid))
+		return true;
+
+	/*
+	 * Try to open the relation. If we can't open it, the table was likely
+	 * dropped by the executed procedure - this is a schema change error.
+	 */
+	oldcontext = CurrentMemoryContext;
+	PG_TRY();
+	{
+		rel = table_open(insert_exec_ctx.target_rel_oid, NoLock);  /* Already have lock */
+	}
+	PG_CATCH();
+	{
+		/*
+		 * Could not open relation - table was dropped or OID is stale.
+		 * This is a schema change, return false to trigger the error.
+		 */
+		MemoryContextSwitchTo(oldcontext);
+		FlushErrorState();
+		return false;  /* Schema changed - table no longer exists */
+	}
+	PG_END_TRY();
+
+	tupdesc = RelationGetDescr(rel);
+
+	/* Check if column count changed */
+	if (tupdesc->natts != insert_exec_ctx.schema_sig->natts)
+	{
+		schema_changed = true;
+	}
+	else
+	{
+		/* Check if any column type changed */
+		for (i = 0; i < tupdesc->natts; i++)
+		{
+			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+			if (attr->atttypid != insert_exec_ctx.schema_sig->atttypids[i] ||
+				attr->atttypmod != insert_exec_ctx.schema_sig->atttypmods[i])
+			{
+				schema_changed = true;
+				break;
+			}
+		}
+	}
+
+	table_close(rel, NoLock);  /* Keep the lock */
+
+	return !schema_changed;
+}
+
+/*
+ * Helper function to check if a target list contains SELECT * (star expansion).
+ * Returns true if any target contains a star, false otherwise.
+ */
+static bool
+target_list_contains_star(List *targetList)
+{
+	ListCell *lc;
+
+	foreach(lc, targetList)
+	{
+		ResTarget *rt = (ResTarget *) lfirst(lc);
+
+		if (rt == NULL || !IsA(rt, ResTarget))
+			continue;
+
+		/* Check if the value is a ColumnRef with A_Star */
+		if (rt->val != NULL && IsA(rt->val, ColumnRef))
+		{
+			ColumnRef *cref = (ColumnRef *) rt->val;
+			ListCell *field_lc;
+
+			foreach(field_lc, cref->fields)
+			{
+				Node *field = (Node *) lfirst(field_lc);
+				if (IsA(field, A_Star))
+					return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Helper function to count target list columns in a SelectStmt.
+ * Handles UNION/INTERSECT/EXCEPT by recursively checking the left branch.
+ * Returns -1 if the statement is not a SELECT, if column count cannot be determined,
+ * or if the SELECT uses * (star expansion) which requires table resolution.
+ */
+static int
+count_select_target_columns(SelectStmt *stmt)
+{
+	if (stmt == NULL)
+		return -1;
+
+	/* For set operations (UNION, INTERSECT, EXCEPT), check the left branch */
+	if (stmt->op != SETOP_NONE)
+	{
+		return count_select_target_columns(stmt->larg);
+	}
+
+	/* For a simple SELECT, count the target list */
+	if (stmt->targetList != NULL)
+	{
+		/*
+		 * If the target list contains SELECT *, we can't determine the
+		 * actual column count without resolving the table reference.
+		 * Return -1 to skip early validation and let the normal path handle it.
+		 */
+		if (target_list_contains_star(stmt->targetList))
+			return -1;
+
+		return list_length(stmt->targetList);
+	}
+
+	return -1;
+}
+
+/*
+ * Validate column count from query string BEFORE plan preparation. tsql requires
+ * column mismatch errors to take priority over runtime errors (e.g., division by zero),
+ * so we parse and count columns here without evaluation. If count cannot be determined
+ * (SELECT *, complex queries, parse errors), we defer to the DestReceiver validation.
+ * Returns true if validation passes or cannot be performed; false only on definite mismatch.
+ */
+bool
+pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
+{
+	List		*parsetree_list;
+	RawStmt		*raw_stmt;
+	Node		*stmt;
+	int			query_natts;
+	Oid			temp_table_oid;
+	Relation	temp_rel;
+	TupleDesc	temp_tupdesc;
+	int			temp_natts;
+	MemoryContext oldcontext;
+
+	/* Caller must ensure INSERT EXEC is active before calling */
+	Assert(pltsql_insert_exec_active());
+
+	/* Temp table must exist - caller checks pltsql_insert_exec_in_execution() */
+	temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
+	Assert(OidIsValid(temp_table_oid));
+
+	/* Parse the query string - if parsing fails, defer to normal execution */
+	oldcontext = CurrentMemoryContext;
+	PG_TRY();
+	{
+		parsetree_list = raw_parser(query_string, RAW_PARSE_DEFAULT);
+	}
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(oldcontext);
+		FlushErrorState();
+		return true;  /* Parse error - normal path will report it */
+	}
+	PG_END_TRY();
+
+	/* Only handle single-statement queries */
+	if (list_length(parsetree_list) != 1)
+		return true;  /* Multiple statements, defer to runtime */
+
+	raw_stmt = (RawStmt *) linitial(parsetree_list);
+	stmt = raw_stmt->stmt;
+
+	/* Only validate SELECT statements */
+	if (!IsA(stmt, SelectStmt))
+		return true;  /* Not a SELECT (e.g., EXEC), defer to runtime */
+
+	/*
+	 * Count target list columns. Returns -1 for SELECT *, complex queries,
+	 * or when column count can't be determined statically. In those cases,
+	 * skip early validation - the DestReceiver will catch mismatches at runtime.
+	 */
+	query_natts = count_select_target_columns((SelectStmt *) stmt);
+	if (query_natts < 0)
+		return true;  /* Can't determine count statically, defer to runtime */
+
+	/* Get temp table column count */
+	PG_TRY();
+	{
+		temp_rel = table_open(temp_table_oid, AccessShareLock);
+		temp_tupdesc = RelationGetDescr(temp_rel);
+		temp_natts = temp_tupdesc->natts;
+		table_close(temp_rel, AccessShareLock);
+	}
+	PG_CATCH();
+	{
+		/* If we can't open the temp table, let normal path handle it */
+		MemoryContextSwitchTo(oldcontext);
+		FlushErrorState();
+		return true;
+	}
+	PG_END_TRY();
+
+	/* Check for column count mismatch */
+	if (query_natts != temp_natts)
+	{
+		/*
+		 * Set error flag BEFORE throwing so flush is skipped even if TRY-CATCH
+		 * catches it. Column mismatch errors roll back all rows, unlike data-level
+		 * errors (e.g., division by zero) which only affect the current row.
+		 */
+		pltsql_insert_exec_set_error_flag();
+
+		/*
+		 * Use ERRCODE_DATATYPE_MISMATCH to avoid the error mapping in
+		 * error_mapping.txt. We want to keep the internal error code for
+		 * test compatibility.
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("Column name or number of supplied values does not match table definition.")));
+		return false;  /* Not reached, but for clarity */
+	}
+
+	return true;
+}
+
+/*
+ * Check if INSERT EXEC context is active (target table info is set).
+ * This returns true even before temp table is created.
+ */
+bool
+pltsql_insert_exec_active(void)
+{
+	return (insert_exec_ctx.target_table != NULL);
+}
+
+/*
+ * Check if INSERT EXEC is actively in execution with a valid temp table.
+ * Unlike pltsql_insert_exec_active(), this also verifies the temp table exists.
+ * Returns false if context is not set, temp table was dropped, or not yet created.
+ */
+bool
+pltsql_insert_exec_in_execution(void)
+{
+	PLExecStateCallStack *cur;
+	int current_depth = 0;
+	Oid temp_table_oid;
+
+	if (insert_exec_ctx.target_table == NULL)
+		return false;
+
+	/*
+	 * If call_stack_depth is 0, the context was never properly set or was
+	 * cleared. This shouldn't happen if target_table is set, but check anyway.
+	 */
+	if (insert_exec_ctx.call_stack_depth == 0)
+		return false;
+
+	/*
+	 * Check if the temp table OID is valid. If the INSERT EXEC context is
+	 * stale (from a previous execution), the temp table would have been
+	 * dropped and the OID would be invalid.
+	 */
+	temp_table_oid = insert_exec_ctx.temp_table_oid;
+	if (!OidIsValid(temp_table_oid))
+		return false;
+
+	/*
+	 * Verify temp table still exists - OID may be stale if table was dropped
+	 * after rollback. Use syscache check to avoid errors from opening missing relation.
+	 */
+	if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(temp_table_oid)))
+		return false;
+
+	/*
+	 * Get current call stack depth.
+	 */
+	cur = exec_state_call_stack;
+	while (cur != NULL)
+	{
+		current_depth++;
+		cur = cur->next;
+	}
+
+	/*
+	 * Empty call stack (depth 0) means no PL/tsql execution in progress.
+	 * Also handles stale context from previous batches - new batch starts with empty stack.
+	 */
+	if (current_depth == 0)
+		return false;
+
+	/*
+	 * Check if the current call stack depth is consistent with the INSERT EXEC
+	 * context. If we're at a shallower level than when INSERT EXEC started,
+	 * the context is stale.
+	 */
+	if (current_depth < insert_exec_ctx.call_stack_depth)
+		return false;  /* Context is stale - we've returned from INSERT EXEC */
+
+	/*
+	 * We're at or below the INSERT EXEC call stack depth, and the temp table
+	 * OID is valid. Final check: verify the execution_id is non-zero.
+	 */
+	if (insert_exec_ctx.execution_id == 0)
+		return false;
+
+	return true;
+}
+
+/*
+ * Check if INSERT EXEC flush is in progress.
+ * During flush, we temporarily clear the INSERT EXEC context to allow
+ * INSTEAD OF triggers to fire, but we still need to block commit_stmt.
+ */
+bool
+pltsql_insert_exec_flush_in_progress(void)
+{
+	return insert_exec_ctx.flush_in_progress;
+}
+
+/*
+ * Set the INSERT EXEC flush in progress flag.
+ * Called when starting/ending the flush operation.
+ */
+void
+pltsql_insert_exec_set_flush_in_progress(bool in_progress)
+{
+	insert_exec_ctx.flush_in_progress = in_progress;
+}
+
+/*
+ * Set the INSERT EXEC target table pointer.
+ * Used during flush to temporarily clear and restore the target table.
+ */
+void
+pltsql_insert_exec_set_target_table(const char *target_table)
+{
+	/* Free old value if setting to a new value */
+	if (insert_exec_ctx.target_table != NULL && target_table != insert_exec_ctx.target_table)
+	{
+		pfree(insert_exec_ctx.target_table);
+	}
+
+	if (target_table != NULL)
+	{
+		MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+		insert_exec_ctx.target_table = pstrdup(target_table);
+		MemoryContextSwitchTo(oldcontext);
+	}
+	else
+	{
+		insert_exec_ctx.target_table = NULL;
+	}
+}
+
+/*
+ * Get the temp table OID for INSERT EXEC buffering.
+ */
+Oid
+pltsql_get_insert_exec_temp_table_oid(void)
+{
+	return insert_exec_ctx.temp_table_oid;
+}
+
+/*
+ * Get the target table name for INSERT EXEC.
+ */
+const char *
+pltsql_get_insert_exec_target_table(void)
+{
+	return insert_exec_ctx.target_table;
+}
+
+/*
+ * Get the target table OID for INSERT EXEC.
+ * This is the OID of the actual target table (not the temp table).
+ * Used for schema-qualified DROP TABLE checks.
+ */
+Oid
+pltsql_get_insert_exec_target_rel_oid(void)
+{
+	return insert_exec_ctx.target_rel_oid;
+}
+
+/*
+ * Get the column list for INSERT EXEC.
+ */
+const char *
+pltsql_get_insert_exec_column_list(void)
+{
+	return insert_exec_ctx.column_list;
+}
+
+/*
+ * Get the temp table name for INSERT EXEC.
+ * This is the dynamically chosen name with suffix (e.g., __insert_exec_buf_12345_1).
+ */
+const char *
+pltsql_get_insert_exec_temp_table_name(void)
+{
+	return insert_exec_ctx.temp_table_name;
+}
+
+/*
+ * Check if we're inside a TRY-CATCH block during INSERT EXEC.
+ * This checks the exec_state_call_stack to see if any estate has a TRY-CATCH block active.
+ */
+bool
+pltsql_insert_exec_in_trycatch(void)
+{
+	PLExecStateCallStack *cur;
+
+	if (insert_exec_ctx.target_table == NULL)
+		return false;
+
+	/* Check the call stack for any active TRY-CATCH blocks */
+	cur = exec_state_call_stack;
+	while (cur != NULL)
+	{
+		/* There is at-least one try block active for sure */
+		if (vec_size(cur->estate->err_ctx_stack) > 1)
+			return true;
+		/* Either try or catch block is active */
+		if (vec_size(cur->estate->err_ctx_stack) == 1)
+		{
+			PLtsql_errctx *err_ctx = *(PLtsql_errctx **) vec_at(cur->estate->err_ctx_stack, 0);
+
+			/* Make sure that we are not inside the catch block */
+			if (!err_ctx->partial_restored)
+				return true;
+		}
+		cur = cur->next;
+	}
+
+	return false;
+}
+
+/*
+ * Called from sigsetjmp handler when TRY-CATCH catches an error.
+ * Returns true if we should clean up INSERT EXEC context - only when the
+ * TRY-CATCH is at or above the INSERT EXEC level. If TRY-CATCH is inside
+ * the executed procedure (deeper stack), INSERT EXEC is still in progress.
+ */
+bool
+pltsql_insert_exec_should_cleanup_on_trycatch(void)
+{
+	PLExecStateCallStack *cur;
+	int current_depth = 0;
+
+	if (insert_exec_ctx.target_table == NULL)
+		return false;
+
+	/* Get current call stack depth */
+	cur = exec_state_call_stack;
+	while (cur != NULL)
+	{
+		current_depth++;
+		cur = cur->next;
+	}
+
+	/*
+	 * If current depth is greater than INSERT EXEC depth, the TRY-CATCH
+	 * is inside the procedure being executed, so don't clean up.
+	 *
+	 * If current depth is equal to or less than INSERT EXEC depth, the
+	 * TRY-CATCH is at the same level or higher, so clean up.
+	 */
+	return current_depth <= insert_exec_ctx.call_stack_depth;
+}
+
+/*
+ * Get and clear the temp table OID for INSERT EXEC cleanup.
+ * Called from iterative_exec.c after TRY-CATCH catches an error.
+ * Returns the temp table OID that needs to be dropped, or InvalidOid if none.
+ *
+ * This is used when an error occurs during INSERT EXEC and is caught by TRY-CATCH.
+ * The PG_CATCH in exec_stmt_exec clears the INSERT EXEC context but leaves the
+ * temp table OID for iterative_exec.c to drop.
+ */
+Oid
+pltsql_get_and_clear_insert_exec_temp_table_for_cleanup(void)
+{
+	Oid temp_oid = insert_exec_ctx.temp_table_oid;
+	insert_exec_ctx.temp_table_oid = InvalidOid;
+	return temp_oid;
+}
+
+
+/*
+ * =============================================================================
+ * STUB FUNCTIONS - To be implemented in subsequent PRs
+ * =============================================================================
+ * These functions are placeholders that allow the code to compile.
+ * They will be replaced with real implementations in later PRs:
+ *   - PR3: CreateInsertExecDestReceiver (DestReceiver implementation)
+ *   - PR4: create_insert_exec_temp_table, drop_insert_exec_temp_table
+ *   - PR5: flush_insert_exec_temp_table, insert_exec_setup,
+ *          insert_exec_error_cleanup, insert_exec_success_cleanup
+ * =============================================================================
+ */
+
+/*
+ * STUB: Create a DestReceiver for INSERT EXEC that writes to a temp table.
+ * Real implementation in PR3 (DestReceiver).
+ */
+DestReceiver *
+CreateInsertExecDestReceiver(Oid temp_table_oid)
+{
+	/* STUB: Returns NULL - real implementation in PR3 */
+	return NULL;
+}
+
+/*
+ * STUB: Create a temp table for INSERT EXEC buffering.
+ * Real implementation in PR4 (Temp Table Create/Drop).
+ */
+Oid
+create_insert_exec_temp_table(const char *target_table, const char *column_list)
+{
+	/* STUB: Returns InvalidOid - real implementation in PR4 */
+	return InvalidOid;
+}
+
+/*
+ * STUB: Drop the temp table used for INSERT EXEC buffering.
+ * Real implementation in PR4 (Temp Table Create/Drop).
+ */
+void
+drop_insert_exec_temp_table(Oid temp_table_oid)
+{
+	/* STUB: Does nothing - real implementation in PR4 */
+}
+
+/*
+ * STUB: Flush data from temp table to target table.
+ * Real implementation in PR5 (Flush Logic + Executor Integration).
+ */
+void
+flush_insert_exec_temp_table(PLtsql_execstate *estate)
+{
+	/* STUB: Does nothing - real implementation in PR5 */
+}
+
+/*
+ * STUB: Set up INSERT EXEC execution context.
+ * Real implementation in PR5 (Flush Logic + Executor Integration).
+ */
+bool
+insert_exec_setup(PLtsql_execstate *estate,
+				  const char *target_table,
+				  const char *column_list,
+				  Oid *temp_table_oid_out,
+				  DestReceiver **dest_out)
+{
+	/* STUB: Returns false (setup not done) - real implementation in PR5 */
+	return false;
+}
+
+/*
+ * STUB: Clean up INSERT EXEC context on error.
+ * Real implementation in PR5 (Flush Logic + Executor Integration).
+ */
+void
+insert_exec_error_cleanup(bool setup_done)
+{
+	/* STUB: Does nothing - real implementation in PR5 */
+}
+
+/*
+ * STUB: Clean up INSERT EXEC context on success.
+ * Real implementation in PR5 (Flush Logic + Executor Integration).
+ */
+void
+insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
+{
+	/* STUB: Does nothing - real implementation in PR5 */
+}

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1195,17 +1195,6 @@ pltsql_get_and_clear_insert_exec_temp_table_for_cleanup(void)
 
 
 /*
- * =============================================================================
- * STUB FUNCTIONS - To be implemented in subsequent PRs
- * =============================================================================
- * These functions are placeholders that allow the code to compile.
- * They will be replaced with real implementations in later PRs:
- *   - PR5: flush_insert_exec_temp_table, insert_exec_setup,
- *          insert_exec_error_cleanup, insert_exec_success_cleanup
- * =============================================================================
- */
-
-/*
  * Create a DestReceiver for INSERT EXEC that writes to a temp table.
  */
 DestReceiver *
@@ -1972,18 +1961,188 @@ drop_insert_exec_temp_table(Oid temp_table_oid)
 }
 
 /*
- * STUB: Flush data from temp table to target table.
- * Real implementation in PR5 (Flush Logic + Executor Integration).
+ * Flush data from temp table to target table.
+ *
+ * Executes INSERT INTO target SELECT * FROM temp_table in a subtransaction.
+ * Uses exec_stmt_execsql to properly handle triggers, rowcount, and FOUND.
+ * Switches to procedure owner's identity for ownership chaining.
  */
 void
 flush_insert_exec_temp_table(PLtsql_execstate *estate)
 {
-	/* STUB: Does nothing - real implementation in PR5 */
+	const char		   *temp_table_name;
+	StringInfoData		flush_query;
+	int					rc;
+	const char		   *target_table = pltsql_get_insert_exec_target_table();
+	const char		   *column_list = pltsql_get_insert_exec_column_list();
+	Oid					temp_oid = pltsql_get_insert_exec_temp_table_oid();
+	MemoryContext		oldcontext = CurrentMemoryContext;
+	ResourceOwner		oldowner = CurrentResourceOwner;
+	volatile bool		subtxn_started = false;
+	char			   *saved_target_table = NULL;
+	Oid					flush_save_userid = InvalidOid;
+	int					flush_save_sec_context = 0;
+	volatile bool		flush_switched_context = false;
+	PLtsql_stmt_execsql flush_stmt;
+	PLtsql_expr			flush_expr;
+
+	if (!OidIsValid(temp_oid) || target_table == NULL)
+		return;
+
+	/*
+	 * Check if an error occurred during INSERT EXEC that should prevent flush.
+	 * Column mismatch errors cause all rows to be rolled back, even if caught
+	 * by TRY-CATCH.
+	 */
+	if (pltsql_insert_exec_had_error())
+		return;
+
+	/*
+	 * Verify target table schema hasn't changed since INSERT EXEC started.
+	 */
+	if (!pltsql_insert_exec_verify_schema())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table.")));
+	}
+
+	saved_target_table = pstrdup(target_table);
+
+	temp_table_name = pltsql_get_insert_exec_temp_table_name();
+	if (temp_table_name == NULL)
+		elog(ERROR, "INSERT-EXEC: No temp table name stored, cannot flush");
+
+	initStringInfo(&flush_query);
+
+	if (column_list != NULL)
+	{
+		appendStringInfo(&flush_query,
+			"INSERT INTO %s (%s) SELECT * FROM %s",
+			target_table, column_list, temp_table_name);
+	}
+	else
+	{
+		appendStringInfo(&flush_query,
+			"INSERT INTO %s SELECT * FROM %s",
+			target_table, temp_table_name);
+	}
+
+	PG_TRY();
+	{
+		BeginInternalSubTransaction("insert_exec_flush");
+		subtxn_started = true;
+		MemoryContextSwitchTo(oldcontext);
+
+		pltsql_insert_exec_set_flush_in_progress(true);
+		pltsql_insert_exec_set_target_table(NULL);
+
+		/* Switch to procedure owner for ownership chaining */
+		if (estate && estate->func && OidIsValid(estate->func->fn_oid))
+		{
+			GetUserIdAndSecContext(&flush_save_userid, &flush_save_sec_context);
+			SetUserIdAndSecContext(get_func_owner(estate->func->fn_oid),
+								   flush_save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+			flush_switched_context = true;
+		}
+
+		/* Build minimal PLtsql_stmt_execsql for exec_stmt_execsql */
+		memset(&flush_stmt, 0, sizeof(flush_stmt));
+		memset(&flush_expr, 0, sizeof(flush_expr));
+
+		flush_expr.query = flush_query.data;
+		flush_expr.plan = NULL;
+		flush_expr.paramnos = NULL;
+		flush_expr.rwparam = -1;
+		flush_expr.func = estate->func;
+		flush_expr.ns = NULL;
+
+		flush_stmt.cmd_type = PLTSQL_STMT_EXECSQL;
+		flush_stmt.lineno = 0;
+		flush_stmt.sqlstmt = &flush_expr;
+		flush_stmt.mod_stmt = true;
+		flush_stmt.into = false;
+		flush_stmt.strict = false;
+		flush_stmt.txn_data = NULL;
+		flush_stmt.target = NULL;
+		flush_stmt.mod_stmt_tablevar = false;
+		flush_stmt.need_to_push_result = false;
+		flush_stmt.is_tsql_select_assign_stmt = false;
+		flush_stmt.insert_exec = false;
+		flush_stmt.is_cross_db = false;
+		flush_stmt.is_ddl = false;
+		flush_stmt.schema_name = NULL;
+		flush_stmt.db_name = NULL;
+		flush_stmt.is_create_view = false;
+		flush_stmt.is_set_tran_isolation = false;
+		flush_stmt.original_query = NULL;
+		flush_stmt.is_schemabinding = false;
+
+		rc = exec_stmt_execsql(estate, &flush_stmt);
+
+		if (flush_expr.plan != NULL)
+		{
+			SPI_freeplan(flush_expr.plan);
+			flush_expr.plan = NULL;
+		}
+
+		if (flush_switched_context)
+		{
+			SetUserIdAndSecContext(flush_save_userid, flush_save_sec_context);
+			flush_switched_context = false;
+		}
+
+		if (rc != PLTSQL_RC_OK)
+			elog(ERROR, "INSERT-EXEC: Failed to flush temp table to target");
+
+		pltsql_insert_exec_set_flush_in_progress(false);
+		pltsql_insert_exec_set_target_table(saved_target_table);
+
+		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+	}
+	PG_CATCH();
+	{
+		if (flush_switched_context)
+		{
+			SetUserIdAndSecContext(flush_save_userid, flush_save_sec_context);
+			flush_switched_context = false;
+		}
+
+		if (flush_expr.plan != NULL)
+		{
+			SPI_freeplan(flush_expr.plan);
+			flush_expr.plan = NULL;
+		}
+
+		pltsql_insert_exec_set_flush_in_progress(false);
+		pltsql_insert_exec_set_target_table(saved_target_table);
+
+		if (subtxn_started)
+			RollbackAndReleaseCurrentSubTransaction();
+
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+
+		pfree(flush_query.data);
+		if (saved_target_table)
+			pfree(saved_target_table);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	pfree(flush_query.data);
+	if (saved_target_table)
+		pfree(saved_target_table);
 }
 
 /*
- * STUB: Set up INSERT EXEC execution context.
- * Real implementation in PR5 (Flush Logic + Executor Integration).
+ * insert_exec_setup - Initialize INSERT EXEC context and create temp table.
+ *
+ * If start_implicit_txn is true, starts an implicit transaction for stored
+ * procedure calls. Returns the temp table OID via temp_table_oid_out.
+ * Throws an error if nested INSERT EXEC is detected.
  */
 bool
 insert_exec_setup(PLtsql_execstate *estate,
@@ -1994,26 +2153,129 @@ insert_exec_setup(PLtsql_execstate *estate,
                   bool start_implicit_txn,
                   Oid *temp_table_oid_out)
 {
-	/* STUB: Returns false (setup not done) - real implementation in PR5 */
-	return false;
+	Oid temp_table_oid;
+
+	*temp_table_oid_out = InvalidOid;
+
+	/* Check for nested INSERT EXEC */
+	if (pltsql_insert_exec_active())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("nested INSERT ... EXECUTE statements are not allowed")));
+	}
+
+	/*
+	 * Start implicit transaction for INSERT EXEC if requested and not already in one.
+	 */
+	if (start_implicit_txn)
+	{
+		bool in_function = (estate->func &&
+							estate->func->fn_oid != InvalidOid &&
+							estate->func->fn_prokind == PROKIND_FUNCTION &&
+							estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER);
+
+		if (!pltsql_disable_batch_auto_commit &&
+			pltsql_support_tsql_transactions() &&
+			!IsTransactionBlockActive() &&
+			!in_function)
+		{
+			elog(DEBUG4, "TSQL TXN Start internal transaction for INSERT EXEC");
+			pltsql_start_txn();
+			pltsql_insert_exec_set_implicit_txn_flag();
+			estate->tsql_trigger_flags |= TSQL_TRAN_STARTED;
+		}
+	}
+
+	pltsql_set_insert_exec_context_info(target_table, column_list);
+	pltsql_insert_exec_open_target_table(target_table);
+
+	temp_table_oid = create_insert_exec_temp_table(target_table, column_list);
+	pltsql_set_insert_exec_context(temp_table_oid);
+
+	*temp_table_oid_out = temp_table_oid;
+	return true;
 }
 
 /*
- * STUB: Clean up INSERT EXEC context on error.
- * Real implementation in PR5 (Flush Logic + Executor Integration).
+ * insert_exec_error_cleanup - Clean up INSERT EXEC state on error.
  */
 void
 insert_exec_error_cleanup(bool setup_done)
 {
-	/* STUB: Does nothing - real implementation in PR5 */
+	if (setup_done)
+	{
+		pltsql_insert_exec_set_error_flag();
+		pltsql_insert_exec_set_pending_drop();
+		pltsql_insert_exec_clear_implicit_txn_flag();
+		pltsql_insert_exec_close_target_table();
+		pltsql_clear_insert_exec_context();
+	}
+	else if (pltsql_insert_exec_active())
+	{
+		pltsql_insert_exec_set_error_flag();
+		pltsql_insert_exec_clear_implicit_txn_flag();
+		pltsql_insert_exec_close_target_table();
+		pltsql_clear_insert_exec_context();
+	}
 }
 
 /*
- * STUB: Clean up INSERT EXEC context on success.
- * Real implementation in PR5 (Flush Logic + Executor Integration).
+ * insert_exec_success_cleanup - Clean up INSERT EXEC after successful execution.
+ *
+ * Flushes temp table to target, drops temp table, clears context,
+ * and commits the implicit transaction if one was started.
  */
 void
 insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
 {
-	/* STUB: Does nothing - real implementation in PR5 */
+	MemoryContext oldcontext = CurrentMemoryContext;
+	ResourceOwner oldowner = CurrentResourceOwner;
+
+	PG_TRY();
+	{
+		flush_insert_exec_temp_table(estate);
+		pltsql_insert_exec_close_target_table();
+	}
+	PG_CATCH();
+	{
+		pltsql_insert_exec_close_target_table();
+		drop_insert_exec_temp_table(temp_table_oid);
+		pltsql_insert_exec_clear_implicit_txn_flag();
+		pltsql_clear_insert_exec_context();
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	/* Drop temp table in separate subtransaction */
+	BeginInternalSubTransaction(NULL);
+	MemoryContextSwitchTo(oldcontext);
+
+	PG_TRY();
+	{
+		drop_insert_exec_temp_table(temp_table_oid);
+		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+	}
+	PG_CATCH();
+	{
+		RollbackAndReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+		elog(WARNING, "INSERT EXEC: failed to drop temp table, will be cleaned up at transaction end");
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pltsql_clear_insert_exec_context();
+
+	if (pltsql_insert_exec_started_implicit_txn())
+	{
+		elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
+		commit_stmt(estate, true);
+		pltsql_insert_exec_clear_implicit_txn_flag();
+	}
+
+	estate->tsql_trigger_flags &= ~TSQL_TRAN_STARTED;
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -58,8 +58,27 @@
 extern int exec_stmt_execsql(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
 
 /*
- * DestReceiver that writes tuples to a temp table for INSERT EXEC buffering.
+ * DestReceiver struct for INSERT EXEC - captures procedure output into a temp table.
  */
+typedef struct
+{
+	DestReceiver pub;			/* public fields */
+	Oid			temp_table_oid;	/* OID of temp table to insert into */
+	TupleDesc	typeinfo;		/* tuple descriptor from startup */
+	uint64		rows_inserted;	/* count of rows inserted */
+	/* Coercion infrastructure using ExecProject */
+	ExprContext *econtext;		/* expression context for projection */
+	ProjectionInfo *proj_info;	/* projection info for type coercion (NULL if no coercion needed) */
+	TupleTableSlot *proj_slot;	/* result slot for projection */
+	int			natts;			/* number of attributes */
+	bool		needs_coercion;	/* true if any column needs coercion */
+} DR_insertexec;
+
+/* Forward declarations for DestReceiver callbacks */
+static void insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo);
+static bool insertexec_receive(TupleTableSlot *slot, DestReceiver *self);
+static void insertexec_shutdown(DestReceiver *self);
+static void insertexec_destroy(DestReceiver *self);
 
 /*
  * Schema signature (column count and types) captured at INSERT EXEC start,
@@ -1131,7 +1150,6 @@ pltsql_get_and_clear_insert_exec_temp_table_for_cleanup(void)
  * =============================================================================
  * These functions are placeholders that allow the code to compile.
  * They will be replaced with real implementations in later PRs:
- *   - PR3: CreateInsertExecDestReceiver (DestReceiver implementation)
  *   - PR4: create_insert_exec_temp_table, drop_insert_exec_temp_table
  *   - PR5: flush_insert_exec_temp_table, insert_exec_setup,
  *          insert_exec_error_cleanup, insert_exec_success_cleanup
@@ -1139,14 +1157,259 @@ pltsql_get_and_clear_insert_exec_temp_table_for_cleanup(void)
  */
 
 /*
- * STUB: Create a DestReceiver for INSERT EXEC that writes to a temp table.
- * Real implementation in PR3 (DestReceiver).
+ * Create a DestReceiver for INSERT EXEC that writes to a temp table.
  */
 DestReceiver *
 CreateInsertExecDestReceiver(Oid temp_table_oid)
 {
-	/* STUB: Returns NULL - real implementation in PR3 */
-	return NULL;
+	DR_insertexec *self = (DR_insertexec *) palloc0(sizeof(DR_insertexec));
+
+	self->pub.receiveSlot = insertexec_receive;
+	self->pub.rStartup = insertexec_startup;
+	self->pub.rShutdown = insertexec_shutdown;
+	self->pub.rDestroy = insertexec_destroy;
+	self->pub.mydest = DestNone;  /* no standard dest type fits; avoids miscast risks */
+	self->temp_table_oid = temp_table_oid;
+
+	return (DestReceiver *) self;
+}
+
+/*
+ * insertexec_startup --- executor startup for INSERT EXEC receiver
+ *
+ * Validates column count matches temp table and builds coercion expressions
+ * for type conversion. We open/close the relation per-tuple in insertexec_receive
+ * to avoid holding stale handles across subtransaction boundaries.
+ */
+static void
+insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+	Relation	temp_rel;
+	TupleDesc	temp_tupdesc;
+	int			result_natts;
+	int			temp_natts;
+	int			i;
+	List	   *target_list = NIL;
+
+	/* Store the tuple descriptor for later use */
+	myState->typeinfo = typeinfo;
+	myState->rows_inserted = 0;
+	myState->proj_info = NULL;
+	myState->proj_slot = NULL;
+
+	/* Validate column count matches temp table */
+	result_natts = typeinfo->natts;
+
+	temp_rel = table_open(myState->temp_table_oid, AccessShareLock);
+	temp_tupdesc = RelationGetDescr(temp_rel);
+	temp_natts = temp_tupdesc->natts;
+
+	if (result_natts != temp_natts)
+	{
+		table_close(temp_rel, AccessShareLock);
+		/*
+		 * Set error flag BEFORE throwing so flush is skipped even if TRY-CATCH
+		 * catches it. Column mismatch errors roll back all rows, unlike data-level
+		 * errors (e.g., division by zero) which only affect the current row.
+		 */
+		pltsql_insert_exec_set_error_flag();
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("Column name or number of supplied values does not match table definition.")));
+	}
+
+	/* Build target list for projection with type coercion */
+	myState->natts = temp_natts;
+	myState->needs_coercion = false;
+
+	for (i = 0; i < temp_natts; i++)
+	{
+		Form_pg_attribute src_att = TupleDescAttr(typeinfo, i);
+		Form_pg_attribute tgt_att = TupleDescAttr(temp_tupdesc, i);
+		Var		   *var;
+		Node	   *expr;
+		TargetEntry *tle;
+
+		/* Create Var node referencing input tuple column (OUTER_VAR for ecxt_outertuple) */
+		var = makeVar(OUTER_VAR,
+					  i + 1,			/* attnum is 1-based */
+					  src_att->atttypid,
+					  src_att->atttypmod,
+					  src_att->attcollation,
+					  0);				/* varlevelsup */
+
+		expr = (Node *) var;
+
+		/* Check if coercion is needed */
+		if (src_att->atttypid != tgt_att->atttypid ||
+			(src_att->atttypmod != tgt_att->atttypmod && tgt_att->atttypmod != -1))
+		{
+			Node	   *cast_expr;
+
+			myState->needs_coercion = true;
+
+			/* Build coercion expression using ASSIGNMENT coercion (matches tsql INSERT behavior) */
+			cast_expr = coerce_to_target_type(NULL,
+											  expr,
+											  src_att->atttypid,
+											  tgt_att->atttypid,
+											  tgt_att->atttypmod,
+											  COERCION_ASSIGNMENT,
+											  COERCE_IMPLICIT_CAST,
+											  -1);
+
+			/* If no direct coercion, fall back to I/O coercion (text round-trip) */
+			if (cast_expr == NULL)
+			{
+				CoerceViaIO *iocoerce = makeNode(CoerceViaIO);
+
+				iocoerce->arg = (Expr *) expr;
+				iocoerce->resulttype = tgt_att->atttypid;
+				iocoerce->resultcollid = InvalidOid;
+				iocoerce->coerceformat = COERCE_IMPLICIT_CAST;
+				iocoerce->location = -1;
+				cast_expr = (Node *) iocoerce;
+
+				/* Apply typmod coercion if needed */
+				if (tgt_att->atttypmod != -1)
+					cast_expr = coerce_to_target_type(NULL,
+													  cast_expr,
+													  tgt_att->atttypid,
+													  tgt_att->atttypid,
+													  tgt_att->atttypmod,
+													  COERCION_ASSIGNMENT,
+													  COERCE_IMPLICIT_CAST,
+													  -1);
+			}
+
+			if (cast_expr == NULL)
+			{
+				table_close(temp_rel, AccessShareLock);
+				ereport(ERROR,
+						(errcode(ERRCODE_CANNOT_COERCE),
+						 errmsg("cannot convert type %s to %s",
+								format_type_be(src_att->atttypid),
+								format_type_be(tgt_att->atttypid))));
+			}
+
+			expr = cast_expr;
+		}
+
+		/* Create TargetEntry for this column */
+		tle = makeTargetEntry((Expr *) expr,
+							  i + 1,		/* resno is 1-based */
+							  NULL,			/* resname */
+							  false);		/* resjunk */
+		target_list = lappend(target_list, tle);
+	}
+
+	/* Create expression context and projection info if coercion needed */
+	if (myState->needs_coercion)
+	{
+		TupleDesc	proj_tupdesc;
+
+		myState->econtext = CreateStandaloneExprContext();
+		proj_tupdesc = CreateTupleDescCopy(temp_tupdesc);
+		myState->proj_slot = MakeSingleTupleTableSlot(proj_tupdesc, &TTSOpsVirtual);
+		myState->proj_info = ExecBuildProjectionInfo(target_list,
+													 myState->econtext,
+													 myState->proj_slot,
+													 NULL,		/* no parent PlanState */
+													 typeinfo);	/* input descriptor */
+	}
+
+	table_close(temp_rel, AccessShareLock);
+
+	/*
+	 * Pre-assign transaction ID before parallel mode starts. This is critical
+	 * for parallel query: insertexec_receive calls table_tuple_insert which
+	 * needs a transaction ID, but AssignTransactionId fails during parallel mode.
+	 */
+	(void) GetCurrentTransactionId();
+}
+
+/*
+ * insertexec_receive --- receive one tuple and insert into temp table
+ *
+ * Opens/closes the relation for each tuple to avoid holding stale handles
+ * across subtransaction boundaries (e.g., inner TRY/CATCH blocks).
+ *
+ * Note: Each open acquires RowExclusiveLock but we don't release it (NoLock
+ * on close), accumulating lock refs. For temp tables this is fine - no shared
+ * memory contention - but could be optimized to open once in startup if needed.
+ */
+static bool
+insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+	Relation	temp_rel;
+	CommandId	cid;
+	TupleTableSlot *insert_slot;
+
+	/* Open temp table fresh for each tuple */
+	temp_rel = table_open(myState->temp_table_oid, RowExclusiveLock);
+	cid = GetCurrentCommandId(true);
+
+	if (myState->needs_coercion)
+	{
+		ExprContext *econtext = myState->econtext;
+
+		ResetExprContext(econtext);
+		econtext->ecxt_outertuple = slot;
+
+		/* Project tuple with type coercion */
+		insert_slot = ExecProject(myState->proj_info);
+
+		table_tuple_insert(temp_rel, insert_slot, cid, 0, NULL);
+	}
+	else
+	{
+		/* No coercion needed - insert directly */
+		table_tuple_insert(temp_rel, slot, cid, 0, NULL);
+	}
+
+	table_close(temp_rel, NoLock);
+	myState->rows_inserted++;
+
+	return true;
+}
+
+/*
+ * insertexec_shutdown --- executor end for INSERT EXEC receiver
+ */
+static void
+insertexec_shutdown(DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+
+	if (myState->proj_slot != NULL)
+	{
+		ExecDropSingleTupleTableSlot(myState->proj_slot);
+		myState->proj_slot = NULL;
+	}
+
+	if (myState->econtext != NULL)
+	{
+		FreeExprContext(myState->econtext, true);
+		myState->econtext = NULL;
+	}
+}
+
+/*
+ * insertexec_destroy --- release DestReceiver object
+ */
+static void
+insertexec_destroy(DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+
+	/* Defensive: ensure resources are freed even if shutdown was skipped */
+	if (myState->proj_slot != NULL || myState->econtext != NULL)
+		insertexec_shutdown(self);
+
+	myState->proj_info = NULL;  /* allocated in expression context */
+	pfree(self);
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1970,24 +1970,32 @@ drop_insert_exec_temp_table(Oid temp_table_oid)
 void
 flush_insert_exec_temp_table(PLtsql_execstate *estate)
 {
-	const char		   *temp_table_name;
-	StringInfoData		flush_query;
-	int					rc;
-	const char		   *target_table = pltsql_get_insert_exec_target_table();
-	const char		   *column_list = pltsql_get_insert_exec_column_list();
-	Oid					temp_oid = pltsql_get_insert_exec_temp_table_oid();
-	MemoryContext		oldcontext = CurrentMemoryContext;
-	ResourceOwner		oldowner = CurrentResourceOwner;
-	volatile bool		subtxn_started = false;
-	char			   *saved_target_table = NULL;
-	Oid					flush_save_userid = InvalidOid;
-	int					flush_save_sec_context = 0;
-	volatile bool		flush_switched_context = false;
+	const char		*temp_table_name;
+	StringInfoData	flush_query;
+	int				rc;
+	const char		*target_table = pltsql_get_insert_exec_target_table();
+	const char		*column_list = pltsql_get_insert_exec_column_list();
+	Oid				temp_oid = pltsql_get_insert_exec_temp_table_oid();
+	MemoryContext	oldcontext = CurrentMemoryContext;
+	ResourceOwner	oldowner = CurrentResourceOwner;
+	volatile bool	subtxn_started = false;
+
+	/* Save INSERT EXEC context to restore after flush */
+	char		   *saved_target_table = NULL;
+
+	/* Security context for ownership chaining */
+	Oid				flush_save_userid = InvalidOid;
+	int				flush_save_sec_context = 0;
+	volatile bool	flush_switched_context = false;
+
+	/* For exec_stmt_execsql */
 	PLtsql_stmt_execsql flush_stmt;
-	PLtsql_expr			flush_expr;
+	PLtsql_expr		flush_expr;
 
 	if (!OidIsValid(temp_oid) || target_table == NULL)
+	{
 		return;
+	}
 
 	/*
 	 * Check if an error occurred during INSERT EXEC that should prevent flush.
@@ -2007,27 +2015,50 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate)
 				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table.")));
 	}
 
+	/*
+	 * Save the INSERT EXEC context info before clearing it.
+	 * We need to temporarily clear the context so that the flush INSERT
+	 * behaves like a normal INSERT and fires INSTEAD OF triggers properly.
+	 */
 	saved_target_table = pstrdup(target_table);
 
+	/* Get the dynamically chosen temp table name from the context */
 	temp_table_name = pltsql_get_insert_exec_temp_table_name();
 	if (temp_table_name == NULL)
+	{
 		elog(ERROR, "INSERT-EXEC: No temp table name stored, cannot flush");
+	}
 
 	initStringInfo(&flush_query);
 
 	if (column_list != NULL)
 	{
+		/*
+		 * User specified columns - use them directly.
+		 * The temp table was created with columns in the same order as the
+		 * user's column list, so SELECT * gives values in the correct order.
+		 */
 		appendStringInfo(&flush_query,
 			"INSERT INTO %s (%s) SELECT * FROM %s",
-			target_table, column_list, temp_table_name);
+			target_table,
+			column_list,
+			temp_table_name);
 	}
 	else
 	{
 		appendStringInfo(&flush_query,
 			"INSERT INTO %s SELECT * FROM %s",
-			target_table, temp_table_name);
+			target_table,
+			temp_table_name);
 	}
 
+	/*
+	 * Execute the flush INSERT in its own subtransaction that commits
+	 * immediately. This is critical for TRY-CATCH behavior.
+	 *
+	 * We route through exec_stmt_execsql to reuse the standard SQL execution
+	 * path which handles triggers, rowcount, and FOUND properly.
+	 */
 	PG_TRY();
 	{
 		BeginInternalSubTransaction("insert_exec_flush");
@@ -2060,7 +2091,7 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate)
 		flush_stmt.cmd_type = PLTSQL_STMT_EXECSQL;
 		flush_stmt.lineno = 0;
 		flush_stmt.sqlstmt = &flush_expr;
-		flush_stmt.mod_stmt = true;
+		flush_stmt.mod_stmt = true;  /* This is an INSERT statement */
 		flush_stmt.into = false;
 		flush_stmt.strict = false;
 		flush_stmt.txn_data = NULL;
@@ -2068,7 +2099,7 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate)
 		flush_stmt.mod_stmt_tablevar = false;
 		flush_stmt.need_to_push_result = false;
 		flush_stmt.is_tsql_select_assign_stmt = false;
-		flush_stmt.insert_exec = false;
+		flush_stmt.insert_exec = false;  /* This flush INSERT is not itself an INSERT EXEC */
 		flush_stmt.is_cross_db = false;
 		flush_stmt.is_ddl = false;
 		flush_stmt.schema_name = NULL;
@@ -2078,14 +2109,17 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate)
 		flush_stmt.original_query = NULL;
 		flush_stmt.is_schemabinding = false;
 
+		/* Execute through exec_stmt_execsql - this handles triggers, rowcount, FOUND */
 		rc = exec_stmt_execsql(estate, &flush_stmt);
 
+		/* Free the plan if one was created */
 		if (flush_expr.plan != NULL)
 		{
 			SPI_freeplan(flush_expr.plan);
 			flush_expr.plan = NULL;
 		}
 
+		/* Restore security context immediately after execution */
 		if (flush_switched_context)
 		{
 			SetUserIdAndSecContext(flush_save_userid, flush_save_sec_context);
@@ -2095,33 +2129,42 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate)
 		if (rc != PLTSQL_RC_OK)
 			elog(ERROR, "INSERT-EXEC: Failed to flush temp table to target");
 
+		/* Clear the flush flag after successful flush */
 		pltsql_insert_exec_set_flush_in_progress(false);
 		pltsql_insert_exec_set_target_table(saved_target_table);
 
+		/* Commit the flush subtransaction - this "locks in" the data */
 		ReleaseCurrentSubTransaction();
 		MemoryContextSwitchTo(oldcontext);
 		CurrentResourceOwner = oldowner;
 	}
 	PG_CATCH();
 	{
+		/* Restore security context on error if it was switched */
 		if (flush_switched_context)
 		{
 			SetUserIdAndSecContext(flush_save_userid, flush_save_sec_context);
 			flush_switched_context = false;
 		}
 
+		/* Free the plan if one was created */
 		if (flush_expr.plan != NULL)
 		{
 			SPI_freeplan(flush_expr.plan);
 			flush_expr.plan = NULL;
 		}
 
+		/* Clear the flush flag on error */
 		pltsql_insert_exec_set_flush_in_progress(false);
+
+		/* Restore the target table pointer on error */
 		pltsql_insert_exec_set_target_table(saved_target_table);
 
+		/* Roll back the flush subtransaction on error */
 		if (subtxn_started)
+		{
 			RollbackAndReleaseCurrentSubTransaction();
-
+		}
 		MemoryContextSwitchTo(oldcontext);
 		CurrentResourceOwner = oldowner;
 
@@ -2155,6 +2198,7 @@ insert_exec_setup(PLtsql_execstate *estate,
 {
 	Oid temp_table_oid;
 
+	/* Initialize output */
 	*temp_table_oid_out = InvalidOid;
 
 	/* Check for nested INSERT EXEC */
@@ -2167,6 +2211,8 @@ insert_exec_setup(PLtsql_execstate *estate,
 
 	/*
 	 * Start implicit transaction for INSERT EXEC if requested and not already in one.
+	 * This is used for stored procedure calls (exec_stmt_exec) but not for
+	 * dynamic SQL (exec_stmt_exec_batch) which has different transaction semantics.
 	 */
 	if (start_implicit_txn)
 	{
@@ -2187,10 +2233,16 @@ insert_exec_setup(PLtsql_execstate *estate,
 		}
 	}
 
+	/* Set global context info for flush function */
 	pltsql_set_insert_exec_context_info(target_table, column_list);
+
+	/* Hold target table open to detect schema alterations during execution */
 	pltsql_insert_exec_open_target_table(target_table);
 
+	/* Create temp table based on target table structure */
 	temp_table_oid = create_insert_exec_temp_table(target_table, column_list);
+
+	/* Set global context so DestReceiver knows where to write */
 	pltsql_set_insert_exec_context(temp_table_oid);
 
 	*temp_table_oid_out = temp_table_oid;
@@ -2199,6 +2251,9 @@ insert_exec_setup(PLtsql_execstate *estate,
 
 /*
  * insert_exec_error_cleanup - Clean up INSERT EXEC state on error.
+ *
+ * Sets error/pending-drop flags, clears implicit transaction flag,
+ * closes target table, and clears the context.
  */
 void
 insert_exec_error_cleanup(bool setup_done)
@@ -2213,6 +2268,7 @@ insert_exec_error_cleanup(bool setup_done)
 	}
 	else if (pltsql_insert_exec_active())
 	{
+		/* Cleanup partially initialized context from setup failure */
 		pltsql_insert_exec_set_error_flag();
 		pltsql_insert_exec_clear_implicit_txn_flag();
 		pltsql_insert_exec_close_target_table();
@@ -2232,13 +2288,24 @@ insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
 	MemoryContext oldcontext = CurrentMemoryContext;
 	ResourceOwner oldowner = CurrentResourceOwner;
 
+	/*
+	 * Flush temp table to target table and cleanup after procedure completes.
+	 */
 	PG_TRY();
 	{
+		/* Flush temp table to target table */
 		flush_insert_exec_temp_table(estate);
+
+		/* Close target table after flush completes */
 		pltsql_insert_exec_close_target_table();
 	}
 	PG_CATCH();
 	{
+		/*
+		 * Close target table and drop temp table before clearing context.
+		 * Also clear the implicit transaction flag since the transaction
+		 * will be rolled back due to the flush error.
+		 */
 		pltsql_insert_exec_close_target_table();
 		drop_insert_exec_temp_table(temp_table_oid);
 		pltsql_insert_exec_clear_implicit_txn_flag();
@@ -2260,6 +2327,7 @@ insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
 	}
 	PG_CATCH();
 	{
+		/* DROP failed - log warning but don't fail the INSERT EXEC */
 		RollbackAndReleaseCurrentSubTransaction();
 		MemoryContextSwitchTo(oldcontext);
 		CurrentResourceOwner = oldowner;
@@ -2268,8 +2336,15 @@ insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
 	}
 	PG_END_TRY();
 
+	/*
+	 * Clear the INSERT EXEC context AFTER the drop completes.
+	 * This must be last because it frees temp_table_name which drop needs.
+	 */
 	pltsql_clear_insert_exec_context();
 
+	/*
+	 * Commit the implicit transaction that was started for INSERT EXEC.
+	 */
 	if (pltsql_insert_exec_started_implicit_txn())
 	{
 		elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
@@ -2277,5 +2352,6 @@ insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
 		pltsql_insert_exec_clear_implicit_txn_flag();
 	}
 
+	/* Clear the TSQL_TRAN_STARTED flag */
 	estate->tsql_trigger_flags &= ~TSQL_TRAN_STARTED;
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -32,6 +32,7 @@
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
 #include "executor/executor.h"
+#include "executor/spi_priv.h"
 #include "executor/tstoreReceiver.h"
 #include "executor/tuptable.h"
 #include "miscadmin.h"
@@ -50,7 +51,6 @@
 #include "session.h"
 #include "parser/scansup.h"
 #include "parser/parse_oper.h"
-#include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/varlena.h"
 
@@ -75,17 +75,13 @@ typedef struct InsertExecSchemaSignature
 /*
  * Global context for INSERT EXEC - bundled into a single struct for cleaner code.
  * This context is needed for nested procedure calls during INSERT EXEC.
- *
- * Note: target_table and column_list use a legacy string interface. The parser
- * stores these as separate components in InsertExecInfo; the executor will use
- * those fields with quote_identifier() for SQL safety.
  */
 typedef struct InsertExecContext
 {
 	Oid			temp_table_oid;			/* OID of temp table for buffering */
 	char	   *temp_table_name;		/* Name of temp table for buffering (dynamically chosen) */
-	char	   *target_table;			/* Target table name (legacy interface) */
-	char	   *column_list;			/* Column list for INSERT (legacy interface, see note above) */
+	char	   *target_table;			/* Target table name */
+	char	   *column_list;			/* Column list for INSERT */
 	bool		flush_in_progress;		/* True during flush phase to block commit_stmt */
 	int			call_stack_depth;		/* Call stack depth when INSERT EXEC was started */
 	bool		had_error;				/* True if INSERT EXEC had an error */
@@ -116,12 +112,8 @@ static InsertExecContext insert_exec_ctx = {
 };
 
 /*
- * Parse tsql table name (1-part, 2-part, or 3-part) into schema and table.
+ * Parse a T-SQL table name (1-part, 2-part, or 3-part) into schema and table.
  * Returns true on success. Caller must pfree the output strings.
- *
- * Note: Uses simple strrchr splitting - doesn't handle bracket-quoted identifiers
- * or cross-database names. The parser already handles these cases and stores
- * components separately in InsertExecInfo. Unqualified names default to "dbo".
  */
 bool
 parse_insert_exec_table_name(const char *target_table,
@@ -135,7 +127,6 @@ parse_insert_exec_table_name(const char *target_table,
 	char	   *second_dot;
 	char	   *schema_name = NULL;
 	char	   *table_name = NULL;
-	const char *cur_db;
 
 	if (target_table == NULL)
 		return false;
@@ -153,11 +144,7 @@ parse_insert_exec_table_name(const char *target_table,
 		second_dot = strrchr(target_copy, '.');
 		if (second_dot != NULL)
 		{
-			/*
-			 * db.schema.table - schema is after the second dot.
-			 * Note: database part is ignored - we always resolve against
-			 * the current database. Cross-database INSERT EXEC is not supported.
-			 */
+			/* db.schema.table - schema is after the second dot */
 			schema_name = pstrdup(second_dot + 1);
 		}
 		else
@@ -169,9 +156,9 @@ parse_insert_exec_table_name(const char *target_table,
 	else
 	{
 		/*
-		 * Just table name, no schema specified - default to dbo.
-		 * This matches T-SQL behavior where dbo is the default schema
-		 * for unqualified object references.
+		 * Just table name, no schema specified - default to dbo for now.
+		 * TODO: Ideally we should respect the user's default schema,
+		 * but that requires changes to how ownership chaining works.
 		 */
 		table_name = pstrdup(target_copy);
 		schema_name = pstrdup("dbo");
@@ -183,11 +170,7 @@ parse_insert_exec_table_name(const char *target_table,
 
 	if (get_physical && physical_schema_out != NULL)
 	{
-		cur_db = get_cur_db_name();
-		if (cur_db != NULL)
-			*physical_schema_out = get_physical_schema_name((char *) cur_db, schema_name);
-		else
-			*physical_schema_out = NULL;
+		*physical_schema_out = get_physical_schema_name(get_cur_db_name(), schema_name);
 	}
 	else if (physical_schema_out != NULL)
 	{
@@ -349,9 +332,10 @@ pltsql_insert_exec_clear_error_flag(void)
 void
 pltsql_insert_exec_set_implicit_txn_flag(void)
 {
-	elog(DEBUG4, "TSQL TXN INSERT EXEC implicit txn flag: %d -> true",
+	elog(DEBUG4, "TSQL TXN Setting implicit txn flag for INSERT EXEC (was %d, setting to true)",
 		 insert_exec_ctx.started_implicit_txn);
 	insert_exec_ctx.started_implicit_txn = true;
+	elog(DEBUG4, "TSQL TXN After setting implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
 }
 
 /*
@@ -361,6 +345,7 @@ pltsql_insert_exec_set_implicit_txn_flag(void)
 bool
 pltsql_insert_exec_started_implicit_txn(void)
 {
+	elog(DEBUG4, "TSQL TXN Checking implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
 	return insert_exec_ctx.started_implicit_txn;
 }
 
@@ -371,8 +356,7 @@ pltsql_insert_exec_started_implicit_txn(void)
 void
 pltsql_insert_exec_clear_implicit_txn_flag(void)
 {
-	elog(DEBUG4, "TSQL TXN INSERT EXEC implicit txn flag: %d -> false",
-		 insert_exec_ctx.started_implicit_txn);
+	elog(DEBUG4, "TSQL TXN Clearing implicit txn flag (was %d)", insert_exec_ctx.started_implicit_txn);
 	insert_exec_ctx.started_implicit_txn = false;
 }
 
@@ -400,23 +384,8 @@ pltsql_insert_exec_check_pending_drop(void)
 		StringInfoData drop_stmt;
 		int			rc;
 
-		/*
-		 * Defensive check: temp table names are internally generated with a known
-		 * prefix. If this doesn't match, something is wrong - skip the drop.
-		 */
-		if (strncmp(insert_exec_ctx.temp_table_name, "#__insert_exec_buf_", 19) != 0)
-		{
-			elog(WARNING, "unexpected INSERT EXEC temp table name format: %s",
-				 insert_exec_ctx.temp_table_name);
-			pfree(insert_exec_ctx.temp_table_name);
-			insert_exec_ctx.temp_table_name = NULL;
-			insert_exec_ctx.pending_drop = false;
-			return;
-		}
-
 		initStringInfo(&drop_stmt);
-		appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s",
-						 quote_identifier(insert_exec_ctx.temp_table_name));
+		appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s", insert_exec_ctx.temp_table_name);
 
 		rc = SPI_execute(drop_stmt.data, false, 0);
 		if (rc != SPI_OK_UTILITY)
@@ -435,9 +404,6 @@ pltsql_insert_exec_check_pending_drop(void)
  * We record column count and types at INSERT EXEC start, then verify they
  * haven't changed before flushing. Regular tables get RowExclusiveLock to
  * block concurrent DDL; temp tables only get schema captured (session-local).
- *
- * For regular tables, we check INSERT permission early to fail fast rather
- * than executing the procedure and buffering data only to fail at flush.
  */
 void
 pltsql_insert_exec_open_target_table(const char *target_table)
@@ -500,19 +466,11 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 		}
 
 		/*
-		 * Check INSERT permission on the target table early. This prevents
-		 * executing the procedure and buffering data only to fail at flush.
-		 * Note: ownership chaining may allow the INSERT at flush time even
-		 * if this check fails, but failing early is safer and matches SQL
-		 * Server behavior for most cases.
-		 */
-		if (pg_class_aclcheck(relid, GetUserId(), ACL_INSERT) != ACLCHECK_OK)
-			aclcheck_error(ACLCHECK_NO_PRIV, OBJECT_TABLE, target_table);
-
-		/*
 		 * Acquire RowExclusiveLock on the target table.
 		 * This lock will be held until the end of the transaction.
 		 * It blocks concurrent sessions from modifying the table.
+		 * Note: Same-session DROP/ALTER is still allowed by PostgreSQL,
+		 * but we detect it via schema verification at flush time.
 		 */
 		oldcontext = CurrentMemoryContext;
 		PG_TRY();
@@ -521,10 +479,6 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 		}
 		PG_CATCH();
 		{
-			/*
-			 * If we can't lock, skip schema capture. Permission was already
-			 * checked above, so this is likely a lock timeout or similar.
-			 */
 			MemoryContextSwitchTo(oldcontext);
 			FlushErrorState();
 			return;
@@ -545,10 +499,6 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 	}
 	PG_CATCH();
 	{
-		/*
-		 * Best-effort: if we can't open the table, skip schema capture.
-		 * The flush operation will report the proper error.
-		 */
 		MemoryContextSwitchTo(oldcontext);
 		FlushErrorState();
 		insert_exec_ctx.target_rel_oid = InvalidOid;
@@ -557,18 +507,6 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 	PG_END_TRY();
 
 	tupdesc = RelationGetDescr(rel);
-
-	/*
-	 * Defensive check: ensure natts is valid before allocating arrays.
-	 * PostgreSQL caps this at MaxTupleAttributeNumber (1664), but check
-	 * anyway to guard against corrupt catalogs or buggy extensions.
-	 */
-	if (tupdesc->natts < 0 || tupdesc->natts > MaxTupleAttributeNumber)
-	{
-		table_close(rel, NoLock);
-		elog(WARNING, "invalid target table attribute count: %d", tupdesc->natts);
-		return;
-	}
 
 	/* Allocate schema signature in TopMemoryContext so it survives error handling */
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
@@ -584,10 +522,10 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 		insert_exec_ctx.schema_sig = NULL;
 	}
 
-	insert_exec_ctx.schema_sig = palloc0(sizeof(InsertExecSchemaSignature));
+	insert_exec_ctx.schema_sig = palloc(sizeof(InsertExecSchemaSignature));
 	insert_exec_ctx.schema_sig->natts = tupdesc->natts;
-	insert_exec_ctx.schema_sig->atttypids = palloc0(tupdesc->natts * sizeof(Oid));
-	insert_exec_ctx.schema_sig->atttypmods = palloc0(tupdesc->natts * sizeof(int32));
+	insert_exec_ctx.schema_sig->atttypids = palloc(tupdesc->natts * sizeof(Oid));
+	insert_exec_ctx.schema_sig->atttypmods = palloc(tupdesc->natts * sizeof(int32));
 
 	for (i = 0; i < tupdesc->natts; i++)
 	{
@@ -607,6 +545,9 @@ pltsql_insert_exec_open_target_table(const char *target_table)
  *
  * For regular tables: Release the RowExclusiveLock we acquired.
  * For temp tables: Just clear the OID (no lock was acquired).
+ *
+ * Note: We only release the lock if we're not in an aborted transaction state.
+ * If the transaction was aborted, the lock has already been released.
  */
 void
 pltsql_insert_exec_close_target_table(void)
@@ -656,6 +597,10 @@ pltsql_insert_exec_close_target_table(void)
  *
  * This is called before flushing data to the target table to detect if the
  * executed procedure altered the target table's schema.
+ *
+ * Note: In major version upgrade scenarios, the OID captured at INSERT EXEC start
+ * may become stale. We handle this gracefully by skipping the check if we can't
+ * open the relation - the actual INSERT will validate the data anyway.
  */
 bool
 pltsql_insert_exec_verify_schema(void)
@@ -788,11 +733,19 @@ count_select_target_columns(SelectStmt *stmt)
 }
 
 /*
- * Validate column count from query string BEFORE plan preparation. tsql requires
- * column mismatch errors to take priority over runtime errors (e.g., division by zero),
- * so we parse and count columns here without evaluation. If count cannot be determined
- * (SELECT *, complex queries, parse errors), we defer to the DestReceiver validation.
- * Returns true if validation passes or cannot be performed; false only on definite mismatch.
+ * Validate column count from query string BEFORE plan preparation.
+ *
+ * T-SQL requires column mismatch errors to take priority over runtime errors
+ * like division by zero. PostgreSQL's plan preparation evaluates constant
+ * expressions, so we parse and count columns here without evaluation.
+ *
+ * This is an OPTIMIZATION for early error detection, not a correctness
+ * requirement. If we can't determine the column count (SELECT *, complex
+ * queries, parse errors), we skip early validation and let the normal
+ * execution path handle it - the DestReceiver will still catch mismatches.
+ *
+ * Returns true if validation passes OR cannot be performed (defer to normal path).
+ * Returns false only if column count mismatch is definitively detected.
  */
 bool
 pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
@@ -814,11 +767,7 @@ pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
 	temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
 	Assert(OidIsValid(temp_table_oid));
 
-	/*
-	 * Parse the query string. For syntax errors, defer to normal execution
-	 * which will report the error properly. For other errors (e.g., OOM),
-	 * re-throw since they indicate a serious problem.
-	 */
+	/* Parse the query string - if parsing fails, defer to normal execution */
 	oldcontext = CurrentMemoryContext;
 	PG_TRY();
 	{
@@ -826,23 +775,9 @@ pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
 	}
 	PG_CATCH();
 	{
-		ErrorData  *edata;
-
 		MemoryContextSwitchTo(oldcontext);
-		edata = CopyErrorData();
 		FlushErrorState();
-
-		/*
-		 * Only swallow syntax errors - these will be reported properly by
-		 * the normal execution path. Re-throw other errors like OOM.
-		 */
-		if (edata->sqlerrcode != ERRCODE_SYNTAX_ERROR &&
-			edata->sqlerrcode != ERRCODE_FEATURE_NOT_SUPPORTED)
-		{
-			ReThrowError(edata);
-		}
-		FreeErrorData(edata);
-		return true;  /* Syntax error - normal path will report it */
+		return true;  /* Parse error - normal path will report it */
 	}
 	PG_END_TRY();
 
@@ -887,9 +822,13 @@ pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
 	if (query_natts != temp_natts)
 	{
 		/*
-		 * Set error flag BEFORE throwing so flush is skipped even if TRY-CATCH
-		 * catches it. Column mismatch errors roll back all rows, unlike data-level
-		 * errors (e.g., division by zero) which only affect the current row.
+		 * Set the error flag BEFORE throwing the error. This ensures that
+		 * even if TRY-CATCH catches the error, the flush will be skipped.
+		 *
+		 * Expected behavior: Column mismatch errors cause all rows to be
+		 * rolled back, even if caught by TRY-CATCH. This is different from
+		 * data-level errors like division by zero, which only affect the
+		 * current row and allow previously inserted rows to be kept.
 		 */
 		pltsql_insert_exec_set_error_flag();
 
@@ -918,9 +857,10 @@ pltsql_insert_exec_active(void)
 }
 
 /*
- * Check if INSERT EXEC is actively in execution with a valid temp table.
- * Unlike pltsql_insert_exec_active(), this also verifies the temp table exists.
- * Returns false if context is not set, temp table was dropped, or not yet created.
+ * Stricter check than pltsql_insert_exec_active() - also verifies the temp
+ * table still exists. Returns false if context is stale (e.g., temp table
+ * was dropped after rollback). May return false early in INSERT EXEC before
+ * temp table is created, which is fine - validation happens later anyway.
  */
 bool
 pltsql_insert_exec_in_execution(void)
@@ -949,8 +889,14 @@ pltsql_insert_exec_in_execution(void)
 		return false;
 
 	/*
-	 * Verify temp table still exists - OID may be stale if table was dropped
-	 * after rollback. Use syscache check to avoid errors from opening missing relation.
+	 * Additional check: verify the temp table actually exists.
+	 * The OID might still be "valid" (non-zero) but the table could have been
+	 * dropped due to transaction rollback. This happens when INSERT EXEC fails
+	 * and the transaction is rolled back - the temp table is dropped but the
+	 * OID in the context is not cleared.
+	 *
+	 * We use SearchSysCacheExists1 to check if the relation exists without
+	 * opening it (which would fail if it doesn't exist).
 	 */
 	if (!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(temp_table_oid)))
 		return false;
@@ -966,8 +912,13 @@ pltsql_insert_exec_in_execution(void)
 	}
 
 	/*
-	 * Empty call stack (depth 0) means no PL/tsql execution in progress.
-	 * Also handles stale context from previous batches - new batch starts with empty stack.
+	 * If current_depth is 0, we're not inside any PL/tsql execution,
+	 * so we can't be inside INSERT EXEC execution either.
+	 *
+	 * IMPORTANT: This also handles the case where the INSERT EXEC context
+	 * is stale from a previous batch. When a new batch starts, the call
+	 * stack is empty (depth 0), so we return false here. This prevents
+	 * stale context from affecting subsequent batches.
 	 */
 	if (current_depth == 0)
 		return false;
@@ -976,6 +927,9 @@ pltsql_insert_exec_in_execution(void)
 	 * Check if the current call stack depth is consistent with the INSERT EXEC
 	 * context. If we're at a shallower level than when INSERT EXEC started,
 	 * the context is stale.
+	 *
+	 * Note: We use < instead of <= because the INSERT EXEC statement itself
+	 * is at call_stack_depth, and the called procedure is at call_stack_depth+1.
 	 */
 	if (current_depth < insert_exec_ctx.call_stack_depth)
 		return false;  /* Context is stale - we've returned from INSERT EXEC */

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1150,7 +1150,6 @@ pltsql_get_and_clear_insert_exec_temp_table_for_cleanup(void)
  * =============================================================================
  * These functions are placeholders that allow the code to compile.
  * They will be replaced with real implementations in later PRs:
- *   - PR4: create_insert_exec_temp_table, drop_insert_exec_temp_table
  *   - PR5: flush_insert_exec_temp_table, insert_exec_setup,
  *          insert_exec_error_cleanup, insert_exec_success_cleanup
  * =============================================================================
@@ -1444,24 +1443,390 @@ insertexec_destroy(DestReceiver *self)
 }
 
 /*
- * STUB: Create a temp table for INSERT EXEC buffering.
- * Real implementation in PR4 (Temp Table Create/Drop).
+ * Create a temp table for INSERT EXEC buffering.
+ *
+ * Creates a PostgreSQL temp table (not Babelfish #temp) with schema matching
+ * the target table. Uses a unique name pattern __insert_exec_buf_PID_N to avoid
+ * conflicts. For regular tables, queries pg_attribute to get column definitions
+ * (avoids needing SELECT permission for ownership chaining).
  */
 Oid
 create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in)
 {
-	/* STUB: Returns InvalidOid - real implementation in PR4 */
-	return InvalidOid;
+	StringInfoData create_stmt;
+	StringInfoData col_query;
+	int			rc;
+	Oid			temp_table_oid;
+	char		temp_table_name[NAMEDATALEN];
+	char	   *schema_name = NULL;
+	char	   *table_name = NULL;
+	char	   *physical_schema = NULL;
+	Oid			temp_nsp_oid;
+	int			suffix = 1;
+	MemoryContext oldcontext;
+
+	/*
+	 * Generate a unique temp table name using backend PID and a suffix.
+	 * We use PostgreSQL temp tables (not Babelfish temp tables with # prefix)
+	 * because they are more stable and don't have ENR-related issues.
+	 */
+	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
+
+	for (;;)
+	{
+		Oid existing_relid;
+
+		snprintf(temp_table_name, sizeof(temp_table_name),
+				 "__insert_exec_buf_%d_%d", MyProcPid, suffix);
+
+		/*
+		 * Check if a table with this name already exists in pg_temp.
+		 * If temp namespace doesn't exist yet, the name is definitely available.
+		 */
+		if (!OidIsValid(temp_nsp_oid))
+			break;
+
+		existing_relid = get_relname_relid(temp_table_name, temp_nsp_oid);
+		if (!OidIsValid(existing_relid))
+			break;  /* Name is available */
+
+		suffix++;
+
+		if (suffix > 10000)
+			elog(ERROR, "INSERT-EXEC: Could not find available temp table name after 10000 attempts");
+	}
+
+	/* Store the temp table name in the context for later cleanup */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	if (insert_exec_ctx.temp_table_name != NULL)
+		pfree(insert_exec_ctx.temp_table_name);
+	insert_exec_ctx.temp_table_name = pstrdup(temp_table_name);
+	MemoryContextSwitchTo(oldcontext);
+
+	/*
+	 * Drop any existing temp table with this name. This handles catalog cache
+	 * issues where get_relname_relid didn't find the table but it exists.
+	 */
+	initStringInfo(&create_stmt);
+	appendStringInfo(&create_stmt, "DROP TABLE IF EXISTS %s",
+					 quote_identifier(temp_table_name));
+	rc = SPI_execute(create_stmt.data, false, 0);
+	if (rc != SPI_OK_UTILITY)
+		elog(WARNING, "failed to drop existing INSERT EXEC temp table: %s",
+			 SPI_result_code_string(rc));
+	pfree(create_stmt.data);
+
+	insert_exec_ctx.pending_drop = false;
+
+	/*
+	 * Parse schema and table name from target_table.
+	 * For temp tables (starting with #), we don't need schema parsing.
+	 */
+	if (target_table[0] == '#' || target_table[0] == '@')
+	{
+		table_name = pstrdup(target_table);
+		schema_name = NULL;
+		physical_schema = NULL;
+	}
+	else
+	{
+		if (!parse_insert_exec_table_name(target_table, &schema_name, &table_name,
+										  &physical_schema, true))
+		{
+			elog(ERROR, "INSERT-EXEC: Failed to parse target table name: %s", target_table);
+		}
+	}
+
+	initStringInfo(&create_stmt);
+
+	if (column_list != NULL)
+	{
+		/*
+		 * User specified columns - create temp table with only those columns.
+		 * For temp tables, use SELECT INTO. For regular tables, query pg_attribute
+		 * to avoid needing SELECT permission (ownership chaining fix).
+		 */
+		if (physical_schema == NULL)
+		{
+			/*
+			 * Temp table or table variable target - use SELECT INTO.
+			 * Quote identifiers to prevent SQL injection.
+			 */
+			appendStringInfo(&create_stmt,
+				"SELECT %s INTO %s FROM %s WHERE 1=0",
+				column_list,
+				quote_identifier(temp_table_name),
+				quote_identifier(target_table));
+		}
+		else
+		{
+			StringInfoData col_defs;
+			bool		first_col = true;
+			int			proc_count;
+			int			i;
+			RangeVar   *target_rv;
+			Oid			target_relid;
+			char	   *col_list_copy;
+			char	   *col_name;
+			char	   *saveptr;
+			StringInfoData col_names_sql;
+
+			initStringInfo(&col_query);
+			initStringInfo(&col_defs);
+			initStringInfo(&col_names_sql);
+
+			/*
+			 * Resolve target table OID to avoid SQL injection via regclass.
+			 * Using OID directly is safer than string interpolation.
+			 */
+			target_rv = makeRangeVar(physical_schema, table_name, -1);
+			target_relid = RangeVarGetRelid(target_rv, AccessShareLock, false);
+
+			/*
+			 * Parse column_list to build SQL IN clause. Lowercase column names
+			 * to match pg_attribute storage.
+			 *
+			 * Note: strtok_r splits on both comma and space, so quoted identifiers
+			 * with embedded spaces in the column list are not supported.
+			 */
+			col_list_copy = pstrdup(column_list);
+			first_col = true;
+			appendStringInfoChar(&col_names_sql, '(');
+			col_name = strtok_r(col_list_copy, ", ", &saveptr);
+			while (col_name != NULL)
+			{
+				while (*col_name == ' ' || *col_name == '\t')
+					col_name++;
+				if (*col_name != '\0')
+				{
+					char *lower_col_name;
+					if (!first_col)
+						appendStringInfoString(&col_names_sql, ", ");
+					lower_col_name = downcase_identifier(col_name, strlen(col_name), false, false);
+					appendStringInfoString(&col_names_sql, quote_literal_cstr(lower_col_name));
+					pfree(lower_col_name);
+					first_col = false;
+				}
+				col_name = strtok_r(NULL, ", ", &saveptr);
+			}
+			appendStringInfoChar(&col_names_sql, ')');
+			pfree(col_list_copy);
+
+			appendStringInfo(&col_query,
+				"SELECT a.attname, format_type(a.atttypid, a.atttypmod) as coltype "
+				"FROM pg_attribute a "
+				"WHERE a.attrelid = %u "
+				"AND a.attnum > 0 "
+				"AND NOT a.attisdropped "
+				"AND lower(a.attname) IN %s "
+				"ORDER BY a.attnum",
+				target_relid, col_names_sql.data);
+
+			pfree(col_names_sql.data);
+
+			rc = SPI_execute(col_query.data, false, 0);
+			if (rc != SPI_OK_SELECT)
+			{
+				pfree(col_query.data);
+				pfree(col_defs.data);
+				elog(ERROR, "failed to query target table columns for INSERT EXEC: %s",
+					 SPI_result_code_string(rc));
+			}
+
+			proc_count = (int) SPI_processed;
+			if (proc_count == 0)
+			{
+				pfree(col_query.data);
+				pfree(col_defs.data);
+				elog(ERROR, "INSERT-EXEC: No matching columns found in target table");
+			}
+
+			first_col = true;
+			for (i = 0; i < proc_count; i++)
+			{
+				HeapTuple	tuple = SPI_tuptable->vals[i];
+				TupleDesc	tupdesc = SPI_tuptable->tupdesc;
+				char	   *attname = SPI_getvalue(tuple, tupdesc, 1);
+				char	   *coltype = SPI_getvalue(tuple, tupdesc, 2);
+
+				/* Defensive: SPI_getvalue returns NULL for SQL NULL */
+				if (attname == NULL || coltype == NULL)
+				{
+					if (attname) pfree(attname);
+					if (coltype) pfree(coltype);
+					pfree(col_query.data);
+					pfree(col_defs.data);
+					elog(ERROR, "INSERT-EXEC: NULL column name or type from pg_attribute");
+				}
+
+				if (!first_col)
+					appendStringInfoString(&col_defs, ", ");
+				appendStringInfo(&col_defs, "%s %s", quote_identifier(attname), coltype);
+				first_col = false;
+
+				pfree(attname);
+				pfree(coltype);
+			}
+
+			appendStringInfo(&create_stmt, "CREATE TEMP TABLE %s (%s)",
+							 quote_identifier(temp_table_name), col_defs.data);
+
+			pfree(col_query.data);
+			pfree(col_defs.data);
+		}
+	}
+	else
+	{
+		/*
+		 * No column list - create temp table with all columns from target.
+		 * For temp tables, use SELECT INTO. For regular tables, query pg_attribute.
+		 */
+		if (physical_schema == NULL)
+		{
+			/*
+			 * Temp table or table variable target - use SELECT INTO.
+			 * Quote identifiers to prevent SQL injection.
+			 */
+			appendStringInfo(&create_stmt,
+				"SELECT * INTO %s FROM %s WHERE 1=0",
+				quote_identifier(temp_table_name),
+				quote_identifier(target_table));
+		}
+		else
+		{
+			StringInfoData col_defs;
+			bool		first_col = true;
+			int			proc_count;
+			int			i;
+			RangeVar   *target_rv;
+			Oid			target_relid;
+
+			initStringInfo(&col_query);
+			initStringInfo(&col_defs);
+
+			/*
+			 * Resolve target table OID to avoid SQL injection via regclass.
+			 * Using OID directly is safer than string interpolation.
+			 */
+			target_rv = makeRangeVar(physical_schema, table_name, -1);
+			target_relid = RangeVarGetRelid(target_rv, AccessShareLock, false);
+
+			appendStringInfo(&col_query,
+				"SELECT a.attname, format_type(a.atttypid, a.atttypmod) as coltype "
+				"FROM pg_attribute a "
+				"WHERE a.attrelid = %u "
+				"AND a.attnum > 0 "
+				"AND NOT a.attisdropped "
+				"ORDER BY a.attnum",
+				target_relid);
+
+			rc = SPI_execute(col_query.data, false, 0);
+			if (rc != SPI_OK_SELECT)
+			{
+				pfree(col_query.data);
+				pfree(col_defs.data);
+				elog(ERROR, "failed to query target table columns for INSERT EXEC: %s",
+					 SPI_result_code_string(rc));
+			}
+
+			proc_count = (int) SPI_processed;
+			if (proc_count == 0)
+			{
+				pfree(col_query.data);
+				pfree(col_defs.data);
+				elog(ERROR, "INSERT-EXEC: Target table has no columns");
+			}
+
+			first_col = true;
+			for (i = 0; i < proc_count; i++)
+			{
+				HeapTuple	tuple = SPI_tuptable->vals[i];
+				TupleDesc	tupdesc = SPI_tuptable->tupdesc;
+				char	   *attname = SPI_getvalue(tuple, tupdesc, 1);
+				char	   *coltype = SPI_getvalue(tuple, tupdesc, 2);
+
+				/* Defensive: SPI_getvalue returns NULL for SQL NULL */
+				if (attname == NULL || coltype == NULL)
+				{
+					if (attname) pfree(attname);
+					if (coltype) pfree(coltype);
+					pfree(col_query.data);
+					pfree(col_defs.data);
+					elog(ERROR, "INSERT-EXEC: NULL column name or type from pg_attribute");
+				}
+
+				if (!first_col)
+					appendStringInfoString(&col_defs, ", ");
+				appendStringInfo(&col_defs, "%s %s", quote_identifier(attname), coltype);
+				first_col = false;
+
+				pfree(attname);
+				pfree(coltype);
+			}
+
+			appendStringInfo(&create_stmt, "CREATE TEMP TABLE %s (%s)",
+							 quote_identifier(temp_table_name), col_defs.data);
+
+			pfree(col_query.data);
+			pfree(col_defs.data);
+		}
+	}
+
+	if (schema_name) pfree(schema_name);
+	if (table_name) pfree(table_name);
+	if (physical_schema) pfree(physical_schema);
+
+	rc = SPI_execute(create_stmt.data, false, 0);
+	pfree(create_stmt.data);
+
+	if (rc != SPI_OK_UTILITY && rc != SPI_OK_SELINTO)
+		elog(ERROR, "failed to create INSERT EXEC temp table: %s", SPI_result_code_string(rc));
+
+	/* Get the OID of the newly created temp table */
+	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
+	if (!OidIsValid(temp_nsp_oid))
+		elog(ERROR, "INSERT-EXEC: pg_temp namespace not found after creating temp table");
+
+	temp_table_oid = get_relname_relid(temp_table_name, temp_nsp_oid);
+	if (!OidIsValid(temp_table_oid))
+		elog(ERROR, "INSERT-EXEC: Could not find temp table %s after creation", temp_table_name);
+
+	return temp_table_oid;
 }
 
 /*
- * STUB: Drop the temp table used for INSERT EXEC buffering.
- * Real implementation in PR4 (Temp Table Create/Drop).
+ * Drop the INSERT EXEC temp table.
+ * Uses the stored temp table name from the INSERT EXEC context.
  */
 void
 drop_insert_exec_temp_table(Oid temp_table_oid)
 {
-	/* STUB: Does nothing - real implementation in PR4 */
+	StringInfoData drop_stmt;
+	int			rc;
+
+	/* Parameter kept for interface consistency; we drop by name from context */
+	(void) temp_table_oid;
+
+	if (insert_exec_ctx.temp_table_name == NULL)
+	{
+		elog(DEBUG1, "INSERT-EXEC: No temp table name stored, cannot drop");
+		return;
+	}
+
+	initStringInfo(&drop_stmt);
+	appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s",
+					 quote_identifier(insert_exec_ctx.temp_table_name));
+
+	rc = SPI_execute(drop_stmt.data, false, 0);
+	if (rc != SPI_OK_UTILITY)
+		elog(WARNING, "failed to drop INSERT EXEC temp table %s: %s",
+			 insert_exec_ctx.temp_table_name, SPI_result_code_string(rc));
+
+	pfree(drop_stmt.data);
+
+	pfree(insert_exec_ctx.temp_table_name);
+	insert_exec_ctx.temp_table_name = NULL;
+	insert_exec_ctx.temp_table_oid = InvalidOid;
 }
 
 /*

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -406,7 +406,9 @@ pltsql_insert_exec_check_pending_drop(void)
  * block concurrent DDL; temp tables only get schema captured (session-local).
  */
 void
-pltsql_insert_exec_open_target_table(const char *target_table)
+pltsql_insert_exec_open_target_table(const char *target_table,
+                                     const char *schema_name_in,
+                                     const char *db_name_in)
 {
 	RangeVar   *rv;
 	Oid			relid;
@@ -441,12 +443,12 @@ pltsql_insert_exec_open_target_table(const char *target_table)
 	}
 	else
 	{
-		/* Regular table - parse schema and table name */
-		if (!parse_insert_exec_table_name(target_table, &schema_name, &table_name,
-										  &physical_schema, true))
-		{
-			return;
-		}
+		table_name = pstrdup(target_table);
+		if (schema_name_in != NULL)
+			schema_name = pstrdup(schema_name_in);
+		else
+			schema_name = pstrdup("dbo");  /* default schema */
+		physical_schema = get_physical_schema_name(get_cur_db_name(), schema_name);
 
 		/* Create RangeVar and get the relation OID */
 		rv = makeRangeVar(physical_schema, table_name, -1);
@@ -1152,7 +1154,7 @@ CreateInsertExecDestReceiver(Oid temp_table_oid)
  * Real implementation in PR4 (Temp Table Create/Drop).
  */
 Oid
-create_insert_exec_temp_table(const char *target_table, const char *column_list)
+create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in)
 {
 	/* STUB: Returns InvalidOid - real implementation in PR4 */
 	return InvalidOid;
@@ -1184,10 +1186,12 @@ flush_insert_exec_temp_table(PLtsql_execstate *estate)
  */
 bool
 insert_exec_setup(PLtsql_execstate *estate,
-				  const char *target_table,
-				  const char *column_list,
-				  Oid *temp_table_oid_out,
-				  DestReceiver **dest_out)
+                  const char *target_table,
+                  const char *schema_name,
+                  const char *db_name,
+                  const char *column_list,
+                  bool start_implicit_txn,
+                  Oid *temp_table_oid_out)
 {
 	/* STUB: Returns false (setup not done) - real implementation in PR5 */
 	return false;

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -58,6 +58,56 @@
 extern int exec_stmt_execsql(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
 
 /*
+ * Strip timezone suffixes from format_type() output that are invalid in
+ * CREATE TABLE statements (e.g., "without time zone").
+ */
+static char *
+clean_format_type_string(const char *coltype)
+{
+	char *result;
+	char *suffix_pos;
+
+	if (coltype == NULL)
+		return NULL;
+
+	result = pstrdup(coltype);
+
+	/* Strip " without time zone" suffix if present */
+	suffix_pos = strstr(result, " without time zone");
+	if (suffix_pos != NULL)
+		*suffix_pos = '\0';
+
+	/* Also strip " with time zone" suffix if present (for completeness) */
+	suffix_pos = strstr(result, " with time zone");
+	if (suffix_pos != NULL)
+		*suffix_pos = '\0';
+
+	/*
+	 * Append "(max)" for varchar/nvarchar/varbinary without length modifier.
+	 */
+	if (strchr(result, '(') == NULL &&
+		(strcmp(result, "sys.varchar") == 0 ||
+		 strcmp(result, "sys.\"varchar\"") == 0 ||
+		 strcmp(result, "varchar") == 0 ||
+		 strcmp(result, "\"varchar\"") == 0 ||
+		 strcmp(result, "sys.nvarchar") == 0 ||
+		 strcmp(result, "sys.\"nvarchar\"") == 0 ||
+		 strcmp(result, "nvarchar") == 0 ||
+		 strcmp(result, "\"nvarchar\"") == 0 ||
+		 strcmp(result, "sys.varbinary") == 0 ||
+		 strcmp(result, "sys.\"varbinary\"") == 0 ||
+		 strcmp(result, "varbinary") == 0 ||
+		 strcmp(result, "\"varbinary\"") == 0))
+	{
+		char *new_result = psprintf("%s(max)", result);
+		pfree(result);
+		result = new_result;
+	}
+
+	return result;
+}
+
+/*
  * DestReceiver struct for INSERT EXEC - captures procedure output into a temp table.
  */
 typedef struct

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -8,9 +8,11 @@
  */
 typedef struct InsertExecInfo
 {
-	bool		is_insert_exec;		/* Is this INSERT EXEC? */
-	char	   *target;				/* Target table for INSERT-EXEC */
-	char	   *columns;			/* Column list for INSERT-EXEC */
+    bool        is_insert_exec;     /* Is this INSERT EXEC? */
+    char       *target;             /* Target table name (bare name only, no schema/db prefix) */
+    char       *schema;             /* Schema name, or NULL if not specified */
+    char       *db_name;            /* Database name, or NULL if not specified */
+    char       *columns;            /* Column list for INSERT-EXEC */
 } InsertExecInfo;
 
 /*

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -3,6 +3,17 @@
 #include "pg_config_manual.h"
 
 /*
+ * INSERT EXEC info - shared by PLtsql_stmt_exec, PLtsql_stmt_exec_sp,
+ * and PLtsql_stmt_exec_batch.
+ */
+typedef struct InsertExecInfo
+{
+	bool		is_insert_exec;		/* Is this INSERT EXEC? */
+	char	   *target;				/* Target table for INSERT-EXEC */
+	char	   *columns;			/* Column list for INSERT-EXEC */
+} InsertExecInfo;
+
+/*
  * PRINT statement
  */
 typedef struct
@@ -90,6 +101,8 @@ typedef struct PLtsql_stmt_exec
 	char	   *db_name;
 	char	   *proc_name;
 	char	   *schema_name;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 		
 	bool		exec_with_recompile; /* forced recompile through EXECUTE */	
 } PLtsql_stmt_exec;
@@ -145,6 +158,8 @@ typedef struct PLtsql_stmt_exec_sp
 	PLtsql_expr *opt2;
 	PLtsql_expr *opt3;
 	List	   *stropt;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 } PLtsql_stmt_exec_sp;
 
 /*
@@ -165,6 +180,8 @@ typedef struct PLtsql_stmt_exec_batch
 	PLtsql_stmt_type cmd_type;
 	int			lineno;
 	PLtsql_expr *expr;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 } PLtsql_stmt_exec_batch;
 
 typedef struct PLtsql_stmt_raiserror

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -5,18 +5,12 @@
 /*
  * INSERT EXEC info - shared by PLtsql_stmt_exec, PLtsql_stmt_exec_sp,
  * and PLtsql_stmt_exec_batch.
- *
- * Table identifiers are stored separately (not pre-concatenated) to allow
- * the executor to properly quote each component when building queries,
- * preventing SQL injection from crafted identifiers.
  */
 typedef struct InsertExecInfo
 {
 	bool		is_insert_exec;		/* Is this INSERT EXEC? */
-	char	   *target_db;			/* Database name (or NULL) */
-	char	   *target_schema;		/* Schema name (or NULL) */
-	char	   *target_table;		/* Table name */
-	List	   *columns;			/* List of column name strings (char *) */
+	char	   *target;				/* Target table for INSERT-EXEC */
+	char	   *columns;			/* Column list for INSERT-EXEC */
 } InsertExecInfo;
 
 /*

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -5,12 +5,18 @@
 /*
  * INSERT EXEC info - shared by PLtsql_stmt_exec, PLtsql_stmt_exec_sp,
  * and PLtsql_stmt_exec_batch.
+ *
+ * Table identifiers are stored separately (not pre-concatenated) to allow
+ * the executor to properly quote each component when building queries,
+ * preventing SQL injection from crafted identifiers.
  */
 typedef struct InsertExecInfo
 {
 	bool		is_insert_exec;		/* Is this INSERT EXEC? */
-	char	   *target;				/* Target table for INSERT-EXEC */
-	char	   *columns;			/* Column list for INSERT-EXEC */
+	char	   *target_db;			/* Database name (or NULL) */
+	char	   *target_schema;		/* Schema name (or NULL) */
+	char	   *target_table;		/* Table name */
+	List	   *columns;			/* List of column name strings (char *) */
 } InsertExecInfo;
 
 /*

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2424,6 +2424,12 @@ extern void pltsql_insert_exec_close_target_table(void);
 extern bool pltsql_insert_exec_verify_schema(void);
 extern bool pltsql_insert_exec_validate_column_count_from_query(const char *query_string);
 
+/* Transaction helper - used by INSERT EXEC for implicit transaction commit */
+extern void commit_stmt(PLtsql_execstate *estate, bool txnStarted);
+
+/* SQL execution helper - used by INSERT EXEC for flush */
+extern int exec_stmt_execsql(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
+
 /* INSERT EXEC helper functions */
 extern bool insert_exec_setup(PLtsql_execstate *estate,
                               const char *target_table,

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2390,6 +2390,57 @@ extern bool 	is_numeric_datatype(Oid typid);
  */
 extern char *tsql_format_type_extended(Oid type_oid, int32 typemod, bits16 flags);
 
+/*
+ * INSERT EXEC functions (pl_insert_exec.c)
+ */
+extern void pltsql_set_insert_exec_context_info(const char *target_table, const char *column_list);
+extern void pltsql_set_insert_exec_context(Oid temp_table_oid);
+extern void pltsql_clear_insert_exec_context(void);
+extern void pltsql_insert_exec_reset_all(void);
+extern bool pltsql_insert_exec_active(void);
+extern bool pltsql_insert_exec_in_execution(void);
+extern bool pltsql_insert_exec_flush_in_progress(void);
+extern void pltsql_insert_exec_set_flush_in_progress(bool in_progress);
+extern void pltsql_insert_exec_set_target_table(const char *target_table);
+extern Oid pltsql_get_insert_exec_temp_table_oid(void);
+extern const char *pltsql_get_insert_exec_target_table(void);
+extern Oid pltsql_get_insert_exec_target_rel_oid(void);
+extern const char *pltsql_get_insert_exec_column_list(void);
+extern const char *pltsql_get_insert_exec_temp_table_name(void);
+extern bool pltsql_insert_exec_in_trycatch(void);
+extern bool pltsql_insert_exec_should_cleanup_on_trycatch(void);
+extern Oid pltsql_get_and_clear_insert_exec_temp_table_for_cleanup(void);
+extern void pltsql_insert_exec_set_error_flag(void);
+extern bool pltsql_insert_exec_had_error(void);
+extern void pltsql_insert_exec_clear_error_flag(void);
+extern void pltsql_insert_exec_set_implicit_txn_flag(void);
+extern bool pltsql_insert_exec_started_implicit_txn(void);
+extern void pltsql_insert_exec_clear_implicit_txn_flag(void);
+extern void pltsql_insert_exec_set_pending_drop(void);
+extern void pltsql_insert_exec_check_pending_drop(void);
+extern void pltsql_insert_exec_open_target_table(const char *target_table);
+extern void pltsql_insert_exec_close_target_table(void);
+extern bool pltsql_insert_exec_verify_schema(void);
+extern bool pltsql_insert_exec_validate_column_count_from_query(const char *query_string);
+
+/* INSERT EXEC helper functions */
+extern bool insert_exec_setup(PLtsql_execstate *estate,
+							  const char *target_table,
+							  const char *column_list,
+							  Oid *temp_table_oid_out,
+							  DestReceiver **dest_out);
+extern void insert_exec_error_cleanup(bool setup_done);
+extern void insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid);
+extern bool parse_insert_exec_table_name(const char *target_table,
+										 char **schema_name_out,
+										 char **table_name_out,
+										 char **physical_schema_out,
+										 bool get_physical);
+extern DestReceiver *CreateInsertExecDestReceiver(Oid temp_table_oid);
+extern Oid create_insert_exec_temp_table(const char *target_table, const char *column_list);
+extern void drop_insert_exec_temp_table(Oid temp_table_oid);
+extern void flush_insert_exec_temp_table(PLtsql_execstate *estate);
+
 #define NUM_DB_OBJECTS 11
 
 extern const char *shipped_objects_not_in_sys_db[NUM_DB_OBJECTS][2];

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -2418,17 +2418,20 @@ extern bool pltsql_insert_exec_started_implicit_txn(void);
 extern void pltsql_insert_exec_clear_implicit_txn_flag(void);
 extern void pltsql_insert_exec_set_pending_drop(void);
 extern void pltsql_insert_exec_check_pending_drop(void);
-extern void pltsql_insert_exec_open_target_table(const char *target_table);
+extern void pltsql_insert_exec_open_target_table(const char *target_table,const char *schema_name_in,
+                                                  const char *db_name_in);
 extern void pltsql_insert_exec_close_target_table(void);
 extern bool pltsql_insert_exec_verify_schema(void);
 extern bool pltsql_insert_exec_validate_column_count_from_query(const char *query_string);
 
 /* INSERT EXEC helper functions */
 extern bool insert_exec_setup(PLtsql_execstate *estate,
-							  const char *target_table,
-							  const char *column_list,
-							  Oid *temp_table_oid_out,
-							  DestReceiver **dest_out);
+                              const char *target_table,
+                              const char *schema_name,
+                              const char *db_name,
+                              const char *column_list,
+                              bool start_implicit_txn,
+                              Oid *temp_table_oid_out);
 extern void insert_exec_error_cleanup(bool setup_done);
 extern void insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid);
 extern bool parse_insert_exec_table_name(const char *target_table,
@@ -2437,7 +2440,9 @@ extern bool parse_insert_exec_table_name(const char *target_table,
 										 char **physical_schema_out,
 										 bool get_physical);
 extern DestReceiver *CreateInsertExecDestReceiver(Oid temp_table_oid);
-extern Oid create_insert_exec_temp_table(const char *target_table, const char *column_list);
+extern Oid create_insert_exec_temp_table(const char *target_table,
+                                          const char *column_list,
+                                          const char *schema_name_in);
 extern void drop_insert_exec_temp_table(Oid temp_table_oid);
 extern void flush_insert_exec_temp_table(PLtsql_execstate *estate);
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2100,41 +2100,41 @@ public:
 						column_list += ", ";
 					first = false;
 					auto ids = col->id();
-					if (!ids.empty())
+					if (!ids.empty() && ids.back() != nullptr)
 						column_list += stripQuoteFromId(ids.back());
 				}
 			}
+
+			/*
+			 * Helper lambda to set INSERT EXEC fields on the statement.
+			 * This avoids duplicating the same 5-line block for each statement type.
+			 */
+			auto setInsertExecInfo = [&](InsertExecInfo *info) {
+				info->is_insert_exec = true;
+				if (!target_table.empty())
+					info->target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					info->columns = pstrdup(column_list.c_str());
+			};
 
 			/* Set INSERT EXEC fields based on the actual statement type */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
 				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				exec_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-				exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
 				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				exec_batch_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-				exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_batch_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
 			{
 				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
 				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				exec_sp_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_sp_stmt->insert_exec);
 			}
 
 			/*

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2180,11 +2180,42 @@ public:
 			/* Clear the mutator since we're not using the execsql statement */
 			statementMutator.reset();
 			clear_rewritten_query_fragment();
+			clear_query_hints();
+			clear_tables_info();
 			return;
 		}
+		/*
+		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
+		 * This code is only needed when the new INSERT EXEC implementation is disabled.
+		 * When the GUC is true, we use PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
+		 * and the cross-database handling is done differently.
+		 * TODO: Remove this block when the new INSERT EXEC implementation is stable
+		 * and the GUC default is flipped to true.
+		 */
+		stmt->insert_exec = is_insert_exec;
 
-		/* For non-INSERT-EXEC statements, continue with normal processing */
-		stmt->insert_exec = false;
+		/* Extract db_name and schema_name for cross-database INSERT EXEC (legacy path only) */
+		if (is_insert_exec && !pltsql_enable_new_insert_exec)
+		{
+			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
+			TSqlParser::Execute_bodyContext *body = nullptr;
+
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			body = ctxES->execute_body();
+			Assert(body);
+
+			ctx_name = body->func_proc_name_server_database_schema();
+			if (ctx_name)
+			{
+				if (ctx_name->database)
+				{
+					db_name = stripQuoteFromId(ctx_name->database);
+					is_cross_db = true;
+				}
+				if (ctx_name->schema)
+					schema_name = stripQuoteFromId(ctx_name->schema);
+			}
+		}
 
 		// record whether stmt is cross-db
 		if (is_cross_db)

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1632,7 +1632,11 @@ public:
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
 		ParserRuleContext *container = peekContainer();
 
-		if (old_stmt && container)
+		/* Container must be valid to graft statements */
+		if (!container)
+			return;
+
+		if (old_stmt)
 		{
 			List *siblings = getCode(container);
 
@@ -2027,22 +2031,23 @@ public:
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/* Extract target table name and schema */
-			std::string target_table;
-			std::string target_schema;
+			/*
+			 * Extract target table components separately to prevent SQL injection.
+			 * Each component (db, schema, table) is stored individually so the executor
+			 * can properly quote them when building queries.
+			 */
+			std::string tbl_db, tbl_schema, tbl_name;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is, no schema needed */
-					target_table = ::getFullText(ddl_object->local_id());
-					target_schema = "";  /* Table variables don't need schema */
+					/* Table variable like @tablevar - use as-is */
+					tbl_name = ::getFullText(ddl_object->local_id());
 				}
 				else if (ddl_object->full_object_name())
 				{
-					/* Regular table or temp table - extract name and schema separately */
-					std::string tbl_name, tbl_schema, tbl_db;
+					/* Regular table or temp table - extract components separately */
 					if (ddl_object->full_object_name()->object_name)
 						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
 					if (ddl_object->full_object_name()->schema)
@@ -2051,84 +2056,60 @@ public:
 						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
 
 					/*
-					 * Temp tables (starting with #) use pg_temp schema, so strip
+					 * Temp tables (starting with #) use pg_temp schema, so clear
 					 * any user-provided schema prefix like dbo.#temp.
 					 */
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
-						target_table = tbl_name;
-						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
-					}
-					/* Build table reference with explicit schema if provided */
-					else if (!tbl_db.empty())
-					{
-						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
-						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
-					}
-					else if (!tbl_schema.empty())
-					{
-						target_table = tbl_schema + "." + tbl_name;
-						target_schema = tbl_schema;
-					}
-					else
-					{
-						/*
-						 * No schema specified - don't hardcode dbo. Let the search path
-						 * resolve the table, which respects the user's default schema.
-						 */
-						target_table = tbl_name;
-						target_schema = "";
+						tbl_schema.clear();
+						tbl_db.clear();
 					}
 				}
 			}
 
-			/* Extract column list */
-			std::string column_list;
+			/* Extract column list as a List of column name strings */
+			List *column_list = NIL;
 			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
 			if (column_list_ctx)
 			{
-				bool first = true;
 				for (auto col : column_list_ctx->col)
 				{
-					if (!first)
-						column_list += ", ";
-					first = false;
 					auto ids = col->id();
-					if (!ids.empty())
-						column_list += stripQuoteFromId(ids.back());
+					if (!ids.empty() && ids.back() != nullptr)
+					{
+						std::string col_name = stripQuoteFromId(ids.back());
+						column_list = lappend(column_list, pstrdup(col_name.c_str()));
+					}
 				}
 			}
+
+			/*
+			 * Helper lambda to set InsertExecInfo fields.
+			 * This avoids code duplication across the three statement types.
+			 */
+			auto setInsertExecInfo = [&](InsertExecInfo *info) {
+				info->is_insert_exec = true;
+				info->target_db = tbl_db.empty() ? NULL : pstrdup(tbl_db.c_str());
+				info->target_schema = tbl_schema.empty() ? NULL : pstrdup(tbl_schema.c_str());
+				info->target_table = tbl_name.empty() ? NULL : pstrdup(tbl_name.c_str());
+				info->columns = column_list;
+			};
 
 			/* Set INSERT EXEC fields based on the actual statement type */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
-				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				exec_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
-				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				exec_batch_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_batch_stmt->insert_exec);
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
 			{
-				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
 				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				exec_sp_stmt->insert_exec.is_insert_exec = true;
-				if (!target_table.empty())
-					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
-				if (!column_list.empty())
-					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+				setInsertExecInfo(&exec_sp_stmt->insert_exec);
 			}
 
 			/*
@@ -2136,6 +2117,10 @@ public:
 			 * This is needed to convert double-quoted strings to single-quoted strings
 			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
 			 * Without this, double-quoted strings would be interpreted as column references.
+			 *
+			 * Note: PLTSQL_STMT_EXEC_SP (sp_executesql, etc.) does not need rewriting here
+			 * because its SQL string parameter is already handled as a string literal, not
+			 * as an expression that could contain double-quoted identifiers.
 			 */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
@@ -2148,10 +2133,6 @@ public:
 			{
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
 				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
-				/*
-				 * For dynamic SQL, rewrite the entire expression - no need to limit
-				 * the rewriting range since the expression is the full SQL string.
-				 */
 				add_rewritten_query_fragment_to_mutator(&mutator);
 				mutator.run();
 			}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1626,6 +1626,37 @@ public:
 	}
 
 	/*
+	 * Apply expression rewriting for INSERT EXEC statements.
+	 * Converts double-quoted strings to single-quoted strings
+	 * (e.g., "master" -> 'master') for PostgreSQL compatibility.
+	 * PLTSQL_STMT_EXEC_SP does not need rewriting — system SP arguments
+	 * are explicit typed parameters, not general SQL expressions.
+	*/
+	void applyInsertExecRewriting(PLtsql_stmt *base_stmt,
+                               TSqlParser::Execute_statementContext *ctxES)
+	{
+    	if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+    	{
+        	PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+        	PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
+        	add_rewritten_query_fragment_to_mutator(&mutator);
+        	mutator.run();
+    	}
+		else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+		{
+			PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+			PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+			/*
+			* We don't call markSelectFragment here — selectFragmentOffsets was
+			* recorded with ctx->parent as key, not ctxES. For dynamic SQL in
+			* INSERT EXEC, we rewrite the entire expression string.
+			*/
+			add_rewritten_query_fragment_to_mutator(&mutator);
+			mutator.run();
+		}
+	}
+
+	/*
 	 * Replace a grafted statement with a new one.
 	 * Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
 	 */
@@ -1659,17 +1690,16 @@ public:
 			/* Update the fragment mapping */
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
-		else if (new_stmt && container)
+		else
 		{
-			/* No old statement, just graft the new one */
-			graft(new_stmt, container);
-			attachPLtsql_fragment(ctx, new_stmt);
+    		/*
+    		 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
+    		 * a PLtsql_stmt_execsql fragment before this function is called.
+    		* Reaching here means a broken parser state.
+    		*/
+    		Assert(false);
 		}
-		else if (new_stmt)
-		{
-			/* container is NULL - broken parser state, INSERT EXEC statement would be lost */
-			Assert(false);
-		}
+
 	}
 
 	//////////////////////////////////////////////////////////////////////////////
@@ -2048,20 +2078,18 @@ public:
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/* Extract target table name */
-			std::string target_table;
+			/* Extract target table name, schema, and database separately */
+			std::string tbl_name, tbl_schema, tbl_db;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is */
-					target_table = ::getFullText(ddl_object->local_id());
+					/* Table variable like @tablevar - no schema or db */
+					tbl_name = ::getFullText(ddl_object->local_id());
 				}
 				else if (ddl_object->full_object_name())
 				{
-					/* Regular table or temp table - extract name and schema separately */
-					std::string tbl_name, tbl_schema, tbl_db;
 					if (ddl_object->full_object_name()->object_name)
 						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
 					if (ddl_object->full_object_name()->schema)
@@ -2070,40 +2098,13 @@ public:
 						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
 
 					/*
-					 * Check if this is a temp table (starts with #).
-					 * In PostgreSQL, temp tables live in pg_temp schema, not user
-					 * schemas like dbo. We strip any schema prefix the user may have
-					 * provided (e.g., dbo.#temp) since it's not meaningful for temp tables.
-					 */
+					* Temp tables live in pg_temp, not user schemas. Strip any schema
+					* prefix the user may have provided (e.g., dbo.#temp).
+					*/
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
-						target_table = tbl_name;
-					}
-					/* Build table reference with explicit schema if provided */
-					else if (!tbl_db.empty())
-					{
-						/*
-						 * Three-part name: db..table or db.schema.table
-						 * When schema is empty (db..table), leave it empty and let the
-						 * executor resolve using the user's default schema, matching
-						 * T-SQL semantics.
-						 */
-						if (tbl_schema.empty())
-							target_table = tbl_db + ".." + tbl_name;
-						else
-							target_table = tbl_db + "." + tbl_schema + "." + tbl_name;
-					}
-					else if (!tbl_schema.empty())
-					{
-						target_table = tbl_schema + "." + tbl_name;
-					}
-					else
-					{
-						/*
-						 * No schema specified - don't hardcode dbo. Let the search path
-						 * resolve the table, which respects the user's default schema.
-						 */
-						target_table = tbl_name;
+						tbl_schema.clear();
+						tbl_db.clear();
 					}
 				}
 			}
@@ -2120,10 +2121,21 @@ public:
 						column_list += ", ";
 					first = false;
 					auto ids = col->id();
+					/* A column reference always has at least one identifier token per grammar */
+        			Assert(!ids.empty());
 					if (!ids.empty() && ids.back() != nullptr)
 						column_list += stripQuoteFromId(ids.back());
 				}
 			}
+
+			/*
+			 * target_table must be set for INSERT EXEC — if it's empty here,
+			 * the parse tree is malformed (ddl_object missing or has no object name).
+			 */
+			if (tbl_name.empty())
+				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+					"INSERT EXEC requires a valid target table",
+					getLineAndPos(ctx->insert_statement()->ddl_object()));
 
 			/*
 			 * Helper lambda to set INSERT EXEC fields on the statement.
@@ -2131,8 +2143,11 @@ public:
 			 */
 			auto setInsertExecInfo = [&](InsertExecInfo *info) {
 				info->is_insert_exec = true;
-				if (!target_table.empty())
-					info->target = pstrdup(target_table.c_str());
+				info->target = pstrdup(tbl_name.c_str());
+				if (!tbl_schema.empty())
+					info->schema = pstrdup(tbl_schema.c_str());
+				if (!tbl_db.empty())
+					info->db_name = pstrdup(tbl_db.c_str());
 				if (!column_list.empty())
 					info->columns = pstrdup(column_list.c_str());
 			};
@@ -2157,32 +2172,7 @@ public:
 				setInsertExecInfo(&exec_sp_stmt->insert_exec);
 			}
 
-			/*
-			 * Apply rewriting to the EXEC statement's expression.
-			 * This is needed to convert double-quoted strings to single-quoted strings
-			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
-			 * Without this, double-quoted strings would be interpreted as column references.
-			 */
-			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
-			{
-				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
-				add_rewritten_query_fragment_to_mutator(&mutator);
-				mutator.run();
-			}
-			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
-			{
-				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
-				/*
-				 * Note: We don't call markSelectFragment here because the selectFragmentOffsets
-				 * was recorded with ctx->parent as the key in makeExecuteStatement, not ctxES.
-				 * For INSERT EXEC with dynamic SQL, we don't need to limit the rewriting range
-				 * since the expression is the entire dynamic SQL string.
-				 */
-				add_rewritten_query_fragment_to_mutator(&mutator);
-				mutator.run();
-			}
+			applyInsertExecRewriting(base_stmt, ctxES);
 
 			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
 			replaceGraftedStatement(ctx, base_stmt);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1635,19 +1635,29 @@ public:
 		if (old_stmt && container)
 		{
 			List *siblings = getCode(container);
+			ListCell *lc;
+			int pos = 0;
 
 			if (pltsql_enable_antlr_detailed_log)
 				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
 
-			// Remove old statement and add new one
+			// Find the position of the old statement
+			foreach(lc, siblings)
+			{
+				if (lfirst(lc) == old_stmt)
+					break;
+				pos++;
+			}
+
+			// Remove old statement and insert new one at the same position
 			siblings = list_delete_ptr(siblings, old_stmt);
-			siblings = lappend(siblings, new_stmt);
+			siblings = list_insert_nth(siblings, pos, new_stmt);
 			setCode(container, siblings);
 
 			// Update the fragment mapping
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
-		else if (new_stmt)
+		else if (new_stmt && container)
 		{
 			// No old statement, just graft the new one
 			graft(new_stmt, container);
@@ -2017,7 +2027,7 @@ public:
 			}
 
 			/*
-			 *Instead of creating a PLtsql_stmt_execsql for
+			 * Instead of creating a PLtsql_stmt_execsql for
 			 * "INSERT INTO t EXEC p", we create a PLtsql_stmt_exec for just "EXEC p"
 			 * and set the INSERT EXEC fields. This allows exec_stmt_exec to handle
 			 * the temp table lifecycle and avoids parser-level issues.
@@ -2026,22 +2036,20 @@ public:
 			 * or PLtsql_stmt_exec_batch (for dynamic SQL like EXEC(@variable)). We need to
 			 * handle both cases and set the INSERT EXEC fields on the correct struct.
 			 */
-
 			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/* Extract target table name and schema */
+			/* Extract target table name */
 			std::string target_table;
-			std::string target_schema;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is, no schema needed */
+					/* Table variable like @tablevar - use as-is */
 					target_table = ::getFullText(ddl_object->local_id());
-					target_schema = "";  /* Table variables don't need schema */
 				}
 				else if (ddl_object->full_object_name())
 				{
@@ -2063,18 +2071,24 @@ public:
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
 						target_table = tbl_name;
-						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
 					}
 					/* Build table reference with explicit schema if provided */
 					else if (!tbl_db.empty())
 					{
-						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
-						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
+						/*
+						 * Three-part name: db..table or db.schema.table
+						 * When schema is empty (db..table), leave it empty and let the
+						 * executor resolve using the user's default schema, matching
+						 * T-SQL semantics.
+						 */
+						if (tbl_schema.empty())
+							target_table = tbl_db + ".." + tbl_name;
+						else
+							target_table = tbl_db + "." + tbl_schema + "." + tbl_name;
 					}
 					else if (!tbl_schema.empty())
 					{
 						target_table = tbl_schema + "." + tbl_name;
-						target_schema = tbl_schema;
 					}
 					else
 					{
@@ -2083,7 +2097,6 @@ public:
 						 * resolve the table, which respects the user's default schema.
 						 */
 						target_table = tbl_name;
-						target_schema = "";
 					}
 				}
 			}
@@ -2170,6 +2183,8 @@ public:
 			/* Clear the mutator since we're not using the execsql statement */
 			statementMutator.reset();
 			clear_rewritten_query_fragment();
+			clear_query_hints();
+			clear_tables_info();
 			return;
 		}
 		/*

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1625,8 +1625,10 @@ public:
 		setCode(container, list_delete_ptr(siblings, stmt));
 	}
 
-	// Replace a grafted statement with a new one
-	// Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	/*
+	 * Replace a grafted statement with a new one.
+	 * Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	 */
 	void replaceGraftedStatement(ParserRuleContext *ctx, PLtsql_stmt *new_stmt)
 	{
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
@@ -1641,7 +1643,7 @@ public:
 			if (pltsql_enable_antlr_detailed_log)
 				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
 
-			// Find the position of the old statement
+			/* Find the position of the old statement */
 			foreach(lc, siblings)
 			{
 				if (lfirst(lc) == old_stmt)
@@ -1649,24 +1651,24 @@ public:
 				pos++;
 			}
 
-			// Remove old statement and insert new one at the same position
+			/* Remove old statement and insert new one at the same position */
 			siblings = list_delete_ptr(siblings, old_stmt);
 			siblings = list_insert_nth(siblings, pos, new_stmt);
 			setCode(container, siblings);
 
-			// Update the fragment mapping
+			/* Update the fragment mapping */
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+		else if (new_stmt && container)
+		{
+			/* No old statement, just graft the new one */
+			graft(new_stmt, container);
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
 		else if (new_stmt)
 		{
-			/* Parser state error if container is NULL - INSERT EXEC statement would be lost */
-			Assert(container != NULL);
-			if (container)
-			{
-				// No old statement, just graft the new one
-				graft(new_stmt, container);
-				attachPLtsql_fragment(ctx, new_stmt);
-			}
+			/* container is NULL - broken parser state, INSERT EXEC statement would be lost */
+			Assert(false);
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2180,42 +2180,11 @@ public:
 			/* Clear the mutator since we're not using the execsql statement */
 			statementMutator.reset();
 			clear_rewritten_query_fragment();
-			clear_query_hints();
-			clear_tables_info();
 			return;
 		}
-		/*
-		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
-		 * This code is only needed when the new INSERT EXEC implementation is disabled.
-		 * When the GUC is true, we use PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
-		 * and the cross-database handling is done differently.
-		 * TODO: Remove this block when the new INSERT EXEC implementation is stable
-		 * and the GUC default is flipped to true.
-		 */
-		stmt->insert_exec = is_insert_exec;
 
-		/* Extract db_name and schema_name for cross-database INSERT EXEC (legacy path only) */
-		if (is_insert_exec && !pltsql_enable_new_insert_exec)
-		{
-			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
-			TSqlParser::Execute_bodyContext *body = nullptr;
-
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
-			body = ctxES->execute_body();
-			Assert(body);
-
-			ctx_name = body->func_proc_name_server_database_schema();
-			if (ctx_name)
-			{
-				if (ctx_name->database)
-				{
-					db_name = stripQuoteFromId(ctx_name->database);
-					is_cross_db = true;
-				}
-				if (ctx_name->schema)
-					schema_name = stripQuoteFromId(ctx_name->schema);
-			}
-		}
+		/* For non-INSERT-EXEC statements, continue with normal processing */
+		stmt->insert_exec = false;
 
 		// record whether stmt is cross-db
 		if (is_cross_db)

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1632,11 +1632,7 @@ public:
 		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
 		ParserRuleContext *container = peekContainer();
 
-		/* Container must be valid to graft statements */
-		if (!container)
-			return;
-
-		if (old_stmt)
+		if (old_stmt && container)
 		{
 			List *siblings = getCode(container);
 
@@ -2005,7 +2001,7 @@ public:
 				if (ddl_object && !ddl_object->local_id())
 				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
-							"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
+						"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}
 			}
 
@@ -2021,33 +2017,36 @@ public:
 			}
 
 			/*
-			 * For INSERT EXEC, create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql.
-			 * This allows the executor to handle INSERT EXEC specially. makeExecuteStatement
-			 * returns PLtsql_stmt_exec for procedure calls, PLtsql_stmt_exec_batch for
-			 * dynamic SQL (EXEC(@var)), or PLtsql_stmt_exec_sp for system procedures.
+			 *Instead of creating a PLtsql_stmt_execsql for
+			 * "INSERT INTO t EXEC p", we create a PLtsql_stmt_exec for just "EXEC p"
+			 * and set the INSERT EXEC fields. This allows exec_stmt_exec to handle
+			 * the temp table lifecycle and avoids parser-level issues.
+			 *
+			 * Note: makeExecuteStatement returns either PLtsql_stmt_exec (for procedure calls)
+			 * or PLtsql_stmt_exec_batch (for dynamic SQL like EXEC(@variable)). We need to
+			 * handle both cases and set the INSERT EXEC fields on the correct struct.
 			 */
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
 
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
 			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
 			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
 
-			/*
-			 * Extract target table components separately to prevent SQL injection.
-			 * Each component (db, schema, table) is stored individually so the executor
-			 * can properly quote them when building queries.
-			 */
-			std::string tbl_db, tbl_schema, tbl_name;
+			/* Extract target table name and schema */
+			std::string target_table;
+			std::string target_schema;
 			auto ddl_object = ctx->insert_statement()->ddl_object();
 			if (ddl_object)
 			{
 				if (ddl_object->local_id())
 				{
-					/* Table variable like @tablevar - use as-is */
-					tbl_name = ::getFullText(ddl_object->local_id());
+					/* Table variable like @tablevar - use as-is, no schema needed */
+					target_table = ::getFullText(ddl_object->local_id());
+					target_schema = "";  /* Table variables don't need schema */
 				}
 				else if (ddl_object->full_object_name())
 				{
-					/* Regular table or temp table - extract components separately */
+					/* Regular table or temp table - extract name and schema separately */
+					std::string tbl_name, tbl_schema, tbl_db;
 					if (ddl_object->full_object_name()->object_name)
 						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
 					if (ddl_object->full_object_name()->schema)
@@ -2056,60 +2055,86 @@ public:
 						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
 
 					/*
-					 * Temp tables (starting with #) use pg_temp schema, so clear
-					 * any user-provided schema prefix like dbo.#temp.
+					 * Check if this is a temp table (starts with #).
+					 * In PostgreSQL, temp tables live in pg_temp schema, not user
+					 * schemas like dbo. We strip any schema prefix the user may have
+					 * provided (e.g., dbo.#temp) since it's not meaningful for temp tables.
 					 */
 					if (!tbl_name.empty() && tbl_name[0] == '#')
 					{
-						tbl_schema.clear();
-						tbl_db.clear();
+						target_table = tbl_name;
+						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
+					}
+					/* Build table reference with explicit schema if provided */
+					else if (!tbl_db.empty())
+					{
+						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
+						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
+					}
+					else if (!tbl_schema.empty())
+					{
+						target_table = tbl_schema + "." + tbl_name;
+						target_schema = tbl_schema;
+					}
+					else
+					{
+						/*
+						 * No schema specified - don't hardcode dbo. Let the search path
+						 * resolve the table, which respects the user's default schema.
+						 */
+						target_table = tbl_name;
+						target_schema = "";
 					}
 				}
 			}
 
-			/* Extract column list as a List of column name strings */
-			List *column_list = NIL;
+			/* Extract column list */
+			std::string column_list;
 			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
 			if (column_list_ctx)
 			{
+				bool first = true;
 				for (auto col : column_list_ctx->col)
 				{
+					if (!first)
+						column_list += ", ";
+					first = false;
 					auto ids = col->id();
-					if (!ids.empty() && ids.back() != nullptr)
-					{
-						std::string col_name = stripQuoteFromId(ids.back());
-						column_list = lappend(column_list, pstrdup(col_name.c_str()));
-					}
+					if (!ids.empty())
+						column_list += stripQuoteFromId(ids.back());
 				}
 			}
-
-			/*
-			 * Helper lambda to set InsertExecInfo fields.
-			 * This avoids code duplication across the three statement types.
-			 */
-			auto setInsertExecInfo = [&](InsertExecInfo *info) {
-				info->is_insert_exec = true;
-				info->target_db = tbl_db.empty() ? NULL : pstrdup(tbl_db.c_str());
-				info->target_schema = tbl_schema.empty() ? NULL : pstrdup(tbl_schema.c_str());
-				info->target_table = tbl_name.empty() ? NULL : pstrdup(tbl_name.c_str());
-				info->columns = column_list;
-			};
 
 			/* Set INSERT EXEC fields based on the actual statement type */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
+				/* Procedure call: EXEC proc_name */
 				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
-				setInsertExecInfo(&exec_stmt->insert_exec);
+				exec_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+				exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
 			{
+				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
-				setInsertExecInfo(&exec_batch_stmt->insert_exec);
+				exec_batch_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+				exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
 			}
 			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
 			{
+				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
 				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
-				setInsertExecInfo(&exec_sp_stmt->insert_exec);
+				exec_sp_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
 			}
 
 			/*
@@ -2117,10 +2142,6 @@ public:
 			 * This is needed to convert double-quoted strings to single-quoted strings
 			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
 			 * Without this, double-quoted strings would be interpreted as column references.
-			 *
-			 * Note: PLTSQL_STMT_EXEC_SP (sp_executesql, etc.) does not need rewriting here
-			 * because its SQL string parameter is already handled as a string literal, not
-			 * as an expression that could contain double-quoted identifiers.
 			 */
 			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
 			{
@@ -2133,6 +2154,12 @@ public:
 			{
 				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
 				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+				/*
+				 * Note: We don't call markSelectFragment here because the selectFragmentOffsets
+				 * was recorded with ctx->parent as the key in makeExecuteStatement, not ctxES.
+				 * For INSERT EXEC with dynamic SQL, we don't need to limit the rewriting range
+				 * since the expression is the entire dynamic SQL string.
+				 */
 				add_rewritten_query_fragment_to_mutator(&mutator);
 				mutator.run();
 			}
@@ -2145,7 +2172,6 @@ public:
 			clear_rewritten_query_fragment();
 			return;
 		}
-
 		/*
 		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
 		 * This code is only needed when the new INSERT EXEC implementation is disabled.
@@ -2202,8 +2228,7 @@ public:
 			if (ctx->insert_statement())
 			{
 				auto ddl_object = ctx->insert_statement()->ddl_object();
-				/* INSERT EXEC in functions: when GUC is on, handled earlier; when off, check here */
-				if (stmt->insert_exec && ddl_object && !ddl_object->local_id())
+				if (stmt->insert_exec && ddl_object && !ddl_object->local_id()) /* insert into non-local object */
 				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2165,8 +2165,38 @@ public:
 			return;
 		}
 
-		/* Record INSERT EXEC flag for legacy code path (when GUC is off) */
+		/*
+		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
+		 * This code is only needed when the new INSERT EXEC implementation is disabled.
+		 * When the GUC is true, we use PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
+		 * and the cross-database handling is done differently.
+		 * TODO: Remove this block when the new INSERT EXEC implementation is stable
+		 * and the GUC default is flipped to true.
+		 */
 		stmt->insert_exec = is_insert_exec;
+
+		/* Extract db_name and schema_name for cross-database INSERT EXEC (legacy path only) */
+		if (is_insert_exec && !pltsql_enable_new_insert_exec)
+		{
+			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
+			TSqlParser::Execute_bodyContext *body = nullptr;
+
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			body = ctxES->execute_body();
+			Assert(body);
+
+			ctx_name = body->func_proc_name_server_database_schema();
+			if (ctx_name)
+			{
+				if (ctx_name->database)
+				{
+					db_name = stripQuoteFromId(ctx_name->database);
+					is_cross_db = true;
+				}
+				if (ctx_name->schema)
+					schema_name = stripQuoteFromId(ctx_name->schema);
+			}
+		}
 
 		// record whether stmt is cross-db
 		if (is_cross_db)

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -1657,11 +1657,16 @@ public:
 			// Update the fragment mapping
 			attachPLtsql_fragment(ctx, new_stmt);
 		}
-		else if (new_stmt && container)
+		else if (new_stmt)
 		{
-			// No old statement, just graft the new one
-			graft(new_stmt, container);
-			attachPLtsql_fragment(ctx, new_stmt);
+			/* Parser state error if container is NULL - INSERT EXEC statement would be lost */
+			Assert(container != NULL);
+			if (container)
+			{
+				// No old statement, just graft the new one
+				graft(new_stmt, container);
+				attachPLtsql_fragment(ctx, new_stmt);
+			}
 		}
 	}
 

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -119,6 +119,7 @@ PLtsql_stmt *makeCfl(TSqlParser::Cfl_statementContext *ctx, tsqlBuilder &builder
 PLtsql_stmt *makeSQL(ParserRuleContext *ctx);
 std::vector<PLtsql_stmt *> makeAnother(TSqlParser::Another_statementContext *ctx, tsqlBuilder &builder);
 PLtsql_stmt *makeExecBodyBatch(TSqlParser::Execute_body_batchContext *ctx);
+PLtsql_stmt *makeExecuteStatement(TSqlParser::Execute_statementContext *ctx);
 PLtsql_stmt *makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type);
 PLtsql_stmt *makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx);
 PLtsql_stmt *makeDbccCheckidentStatement(TSqlParser::Dbcc_statementContext *ctx);
@@ -1624,6 +1625,36 @@ public:
 		setCode(container, list_delete_ptr(siblings, stmt));
 	}
 
+	// Replace a grafted statement with a new one
+	// Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	void replaceGraftedStatement(ParserRuleContext *ctx, PLtsql_stmt *new_stmt)
+	{
+		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
+		ParserRuleContext *container = peekContainer();
+
+		if (old_stmt && container)
+		{
+			List *siblings = getCode(container);
+
+			if (pltsql_enable_antlr_detailed_log)
+				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
+
+			// Remove old statement and add new one
+			siblings = list_delete_ptr(siblings, old_stmt);
+			siblings = lappend(siblings, new_stmt);
+			setCode(container, siblings);
+
+			// Update the fragment mapping
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+		else if (new_stmt)
+		{
+			// No old statement, just graft the new one
+			graft(new_stmt, container);
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+	}
+
 	//////////////////////////////////////////////////////////////////////////////
 	// Container statement management
 	//////////////////////////////////////////////////////////////////////////////
@@ -1947,32 +1978,195 @@ public:
 		process_execsql_remove_unsupported_tokens(ctx, statementMutator.get());
 
 		// record whether the stmt is an INSERT-EXEC stmt
-		stmt->insert_exec =
+		bool is_insert_exec =
 			ctx->insert_statement() &&
 			ctx->insert_statement()->insert_statement_value() &&
 			ctx->insert_statement()->insert_statement_value()->execute_statement();
 
-		if (stmt->insert_exec)
+		/*
+		 * New INSERT EXEC code path - gated behind GUC pltsql_enable_new_insert_exec.
+		 * When enabled, we create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
+		 * which allows the executor to handle INSERT EXEC with the new DestReceiver
+		 * and temp table approach. When disabled, fall through to legacy behavior.
+		 */
+		if (is_insert_exec && pltsql_enable_new_insert_exec)
 		{
-			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
-			TSqlParser::Execute_bodyContext *body = nullptr;
-
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
-			body = ctxES->execute_body();
-			Assert(body);
-			
-			ctx_name       = body->func_proc_name_server_database_schema();
-			if (ctx_name) 
-			{				
-				if (ctx_name->database)
+			/*
+			 * Check if we're inside a function - INSERT EXEC is not allowed in functions
+			 * unless the target is a table variable (local_id).
+			 */
+			if (is_compiling_create_function())
+			{
+				auto ddl_object = ctx->insert_statement()->ddl_object();
+				if (ddl_object && !ddl_object->local_id())
 				{
-					db_name = stripQuoteFromId(ctx_name->database);
-					is_cross_db = true;
+					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
+							"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}
-				if (ctx_name->schema)
-					schema_name = stripQuoteFromId(ctx_name->schema);
 			}
+
+			/*
+			 * The OUTPUT clause cannot be used in an INSERT...EXEC statement.
+			 * Check for OUTPUT clause and throw error if present.
+			 */
+			if (ctx->insert_statement()->output_clause())
+			{
+				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+					"The OUTPUT clause cannot be used in an INSERT...EXEC statement.",
+					getLineAndPos(ctx->insert_statement()->output_clause()));
+			}
+
+			/*
+			 * For INSERT EXEC, create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql.
+			 * This allows the executor to handle INSERT EXEC specially. makeExecuteStatement
+			 * returns PLtsql_stmt_exec for procedure calls, PLtsql_stmt_exec_batch for
+			 * dynamic SQL (EXEC(@var)), or PLtsql_stmt_exec_sp for system procedures.
+			 */
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+
+			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
+			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
+
+			/* Extract target table name and schema */
+			std::string target_table;
+			std::string target_schema;
+			auto ddl_object = ctx->insert_statement()->ddl_object();
+			if (ddl_object)
+			{
+				if (ddl_object->local_id())
+				{
+					/* Table variable like @tablevar - use as-is, no schema needed */
+					target_table = ::getFullText(ddl_object->local_id());
+					target_schema = "";  /* Table variables don't need schema */
+				}
+				else if (ddl_object->full_object_name())
+				{
+					/* Regular table or temp table - extract name and schema separately */
+					std::string tbl_name, tbl_schema, tbl_db;
+					if (ddl_object->full_object_name()->object_name)
+						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
+					if (ddl_object->full_object_name()->schema)
+						tbl_schema = stripQuoteFromId(ddl_object->full_object_name()->schema);
+					if (ddl_object->full_object_name()->database)
+						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
+
+					/*
+					 * Temp tables (starting with #) use pg_temp schema, so strip
+					 * any user-provided schema prefix like dbo.#temp.
+					 */
+					if (!tbl_name.empty() && tbl_name[0] == '#')
+					{
+						target_table = tbl_name;
+						target_schema = "";  /* Temp tables use pg_temp, not user schemas */
+					}
+					/* Build table reference with explicit schema if provided */
+					else if (!tbl_db.empty())
+					{
+						target_table = tbl_db + "." + (tbl_schema.empty() ? "dbo" : tbl_schema) + "." + tbl_name;
+						target_schema = tbl_schema.empty() ? "dbo" : tbl_schema;
+					}
+					else if (!tbl_schema.empty())
+					{
+						target_table = tbl_schema + "." + tbl_name;
+						target_schema = tbl_schema;
+					}
+					else
+					{
+						/*
+						 * No schema specified - don't hardcode dbo. Let the search path
+						 * resolve the table, which respects the user's default schema.
+						 */
+						target_table = tbl_name;
+						target_schema = "";
+					}
+				}
+			}
+
+			/* Extract column list */
+			std::string column_list;
+			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
+			if (column_list_ctx)
+			{
+				bool first = true;
+				for (auto col : column_list_ctx->col)
+				{
+					if (!first)
+						column_list += ", ";
+					first = false;
+					auto ids = col->id();
+					if (!ids.empty())
+						column_list += stripQuoteFromId(ids.back());
+				}
+			}
+
+			/* Set INSERT EXEC fields based on the actual statement type */
+			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+			{
+				/* Procedure call: EXEC proc_name */
+				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+				exec_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+			{
+				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
+				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+				exec_batch_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_batch_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_batch_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
+			{
+				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
+				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
+				exec_sp_stmt->insert_exec.is_insert_exec = true;
+				if (!target_table.empty())
+					exec_sp_stmt->insert_exec.target = pstrdup(target_table.c_str());
+				if (!column_list.empty())
+					exec_sp_stmt->insert_exec.columns = pstrdup(column_list.c_str());
+			}
+
+			/*
+			 * Apply rewriting to the EXEC statement's expression.
+			 * This is needed to convert double-quoted strings to single-quoted strings
+			 * (e.g., "master" -> 'master') which is required for PostgreSQL compatibility.
+			 * Without this, double-quoted strings would be interpreted as column references.
+			 */
+			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+			{
+				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+				PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
+				add_rewritten_query_fragment_to_mutator(&mutator);
+				mutator.run();
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+			{
+				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+				PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+				/*
+				 * For dynamic SQL, rewrite the entire expression - no need to limit
+				 * the rewriting range since the expression is the full SQL string.
+				 */
+				add_rewritten_query_fragment_to_mutator(&mutator);
+				mutator.run();
+			}
+
+			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
+			replaceGraftedStatement(ctx, base_stmt);
+
+			/* Clear the mutator since we're not using the execsql statement */
+			statementMutator.reset();
+			clear_rewritten_query_fragment();
+			return;
 		}
+
+		/* Record INSERT EXEC flag for legacy code path (when GUC is off) */
+		stmt->insert_exec = is_insert_exec;
 
 		// record whether stmt is cross-db
 		if (is_cross_db)
@@ -1997,7 +2191,8 @@ public:
 			if (ctx->insert_statement())
 			{
 				auto ddl_object = ctx->insert_statement()->ddl_object();
-				if (stmt->insert_exec && ddl_object && !ddl_object->local_id()) /* insert into non-local object */
+				/* INSERT EXEC in functions: when GUC is on, handled earlier; when off, check here */
+				if (stmt->insert_exec && ddl_object && !ddl_object->local_id())
 				{
 					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}


### PR DESCRIPTION
### Description

**Background: INSERT...EXEC Redesign**

The current INSERT...EXEC implementation has limitations with transaction handling, error recovery, and TRY-CATCH compatibility. We're redesigning it using a **temp table buffering approach**:
1. Procedure output is captured into a temporary buffer table via a custom DestReceiver
2. After procedure execution completes, buffered rows are flushed to the target table
3. This enables proper TRY-CATCH error handling and transaction semantics matching SQL Server

**PR Series Overview:**
| PR | Focus | Description |
|----|-------|-------------|
| PR0 | GUC | Feature flag to gate the new code path |
| PR1 | Parser | Parse INSERT...EXEC and extract target table info |
| PR2 | Executor | Core state management and schema detection |
| PR3 | DestReceiver | Capture procedure output to temp table |
| PR4 | Temp Table | Create/drop temp buffer table with correct schema |
| **PR5** | **Flush** | **Transfer buffered data to target table** |
| PR6 | Integration | Wire everything together with tests |

**PR Chain:** [← PR4](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4784) | [PR6 →](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4794)

**This PR:**

Adds the flush logic that transfers buffered data from the temp table to the target table, along with setup and cleanup helper functions.

**Changes:**
- `flush_insert_exec_temp_table()` - Flushes buffered rows using `INSERT INTO target SELECT * FROM temp_table`
  - Uses subtransaction for atomicity
  - Implements ownership chaining by temporarily clearing INSERT EXEC context during flush
  - Allows INSTEAD OF triggers to fire correctly
- `insert_exec_setup()` - Sets up execution context, creates temp table, returns DestReceiver
- `insert_exec_error_cleanup()` - Cleans up on error, drops temp table, releases target table lock
- `insert_exec_success_cleanup()` - Cleans up on success after flush completes
- Exports `commit_stmt()` and `exec_stmt_execsql()` from `pl_exec.c` for use by flush logic

### Issues Resolved
PR5 of Task: [BABEL-5522](https://jira.rds.a2z.com/browse/BABEL-5522)

### Test Scenarios Covered
* **Use case based -** Tests included in PR6 (Executor Integration + Tests)
* **Boundary conditions -** Covered in PR6
* **Arbitrary inputs -** Covered in PR6
* **Negative test cases -** Covered in PR6
* **Minor version upgrade tests -** N/A (new feature, GUC-gated)
* **Major version upgrade tests -** N/A (new feature, GUC-gated)
* **Performance tests -** N/A
* **Tooling impact -** None
* **Client tests -** Covered in PR6 via JDBC tests

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.
