### PR TITLE
[OSS-ONLY] Update code-coverage GH action to do a engine restart before reinstalling babelfish extensions(#4789)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -85,9 +85,15 @@ jobs:
         if: always() && steps.install-extensions.outcome == 'success'
         uses: ./.github/composite-actions/install-and-run-odbc
 
+      - name: Restart Engine
+        id: restart-db-engine
+        if: always() && steps.install-extensions.outcome == 'success'
+        run: |
+          ~/psql/bin/pg_ctl -c -D ~/psql/data/ -l logfile restart
+
       - name: Drop and re-create Babelfish database
         id: re-install-extensions-2
-        if: always() && steps.install-extensions.outcome == 'success'
+        if: always() && steps.install-extensions.outcome == 'success' && steps.restart-db-engine.outcome == 'success'
         run: |
           sudo ~/psql/bin/psql -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -f .github/scripts/cleanup_babelfish_database.sql
           sudo ~/psql/bin/psql -v ON_ERROR_STOP=1 -d postgres -U runner -v user="jdbc_user" -v db="babelfish_db" -v migration_mode="multi-db" -v tsql_port=1433 -v parallel_query_mode=false -f .github/scripts/create_extension.sql


### PR DESCRIPTION
### Description
Update code-coverage GitHub action to do a engine restart before reinstalling babelfish extensions in order to get rid of any stale shared memory.


(cherry picked from commit e2779e93ded8cec1b714a9e7e3b79fb4682063f7)


### Issues Resolved

no-jira

### Test Scenarios Covered ###
Not required since this is a GH action change



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).