### PR TITLE
[OSS-ONLY] Update code-coverage GH action to do a engine restart before reinstalling extensions in order to get rid of any uncleaned shmem

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Restart Engine
         id: restart-db-engine
-        if: always()
+        if: always() && steps.install-extensions.outcome == 'success'
         run: |
           ~/psql/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Drop and re-create Babelfish database
         id: re-install-extensions-2
-        if: always() && steps.install-extensions.outcome == 'success'
+        if: always() && steps.install-extensions.outcome == 'success' && steps.restart-db-engine.outcome == 'success'
         run: |
           sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
           sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -85,6 +85,12 @@ jobs:
         if: always() && steps.install-extensions.outcome == 'success'
         uses: ./.github/composite-actions/install-and-run-odbc
 
+      - name: Restart Engine
+        id: restart-db-engine
+        if: always()
+        run: |
+          ~/psql/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
+
       - name: Drop and re-create Babelfish database
         id: re-install-extensions-2
         if: always() && steps.install-extensions.outcome == 'success'


### PR DESCRIPTION
### Description

tempOid stays initiailized from the last run however with the reinstallation the GUC is reset, hence when running the reinstallation again it leads to the following failure

```
psql:.github/scripts/create_extension.sql:24: ERROR:  tempOidStart is already set in shmem. temp oid initialization cannot be done.
CONTEXT:  SQL statement "CALL sys.persist_temp_oid_buffer_start()"
PL/pgSQL function sys.initialize_babel_extras() line 60 at CALL
SQL statement "CALL sys.initialize_babel_extras()"
PL/pgSQL function sys.initialize_babelfish(character varying) line 59 at CALL
Error: Process completed with exit code 3.
```

### Issues Resolved

no-jira

### Test Scenarios Covered ###

Not required since this is a GH action change



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).